### PR TITLE
Fix write tools failing when DISABLE_ELICITATION=true

### DIFF
--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -43,6 +43,7 @@ class ElicitationMiddleware(Middleware):
         # DANGER ZONE: both flags set — skip elicitation entirely
         if config.enable_write_tools and config.disable_elicitation:
             enable_write = True
+            await ctx.set_state("disable_elicitation", True)
             logger.warning(
                 "Elicitation: enable_write_tools AND disable_elicitation both set — "
                 "write tools enabled WITHOUT confirmation. Use with caution!"


### PR DESCRIPTION
## Summary

- Fix missing `ctx.set_state("disable_elicitation", True)` in the DANGER ZONE code path of `ElicitationMiddleware.on_initialize`
- When both `ENABLE_WRITE_TOOLS=true` and `DISABLE_ELICITATION=true`, write tools would still attempt user confirmation via `ctx.elicit()`, which throws on clients without elicitation support (Claude Desktop), returning "AI App does not support elicitation"
- One-line fix: set the state so `elicitation_handler` auto-accepts

## Test plan

- [ ] CI passes
- [ ] With `ENABLE_WRITE_TOOLS=true` and `DISABLE_ELICITATION=true`, create a site via Claude Desktop — should succeed without elicitation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)