### PR TITLE
Fix site update/delete using correct mistapi methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.11"
+version = "0.7.12"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -232,9 +232,8 @@ async def change_org_configuration_objects(
                     await process_response(response)
             case "sites":
                 if action_type.value == "update":
-                    response = mistapi.api.v1.orgs.sites.updateOrgSite(
+                    response = mistapi.api.v1.sites.sites.updateSiteInfo(
                         apisession,
-                        org_id=org,
                         site_id=obj,
                         body=payload,
                     )
@@ -243,7 +242,7 @@ async def change_org_configuration_objects(
                     response = mistapi.api.v1.orgs.sites.createOrgSite(apisession, org_id=org, body=payload)
                     await process_response(response)
                 else:
-                    response = mistapi.api.v1.orgs.sites.deleteOrgSite(apisession, org_id=org, site_id=obj)
+                    response = mistapi.api.v1.sites.sites.deleteSite(apisession, site_id=obj)
                     await process_response(response)
             case "wlans":
                 if action_type.value == "update":

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -203,9 +203,8 @@ async def update_org_configuration_objects(
                     await process_response(response)
             case "sites":
                 if obj:
-                    response = mistapi.api.v1.orgs.sites.updateOrgSite(
+                    response = mistapi.api.v1.sites.sites.updateSiteInfo(
                         apisession,
-                        org_id=org,
                         site_id=obj,
                         body=payload,
                     )


### PR DESCRIPTION
## Summary

- Site delete was calling `mistapi.api.v1.orgs.sites.deleteOrgSite` which doesn't exist — fixed to `mistapi.api.v1.sites.sites.deleteSite(site_id)`
- Site update was calling `mistapi.api.v1.orgs.sites.updateOrgSite` which doesn't exist — fixed to `mistapi.api.v1.sites.sites.updateSiteInfo(site_id, body)`
- Site create remains correctly at `mistapi.api.v1.orgs.sites.createOrgSite(org_id, body)`
- Bump version to 0.7.12

## Test plan

- [ ] CI passes
- [ ] Create a site via write tools — verify success
- [ ] Delete the created site — verify success (was 503 before this fix)
- [ ] Update an existing site — verify success

🤖 Generated with [Claude Code](https://claude.com/claude-code)