### PR TITLE
Document sites object type in write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.11] - 2026-04-13
+
+### Added
+- `sites` object type for `mist_change_org_configuration_objects` and `mist_update_org_configuration_objects` — enables site create, update, and delete via write tools
+
+### Fixed
+- Write tools failing with "AI App does not support elicitation" when both `ENABLE_WRITE_TOOLS=true` and `DISABLE_ELICITATION=true` — missing `ctx.set_state("disable_elicitation", True)` in the elicitation middleware
+
+### Changed
+- `__version__` now reads dynamically from package metadata instead of being hardcoded
+- `pyproject.toml` is the single source of truth for version
+
+[v0.7.11]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.11
+
 ## [v0.7.0] - 2026-04-03
 
 ### Added — Central Scope & Configuration Tools

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -465,7 +465,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | org_id | UUID | Yes | Organization ID. |
-| object_type | str | Yes | Object type (e.g. `wlans`, `networktemplates`, `deviceprofiles`). |
+| object_type | str | Yes | `alarmtemplates`, `sites`, `wlans`, `sitegroups`, `avprofiles`, `deviceprofiles`, `gatewaytemplates`, `idpprofiles`, `aamwprofiles`, `nactags`, `nacrules`, `networktemplates`, `networks`, `psks`, `rftemplates`, `services`, `servicepolicies`, `sitetemplates`, `vpns`, `webhooks`, `wlantemplates`, `wxrules`, or `wxtags`. |
 | object_id | UUID | No | ID of the object to update. Omit to create new. |
 | body | dict | Yes | Configuration object body. |
 
@@ -489,7 +489,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 |-----------|------|----------|-------------|
 | action_type | str | Yes | `create`, `update`, or `delete`. |
 | org_id | UUID | Yes | Organization ID. |
-| object_type | str | Yes | Object type (e.g. `wlans`, `networktemplates`, `deviceprofiles`). |
+| object_type | str | Yes | `alarmtemplates`, `sites`, `wlans`, `sitegroups`, `avprofiles`, `deviceprofiles`, `gatewaytemplates`, `idpprofiles`, `aamwprofiles`, `nactags`, `nacrules`, `networktemplates`, `networks`, `psks`, `rftemplates`, `services`, `servicepolicies`, `sitetemplates`, `vpns`, `webhooks`, `wlantemplates`, `wxrules`, or `wxtags`. |
 | object_id | UUID | No | ID of the object to update or delete. |
 | body | dict | No | Configuration object body. Required for create/update. |
 


### PR DESCRIPTION
## Summary

- List all 23 supported object types (including `sites`) in TOOLS.md for `mist_update_org_configuration_objects` and `mist_change_org_configuration_objects` — previously just showed `(e.g. wlans, networktemplates, deviceprofiles)`
- Add v0.7.11 changelog entry covering site CRUD addition and elicitation fix

## Test plan

- [ ] CI passes
- [ ] TOOLS.md renders correctly on GitHub