### PR TITLE
Multi-platform Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -39,5 +45,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   hpe-networking-mcp:
-    # Pre-built image (uncomment for amd64 systems — no build required):
-    # image: ghcr.io/nowireless4u/hpe-networking-mcp:latest
-    # Build from source (required for Apple Silicon / ARM):
-    build: .
+    # Pre-built image (default — supports amd64 and arm64):
+    image: ghcr.io/nowireless4u/hpe-networking-mcp:latest
+    # To build from source instead, comment out 'image' and uncomment 'build':
+    # build: .
     ports:
       - "${MCP_PORT:-8000}:8000"
     environment:


### PR DESCRIPTION
## Summary
The GHCR image was only built for linux/amd64, causing issues on Apple Silicon Macs. This adds multi-platform support.

## Changes
- Docker Publish workflow: added QEMU + Buildx for cross-platform builds
- Builds for both `linux/amd64` and `linux/arm64`
- `docker-compose.yml` restored to GHCR image as default (now works on all platforms)

## Testing
The next release will produce a multi-arch image. Users on both Intel and Apple Silicon can `docker compose up -d` without building from source.