### PR TITLE
Improve scope tool output quality: enriched data, prompts, Mermaid fixes

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,7 @@
 services:
   hpe-networking-mcp:
+    build: .
     volumes:
+      - ./src:/app/src:ro
       - ./tests:/app/tests
       - ./pyproject.toml:/app/pyproject.toml:ro

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -73,8 +73,9 @@ When a Mist tool response includes a `_next` field, use `mist_get_next_page(url=
 - **Scope & Configuration**: central_get_scope_tree, central_get_scope_resources, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram
   - Use `central_get_scope_tree` to view the full scope hierarchy (Global → Collections → Sites → Devices)
   - Use `central_get_scope_resources` to see what configuration profiles are assigned at a specific scope level
-  - Use `central_get_effective_config` to see what configuration a device inherits and from where
+  - Use `central_get_effective_config` to see what configuration a device inherits and from where — pass `include_details=true` for full resource configuration data
   - Use `central_get_scope_diagram` to generate a Mermaid flowchart of the scope hierarchy — render it directly, the string is pre-built
+  - **Presenting scope data**: Each scope node includes `persona_count`, `resource_count`, and per-persona `categories` (e.g. policy, vlan, profile). Present as an indented hierarchy with counts at each level. Group resources by category, not as flat lists. For effective config, show the `inheritance_path` first (Global → Collection → Site), then group resources by origin scope to show what each level contributes. Use the `scope_configuration_overview` or `scope_effective_config` prompts for guided workflows.
 - **WLANs**: central_get_wlans
 - **Clients**: central_get_clients, central_find_client
 - **Alerts**: central_get_alerts

--- a/src/hpe_networking_mcp/platforms/central/scope_builder.py
+++ b/src/hpe_networking_mcp/platforms/central/scope_builder.py
@@ -7,7 +7,7 @@ data and provides query/traversal helpers.
 
 from __future__ import annotations
 
-import re
+from collections import Counter
 from typing import Any, Literal
 
 from loguru import logger
@@ -23,14 +23,34 @@ AP_PATTERNS: list[str] = ["ap", "iap", "access point", "rap"]
 SWITCH_PATTERNS: list[str] = ["switch", "cx", "aos-cx", "2930", "2540", "6300", "6400", "8400"]
 GATEWAY_PATTERNS: list[str] = ["gateway", "gw", "controller", "mc", "vgw", "sd-wan", "edgeconnect"]
 
-MERMAID_COLORS: dict[str, str] = {
-    "GLOBAL": "#808080",
-    "COLLECTION": "#4CAF50",
-    "SITE": "#FF9800",
-    "AP": "#2196F3",
-    "SWITCH": "#9C27B0",
-    "GATEWAY": "#F44336",
-    "OTHER": "#607D8B",
+# Known resource name prefixes for categorization
+RESOURCE_CATEGORY_PREFIXES: dict[str, str] = {
+    "vlan": "vlan",
+    "policy": "policy",
+    "role": "policy",
+    "user-role": "policy",
+    "profile": "profile",
+    "system": "system",
+    "dns": "dns",
+    "interface": "interface",
+    "ssid": "ssid",
+    "wlan": "ssid",
+    "cert": "certificate",
+    "certificate": "certificate",
+    "acl": "acl",
+    "ntp": "ntp",
+    "snmp": "snmp",
+    "aaa": "aaa",
+    "radius": "aaa",
+    "vpn": "vpn",
+    "tunnel": "vpn",
+    "routing": "routing",
+    "route": "routing",
+    "dhcp": "dhcp",
+    "firewall": "firewall",
+    "management": "management",
+    "device-identity": "identity",
+    "mpsk": "ssid",
 }
 
 
@@ -182,6 +202,11 @@ def build_scope_tree(conn: Any) -> Tree:
     return _build_tree(device_data, maps_data)
 
 
+# ---------------------------------------------------------------------------
+# Dict conversion
+# ---------------------------------------------------------------------------
+
+
 def tree_to_dict(tree: Tree, effective: bool = False) -> dict | list:
     """Convert a scope tree to a JSON-serializable structure.
 
@@ -210,27 +235,45 @@ def _node_to_dict(tree: Tree, node_id: str) -> dict | None:
 
     scope_name = _get_scope_name(device)
     device_type = device.get("type", "")
+    personas = _extract_personas(node.data.get("resources"))
+
+    children: list[dict] = []
+    child_scope_count = 0
+    device_count = 0
+    for child in tree.children(node_id):
+        child_dict = _node_to_dict(tree, child.tag)
+        if child_dict is not None:
+            children.append(child_dict)
+            if child_dict.get("type") == "DEVICE":
+                device_count += 1
+            else:
+                child_scope_count += 1
 
     result: dict[str, Any] = {
         "scope_id": device.get("scope_id"),
         "scope_name": scope_name,
         "type": device_type,
-        "personas": _extract_personas(node.data.get("resources")),
-        "children": [],
+        "persona_count": len(personas),
+        "resource_count": sum(p["count"] for p in personas),
+        "child_scope_count": child_scope_count,
+        "device_count": device_count,
+        "personas": personas,
+        "children": children,
     }
     if device_type == "DEVICE":
         result["device_info"] = _get_device_info(device)
         result["persona"] = device.get("persona")
 
-    for child in tree.children(node_id):
-        child_dict = _node_to_dict(tree, child.tag)
-        if child_dict is not None:
-            result["children"].append(child_dict)
     return result
 
 
 def _node_to_dict_effective(tree: Tree, node_id: str) -> dict | None:
     """Recursively convert a tree node to a dict with effective (inherited) resources."""
+    # Import here to avoid circular imports
+    from hpe_networking_mcp.platforms.central.scope_queries import (
+        _collect_effective_for_node,
+    )
+
     node = tree.get_node(node_id)
     if node is None or node.data is None:
         return None
@@ -240,28 +283,44 @@ def _node_to_dict_effective(tree: Tree, node_id: str) -> dict | None:
 
     scope_name = _get_scope_name(device)
     device_type = device.get("type", "")
+    personas = _extract_personas(node.data.get("resources"))
+
+    children: list[dict] = []
+    child_scope_count = 0
+    device_count = 0
+    for child in tree.children(node_id):
+        child_dict = _node_to_dict_effective(tree, child.tag)
+        if child_dict is not None:
+            children.append(child_dict)
+            if child_dict.get("type") == "DEVICE":
+                device_count += 1
+            else:
+                child_scope_count += 1
 
     result: dict[str, Any] = {
         "scope_id": device.get("scope_id"),
         "scope_name": scope_name,
         "type": device_type,
-        "personas": _extract_personas(node.data.get("resources")),
+        "persona_count": len(personas),
+        "resource_count": sum(p["count"] for p in personas),
+        "child_scope_count": child_scope_count,
+        "device_count": device_count,
+        "personas": personas,
         "effective_resources": _collect_effective_for_node(tree, node_id, device),
-        "children": [],
+        "children": children,
     }
     if device_type == "DEVICE":
         result["device_info"] = _get_device_info(device)
         result["persona"] = device.get("persona")
 
-    for child in tree.children(node_id):
-        child_dict = _node_to_dict_effective(tree, child.tag)
-        if child_dict is not None:
-            result["children"].append(child_dict)
     return result
 
 
 def _extract_personas(resources_tree: Tree | None) -> list[dict]:
-    """Extract persona/resource list from a node's resources subtree."""
+    """Extract persona/resource list from a node's resources subtree.
+
+    Returns enriched persona dicts with count and category breakdown.
+    """
     if resources_tree is None or resources_tree.root is None:
         return []
     personas: list[dict] = []
@@ -269,343 +328,34 @@ def _extract_personas(resources_tree: Tree | None) -> list[dict]:
         resource_nodes = resources_tree.children(persona_node.tag)
         resources = [{"name": rn.tag, "has_details": rn.data is not None} for rn in resource_nodes]
         if resources:
-            personas.append({"name": persona_node.tag, "resources": resources})
+            categories = _categorize_resources(resources)
+            personas.append(
+                {
+                    "name": persona_node.tag,
+                    "count": len(resources),
+                    "categories": categories,
+                    "resources": resources,
+                }
+            )
     return personas
 
 
-def _collect_effective_for_node(tree: Tree, node_id: str, device: dict) -> list[dict]:
-    """Collect effective (committed + inherited) resources for a single node."""
-    persona = device.get("persona")
-    path_ids = list(tree.rsearch(node_id))
-
-    effective: dict[str, list[dict]] = {}
-    for ancestor_id in path_ids:
-        ancestor_node = tree.get_node(ancestor_id)
-        if ancestor_node is None or ancestor_node.data is None:
-            continue
-        res_tree: Tree | None = ancestor_node.data.get("resources")
-        if res_tree is None or res_tree.root is None:
-            continue
-        ancestor_device = ancestor_node.data.get("device", {})
-        origin_name = _get_scope_name(ancestor_device)
-
-        # Collect for the specific persona (devices) or all personas (scopes)
-        target_personas = [persona] if persona else [pn.tag for pn in res_tree.children(res_tree.root)]
-        for p in target_personas:
-            if p is None:
-                continue
-            p_node = res_tree.get_node(p)
-            if p_node is None:
-                continue
-            for rn in res_tree.children(p):
-                if rn.tag not in effective:
-                    effective[rn.tag] = []
-                effective[rn.tag].append(
-                    {
-                        "name": rn.tag,
-                        "origin_scope_id": ancestor_device.get("scope_id"),
-                        "origin_scope_name": origin_name,
-                        "persona": p,
-                        "has_details": rn.data is not None,
-                    }
-                )
-    return [{"name": k, "instances": v} for k, v in sorted(effective.items())]
-
-
-# ---------------------------------------------------------------------------
-# Query helpers
-# ---------------------------------------------------------------------------
-
-
-def get_effective_resources_for_node(
-    tree: Tree,
-    scope_id: str,
-    persona: str | None = None,
-) -> list[dict]:
-    """Collect effective (inherited + committed) resources for a given scope node.
-
-    Walks from the node up to the root, collecting resources at each level.
+def _categorize_resources(resources: list[dict]) -> dict[str, int]:
+    """Group resources by category based on name prefixes.
 
     Args:
-        tree: The scope tree.
-        scope_id: Target scope node ID.
-        persona: Optional persona filter.
+        resources: List of resource dicts with "name" keys.
 
     Returns:
-        List of resource groups with origin tracking.
+        Dict mapping category names to counts.
     """
-    node = tree.get_node(scope_id)
-    if node is None or node.data is None:
-        return []
-    device = node.data.get("device", {})
-
-    # If no explicit persona, use the device's own persona or collect all
-    effective_persona = persona or device.get("persona")
-    path_ids = list(tree.rsearch(scope_id))
-
-    effective: dict[str, list[dict]] = {}
-    for ancestor_id in path_ids:
-        ancestor_node = tree.get_node(ancestor_id)
-        if ancestor_node is None or ancestor_node.data is None:
-            continue
-        res_tree: Tree | None = ancestor_node.data.get("resources")
-        if res_tree is None or res_tree.root is None:
-            continue
-        ancestor_device = ancestor_node.data.get("device", {})
-        origin_name = _get_scope_name(ancestor_device)
-
-        target_personas = (
-            [effective_persona] if effective_persona else [pn.tag for pn in res_tree.children(res_tree.root)]
-        )
-        for p in target_personas:
-            if p is None:
-                continue
-            p_node = res_tree.get_node(p)
-            if p_node is None:
-                continue
-            for rn in res_tree.children(p):
-                if rn.tag not in effective:
-                    effective[rn.tag] = []
-                effective[rn.tag].append(
-                    {
-                        "name": rn.tag,
-                        "origin_scope_id": ancestor_device.get("scope_id"),
-                        "origin_scope_name": origin_name,
-                        "persona": p,
-                        "has_details": rn.data is not None,
-                    }
-                )
-    return [{"name": k, "instances": v} for k, v in sorted(effective.items())]
-
-
-def get_devices_in_scope(
-    tree: Tree,
-    scope_id: str,
-    device_type: str | None = None,
-) -> list[dict]:
-    """Find all DEVICE nodes under a given scope.
-
-    Args:
-        tree: The scope tree.
-        scope_id: Scope node ID to search under.
-        device_type: Optional filter -- "AP", "SWITCH", "GATEWAY", or "OTHER".
-
-    Returns:
-        List of device dicts with metadata.
-    """
-    node = tree.get_node(scope_id)
-    if node is None:
-        return []
-    results: list[dict] = []
-    _collect_devices(tree, scope_id, device_type, results)
-    return results
-
-
-def _collect_devices(tree: Tree, node_id: str, device_type: str | None, results: list[dict]) -> None:
-    """Recursively collect DEVICE nodes under a scope."""
-    node = tree.get_node(node_id)
-    if node is None or node.data is None:
-        return
-    device = node.data.get("device", {})
-    if device.get("type") == "DEVICE":
-        meta = device.get("meta") or {}
-        category = classify_device(meta.get("device_type"))
-        if device_type is None or category == device_type.upper():
-            results.append(
-                {
-                    "scope_id": device.get("scope_id"),
-                    "scope_name": _get_scope_name(device),
-                    "category": category,
-                    "persona": device.get("persona"),
-                    **_get_device_info(device),
-                }
-            )
-    for child in tree.children(node_id):
-        _collect_devices(tree, child.tag, device_type, results)
-
-
-# ---------------------------------------------------------------------------
-# Mermaid diagram generation
-# ---------------------------------------------------------------------------
-
-_SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_]")
-
-
-def _safe_id(text: str) -> str:
-    """Convert arbitrary text to a safe Mermaid node ID."""
-    return _SAFE_ID_RE.sub("_", text)
-
-
-def tree_to_mermaid(
-    tree: Tree,
-    scope_id: str | None = None,
-    include_resources: bool = False,
-    include_devices: bool = True,
-) -> str:
-    """Build a Mermaid flowchart with compact circle nodes and a legend.
-
-    Hierarchy flow: Global → Site Collections → Sites → Devices.
-    Device groups shown as separate islands with dashed links
-    to their member devices (they add config independently).
-
-    Args:
-        tree: The scope tree.
-        scope_id: If provided, only render the subtree rooted here.
-        include_resources: Whether to show resource nodes.
-        include_devices: Whether to show device leaf nodes.
-
-    Returns:
-        Mermaid flowchart string.
-    """
-    if tree.root is None:
-        return 'flowchart TD\n    EMPTY["No scope data"]'
-
-    root = scope_id if scope_id else tree.root
-    if tree.get_node(root) is None:
-        return f"flowchart TD\n    EMPTY[\"Scope '{root}' not found\"]"
-
-    lines: list[str] = ["flowchart TD"]
-    class_assignments: dict[str, str] = {}  # m_id -> class name
-    device_group_links: list[tuple[str, str]] = []  # (group_id, device_id)
-    _counter = {"n": 0}
-
-    def next_id(prefix: str) -> str:
-        _counter["n"] += 1
-        return f"{prefix}{_counter['n']}"
-
-    def _get_node_class(
-        node_type: str,
-        device: dict,
-    ) -> tuple[str, str]:
-        """Return (short_label, css_class) for a node."""
-        scope_name = _get_scope_name(device)
-        if node_type == "DEVICE":
-            meta = device.get("meta") or {}
-            cat = classify_device(meta.get("device_type"))
-            model = meta.get("device_model", "")
-            short = model if model and model != "N/A" else scope_name
-            return short, cat.lower()
-        if node_type == "GLOBAL":
-            return scope_name, "global_scope"
-        if node_type == "DEVICE_COLLECTION":
-            return scope_name, "devgroup"
-        if node_type == "SITE":
-            return scope_name, "site"
-        if node_type == "SITE_COLLECTION":
-            return scope_name, "collection"
-        return scope_name, "collection"
-
-    # Track device mermaid IDs for device group linking
-    device_scope_to_mid: dict[str, str] = {}
-    # Track device groups to render separately
-    dev_groups: list[tuple[str, str]] = []
-
-    def render_node(
-        node_id: str,
-        parent_mermaid_id: str | None,
-    ) -> None:
-        node = tree.get_node(node_id)
-        if node is None or node.data is None:
-            return
-        device = node.data.get("device", {})
-        node_type = device.get("type", "")
-
-        is_device = node_type == "DEVICE"
-        if is_device and not include_devices:
-            return
-
-        # Device groups rendered separately
-        if node_type == "DEVICE_COLLECTION":
-            label, css_class = _get_node_class(node_type, device)
-            m_id = next_id("DG")
-            lines.append(f"    {m_id}(({label}))")
-            class_assignments[m_id] = css_class
-            dev_groups.append((node_id, m_id))
-            return
-
-        label, css_class = _get_node_class(node_type, device)
-        m_id = next_id("N")
-
-        lines.append(f"    {m_id}(({label}))")
-        if parent_mermaid_id:
-            lines.append(f"    {parent_mermaid_id} --> {m_id}")
-        class_assignments[m_id] = css_class
-
-        if is_device:
-            device_scope_to_mid[node_id] = m_id
-
-        # Resources as small dashed links
-        if include_resources and not is_device:
-            res_tree: Tree | None = (node.data or {}).get("resources")
-            if res_tree is not None and res_tree.root is not None:
-                for pn in res_tree.children(res_tree.root):
-                    for rn in res_tree.children(pn.tag):
-                        r_id = next_id("R")
-                        short_res = rn.tag.split("/")[-1]
-                        lines.append(f"    {r_id}[/{short_res}/]")
-                        lines.append(f"    {m_id} -.-> {r_id}")
-                        class_assignments[r_id] = "resource"
-
-        for child in tree.children(node_id):
-            render_node(child.tag, m_id)
-
-    render_node(root, None)
-
-    # Link device groups to their member devices
-    for dg_nid, dg_mid in dev_groups:
-        for child in tree.children(dg_nid):
-            cn = tree.get_node(child.tag)
-            if cn is None or cn.data is None:
-                continue
-            if cn.data.get("device", {}).get("type") == "DEVICE":
-                dev_mid = device_scope_to_mid.get(child.tag)
-                if dev_mid:
-                    lines.append(f"    {dg_mid} -.-> {dev_mid}")
-
-    # Class definitions
-    lines.append("")
-    lines.append("    classDef global_scope fill:#808080,color:#fff,stroke-width:0")
-    lines.append("    classDef collection fill:#4CAF50,color:#fff,stroke-width:0")
-    lines.append("    classDef site fill:#FF9800,color:#fff,stroke-width:0")
-    lines.append("    classDef ap fill:#2196F3,color:#fff,stroke-width:0")
-    lines.append("    classDef switch fill:#9C27B0,color:#fff,stroke-width:0")
-    lines.append("    classDef gateway fill:#F44336,color:#fff,stroke-width:0")
-    lines.append("    classDef other fill:#607D8B,color:#fff,stroke-width:0")
-    lines.append("    classDef devgroup fill:#607D8B,color:#fff,stroke-dasharray:5")
-    lines.append("    classDef resource fill:#E0E0E0,color:#333,stroke-width:0")
-
-    # Apply classes
-    for m_id, cls in class_assignments.items():
-        lines.append(f"    class {m_id} {cls}")
-
-    # Device group dashed links
-    for gid, did in device_group_links:
-        lines.append(f"    {gid} -.-> {did}")
-
-    # Legend
-    lines.append("")
-    lines.append("    subgraph Legend")
-    lines.append("        direction LR")
-    lines.append("        L1((Global)):::global_scope")
-    lines.append("        L2((Collection)):::collection")
-    lines.append("        L3((Site)):::site")
-    lines.append("        L4((AP)):::ap")
-    lines.append("        L5((Switch)):::switch")
-    lines.append("        L6((Gateway)):::gateway")
-    lines.append("    end")
-
-    return "\n".join(lines)
-
-
-def _has_device_descendant(tree: Tree, node_id: str) -> bool:
-    """Check if any descendant of a node is a DEVICE."""
-    for child in tree.children(node_id):
-        child_node = tree.get_node(child.tag)
-        if child_node is None or child_node.data is None:
-            continue
-        device = child_node.data.get("device", {})
-        if device.get("type") == "DEVICE":
-            return True
-        if _has_device_descendant(tree, child.tag):
-            return True
-    return False
+    counts: Counter[str] = Counter()
+    for r in resources:
+        name = r.get("name", "").lower()
+        category = "other"
+        for prefix, cat in RESOURCE_CATEGORY_PREFIXES.items():
+            if name.startswith(prefix) or f"/{prefix}" in name:
+                category = cat
+                break
+        counts[category] += 1
+    return dict(sorted(counts.items(), key=lambda x: (-x[1], x[0])))

--- a/src/hpe_networking_mcp/platforms/central/scope_queries.py
+++ b/src/hpe_networking_mcp/platforms/central/scope_queries.py
@@ -1,0 +1,414 @@
+"""Query helpers and Mermaid diagram generation for the Central scope tree.
+
+Provides functions for querying effective (inherited) resources, collecting
+devices within scopes, and rendering Mermaid flowchart diagrams.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from treelib import Tree
+
+from hpe_networking_mcp.platforms.central.scope_builder import (
+    _get_device_info,
+    _get_scope_name,
+    classify_device,
+)
+
+# ---------------------------------------------------------------------------
+# Effective resource collection
+# ---------------------------------------------------------------------------
+
+
+def get_effective_resources_for_node(
+    tree: Tree,
+    scope_id: str,
+    persona: str | None = None,
+    include_details: bool = False,
+) -> list[dict]:
+    """Collect effective (inherited + committed) resources for a given scope node.
+
+    Walks from the node up to the root, collecting resources at each level.
+
+    Args:
+        tree: The scope tree.
+        scope_id: Target scope node ID.
+        persona: Optional persona filter.
+        include_details: If True, include full resource configuration data.
+
+    Returns:
+        List of resource groups with origin tracking.
+    """
+    node = tree.get_node(scope_id)
+    if node is None or node.data is None:
+        return []
+    device = node.data.get("device", {})
+
+    effective_persona = persona or device.get("persona")
+    path_ids = list(tree.rsearch(scope_id))
+
+    effective: dict[str, list[dict]] = {}
+    for ancestor_id in path_ids:
+        ancestor_node = tree.get_node(ancestor_id)
+        if ancestor_node is None or ancestor_node.data is None:
+            continue
+        res_tree: Tree | None = ancestor_node.data.get("resources")
+        if res_tree is None or res_tree.root is None:
+            continue
+        ancestor_device = ancestor_node.data.get("device", {})
+        origin_name = _get_scope_name(ancestor_device)
+
+        target_personas = (
+            [effective_persona] if effective_persona else [pn.tag for pn in res_tree.children(res_tree.root)]
+        )
+        for p in target_personas:
+            if p is None:
+                continue
+            p_node = res_tree.get_node(p)
+            if p_node is None:
+                continue
+            for rn in res_tree.children(p):
+                if rn.tag not in effective:
+                    effective[rn.tag] = []
+                entry: dict[str, Any] = {
+                    "name": rn.tag,
+                    "origin_scope_id": ancestor_device.get("scope_id"),
+                    "origin_scope_name": origin_name,
+                    "persona": p,
+                    "has_details": rn.data is not None,
+                }
+                if include_details and rn.data is not None:
+                    entry["details"] = rn.data
+                effective[rn.tag].append(entry)
+    return [{"name": k, "instances": v} for k, v in sorted(effective.items())]
+
+
+def _collect_effective_for_node(tree: Tree, node_id: str, device: dict) -> list[dict]:
+    """Collect effective (committed + inherited) resources for a single node.
+
+    Internal helper used by tree_to_dict effective view. Delegates to
+    get_effective_resources_for_node with the device's own persona.
+
+    Args:
+        tree: The scope tree.
+        node_id: The node ID.
+        device: The device data dict for this node.
+
+    Returns:
+        List of resource groups with origin tracking.
+    """
+    persona = device.get("persona")
+    return get_effective_resources_for_node(tree, node_id, persona=persona)
+
+
+def build_inheritance_path(tree: Tree, scope_id: str) -> list[dict]:
+    """Build an ordered inheritance path from Global root down to the given scope.
+
+    Args:
+        tree: The scope tree.
+        scope_id: Target scope node ID.
+
+    Returns:
+        List of dicts from root to target, each with scope_name, scope_type,
+        and resource_count at that level.
+    """
+    path_ids = list(reversed(list(tree.rsearch(scope_id))))
+    path: list[dict] = []
+    for nid in path_ids:
+        node = tree.get_node(nid)
+        if node is None or node.data is None:
+            continue
+        device = node.data.get("device", {})
+        res_tree: Tree | None = node.data.get("resources")
+        resource_count = 0
+        if res_tree is not None and res_tree.root is not None:
+            for pn in res_tree.children(res_tree.root):
+                resource_count += len(res_tree.children(pn.tag))
+        path.append(
+            {
+                "scope_id": device.get("scope_id"),
+                "scope_name": _get_scope_name(device),
+                "scope_type": device.get("type", ""),
+                "resource_count": resource_count,
+            }
+        )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Device collection
+# ---------------------------------------------------------------------------
+
+
+def get_devices_in_scope(
+    tree: Tree,
+    scope_id: str,
+    device_type: str | None = None,
+) -> list[dict]:
+    """Find all DEVICE nodes under a given scope.
+
+    Args:
+        tree: The scope tree.
+        scope_id: Scope node ID to search under.
+        device_type: Optional filter -- "AP", "SWITCH", "GATEWAY", or "OTHER".
+
+    Returns:
+        List of device dicts with metadata.
+    """
+    node = tree.get_node(scope_id)
+    if node is None:
+        return []
+    results: list[dict] = []
+    _collect_devices(tree, scope_id, device_type, results)
+    return results
+
+
+def _collect_devices(tree: Tree, node_id: str, device_type: str | None, results: list[dict]) -> None:
+    """Recursively collect DEVICE nodes under a scope."""
+    node = tree.get_node(node_id)
+    if node is None or node.data is None:
+        return
+    device = node.data.get("device", {})
+    if device.get("type") == "DEVICE":
+        meta = device.get("meta") or {}
+        category = classify_device(meta.get("device_type"))
+        if device_type is None or category == device_type.upper():
+            results.append(
+                {
+                    "scope_id": device.get("scope_id"),
+                    "scope_name": _get_scope_name(device),
+                    "category": category,
+                    "persona": device.get("persona"),
+                    **_get_device_info(device),
+                }
+            )
+    for child in tree.children(node_id):
+        _collect_devices(tree, child.tag, device_type, results)
+
+
+# ---------------------------------------------------------------------------
+# Mermaid diagram generation
+# ---------------------------------------------------------------------------
+
+_SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+def _safe_id(text: str) -> str:
+    """Convert arbitrary text to a safe Mermaid node ID."""
+    return _SAFE_ID_RE.sub("_", text)
+
+
+def _get_node_class(
+    node_type: str,
+    device: dict,
+) -> tuple[str, str]:
+    """Return (short_label, css_class) for a Mermaid node.
+
+    Args:
+        node_type: The scope node type (GLOBAL, SITE, DEVICE, etc.).
+        device: The device data dict for this node.
+
+    Returns:
+        Tuple of (display_label, css_class_name).
+    """
+    scope_name = _get_scope_name(device)
+    if node_type == "DEVICE":
+        meta = device.get("meta") or {}
+        cat = classify_device(meta.get("device_type"))
+        short = scope_name if scope_name and scope_name != "<UNKNOWN>" else (meta.get("device_model") or "Device")
+        return short, cat.lower()
+    if node_type == "GLOBAL":
+        return scope_name, "global_scope"
+    if node_type == "DEVICE_COLLECTION":
+        return scope_name, "devgroup"
+    if node_type == "SITE":
+        return scope_name, "site"
+    if node_type == "SITE_COLLECTION":
+        return scope_name, "collection"
+    return scope_name, "collection"
+
+
+def _build_device_id_map(tree: Tree, root: str) -> dict[str, str]:
+    """Pre-scan all DEVICE nodes and assign Mermaid IDs for device group linking.
+
+    Args:
+        tree: The scope tree.
+        root: Root node ID to scan from.
+
+    Returns:
+        Dict mapping scope_id -> scope_name for all DEVICE nodes.
+    """
+    device_map: dict[str, str] = {}
+    for node in tree.all_nodes():
+        if node.data is None:
+            continue
+        device = node.data.get("device", {})
+        if device.get("type") == "DEVICE":
+            device_map[node.tag] = _get_scope_name(device)
+    return device_map
+
+
+def tree_to_mermaid(
+    tree: Tree,
+    scope_id: str | None = None,
+    include_resources: bool = False,
+    include_devices: bool = True,
+) -> str:
+    """Build a Mermaid flowchart with compact circle nodes and a legend.
+
+    Hierarchy flow: Global -> Site Collections -> Sites -> Devices.
+    Device groups shown as separate islands with dashed links
+    to their member devices (they add config independently).
+
+    Args:
+        tree: The scope tree.
+        scope_id: If provided, only render the subtree rooted here.
+        include_resources: Whether to show resource nodes.
+        include_devices: Whether to show device leaf nodes.
+
+    Returns:
+        Mermaid flowchart string.
+    """
+    if tree.root is None:
+        return 'flowchart TD\n    EMPTY["No scope data"]'
+
+    root = scope_id if scope_id else tree.root
+    if tree.get_node(root) is None:
+        return f"flowchart TD\n    EMPTY[\"Scope '{root}' not found\"]"
+
+    lines: list[str] = ["flowchart TD"]
+    class_assignments: dict[str, str] = {}
+    _counter = {"n": 0}
+
+    def next_id(prefix: str) -> str:
+        _counter["n"] += 1
+        return f"{prefix}{_counter['n']}"
+
+    device_scope_to_mid: dict[str, str] = {}
+    dev_groups: list[tuple[str, str]] = []
+
+    def render_node(node_id: str, parent_mermaid_id: str | None) -> None:
+        node = tree.get_node(node_id)
+        if node is None or node.data is None:
+            return
+        device = node.data.get("device", {})
+        node_type = device.get("type", "")
+
+        is_device = node_type == "DEVICE"
+        if is_device and not include_devices:
+            return
+
+        if node_type == "DEVICE_COLLECTION":
+            label, css_class = _get_node_class(node_type, device)
+            m_id = next_id("DG")
+            lines.append(f"    {m_id}(({label}))")
+            class_assignments[m_id] = css_class
+            dev_groups.append((node_id, m_id))
+            return
+
+        label, css_class = _get_node_class(node_type, device)
+        m_id = next_id("N")
+
+        lines.append(f"    {m_id}(({label}))")
+        if parent_mermaid_id:
+            lines.append(f"    {parent_mermaid_id} --> {m_id}")
+        class_assignments[m_id] = css_class
+
+        if is_device:
+            device_scope_to_mid[node_id] = m_id
+
+        if include_resources and not is_device:
+            _render_resource_nodes(node, m_id, lines, class_assignments, next_id)
+
+        for child in tree.children(node_id):
+            render_node(child.tag, m_id)
+
+    render_node(root, None)
+
+    _link_device_groups(tree, dev_groups, device_scope_to_mid, lines)
+    _append_mermaid_styles(lines, class_assignments)
+
+    return "\n".join(lines)
+
+
+def _render_resource_nodes(
+    node: Any,
+    parent_mid: str,
+    lines: list[str],
+    class_assignments: dict[str, str],
+    next_id_fn: Any,
+) -> None:
+    """Render resource nodes as small dashed links from a scope node."""
+    res_tree: Tree | None = (node.data or {}).get("resources")
+    if res_tree is None or res_tree.root is None:
+        return
+    for pn in res_tree.children(res_tree.root):
+        for rn in res_tree.children(pn.tag):
+            r_id = next_id_fn("R")
+            short_res = rn.tag.split("/")[-1]
+            lines.append(f"    {r_id}[/{short_res}/]")
+            lines.append(f"    {parent_mid} -.-> {r_id}")
+            class_assignments[r_id] = "resource"
+
+
+def _link_device_groups(
+    tree: Tree,
+    dev_groups: list[tuple[str, str]],
+    device_scope_to_mid: dict[str, str],
+    lines: list[str],
+) -> None:
+    """Link device group nodes to their member devices via dashed lines."""
+    for dg_nid, dg_mid in dev_groups:
+        for child in tree.children(dg_nid):
+            cn = tree.get_node(child.tag)
+            if cn is None or cn.data is None:
+                continue
+            child_device = cn.data.get("device", {})
+            if child_device.get("type") == "DEVICE":
+                dev_mid = device_scope_to_mid.get(child.tag)
+                if dev_mid:
+                    lines.append(f"    {dg_mid} -.-> {dev_mid}")
+
+
+def _append_mermaid_styles(lines: list[str], class_assignments: dict[str, str]) -> None:
+    """Append Mermaid class definitions, class assignments, and legend."""
+    lines.append("")
+    lines.append("    classDef global_scope fill:#808080,color:#fff,stroke-width:0")
+    lines.append("    classDef collection fill:#4CAF50,color:#fff,stroke-width:0")
+    lines.append("    classDef site fill:#FF9800,color:#fff,stroke-width:0")
+    lines.append("    classDef ap fill:#2196F3,color:#fff,stroke-width:0")
+    lines.append("    classDef switch fill:#9C27B0,color:#fff,stroke-width:0")
+    lines.append("    classDef gateway fill:#F44336,color:#fff,stroke-width:0")
+    lines.append("    classDef other fill:#607D8B,color:#fff,stroke-width:0")
+    lines.append("    classDef devgroup fill:#607D8B,color:#fff,stroke-dasharray:5")
+    lines.append("    classDef resource fill:#E0E0E0,color:#333,stroke-width:0")
+
+    for m_id, cls in class_assignments.items():
+        lines.append(f"    class {m_id} {cls}")
+
+    lines.append("")
+    lines.append("    subgraph Legend")
+    lines.append("        direction LR")
+    lines.append("        L1((Global)):::global_scope")
+    lines.append("        L2((Collection)):::collection")
+    lines.append("        L3((Site)):::site")
+    lines.append("        L4((AP)):::ap")
+    lines.append("        L5((Switch)):::switch")
+    lines.append("        L6((Gateway)):::gateway")
+    lines.append("    end")
+
+
+def _has_device_descendant(tree: Tree, node_id: str) -> bool:
+    """Check if any descendant of a node is a DEVICE."""
+    for child in tree.children(node_id):
+        child_node = tree.get_node(child.tag)
+        if child_node is None or child_node.data is None:
+            continue
+        device = child_node.data.get("device", {})
+        if device.get("type") == "DEVICE":
+            return True
+        if _has_device_descendant(tree, child.tag):
+            return True
+    return False

--- a/src/hpe_networking_mcp/platforms/central/tools/prompts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/prompts.py
@@ -181,3 +181,47 @@ status="Active" to get active alert counts by severity.
 count, client count, alert breakdown (Critical/High/Medium/Low).
 5. Rank sites from worst to best health.
         """.strip()
+
+    @mcp.prompt
+    def scope_configuration_overview(scope_name: str) -> str:
+        """View committed configuration resources at a scope in the hierarchy."""
+        return f"""
+Show the committed configuration at scope "{scope_name}":
+
+1. Call `central_get_scope_tree(view="committed")` to get the full hierarchy.
+2. Search the tree for the scope matching "{scope_name}" by scope_name. \
+Note its scope_id.
+3. Call `central_get_scope_resources(scope_id=<scope_id>)` for that scope.
+4. Present the results as follows:
+   - Show the scope name, type, and position in the hierarchy.
+   - For each persona, show the persona name, total resource count, and \
+category breakdown (e.g. policy: 5, vlan: 3, profile: 2).
+   - List resources grouped by category, not as a flat list.
+   - Use a table or indented list for readability.
+5. Summarize: total resource count across all personas, dominant persona, \
+and any notable patterns (e.g. shared policies, unique resources).
+6. Suggest using `central_get_effective_config` if the user wants to see \
+inherited configuration, or `central_get_scope_diagram` for a visual map.
+        """.strip()
+
+    @mcp.prompt
+    def scope_effective_config(scope_name: str) -> str:
+        """View effective (inherited + committed) configuration at a scope."""
+        return f"""
+Show the effective configuration at scope "{scope_name}":
+
+1. Call `central_get_scope_tree(view="committed")` to get the hierarchy.
+2. Search for the scope matching "{scope_name}" by scope_name. Note its \
+scope_id.
+3. Call `central_get_effective_config(scope_id=<scope_id>)` for that scope.
+4. Present the inheritance path first: show each level from Global down to \
+this scope with how many resources each level contributes.
+5. Then group resources by origin scope. For each origin:
+   - Show the scope name and type (e.g. "Global", "Site Collection").
+   - List the resources contributed at that level, grouped by category.
+6. Highlight any resources that appear at multiple inheritance levels \
+(overrides). When the same resource name appears from different origins, \
+note which level takes precedence (closest scope wins).
+7. Summarize: total effective resource count, how many are inherited vs \
+committed locally, and the inheritance depth.
+        """.strip()

--- a/src/hpe_networking_mcp/platforms/central/tools/scope.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope.py
@@ -11,9 +11,12 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.central.scope_builder import (
     build_scope_tree,
+    tree_to_dict,
+)
+from hpe_networking_mcp.platforms.central.scope_queries import (
+    build_inheritance_path,
     get_devices_in_scope,
     get_effective_resources_for_node,
-    tree_to_dict,
     tree_to_mermaid,
 )
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -113,6 +116,7 @@ def register(mcp):
         ctx: Context,
         scope_id: str,
         persona: str | None = None,
+        include_details: bool = False,
     ) -> dict | str:
         """
         Get the effective (inherited + committed) configuration for a scope node.
@@ -124,10 +128,12 @@ def register(mcp):
         Parameters:
             scope_id: The scope ID to query.
             persona: Optional persona filter (e.g. "access_point", "switch").
+            include_details: If True, include full resource configuration data.
 
         Returns:
-            Dict with scope_id, scope_name, and effective_resources list.
-            Each resource group has a name and list of instances showing
+            Dict with scope_id, scope_name, inheritance_path (ordered from
+            Global root to this scope), and effective_resources list. Each
+            resource group has a name and list of instances showing
             origin_scope_id, origin_scope_name, persona, and has_details.
         """
         conn = ctx.lifespan_context["central_conn"]
@@ -142,12 +148,14 @@ def register(mcp):
 
         device = node.data.get("device", {})
         meta = device.get("meta") or {}
-        effective = get_effective_resources_for_node(tree, scope_id, persona)
+        effective = get_effective_resources_for_node(tree, scope_id, persona, include_details)
+        path = build_inheritance_path(tree, scope_id)
 
         return {
             "scope_id": device.get("scope_id"),
             "scope_name": meta.get("scope_name", scope_id),
             "type": device.get("type", ""),
+            "inheritance_path": path,
             "effective_resources": effective,
         }
 

--- a/tests/unit/test_scope_builder.py
+++ b/tests/unit/test_scope_builder.py
@@ -1,0 +1,341 @@
+"""Unit tests for scope_builder and scope_queries modules."""
+
+import pytest
+from treelib import Tree
+
+from hpe_networking_mcp.platforms.central.scope_builder import (
+    _categorize_resources,
+    _extract_personas,
+    classify_device,
+    tree_to_dict,
+)
+from hpe_networking_mcp.platforms.central.scope_queries import (
+    build_inheritance_path,
+    get_devices_in_scope,
+    get_effective_resources_for_node,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — build mock scope trees for testing
+# ---------------------------------------------------------------------------
+
+
+def _make_device(scope_id: str, scope_name: str, node_type: str, **extra) -> dict:
+    """Create a device dict matching the API structure."""
+    device = {
+        "scope_id": scope_id,
+        "type": node_type,
+        "meta": {"scope_name": scope_name, **extra},
+    }
+    if "persona" in extra:
+        device["persona"] = extra["persona"]
+    return device
+
+
+def _make_resources(*resources: tuple[str, str]) -> Tree:
+    """Create a resources subtree from (persona, resource_name) pairs."""
+    rtree = Tree()
+    rtree.create_node("resources", "resources")
+    personas_added: set[str] = set()
+    for persona, resource_name in resources:
+        if persona not in personas_added:
+            rtree.create_node(persona, persona, parent="resources")
+            personas_added.add(persona)
+        rtree.create_node(resource_name, parent=persona, data={"config": "value"})
+    return rtree
+
+
+def _build_simple_tree() -> Tree:
+    """Build a 3-level scope tree: Global -> Site -> Device."""
+    tree = Tree()
+
+    global_res = _make_resources(
+        ("ACCESS_SWITCH", "policy/global-policy"),
+        ("ACCESS_SWITCH", "dns/PDC DNS"),
+        ("CAMPUS_AP", "policy/global-policy"),
+    )
+    tree.create_node(
+        "global-id",
+        "global-id",
+        data={
+            "device": _make_device("global-id", "GLOBAL", "GLOBAL"),
+            "resources": global_res,
+        },
+    )
+
+    site_res = _make_resources(
+        ("ACCESS_SWITCH", "vlan/VLAN-100"),
+        ("ACCESS_SWITCH", "vlan/VLAN-200"),
+        ("ACCESS_SWITCH", "profile/switch-profile"),
+        ("CAMPUS_AP", "ssid/MySSID"),
+    )
+    tree.create_node(
+        "site-id",
+        "site-id",
+        parent="global-id",
+        data={
+            "device": _make_device("site-id", "HQ Site", "SITE"),
+            "resources": site_res,
+        },
+    )
+
+    dev_res = _make_resources()
+    tree.create_node(
+        "dev-id",
+        "dev-id",
+        parent="site-id",
+        data={
+            "device": _make_device(
+                "dev-id",
+                "switch-01",
+                "DEVICE",
+                device_type="Aruba CX 6200",
+                device_model="6200",
+                serial_number="CN1234",
+                mac_address="AA:BB:CC:DD:EE:FF",
+                persona="ACCESS_SWITCH",
+            ),
+            "resources": dev_res,
+        },
+    )
+
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# classify_device
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestClassifyDevice:
+    def test_ap_patterns(self):
+        assert classify_device("Aruba AP-515") == "AP"
+        assert classify_device("iap-315") == "AP"
+
+    def test_switch_patterns(self):
+        assert classify_device("Aruba CX 6300") == "SWITCH"
+        assert classify_device("AOS-CX Switch") == "SWITCH"
+
+    def test_gateway_patterns(self):
+        assert classify_device("Aruba Gateway 7010") == "GATEWAY"
+        assert classify_device("SD-WAN Edge") == "GATEWAY"
+
+    def test_other(self):
+        assert classify_device("Unknown Thing") == "OTHER"
+        assert classify_device(None) == "OTHER"
+        assert classify_device("") == "OTHER"
+
+
+# ---------------------------------------------------------------------------
+# _categorize_resources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCategorizeResources:
+    def test_groups_by_prefix(self):
+        resources = [
+            {"name": "vlan/VLAN-100"},
+            {"name": "vlan/VLAN-200"},
+            {"name": "policy/my-policy"},
+            {"name": "dns/PDC DNS"},
+        ]
+        result = _categorize_resources(resources)
+        assert result["vlan"] == 2
+        assert result["policy"] == 1
+        assert result["dns"] == 1
+
+    def test_unknown_prefix_categorized_as_other(self):
+        resources = [{"name": "custom-resource-xyz"}]
+        result = _categorize_resources(resources)
+        assert result["other"] == 1
+
+    def test_empty_list(self):
+        assert _categorize_resources([]) == {}
+
+    def test_slash_prefix_detection(self):
+        resources = [{"name": "some/certificate/thing"}]
+        result = _categorize_resources(resources)
+        assert result.get("certificate") == 1
+
+
+# ---------------------------------------------------------------------------
+# _extract_personas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractPersonas:
+    def test_includes_count_and_categories(self):
+        rtree = _make_resources(
+            ("ACCESS_SWITCH", "vlan/VLAN-100"),
+            ("ACCESS_SWITCH", "policy/my-policy"),
+            ("CAMPUS_AP", "ssid/MySSID"),
+        )
+        personas = _extract_personas(rtree)
+        assert len(personas) == 2
+
+        switch_persona = next(p for p in personas if p["name"] == "ACCESS_SWITCH")
+        assert switch_persona["count"] == 2
+        assert "vlan" in switch_persona["categories"]
+        assert "policy" in switch_persona["categories"]
+
+        ap_persona = next(p for p in personas if p["name"] == "CAMPUS_AP")
+        assert ap_persona["count"] == 1
+
+    def test_none_tree_returns_empty(self):
+        assert _extract_personas(None) == []
+
+    def test_empty_tree_returns_empty(self):
+        rtree = Tree()
+        assert _extract_personas(rtree) == []
+
+
+# ---------------------------------------------------------------------------
+# tree_to_dict — committed view with counts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTreeToDict:
+    def test_root_has_counts(self):
+        tree = _build_simple_tree()
+        result = tree_to_dict(tree)
+
+        assert result["scope_name"] == "GLOBAL"
+        assert result["persona_count"] == 2
+        assert result["resource_count"] == 3
+        assert result["child_scope_count"] == 1
+        assert result["device_count"] == 0
+
+    def test_site_has_counts(self):
+        tree = _build_simple_tree()
+        result = tree_to_dict(tree)
+        site = result["children"][0]
+
+        assert site["scope_name"] == "HQ Site"
+        assert site["persona_count"] == 2
+        assert site["resource_count"] == 4
+        assert site["device_count"] == 1
+
+    def test_device_has_device_info(self):
+        tree = _build_simple_tree()
+        result = tree_to_dict(tree)
+        device = result["children"][0]["children"][0]
+
+        assert device["type"] == "DEVICE"
+        assert device["device_info"]["device_model"] == "6200"
+        assert device["persona"] == "ACCESS_SWITCH"
+
+    def test_empty_tree(self):
+        tree = Tree()
+        assert tree_to_dict(tree) == {}
+
+
+# ---------------------------------------------------------------------------
+# get_effective_resources_for_node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEffectiveResources:
+    def test_inherits_from_ancestors(self):
+        tree = _build_simple_tree()
+        effective = get_effective_resources_for_node(tree, "dev-id")
+
+        resource_names = [r["name"] for r in effective]
+        assert "policy/global-policy" in resource_names
+        assert "vlan/VLAN-100" in resource_names
+
+    def test_include_details_returns_data(self):
+        tree = _build_simple_tree()
+        effective = get_effective_resources_for_node(tree, "site-id", include_details=True)
+
+        has_details = False
+        for resource_group in effective:
+            for instance in resource_group["instances"]:
+                if "details" in instance:
+                    has_details = True
+                    assert instance["details"] == {"config": "value"}
+        assert has_details, "Expected at least one resource with details"
+
+    def test_include_details_false_omits_data(self):
+        tree = _build_simple_tree()
+        effective = get_effective_resources_for_node(tree, "site-id", include_details=False)
+
+        for resource_group in effective:
+            for instance in resource_group["instances"]:
+                assert "details" not in instance
+
+    def test_persona_filter(self):
+        tree = _build_simple_tree()
+        effective = get_effective_resources_for_node(tree, "site-id", persona="CAMPUS_AP")
+
+        for resource_group in effective:
+            for instance in resource_group["instances"]:
+                assert instance["persona"] == "CAMPUS_AP"
+
+    def test_nonexistent_scope_returns_empty(self):
+        tree = _build_simple_tree()
+        assert get_effective_resources_for_node(tree, "nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# build_inheritance_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildInheritancePath:
+    def test_path_order_root_to_leaf(self):
+        tree = _build_simple_tree()
+        path = build_inheritance_path(tree, "dev-id")
+
+        assert len(path) == 3
+        assert path[0]["scope_name"] == "GLOBAL"
+        assert path[0]["scope_type"] == "GLOBAL"
+        assert path[1]["scope_name"] == "HQ Site"
+        assert path[1]["scope_type"] == "SITE"
+        assert path[2]["scope_name"] == "switch-01"
+        assert path[2]["scope_type"] == "DEVICE"
+
+    def test_path_includes_resource_counts(self):
+        tree = _build_simple_tree()
+        path = build_inheritance_path(tree, "site-id")
+
+        global_entry = path[0]
+        assert global_entry["resource_count"] == 3
+
+        site_entry = path[1]
+        assert site_entry["resource_count"] == 4
+
+    def test_root_path_is_single_entry(self):
+        tree = _build_simple_tree()
+        path = build_inheritance_path(tree, "global-id")
+        assert len(path) == 1
+        assert path[0]["scope_name"] == "GLOBAL"
+
+
+# ---------------------------------------------------------------------------
+# get_devices_in_scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetDevicesInScope:
+    def test_finds_devices_under_scope(self):
+        tree = _build_simple_tree()
+        devices = get_devices_in_scope(tree, "global-id")
+        assert len(devices) == 1
+        assert devices[0]["scope_name"] == "switch-01"
+        assert devices[0]["category"] == "SWITCH"
+
+    def test_device_type_filter(self):
+        tree = _build_simple_tree()
+        assert len(get_devices_in_scope(tree, "global-id", "SWITCH")) == 1
+        assert len(get_devices_in_scope(tree, "global-id", "AP")) == 0
+
+    def test_nonexistent_scope_returns_empty(self):
+        tree = _build_simple_tree()
+        assert get_devices_in_scope(tree, "nope") == []

--- a/tests/unit/test_scope_mermaid.py
+++ b/tests/unit/test_scope_mermaid.py
@@ -1,0 +1,153 @@
+"""Unit tests for Mermaid diagram generation in scope_queries."""
+
+import pytest
+from treelib import Tree
+
+from hpe_networking_mcp.platforms.central.scope_queries import tree_to_mermaid
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_device(scope_id: str, scope_name: str, node_type: str, **extra) -> dict:
+    """Create a device dict matching the API structure."""
+    device = {
+        "scope_id": scope_id,
+        "type": node_type,
+        "meta": {"scope_name": scope_name, **extra},
+    }
+    if "persona" in extra:
+        device["persona"] = extra["persona"]
+    return device
+
+
+def _make_resources() -> Tree:
+    """Create an empty resources subtree."""
+    rtree = Tree()
+    rtree.create_node("resources", "resources")
+    return rtree
+
+
+def _build_mermaid_tree() -> Tree:
+    """Build a tree: Global -> Site -> 2 Devices (AP + Switch)."""
+    tree = Tree()
+
+    tree.create_node(
+        "g",
+        "g",
+        data={
+            "device": _make_device("g", "GLOBAL", "GLOBAL"),
+            "resources": _make_resources(),
+        },
+    )
+    tree.create_node(
+        "s",
+        "s",
+        parent="g",
+        data={
+            "device": _make_device("s", "HQ Site", "SITE"),
+            "resources": _make_resources(),
+        },
+    )
+    tree.create_node(
+        "ap1",
+        "ap1",
+        parent="s",
+        data={
+            "device": _make_device(
+                "ap1",
+                "ap-lobby-01",
+                "DEVICE",
+                device_type="Aruba AP-515",
+                device_model="AP-515",
+            ),
+            "resources": _make_resources(),
+        },
+    )
+    tree.create_node(
+        "sw1",
+        "sw1",
+        parent="s",
+        data={
+            "device": _make_device(
+                "sw1",
+                "switch-idf-01",
+                "DEVICE",
+                device_type="Aruba CX 6200",
+                device_model="6200",
+            ),
+            "resources": _make_resources(),
+        },
+    )
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTreeToMermaid:
+    def test_contains_flowchart_header(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree)
+        assert result.startswith("flowchart TD")
+
+    def test_device_labels_use_hostname_not_model(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree)
+
+        # Hostnames should appear in the diagram
+        assert "ap-lobby-01" in result
+        assert "switch-idf-01" in result
+
+        # Model numbers should NOT be used as labels
+        # They might appear elsewhere but not as the primary ((label))
+        lines = result.split("\n")
+        label_lines = [line for line in lines if "((" in line and "))" in line]
+        for line in label_lines:
+            # Extract label between (( and ))
+            if "AP-515" in line and "ap-lobby-01" not in line:
+                pytest.fail(f"Model number used as label instead of hostname: {line}")
+            if "6200" in line and "switch-idf-01" not in line:
+                pytest.fail(f"Model number used as label instead of hostname: {line}")
+
+    def test_contains_legend(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree)
+        assert "subgraph Legend" in result
+        assert "L1((Global))" in result
+
+    def test_contains_class_definitions(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree)
+        assert "classDef global_scope" in result
+        assert "classDef site" in result
+        assert "classDef ap" in result
+        assert "classDef switch" in result
+
+    def test_include_devices_false_hides_devices(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree, include_devices=False)
+        assert "ap-lobby-01" not in result
+        assert "switch-idf-01" not in result
+
+    def test_empty_tree(self):
+        tree = Tree()
+        result = tree_to_mermaid(tree)
+        assert "No scope data" in result
+
+    def test_nonexistent_scope_id(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree, scope_id="nonexistent")
+        assert "not found" in result
+
+    def test_subtree_rendering(self):
+        tree = _build_mermaid_tree()
+        result = tree_to_mermaid(tree, scope_id="s")
+        assert "HQ Site" in result
+        assert "ap-lobby-01" in result
+        # Global should NOT appear when rendering subtree
+        assert "GLOBAL" not in result or "global_scope" in result  # class name is ok


### PR DESCRIPTION
## Summary

- **Split `scope_builder.py`** (612 lines, over 500-line limit) into `scope_builder.py` (361) + `scope_queries.py` (414) at the natural seam between tree construction and querying/rendering
- **Enriched tool outputs** with summary statistics: `persona_count`, `resource_count`, `child_scope_count`, `device_count` at every scope node, plus per-persona `categories` breakdown (vlan, policy, profile, etc.)
- **Added `include_details` parameter** to `central_get_effective_config` so full resource configuration data can be returned (data was already in the tree but never exposed)
- **Added `inheritance_path`** to effective config output — ordered list from Global root to target scope with resource counts at each level
- **Added 2 guided prompts** (`scope_configuration_overview`, `scope_effective_config`) that instruct the AI how to present scope data readably — category grouping, layered inheritance views, summaries
- **Fixed Mermaid diagram** device labels to use hostnames instead of model numbers
- **Updated INSTRUCTIONS.md** with scope data presentation guidance
- **Added `docker-compose.dev.yml`** build override and src volume mount so local dev runs use current source
- **34 new unit tests** (153 total, up from 119)

## Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm hpe-networking-mcp sh -c "uv run ruff check . && uv run ruff format --check . && uv run pytest tests/ -q"` — all 153 tests pass, lint/format clean
- [ ] Call `central_get_scope_tree` — verify `persona_count`, `resource_count`, `categories` present at each node
- [ ] Call `central_get_effective_config(scope_id, include_details=True)` — verify `inheritance_path` and `details` in output
- [ ] Call `central_get_scope_diagram` — verify device hostnames in Mermaid labels
- [ ] Invoke `scope_configuration_overview` prompt — verify AI produces categorized, readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)