### PR TITLE
Add site CRUD to Mist org-level write tools

### DIFF
--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -240,16 +240,10 @@ async def change_org_configuration_objects(
                     )
                     await process_response(response)
                 elif action_type.value == "create":
-                    response = mistapi.api.v1.orgs.sites.createOrgSite(
-                        apisession, org_id=org, body=payload
-                    )
+                    response = mistapi.api.v1.orgs.sites.createOrgSite(apisession, org_id=org, body=payload)
                     await process_response(response)
                 else:
-                    response = mistapi.api.v1.orgs.sites.deleteOrgSite(
-                        apisession,
-                        org_id=org,
-                        site_id=obj,
-                    )
+                    response = mistapi.api.v1.orgs.sites.deleteOrgSite(apisession, org_id=org, site_id=obj)
                     await process_response(response)
             case "wlans":
                 if action_type.value == "update":

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -32,6 +32,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 
 class Object_type(Enum):
     ALARMTEMPLATES = "alarmtemplates"
+    SITES = "sites"
     WLANS = "wlans"
     SITEGROUPS = "sitegroups"
     AVPROFILES = "avprofiles"
@@ -227,6 +228,27 @@ async def change_org_configuration_objects(
                         apisession,
                         org_id=org,
                         alarmtemplate_id=obj,
+                    )
+                    await process_response(response)
+            case "sites":
+                if action_type.value == "update":
+                    response = mistapi.api.v1.orgs.sites.updateOrgSite(
+                        apisession,
+                        org_id=org,
+                        site_id=obj,
+                        body=payload,
+                    )
+                    await process_response(response)
+                elif action_type.value == "create":
+                    response = mistapi.api.v1.orgs.sites.createOrgSite(
+                        apisession, org_id=org, body=payload
+                    )
+                    await process_response(response)
+                else:
+                    response = mistapi.api.v1.orgs.sites.deleteOrgSite(
+                        apisession,
+                        org_id=org,
+                        site_id=obj,
                     )
                     await process_response(response)
             case "wlans":

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -34,6 +34,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 
 class Object_type(Enum):
     ALARMTEMPLATES = "alarmtemplates"
+    SITES = "sites"
     WLANS = "wlans"
     SITEGROUPS = "sitegroups"
     AVPROFILES = "avprofiles"
@@ -195,6 +196,22 @@ async def update_org_configuration_objects(
                     await process_response(response)
                 else:
                     response = mistapi.api.v1.orgs.alarmtemplates.createOrgAlarmTemplate(
+                        apisession,
+                        org_id=org,
+                        body=payload,
+                    )
+                    await process_response(response)
+            case "sites":
+                if obj:
+                    response = mistapi.api.v1.orgs.sites.updateOrgSite(
+                        apisession,
+                        org_id=org,
+                        site_id=obj,
+                        body=payload,
+                    )
+                    await process_response(response)
+                else:
+                    response = mistapi.api.v1.orgs.sites.createOrgSite(
                         apisession,
                         org_id=org,
                         body=payload,


### PR DESCRIPTION
## Summary

- Add `sites` as a supported object type to `mist_change_org_configuration_objects` (create/update/delete) and `mist_update_org_configuration_objects` (create/update)
- Wires to `mistapi.api.v1.orgs.sites.createOrgSite`, `updateOrgSite`, and `deleteOrgSite`
- Previously site creation was not possible through the MCP tools — users hit an error when asking the AI to create a site

## Test plan

- [ ] CI passes (lint, format, type check, tests, Docker build)
- [ ] With `ENABLE_WRITE_TOOLS=true`, ask AI to create a site — verify elicitation prompt appears and site is created on accept
- [ ] Verify update and delete operations also work with a site object_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)