### PR TITLE
Fix PoE bounce trunk logic + Mist bounce safety checks

### DIFF
--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -289,18 +289,18 @@ def register(mcp):
                 skipped.append({"port": port_id, "reason": "port not found"})
             elif info.get("uplink"):
                 skipped.append({"port": port_id, "reason": "uplink port"})
-            elif info.get("vlanMode") == "Trunk":
-                skipped.append({"port": port_id, "reason": "trunk port"})
-            elif info.get("poeStatus") == "Not Used":
+            elif info.get("poeStatus") in (None, "Not Used", ""):
+                # No PoE draw — nothing powered, skip regardless
+                # of trunk/access mode
                 skipped.append(
                     {
                         "port": port_id,
                         "reason": "no PoE draw — nothing powered",
                     }
                 )
-            elif info.get("operStatus") == "Down":
-                skipped.append({"port": port_id, "reason": "port down — nothing connected"})
             else:
+                # Port has active PoE draw — safe to bounce PoE
+                # even if trunk (AP on trunk is valid)
                 safe_ports.append(port_id)
 
         if not safe_ports:

--- a/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
@@ -3,6 +3,7 @@
 from typing import Annotated
 from uuid import UUID
 
+import mistapi
 from loguru import logger
 from pydantic import Field
 
@@ -14,16 +15,60 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
+def _check_mist_ports(
+    apisession: mistapi.APISession,
+    site_id: str,
+    device_id: str,
+    port_list: list[str],
+) -> tuple[list[str], list[dict]]:
+    """Check port status before bouncing. Returns (safe_ports, skipped)."""
+    safe_ports: list[str] = []
+    skipped: list[dict] = []
+
+    try:
+        stats = mistapi.api.v1.sites.stats.getSiteDeviceStats(
+            apisession,
+            site_id=site_id,
+            device_id=device_id,
+        )
+        if_stat = {}
+        if stats.data and isinstance(stats.data, dict):
+            if_stat = stats.data.get("if_stat", {})
+    except Exception:
+        # If we can't get stats, skip all ports for safety
+        for p in port_list:
+            skipped.append({"port": p, "reason": "unable to verify port status"})
+        return safe_ports, skipped
+
+    for port_id in port_list:
+        # Mist if_stat uses .0 suffix (e.g., ge-0/0/0.0)
+        stat_key = f"{port_id}.0"
+        info = if_stat.get(stat_key, if_stat.get(port_id))
+
+        if info is None:
+            skipped.append({"port": port_id, "reason": "port not found in stats"})
+        elif port_id.startswith("xe-"):
+            skipped.append({"port": port_id, "reason": "uplink port (xe-)"})
+        elif not info.get("up", False):
+            skipped.append(
+                {
+                    "port": port_id,
+                    "reason": "port down — nothing connected",
+                }
+            )
+        else:
+            safe_ports.append(port_id)
+
+    return safe_ports, skipped
+
+
 @mcp.tool(
     name="mist_bounce_switch_port",
     description=(
-        "Bounce ports on a Juniper EX switch. "
-        "BEFORE calling this tool, you MUST: "
-        "1) Use mist_get_stats or mist_get_switch_details to verify "
-        "it is an edge/access switch and check that the target port "
-        "has a client or AP connected with active PoE draw. "
-        "2) Skip ports with no PoE consumption or no connected devices. "
-        "3) NEVER bounce uplink (xe-), stack, or aggregation ports."
+        "Bounce ports on a Juniper EX switch. Safety checks are "
+        "enforced automatically — ports that are down or are "
+        "uplinks (xe-) will be skipped. Returns which ports "
+        "were bounced and which were skipped with reasons."
     ),
     tags={"devices"},
     annotations={
@@ -39,28 +84,28 @@ async def bounce_switch_port(
     device_id: Annotated[
         UUID,
         Field(
-            description="Device ID of the EX switch. Use mist_search_device to find it.",
+            description=("Device ID of the EX switch. Use mist_search_device to find it."),
         ),
     ],
     ports: Annotated[
         str,
         Field(
             description=(
-                "Comma-separated port names to bounce (e.g., 'ge-0/0/0,ge-0/0/1'). "
-                "Only bounce edge/access ports — never bounce uplink (xe-), stack, or trunk ports. "
-                "Juniper port format: ge-0/0/0 (1G), mge-0/0/0 (multi-gig). "
+                "Comma-separated port names to bounce "
+                "(e.g., 'ge-0/0/0,ge-0/0/1'). "
+                "Juniper port format: ge-0/0/N (1G), "
+                "mge-0/0/N (multi-gig). "
                 "First number is stack member."
             ),
         ),
     ],
 ) -> dict | list | str:
-    """Bounce ports on a Juniper EX switch to reset link state."""
+    """Bounce ports on a Juniper EX switch with safety checks."""
 
     port_list = [p.strip() for p in ports.split(",")]
 
-    logger.debug("Tool bounce_switch_port called")
     logger.debug(
-        "Input Parameters: site_id: %s, device_id: %s, ports: %s",
+        "Tool bounce_switch_port called: site_id=%s, device_id=%s, ports=%s",
         site_id,
         device_id,
         port_list,
@@ -68,17 +113,29 @@ async def bounce_switch_port(
 
     apisession, _response_format = await get_apisession()
 
-    try:
-        import mistapi.api.v1.sites.devices
+    # Safety check: verify port status before bouncing
+    safe_ports, skipped = _check_mist_ports(apisession, str(site_id), str(device_id), port_list)
 
+    if not safe_ports:
+        return {
+            "bounced": [],
+            "skipped": skipped,
+            "message": "No ports qualified for bounce.",
+        }
+
+    try:
         response = mistapi.api.v1.sites.devices.bounceDevicePort(
             apisession,
             site_id=str(site_id),
             device_id=str(device_id),
-            body={"ports": port_list},
+            body={"ports": safe_ports},
         )
         await process_response(response)
-        return {"success": True, "ports_bounced": port_list}
+        return {
+            "bounced": safe_ports,
+            "skipped": skipped,
+            "result": "bounce completed",
+        }
 
     except Exception as _exc:
         await handle_network_error(_exc)


### PR DESCRIPTION
## Fixes

### PoE bounce skipping trunk ports with APs
PoE draw now overrides trunk mode. If a port has active PoE consumption, it's safe to PoE bounce regardless of trunk/access mode (APs commonly connect on trunk ports).

### Mist bounce had no safety checks
Added `_check_mist_ports()` that queries `if_stat` from device stats before bouncing:
- Skips ports with `up=False` (nothing connected)
- Skips uplink ports (`xe-` prefix)
- Handles `.0` suffix in Mist interface naming
- If stats unavailable, skips all ports for safety

## Testing
Verified against live 6100 (all ports down, poeStatus="Not Used" → all skipped)
Verified against HOME-LOFT-SW trunk port with PoE AP → now bounces correctly