### PR TITLE
v0.6.0: Disconnect, port/PoE bounce tools with safety guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.0] - 2026-04-02
+
+### Added — Central
+- `central_disconnect_users_ssid` — Disconnect all users from a specific SSID
+- `central_disconnect_users_ap` — Disconnect all users from an AP
+- `central_disconnect_client_ap` — Disconnect client by MAC from an AP
+- `central_disconnect_client_gateway` — Disconnect client by MAC from a gateway
+- `central_disconnect_clients_gateway` — Disconnect all clients from a gateway
+- `central_port_bounce_switch` — Port bounce on CX switch
+- `central_poe_bounce_switch` — PoE bounce on CX switch
+- `central_port_bounce_gateway` — Port bounce on gateway
+- `central_poe_bounce_gateway` — PoE bounce on gateway
+
+### Added — Mist
+- `mist_bounce_switch_port` — Port bounce on Juniper EX switch
+
+### Added — Safety
+- Port safety rules in INSTRUCTIONS.md — AI must check interfaces before bouncing
+- Platform-specific port naming guidance (Aruba CX vs Juniper EX)
+
+### Changed
+- Mist tool count: 34 → 35
+- Central tool count: 26 → 35 (+ 10 prompts)
+- Total tools: 73 (dynamic mode) or 80 (static mode)
+
+[v0.6.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.6.0
+
 ## [v0.5.1] - 2026-04-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Managing HPE networking infrastructure with AI assistants today means juggling t
 | **Audit Logs** | ✅ | ✅ | ✅ |
 | **Application Visibility** | — | ✅ | — |
 | **SLE / Performance Metrics** | ✅ | — | — |
-| **Troubleshooting (Ping/Traceroute)** | ✅ | ✅ | — |
+| **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — |
+| **Client Disconnect** | — | ✅ | — |
 | **Configuration Management** | ✅ | — | — |
 | **Configuration Write (CRUD)** | ✅ | — | — |
 | **Radio Resource Management** | ✅ | — | — |
@@ -35,7 +36,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling t
 | **Workspaces** | — | — | ✅ |
 | **Guided Prompts** | — | ✅ | — |
 | **Dynamic API Discovery** | — | — | ✅ |
-| **Tools** | **34** | **26 + 10 prompts** | **3 or 10** |
+| **Tools** | **35** | **35 + 10 prompts** | **3 or 10** |
 
 ### Aruba Central Guided Prompts
 
@@ -107,7 +108,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: registered 34 tools` and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`.
+Look for lines like `Mist: registered 35 tools` and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`.
 
 ### Docker Image
 
@@ -115,7 +116,7 @@ The pre-built image is available on GitHub Container Registry:
 
 ```
 ghcr.io/nowireless4u/hpe-networking-mcp:latest
-ghcr.io/nowireless4u/hpe-networking-mcp:0.5.0
+ghcr.io/nowireless4u/hpe-networking-mcp:0.6.0
 ```
 
 You can also pull it directly:
@@ -232,7 +233,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 │   ┌────────────┐ ┌────────────┐ ┌────────────────┐  │
 │   │   Mist     │ │  Central   │ │   GreenLake    │  │
 │   │  mist_*    │ │ central_*  │ │  greenlake_*   │  │
-│   │  34 tools  │ │ 26+10 prmt │ │  3/10 tools    │  │
+│   │  35 tools  │ │ 35+10 prmt │ │  3/10 tools    │  │
 │   └─────┬──────┘ └─────┬──────┘ └───────┬────────┘  │
 │         │              │                │            │
 └─────────┼──────────────┼────────────────┼────────────┘
@@ -333,8 +334,8 @@ hpe-networking-mcp/
 │   ├── INSTRUCTIONS.md          # LLM instructions for all platforms
 │   ├── middleware/              # Elicitation and null-strip middleware
 │   └── platforms/
-│       ├── mist/                # 34 Mist tools + API client
-│       ├── central/             # 26 Central tools + 10 prompts + API client
+│       ├── mist/                # 35 Mist tools + API client
+│       ├── central/             # 35 Central tools + 10 prompts + API client
 │       └── greenlake/           # 3 dynamic or 10 static tools + OAuth2 client
 ├── tests/                       # Unit and integration tests (119 tests)
 ├── docs/                        # PRD, PRP, tool reference

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -8,8 +8,8 @@ and `greenlake_*` (HPE GreenLake).
 
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
-| Juniper Mist | 30 | 4 | -- | 34 |
-| Aruba Central | 26 | -- | 10 | 36 |
+| Juniper Mist | 31 | 4 | -- | 35 |
+| Aruba Central | 35 | -- | 10 | 45 |
 | HPE GreenLake (static mode) | 10 | -- | -- | 10 |
 | HPE GreenLake (dynamic mode) | 3 | -- | -- | 3 |
 
@@ -25,7 +25,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Juniper Mist (34 tools)
+## Juniper Mist (35 tools)
 
 ### Account and Organization
 
@@ -205,6 +205,16 @@ GreenLake supports two mutually exclusive tool modes controlled by
 |-----------|------|----------|-------------|
 | site_id | UUID | Yes | Site ID. |
 | device_id | UUID | Yes | Gateway device ID (use `mist_search_device` to find it). |
+
+#### `mist_bounce_switch_port`
+
+> Bounce ports on a Juniper EX switch to reset link state. Only bounce edge/access ports — never uplinks, stack, or aggregation ports.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| site_id | UUID | Yes | Site ID. |
+| device_id | UUID | Yes | Device ID of the EX switch (use `mist_search_device` to find it). |
+| ports | str | Yes | Comma-separated port names (e.g., `ge-0/0/0,ge-0/0/1`). Juniper format: `ge-0/0/0` (1G), `mge-0/0/0` (multi-gig). |
 
 ### Events, Alarms, and Audit Logs
 
@@ -485,7 +495,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Aruba Central (26 tools + 10 prompts)
+## Aruba Central (35 tools + 10 prompts)
 
 ### Sites
 
@@ -794,6 +804,85 @@ No parameters. Returns a dict sorted by health score (worst first).
 | serial_number | str | Yes | Device serial number. |
 | device_type | str | Yes | `aos-s`, `cx`, or `gateways`. |
 | commands | str | Yes | Comma-separated show commands (e.g. `show version,show interfaces`). |
+
+#### `central_disconnect_users_ssid`
+
+> Disconnect all users from a specific SSID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | AP serial number. |
+| ssid | str | Yes | SSID name to disconnect all users from. |
+
+#### `central_disconnect_users_ap`
+
+> Disconnect all users from a specific AP.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | AP serial number. |
+
+#### `central_disconnect_client_ap`
+
+> Disconnect a specific client by MAC address from an AP.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | AP serial number. |
+| mac_address | str | Yes | Client MAC address. |
+
+#### `central_disconnect_client_gateway`
+
+> Disconnect a specific client by MAC address from a gateway.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Gateway serial number. |
+| mac_address | str | Yes | Client MAC address. |
+
+#### `central_disconnect_clients_gateway`
+
+> Disconnect all clients from a gateway.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Gateway serial number. |
+
+#### `central_port_bounce_switch`
+
+> Bounce a port on a CX switch to reset link state.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Switch serial number. |
+| ports | str | Yes | Comma-separated port list in CX format (e.g. `1/1/1,1/1/2`). |
+
+#### `central_poe_bounce_switch`
+
+> Cycle PoE power on a CX switch port to reset a connected PoE device.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Switch serial number. |
+| ports | str | Yes | Comma-separated port list in CX format (e.g. `1/1/1,1/1/2`). |
+
+#### `central_port_bounce_gateway`
+
+> Bounce a port on a gateway to reset link state.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Gateway serial number. |
+| ports | str | Yes | Comma-separated port list. |
+
+#### `central_poe_bounce_gateway`
+
+> Cycle PoE power on a gateway port to reset a connected PoE device.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | Gateway serial number. |
+| ports | str | Yes | Comma-separated port list. |
 
 ### Guided Prompts
 

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -36,7 +36,7 @@ Tools are namespaced by platform:
 - **Configuration Objects (Read)**: mist_get_configuration_objects, mist_get_configuration_object_schema
 - **Configuration Objects (Write)**: mist_change_org/site_configuration_objects, mist_update_org/site_configuration_objects
 - **WLANs**: mist_get_wlans
-- **Device Management**: mist_search_device, mist_get_stats, mist_get_ap_details, mist_get_switch_details, mist_get_gateway_details
+- **Device Management**: mist_search_device, mist_get_stats, mist_get_ap_details, mist_get_switch_details, mist_get_gateway_details, mist_bounce_switch_port
 - **Site Health**: mist_get_site_health
 - **Client Management**: mist_search_client, mist_search_nac_user_macs, mist_search_guest_authorization
 - **Events & Alarms**: mist_search_events, mist_search_alarms, mist_search_audit_logs
@@ -73,7 +73,7 @@ When a Mist tool response includes a `_next` field, use `mist_get_next_page(url=
 - **Events**: central_get_events, central_get_events_count
 - **Audit Logs**: central_get_audit_logs, central_get_audit_log_detail
 - **Applications**: central_get_applications
-- **Troubleshooting**: central_ping, central_traceroute, central_cable_test, central_show_commands
+- **Troubleshooting**: central_ping, central_traceroute, central_cable_test, central_show_commands, central_disconnect_users_ssid, central_disconnect_users_ap, central_disconnect_client_ap, central_disconnect_client_gateway, central_disconnect_clients_gateway, central_port_bounce_switch, central_poe_bounce_switch, central_port_bounce_gateway, central_poe_bounce_gateway
 
 ## Guidelines
 - ALWAYS start with `central_get_site_name_id_mapping` for a lightweight overview.
@@ -92,6 +92,37 @@ When a Mist tool response includes a `_next` field, use `mist_get_next_page(url=
 - **Users**: greenlake_get_users, greenlake_get_user_details
 - **Workspaces**: greenlake_get_workspace, greenlake_get_workspace_details
 - **Dynamic Tools**: greenlake_list_endpoints, greenlake_get_endpoint_schema, greenlake_invoke_endpoint
+
+---
+
+## Port Bounce and PoE Bounce Safety Rules
+
+**CRITICAL: Port and PoE bounce tools can cause network outages if used incorrectly.**
+
+When asked to bounce a port or cycle PoE on any switch or gateway:
+
+1. **Only use on edge/access layer switches** — switches with end-user devices, APs, cameras, or phones directly connected. **NEVER bounce ports on core or aggregation switches** — these have downstream switches connected and bouncing a port will disconnect an entire switch and all of its clients.
+2. **Always look up the device first** using the appropriate detail tool (`central_get_switch_details`, `mist_search_device`) and determine if it is an edge/access switch by checking:
+   - **Device name** — names containing "access", "edge", "closet", or floor/room identifiers are typically edge switches
+   - **Connected devices on ports** — if ports show APs, phones, cameras, or workstations connected, it is an edge switch. If ports show other switches connected, it is a core/aggregation switch
+   - **Switch model** — smaller form factor switches (e.g., CX 6100, 6200, 6300, EX2300, EX4100) are typically edge; larger chassis switches (e.g., CX 8360, 8400, EX4650, QFX) are typically core/aggregation
+   - **Check the port configuration** — access/untagged ports are edge ports (safe to bounce). Trunk ports are inter-switch links (never bounce). L3 ports with IP addresses assigned are routed uplinks (never bounce)
+   - **If uncertain, ask the user** before proceeding with any port bounce
+7. **Before bouncing across multiple switches** (on any platform — Central or Mist), check each port first:
+   - For PoE bounce: verify the port has active PoE power draw — if PoE consumption is zero, skip that port (nothing is powered on it)
+   - For port bounce: verify a client or AP is connected to the port — if nothing is connected, skip it
+   - This prevents bouncing empty ports and avoids accidentally bouncing uplinks that don't draw PoE
+   - **Central**: Use `central_get_switch_details` to check port PoE and client status
+   - **Mist**: Use `mist_get_stats` or `mist_get_switch_details` to check port PoE and client status
+3. **Never bounce uplink ports, stack ports, trunk ports, inter-switch links, or aggregation ports** — these carry traffic for multiple devices and VLANs.
+4. **Only bounce ports with APs or end-user devices connected** — these are the only safe ports to reset.
+5. **Port numbering differs by platform:**
+   - Aruba CX: `1/1/1` (member/slot/port). Port 1 = `1/1/1`.
+   - Juniper EX: `ge-0/0/0` (1G), `mge-0/0/0` (multi-gig), `xe-0/0/0` (10G SFP+). Port 1 = `ge-0/0/0` or `mge-0/0/0`.
+   - Stack members increment the first number on both platforms.
+6. When the user says "bounce port 1" without specifying format, translate to the correct platform format:
+   - Aruba CX → `1/1/1`
+   - Juniper EX → `ge-0/0/0` (or `mge-0/0/0` for multi-gig models)
 
 ---
 

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -13,6 +13,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     _registry.mcp = mcp
 
     from hpe_networking_mcp.platforms.central.tools import (
+        actions,
         alerts,
         applications,
         audit_logs,
@@ -38,7 +39,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     stats.register(mcp)
     applications.register(mcp)
     troubleshooting.register(mcp)
+    actions.register(mcp)
     prompts.register(mcp)
 
     logger.info("Central: registered tools and prompts")
-    return 27  # 26 tools + 10 prompts registered
+    return 36  # 35 tools + 10 prompts registered

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -1,0 +1,329 @@
+from typing import Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+from pycentral.troubleshooting.troubleshooting import Troubleshooting
+
+OPERATIONAL = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+
+def register(mcp):
+
+    # ── Disconnect Tools ─────────────────────────────────────────────
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_disconnect_users_ssid(
+        ctx: Context,
+        serial_number: str,
+        device_type: Literal["aos-s", "cx"],
+        ssid: str,
+    ) -> dict | str:
+        """
+        Disconnect all users from a specific SSID/WLAN on an access point.
+
+        Use central_find_device to get the serial number and
+        central_get_wlans to get the SSID name.
+
+        Parameters:
+            serial_number: AP serial number (required).
+            device_type: AP type — "aos-s" or "cx" (required).
+            ssid: SSID/WLAN name to disconnect users from (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+
+        try:
+            resp = Troubleshooting.disconnect_all_users_ssid(
+                central_conn=conn,
+                device_type=device_type,
+                serial_number=serial_number,
+                network=ssid,
+            )
+        except Exception as e:
+            return f"Error disconnecting users from SSID: {e}"
+
+        if not resp:
+            return "Disconnect users from SSID returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_disconnect_users_ap(
+        ctx: Context,
+        serial_number: str,
+        device_type: Literal["aos-s", "cx"],
+    ) -> dict | str:
+        """
+        Disconnect all users from an access point.
+
+        Use central_find_device to get the AP serial number.
+
+        Parameters:
+            serial_number: AP serial number (required).
+            device_type: AP type — "aos-s" or "cx" (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+
+        try:
+            resp = Troubleshooting.disconnect_all_users(
+                central_conn=conn,
+                device_type=device_type,
+                serial_number=serial_number,
+            )
+        except Exception as e:
+            return f"Error disconnecting users from AP: {e}"
+
+        if not resp:
+            return "Disconnect users from AP returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_disconnect_client_ap(
+        ctx: Context,
+        serial_number: str,
+        device_type: Literal["aos-s", "cx"],
+        mac_address: str,
+    ) -> dict | str:
+        """
+        Disconnect a specific client by MAC address from an access point.
+
+        Use central_find_client to get the MAC address and
+        central_find_device to get the AP serial number.
+
+        Parameters:
+            serial_number: AP serial number (required).
+            device_type: AP type — "aos-s" or "cx" (required).
+            mac_address: Client MAC address to disconnect (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+
+        try:
+            resp = Troubleshooting.disconnect_client_mac_addr(
+                central_conn=conn,
+                device_type=device_type,
+                serial_number=serial_number,
+                mac_address=mac_address,
+            )
+        except Exception as e:
+            return f"Error disconnecting client from AP: {e}"
+
+        if not resp:
+            return "Disconnect client from AP returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_disconnect_client_gateway(
+        ctx: Context,
+        serial_number: str,
+        mac_address: str,
+    ) -> dict | str:
+        """
+        Disconnect a specific client by MAC address from a gateway.
+
+        Use central_find_client to get the MAC address and
+        central_find_device to get the gateway serial number.
+
+        Parameters:
+            serial_number: Gateway serial number (required).
+            mac_address: Client MAC address to disconnect (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+
+        try:
+            resp = Troubleshooting.disconnect_user_mac_addr(
+                central_conn=conn,
+                device_type="gateways",
+                serial_number=serial_number,
+                mac_address=mac_address,
+            )
+        except Exception as e:
+            return f"Error disconnecting client from gateway: {e}"
+
+        if not resp:
+            return "Disconnect client from gateway returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_disconnect_clients_gateway(
+        ctx: Context,
+        serial_number: str,
+    ) -> dict | str:
+        """
+        Disconnect all clients from a gateway.
+
+        Use central_find_device to get the gateway serial number.
+
+        Parameters:
+            serial_number: Gateway serial number (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+
+        try:
+            resp = Troubleshooting.disconnect_all_clients(
+                central_conn=conn,
+                device_type="gateways",
+                serial_number=serial_number,
+            )
+        except Exception as e:
+            return f"Error disconnecting clients from gateway: {e}"
+
+        if not resp:
+            return "Disconnect clients from gateway returned no results."
+        return resp
+
+    # ── Port / PoE Bounce Tools ──────────────────────────────────────
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_port_bounce_switch(
+        ctx: Context,
+        serial_number: str,
+        ports: str,
+    ) -> dict | str:
+        """
+        Bounce ports on an Aruba CX edge/access switch to reset link state.
+
+        SAFETY: Only use on edge/access layer switches with end-user
+        devices or APs connected. NEVER use on core or aggregation
+        switches — bouncing ports on those will disconnect downstream
+        switches and cause network-wide outages. Only bounce ports
+        with clients or APs connected — never bounce uplink, stack,
+        trunk, or inter-switch ports.
+
+        Use central_get_switch_details to verify the switch role and
+        identify safe edge ports before bouncing.
+        Port format: 1/1/1 (member/slot/port).
+
+        Parameters:
+            serial_number: Edge/access CX switch serial number (required).
+            ports: Comma-separated port list, e.g. "1/1/1,1/1/2" (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+        port_list = [p.strip() for p in ports.split(",")]
+
+        try:
+            resp = Troubleshooting.port_bounce_test(
+                central_conn=conn,
+                device_type="cx",
+                serial_number=serial_number,
+                ports=port_list,
+            )
+        except Exception as e:
+            return f"Error bouncing switch ports: {e}"
+
+        if not resp:
+            return "Port bounce returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_poe_bounce_switch(
+        ctx: Context,
+        serial_number: str,
+        ports: str,
+    ) -> dict | str:
+        """
+        Cycle PoE power on Aruba CX edge/access switch ports to
+        reset connected PoE devices (APs, cameras, phones).
+
+        SAFETY: Only use on edge/access layer switches with end-user
+        devices or APs connected. NEVER use on core or aggregation
+        switches. Only bounce ports with PoE-powered devices — never
+        bounce uplink, stack, trunk, or inter-switch ports.
+
+        Use central_get_switch_details to verify the switch role and
+        identify safe edge ports before bouncing.
+        Port format: 1/1/1 (member/slot/port).
+
+        Parameters:
+            serial_number: CX switch serial number (required).
+            ports: Comma-separated port list, e.g. "1/1/1,1/1/2" (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+        port_list = [p.strip() for p in ports.split(",")]
+
+        try:
+            resp = Troubleshooting.poe_bounce_test(
+                central_conn=conn,
+                device_type="cx",
+                serial_number=serial_number,
+                ports=port_list,
+            )
+        except Exception as e:
+            return f"Error bouncing PoE on switch ports: {e}"
+
+        if not resp:
+            return "PoE bounce returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_port_bounce_gateway(
+        ctx: Context,
+        serial_number: str,
+        ports: str,
+    ) -> dict | str:
+        """
+        Bounce ports on a gateway to reset link state.
+
+        SAFETY: Only bounce edge/access ports with end-user devices
+        connected. NEVER bounce uplink, WAN, or inter-switch ports
+        — this will cause connectivity loss for downstream devices.
+
+        Use central_get_gateway_details to identify safe ports.
+
+        Parameters:
+            serial_number: Gateway serial number (required).
+            ports: Comma-separated port list (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+        port_list = [p.strip() for p in ports.split(",")]
+
+        try:
+            resp = Troubleshooting.port_bounce_test(
+                central_conn=conn,
+                device_type="gateways",
+                serial_number=serial_number,
+                ports=port_list,
+            )
+        except Exception as e:
+            return f"Error bouncing gateway ports: {e}"
+
+        if not resp:
+            return "Port bounce returned no results."
+        return resp
+
+    @mcp.tool(annotations=OPERATIONAL)
+    async def central_poe_bounce_gateway(
+        ctx: Context,
+        serial_number: str,
+        ports: str,
+    ) -> dict | str:
+        """
+        Cycle PoE power on gateway ports to reset connected PoE devices.
+
+        SAFETY: Only bounce edge/access ports with PoE-powered devices
+        connected. NEVER bounce uplink, WAN, or inter-switch ports.
+
+        Use central_get_gateway_details to identify safe ports.
+
+        Parameters:
+            serial_number: Gateway serial number (required).
+            ports: Comma-separated port list (required).
+        """
+        conn = ctx.lifespan_context["central_conn"]
+        port_list = [p.strip() for p in ports.split(",")]
+
+        try:
+            resp = Troubleshooting.poe_bounce_test(
+                central_conn=conn,
+                device_type="gateways",
+                serial_number=serial_number,
+                ports=port_list,
+            )
+        except Exception as e:
+            return f"Error bouncing PoE on gateway ports: {e}"
+
+        if not resp:
+            return "PoE bounce returned no results."
+        return resp

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -22,6 +22,7 @@ TOOLS = {
         "mist_get_ap_details",
         "mist_get_switch_details",
         "mist_get_gateway_details",
+        "mist_bounce_switch_port",
     ],
     "events": [
         "mist_search_events",

--- a/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
@@ -1,0 +1,82 @@
+"""Mist tool: bounce ports on a Juniper EX switch."""
+
+from typing import Annotated
+from uuid import UUID
+
+from loguru import logger
+from pydantic import Field
+
+from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist.client import (
+    get_apisession,
+    handle_network_error,
+    process_response,
+)
+
+
+@mcp.tool(
+    name="mist_bounce_switch_port",
+    description=(
+        "Bounce ports on a Juniper EX switch to reset link state. "
+        "Only bounce edge/access ports with APs or clients connected "
+        "— never bounce uplink (xe-), stack, or aggregation ports. "
+        "Use mist_search_device to find the device_id and check interfaces before bouncing."
+    ),
+    tags={"devices"},
+    annotations={
+        "title": "Bounce switch port",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+async def bounce_switch_port(
+    site_id: Annotated[UUID, Field(description="Site ID")],
+    device_id: Annotated[
+        UUID,
+        Field(
+            description="Device ID of the EX switch. Use mist_search_device to find it.",
+        ),
+    ],
+    ports: Annotated[
+        str,
+        Field(
+            description=(
+                "Comma-separated port names to bounce (e.g., 'ge-0/0/0,ge-0/0/1'). "
+                "Only bounce edge/access ports — never bounce uplink (xe-), stack, or trunk ports. "
+                "Juniper port format: ge-0/0/0 (1G), mge-0/0/0 (multi-gig). "
+                "First number is stack member."
+            ),
+        ),
+    ],
+) -> dict | list | str:
+    """Bounce ports on a Juniper EX switch to reset link state."""
+
+    port_list = [p.strip() for p in ports.split(",")]
+
+    logger.debug("Tool bounce_switch_port called")
+    logger.debug(
+        "Input Parameters: site_id: %s, device_id: %s, ports: %s",
+        site_id,
+        device_id,
+        port_list,
+    )
+
+    apisession, _response_format = await get_apisession()
+
+    try:
+        from mistapi.api.v1.sites.devices import utilities as device_utils
+
+        response = device_utils.bouncePort(
+            apisession,
+            site_id=str(site_id),
+            device_id=str(device_id),
+            body={"ports": port_list},
+        )
+        await process_response(response)
+        return {"success": True, "ports_bounced": port_list}
+
+    except Exception as _exc:
+        await handle_network_error(_exc)
+        return f"Error bouncing ports: {_exc}"


### PR DESCRIPTION
## Summary
10 new operational tools for client disconnect and port/PoE bounce, plus safety guardrails.

## New Central Tools (9)
| Tool | Action |
|------|--------|
| `central_disconnect_users_ssid` | Disconnect all users from a specific SSID |
| `central_disconnect_users_ap` | Disconnect all users from an AP |
| `central_disconnect_client_ap` | Disconnect client by MAC from AP |
| `central_disconnect_client_gateway` | Disconnect client by MAC from gateway |
| `central_disconnect_clients_gateway` | Disconnect all clients from gateway |
| `central_port_bounce_switch` | Port bounce on CX edge switch |
| `central_poe_bounce_switch` | PoE bounce on CX edge switch |
| `central_port_bounce_gateway` | Port bounce on gateway |
| `central_poe_bounce_gateway` | PoE bounce on gateway |

## New Mist Tool (1)
| Tool | Action |
|------|--------|
| `mist_bounce_switch_port` | Port bounce on Juniper EX switch |

## Safety Guardrails (INSTRUCTIONS.md)
- Never bounce on core/aggregation switches — edge/access only
- Check port config: access=safe, trunk/L3=never bounce
- Verify PoE draw or client before bouncing across multiple switches
- Platform-specific port naming (CX: 1/1/1, EX: ge-0/0/0)
- If uncertain, ask the user

## Tool Count
- Mist: 35 (was 34), Central: 35 + 10 prompts (was 26 + 10), Total: 73 dynamic / 80 static

Closes #26, #27, #28, #29, #30, #31, #32, #33, #34, #42