### PR TITLE
Fix CHANGELOG version to v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.7.0] - 2026-04-03
+## [v0.6.6] - 2026-04-03
 
 ### Added
 - `central_get_switch_hardware_trends` — Time-series hardware data per switch member (CPU, memory, temp, PoE capacity/consumption, power). Returns all stack members.
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Central tool count: 35 → 37 (+ 10 prompts)
 - Total tools: 75 (dynamic mode) or 82 (static mode)
 
-[v0.7.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.0
+[v0.6.6]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.6.6
 
 ## [v0.6.0] - 2026-04-02
 


### PR DESCRIPTION
Corrects version from v0.7.0 to v0.6.6 — these were bug fixes and enhancements to existing features, not new capabilities.