### PR TITLE
Bump version to 0.7.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.1.0"
+version = "0.7.10"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/__init__.py
+++ b/src/hpe_networking_mcp/__init__.py
@@ -1,3 +1,5 @@
 """HPE Networking MCP Server — Unified Mist, Central, and GreenLake."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("hpe-networking-mcp")


### PR DESCRIPTION
## Summary

- Bump version to 0.7.10 in pyproject.toml (single source of truth)
- Replace hardcoded `__version__` in `__init__.py` with dynamic read from `importlib.metadata`
- Covers site CRUD addition and Claude Desktop setup guide improvements since v0.7.0

## Test plan

- [ ] CI passes
- [ ] After merge, tag v0.7.10 and create GitHub release to trigger Docker image publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)