### PR TITLE
Fix Mist bounce import + strengthen pre-bounce verification

### DIFF
--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -183,22 +183,23 @@ def register(mcp):
         ports: str,
     ) -> dict | str:
         """
-        Bounce ports on an Aruba CX edge/access switch to reset link state.
+        Bounce ports on an Aruba CX edge/access switch.
 
-        SAFETY: Only use on edge/access layer switches with end-user
-        devices or APs connected. NEVER use on core or aggregation
-        switches — bouncing ports on those will disconnect downstream
-        switches and cause network-wide outages. Only bounce ports
-        with clients or APs connected — never bounce uplink, stack,
-        trunk, or inter-switch ports.
+        BEFORE calling this tool, you MUST:
+        1. Call central_get_switch_details to verify it is an
+           edge/access switch (not core/aggregation)
+        2. Check that the target port has a client or AP connected
+           with active PoE draw — skip ports with no PoE consumption
+        3. Verify the port is an access port (not uplink/trunk/stack)
 
-        Use central_get_switch_details to verify the switch role and
-        identify safe edge ports before bouncing.
+        NEVER bounce ports on core or aggregation switches — this
+        will disconnect downstream switches and cause outages.
+
         Port format: 1/1/1 (member/slot/port).
 
         Parameters:
-            serial_number: Edge/access CX switch serial number (required).
-            ports: Comma-separated port list, e.g. "1/1/1,1/1/2" (required).
+            serial_number: Edge/access CX switch serial number.
+            ports: Comma-separated port list, e.g. "1/1/1,1/1/2".
         """
         conn = ctx.lifespan_context["central_conn"]
         port_list = [p.strip() for p in ports.split(",")]
@@ -224,21 +225,22 @@ def register(mcp):
         ports: str,
     ) -> dict | str:
         """
-        Cycle PoE power on Aruba CX edge/access switch ports to
-        reset connected PoE devices (APs, cameras, phones).
+        Cycle PoE power on Aruba CX edge/access switch ports.
 
-        SAFETY: Only use on edge/access layer switches with end-user
-        devices or APs connected. NEVER use on core or aggregation
-        switches. Only bounce ports with PoE-powered devices — never
-        bounce uplink, stack, trunk, or inter-switch ports.
+        BEFORE calling this tool, you MUST:
+        1. Call central_get_switch_details to verify it is an
+           edge/access switch (not core/aggregation)
+        2. Check that the target port has active PoE power draw
+           — if PoE consumption is zero, SKIP that port
+        3. Verify the port is an access port (not uplink/trunk/stack)
 
-        Use central_get_switch_details to verify the switch role and
-        identify safe edge ports before bouncing.
+        NEVER use on core or aggregation switches.
+
         Port format: 1/1/1 (member/slot/port).
 
         Parameters:
-            serial_number: CX switch serial number (required).
-            ports: Comma-separated port list, e.g. "1/1/1,1/1/2" (required).
+            serial_number: Edge/access CX switch serial number.
+            ports: Comma-separated port list, e.g. "1/1/1,1/1/2".
         """
         conn = ctx.lifespan_context["central_conn"]
         port_list = [p.strip() for p in ports.split(",")]
@@ -266,15 +268,14 @@ def register(mcp):
         """
         Bounce ports on a gateway to reset link state.
 
-        SAFETY: Only bounce edge/access ports with end-user devices
-        connected. NEVER bounce uplink, WAN, or inter-switch ports
-        — this will cause connectivity loss for downstream devices.
-
-        Use central_get_gateway_details to identify safe ports.
+        BEFORE calling this tool, you MUST:
+        1. Call central_get_gateway_details to check the port status
+        2. Verify the port has a client connected — skip empty ports
+        3. NEVER bounce uplink, WAN, or inter-switch ports
 
         Parameters:
-            serial_number: Gateway serial number (required).
-            ports: Comma-separated port list (required).
+            serial_number: Gateway serial number.
+            ports: Comma-separated port list.
         """
         conn = ctx.lifespan_context["central_conn"]
         port_list = [p.strip() for p in ports.split(",")]
@@ -300,12 +301,12 @@ def register(mcp):
         ports: str,
     ) -> dict | str:
         """
-        Cycle PoE power on gateway ports to reset connected PoE devices.
+        Cycle PoE power on gateway ports to reset PoE devices.
 
-        SAFETY: Only bounce edge/access ports with PoE-powered devices
-        connected. NEVER bounce uplink, WAN, or inter-switch ports.
-
-        Use central_get_gateway_details to identify safe ports.
+        BEFORE calling this tool, you MUST:
+        1. Call central_get_gateway_details to check port PoE status
+        2. Verify the port has active PoE draw — skip if zero
+        3. NEVER bounce uplink, WAN, or inter-switch ports
 
         Parameters:
             serial_number: Gateway serial number (required).

--- a/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
@@ -17,10 +17,13 @@ from hpe_networking_mcp.platforms.mist.client import (
 @mcp.tool(
     name="mist_bounce_switch_port",
     description=(
-        "Bounce ports on a Juniper EX switch to reset link state. "
-        "Only bounce edge/access ports with APs or clients connected "
-        "— never bounce uplink (xe-), stack, or aggregation ports. "
-        "Use mist_search_device to find the device_id and check interfaces before bouncing."
+        "Bounce ports on a Juniper EX switch. "
+        "BEFORE calling this tool, you MUST: "
+        "1) Use mist_get_stats or mist_get_switch_details to verify "
+        "it is an edge/access switch and check that the target port "
+        "has a client or AP connected with active PoE draw. "
+        "2) Skip ports with no PoE consumption or no connected devices. "
+        "3) NEVER bounce uplink (xe-), stack, or aggregation ports."
     ),
     tags={"devices"},
     annotations={
@@ -66,9 +69,9 @@ async def bounce_switch_port(
     apisession, _response_format = await get_apisession()
 
     try:
-        from mistapi.api.v1.sites.devices import utilities as device_utils
+        import mistapi.api.v1.sites.devices
 
-        response = device_utils.bouncePort(
+        response = mistapi.api.v1.sites.devices.bounceDevicePort(
             apisession,
             site_id=str(site_id),
             device_id=str(device_id),


### PR DESCRIPTION
## Fixes

### Mist bounce import bug
- `mist_bounce_switch_port` had wrong import: `from mistapi.api.v1.sites.devices import utilities`
- Fixed to use `mistapi.api.v1.sites.devices.bounceDevicePort` (correct REST API method)

### Pre-bounce verification not followed
- Claude Desktop bounced ports without checking PoE draw first
- Strengthened all bounce tool descriptions with explicit "BEFORE calling this tool, you MUST:" checklist
- AI must now verify PoE consumption > 0 before bouncing, skip ports with no draw

## Testing
- Lint/format clean
- Mist import path verified against installed SDK