### PR TITLE
Enrich switch_details with hardware-trends PoE for stacks

### DIFF
--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -68,7 +68,57 @@ def register(mcp):
             return f"No switch found with serial number '{serial_number}'. Verify the serial using central_find_device."
         if not (200 <= code < 300):
             return f"Central API error (HTTP {code}): {resp.get('msg')}"
-        return resp.get("msg", {})
+
+        result = resp.get("msg", {})
+
+        # Enrich with hardware-trends PoE data for all stack
+        # members (switchTrends only shows the conductor)
+        try:
+            hw_resp = retry_central_command(
+                central_conn=conn,
+                api_method="GET",
+                api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
+            )
+            hw_data = hw_resp.get("msg", {})
+            hw_response = hw_data.get("response", hw_data)
+            metrics = hw_response.get("switchMetrics", [])
+
+            if metrics:
+                total_poe_available = 0.0
+                total_poe_consumption = 0.0
+                members_poe = []
+
+                for m in metrics:
+                    member_serial = m.get("serialNumber", "?")
+                    member_role = m.get("switchRole", "")
+                    # Get latest non-None sample
+                    for s in reversed(m.get("samples", [])):
+                        vals = s.get("data", [])
+                        if len(vals) >= 5 and vals[3] is not None:
+                            poe_a = float(vals[3]) if vals[3] else 0
+                            poe_c = float(vals[4]) if vals[4] else 0
+                            total_poe_available += poe_a
+                            total_poe_consumption += poe_c
+                            members_poe.append(
+                                {
+                                    "serial": member_serial,
+                                    "role": member_role,
+                                    "poe_available": poe_a,
+                                    "poe_consumption": poe_c,
+                                }
+                            )
+                            break
+
+                result["poe_summary"] = {
+                    "total_poe_available_watts": total_poe_available,
+                    "total_poe_consumption_watts": total_poe_consumption,
+                    "member_count": len(metrics),
+                    "members": members_poe,
+                }
+        except Exception:
+            pass  # If hardware-trends fails, return base data
+
+        return result
 
     @mcp.tool(annotations=READ_ONLY)
     async def central_get_gateway_details(


### PR DESCRIPTION
## Problem
AI kept using central_get_switch_details for PoE data instead of central_get_switch_hardware_trends, showing only conductor PoE (370W) for stacked switches.

## Fix
central_get_switch_details now automatically calls hardware-trends and adds `poe_summary` to the response:
```json
{
  "poe_summary": {
    "total_poe_available_watts": 740.0,
    "total_poe_consumption_watts": 0.0,
    "member_count": 2,
    "members": [
      {"serial": "SG9AKN5073", "role": "Conductor", "poe_available": 370, "poe_consumption": 0},
      {"serial": "SG11KN503C", "role": "Standby", "poe_available": 370, "poe_consumption": 0}
    ]
  }
}
```

Regardless of which tool the AI uses, it now gets correct stack PoE data.