### PR TITLE
v0.5.1: Fix search_device 503, health check, Claude Desktop bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.6.0] - 2026-03-30
-
-### Changed
-- `docker-compose.yml` defaults to GHCR pre-built image instead of local build
-- Renamed `docker-compose.test.yml` to `docker-compose.dev.yml`
-- README: Complete rewrite of Quick Start with GHCR image pull instructions
-- README: Expanded troubleshooting section (auth, tokens, port conflicts, tool modes)
-- README: Updated Development section to Docker-only workflow
-- README: Added `MCP_TOOL_MODE` to configuration table
-
-### Added
-- `docs/TOOLS.md` — Complete tool reference for all 60+ tools with parameters
-- GHCR image pull instructions: `ghcr.io/nowireless4u/hpe-networking-mcp:latest`
-- Release documentation checklist in project conventions
+## [v0.5.1] - 2026-04-02
 
 ### Fixed
-- Prompt count corrected from 11 to 10 across all documentation
+- `mist_search_device`: removed `vc_mac` parameter not supported by installed `mistapi` SDK version — fixes 503 errors on device search
+- `mist_search_device`: use kwargs dict to only pass non-None parameters to SDK — prevents unexpected keyword argument errors
+- Claude Desktop: switched from `mcp-remote` to `supergateway` for stdio-to-HTTP bridging — fixes tool call timeouts and session loss after system sleep
+- Docker health check: use `uv run --no-sync python` instead of bare `python` to find httpx in the virtual environment — fixes persistent "unhealthy" status
+- Docker Compose: default to local `build: .` instead of GHCR image for Apple Silicon / ARM compatibility
 
-[v0.6.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.6.0
+### Changed
+- README: Claude Desktop setup now uses `supergateway` bridge with full troubleshooting guide
+- README: Added troubleshooting for Claude Desktop configuration errors and tool timeouts
+
+[v0.5.1]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.5.1
 
 ## [v0.5.0] - 2026-03-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,6 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
-    CMD python -c "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5); assert r.status_code < 500" || exit 1
+    CMD uv run --no-sync python -c "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5); assert r.status_code < 500" || exit 1
 
 CMD ["uv", "run", "--no-sync", "python", "-m", "hpe_networking_mcp"]

--- a/README.md
+++ b/README.md
@@ -130,18 +130,20 @@ docker pull ghcr.io/nowireless4u/hpe-networking-mcp:latest
 
 ### Claude Desktop
 
-Add to your `claude_desktop_config.json`:
+Claude Desktop requires a stdio-to-HTTP bridge since it doesn't natively support streamable HTTP. Add to your `claude_desktop_config.json` (located at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
   "mcpServers": {
     "hpe-networking": {
-      "type": "streamable-http",
-      "url": "http://localhost:8000/mcp"
+      "command": "npx",
+      "args": ["-y", "supergateway", "--streamableHttp", "http://localhost:8000/mcp"]
     }
   }
 }
 ```
+
+> **Requires Node.js** — [install Node.js](https://nodejs.org/) if you don't have `npx` available. The `supergateway` package is downloaded automatically on first launch.
 
 ### Claude Code
 
@@ -151,11 +153,11 @@ claude mcp add hpe-networking --transport http http://localhost:8000/mcp
 
 ### VS Code / GitHub Copilot
 
-Add to your `.vscode/mcp.json` or MCP settings:
+Add to your `.vscode/mcp.json` or VS Code MCP settings:
 
 ```json
 {
-  "mcpServers": {
+  "servers": {
     "hpe-networking": {
       "type": "streamable-http",
       "url": "http://localhost:8000/mcp"
@@ -401,8 +403,27 @@ ports:
 
 1. Check the server is running: `docker compose logs | grep "registered"`
 2. Verify the endpoint is reachable: `curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/mcp` (expect `406` — this is normal for a plain GET)
-3. Ensure your client config uses `streamable-http` as the transport type
-4. **Restart your AI client** after adding or changing the MCP server config — tools are discovered at session start
+3. **Restart your AI client** after adding or changing the MCP server config — tools are discovered at session start
+
+### Claude Desktop: "Not a valid MCP server configuration"
+
+Claude Desktop doesn't natively support streamable HTTP — it requires a stdio bridge. Use `supergateway`:
+
+```json
+{
+  "mcpServers": {
+    "hpe-networking": {
+      "command": "npx",
+      "args": ["-y", "supergateway", "--streamableHttp", "http://localhost:8000/mcp"]
+    }
+  }
+}
+```
+
+If tools time out after ~4 minutes, check that:
+- The Docker container is running and healthy: `docker compose ps`
+- Node.js is installed: `npx --version`
+- The container didn't lose connectivity after sleep: `docker compose restart`
 
 ### GreenLake Tools Missing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   hpe-networking-mcp:
-    # Pre-built image (default — no build required)
-    image: ghcr.io/nowireless4u/hpe-networking-mcp:latest
-    # To build from source instead, comment out 'image' and uncomment 'build':
-    # build: .
+    # Pre-built image (uncomment for amd64 systems — no build required):
+    # image: ghcr.io/nowireless4u/hpe-networking-mcp:latest
+    # Build from source (required for Apple Silicon / ARM):
+    build: .
     ports:
       - "${MCP_PORT:-8000}:8000"
     environment:
@@ -28,7 +28,7 @@ services:
       - greenlake_workspace_id
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5)"]
+      test: ["CMD", "uv", "run", "--no-sync", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
@@ -101,13 +101,6 @@ async def search_device(
             default=None,
         ),
     ],
-    vc_mac: Annotated[
-        str,
-        Field(
-            description=("MAC address of the virtual chassis (switch stack) to filter inventory by"),
-            default=None,
-        ),
-    ],
     device_type: Annotated[
         Device_type,
         Field(
@@ -149,15 +142,13 @@ async def search_device(
     logger.debug(
         "Input Parameters: org_id: %s, site_id: %s, "
         "serial: %s, model: %s, mac: %s, version: %s, "
-        "vc_mac: %s, device_type: %s, status: %s, "
-        "text: %s, limit: %s",
+        "device_type: %s, status: %s, text: %s, limit: %s",
         org_id,
         site_id,
         serial,
         model,
         mac,
         version,
-        vc_mac,
         device_type,
         status,
         text,
@@ -167,19 +158,29 @@ async def search_device(
     apisession, response_format = await get_apisession()
 
     try:
+        kwargs: dict = {
+            "org_id": str(org_id),
+            "limit": limit,
+        }
+        if serial:
+            kwargs["serial"] = serial
+        if model:
+            kwargs["model"] = model
+        if device_type:
+            kwargs["type"] = device_type.value
+        if mac:
+            kwargs["mac"] = mac
+        if site_id:
+            kwargs["site_id"] = str(site_id)
+        if version:
+            kwargs["version"] = version
+        if text:
+            kwargs["text"] = text
+        if status:
+            kwargs["status"] = status.value
         response = mistapi.api.v1.orgs.inventory.searchOrgInventory(
             apisession,
-            org_id=str(org_id),
-            serial=serial if serial else None,
-            model=model if model else None,
-            type=(device_type.value if device_type else None),
-            mac=mac if mac else None,
-            site_id=str(site_id) if site_id else None,
-            vc_mac=vc_mac if vc_mac else None,
-            version=version if version else None,
-            text=text if text else None,
-            status=(status.value if status else None),
-            limit=limit,
+            **kwargs,
         )
         await process_response(response)
         if isinstance(response.data, dict):


### PR DESCRIPTION
## Summary
Bug fixes for three issues discovered during live testing.

## Fixes
- **`mist_search_device` 503 error**: Removed `vc_mac` parameter not supported by installed `mistapi` SDK version. Switched to kwargs dict to only pass non-None parameters, preventing unexpected keyword argument errors.
- **Docker health check "unhealthy"**: Changed from bare `python` to `uv run --no-sync python` so httpx is accessible from the virtual environment.
- **Claude Desktop tool timeouts**: Switched from `mcp-remote` to `supergateway` for the stdio-to-HTTP bridge. `mcp-remote` lost HTTP sessions after system sleep causing 4-minute timeouts.
- **Docker Compose ARM**: Default to `build: .` instead of GHCR image for Apple Silicon compatibility.

## Testing
- `mist_search_device` tested via MCP — returns data correctly
- Docker health check shows "healthy" after rebuild
- All existing 119 tests still pass
- Lint and format clean