### PR TITLE
Add Mist best-practice guardrails and site provisioning prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ functions_to_import/
 HANDOFF.md
 TASKS.md
 CLAUDE.md
+
+# Reference documents
+mist-best-practices.docx

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -48,6 +48,40 @@ Tools are namespaced by platform:
 ## Pagination
 When a Mist tool response includes a `_next` field, use `mist_get_next_page(url=<_next>)` for more results.
 
+## Mist Best Practices
+
+### Configuration Hierarchy
+Push configuration as high as possible: Org-level templates → Site group assignment → Site-level → Device-level. Device-level overrides are a last resort — they cannot be managed in bulk and cause drift.
+
+### WLANs
+- **ALWAYS** create SSIDs as org-level WLANs inside WLAN templates. Assign templates to site groups.
+- **NEVER** create site-level WLANs. If asked to create a WLAN at a site, create an org-level WLAN in a WLAN template and assign the template to the site's site group instead.
+- When cloning or copying a site's config, do NOT copy site-level WLANs. Ensure all SSIDs come from org-level WLAN templates.
+- Organize WLAN templates by function: Corporate/Dot1X, MPSK/IoT, Guest, Onboarding.
+
+### RADIUS / Template Variables
+- Use template variables (`{{auth_srv1}}`, `{{auth_srv2}}`) for RADIUS server IPs in auth_servers and acct_servers fields. Never hardcode IP addresses — the same template should work across sites with different RADIUS infrastructure.
+
+### RF Templates
+- Let Mist AI RRM manage channel selection and TX power automatically. Do not set fixed channels or power in RF templates unless explicitly requested with justification.
+- Use 20 MHz only for 2.4 GHz, 40-80 MHz for 5 GHz, 80-160 MHz for 6 GHz.
+- Assign a baseline RF template at the site-group level. Do not create unique RF templates per site.
+
+### PSKs
+- Prefer Cloud PSK (per-user unique passphrase with VLAN assignment) over static shared PSKs. Cloud PSK allows individual key rotation and per-device segmentation.
+
+### Site Groups
+- Assign WLAN templates and RF templates to site groups, not individual sites. New sites added to a group automatically inherit all templates.
+
+### Firmware
+- Auto-upgrade should be enabled at the org level with a maintenance window.
+
+### Site Provisioning
+When asked to create a new site based on an existing site:
+- Use the `provision_site_from_template` prompt for single sites
+- Use the `bulk_provision_sites` prompt for multiple sites
+- NEVER copy site-level WLANs — always use org-level WLAN templates assigned via site groups
+
 ---
 
 # ARUBA CENTRAL (central_* tools)

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -82,4 +82,13 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             except Exception as e:
                 logger.warning("Mist: failed to load tool {} -- {}", tool_name, e)
 
+    # Register prompts (not in TOOLS dict — prompts don't follow mist_* naming)
+    try:
+        from hpe_networking_mcp.platforms.mist.tools import prompts as mist_prompts
+
+        mist_prompts.register(mcp)
+        logger.debug("Mist: loaded prompts")
+    except Exception as e:
+        logger.warning("Mist: failed to load prompts -- {}", e)
+
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -28,6 +28,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.tools.guardrails import validate_org_write
 
 
 class Object_type(Enum):
@@ -176,11 +177,17 @@ async def change_org_configuration_objects(
             )
         action_wording = "delete an existing"
 
+    guardrails = validate_org_write(object_type.value, action_type.value, payload)
+    guardrail_notice = ""
+    if guardrails.warnings:
+        guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
+
     if ctx:
         try:
             elicitation_response = await elicitation_handler(
                 message=(
-                    f"The LLM wants to {action_wording} {object_type.value}. Do you accept to trigger the API call?"
+                    f"The LLM wants to {action_wording} {object_type.value}. "
+                    f"Do you accept to trigger the API call?{guardrail_notice}"
                 ),
                 ctx=ctx,
             )
@@ -664,4 +671,7 @@ async def change_org_configuration_objects(
     except Exception as _exc:
         await handle_network_error(_exc)
 
-    return format_response(response, response_format)
+    result = format_response(response, response_format)
+    if guardrails.suggestions and isinstance(result, dict):
+        result["_best_practice_suggestions"] = guardrails.suggestions
+    return result

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
@@ -28,6 +28,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.tools.guardrails import validate_site_write
 
 
 class Object_type(Enum):
@@ -153,11 +154,17 @@ async def change_site_configuration_objects(
             )
         action_wording = "delete an existing"
 
+    guardrails = validate_site_write(object_type.value, action_type.value, payload)
+    guardrail_notice = ""
+    if guardrails.warnings:
+        guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
+
     if ctx:
         try:
             elicitation_response = await elicitation_handler(
                 message=(
-                    f"The LLM wants to {action_wording} {object_type.value}. Do you accept to trigger the API call?"
+                    f"The LLM wants to {action_wording} {object_type.value}. "
+                    f"Do you accept to trigger the API call?{guardrail_notice}"
                 ),
                 ctx=ctx,
             )
@@ -352,4 +359,7 @@ async def change_site_configuration_objects(
     except Exception as _exc:
         await handle_network_error(_exc)
 
-    return format_response(response, response_format)
+    result = format_response(response, response_format)
+    if guardrails.suggestions and isinstance(result, dict):
+        result["_best_practice_suggestions"] = guardrails.suggestions
+    return result

--- a/src/hpe_networking_mcp/platforms/mist/tools/guardrails.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/guardrails.py
@@ -1,0 +1,158 @@
+"""Best-practice validation for Mist write operations.
+
+Pure validation functions that inspect payloads and return warnings
+when operations violate Mist configuration best practices. No I/O,
+no API calls — takes dicts/strings, returns a GuardrailResult.
+
+Best practices are based on Juniper Mist's recommended configuration
+model: template everything at org level, use template variables for
+site-specific values, let AI RRM manage RF, use Cloud PSK.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# IP address pattern (IPv4) — matches hardcoded IPs but not template variables like {{auth_srv1}}
+_IP_PATTERN = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+
+# Template variable pattern — matches {{variable_name}}
+_TEMPLATE_VAR_PATTERN = re.compile(r"^\{\{.+\}\}$")
+
+
+@dataclass
+class GuardrailResult:
+    """Result of a best-practice validation check.
+
+    Attributes:
+        warnings: Shown in the elicitation message to the user.
+        suggestions: Returned in the tool response for the AI to act on.
+    """
+
+    warnings: list[str] = field(default_factory=list)
+    suggestions: list[str] = field(default_factory=list)
+
+
+def validate_site_write(object_type: str, action_type: str, payload: dict) -> GuardrailResult:
+    """Validate a site-level write operation against best practices.
+
+    Args:
+        object_type: The object type being written (e.g. "wlans", "psks").
+        action_type: The action type ("create", "update", "delete").
+        payload: The JSON payload for the operation.
+
+    Returns:
+        GuardrailResult with any warnings and suggestions.
+    """
+    result = GuardrailResult()
+    _check_site_wlan_creation(object_type, action_type, result)
+    _check_site_level_override(object_type, action_type, result)
+    _check_hardcoded_radius(object_type, payload, result)
+    _check_static_psk(object_type, payload, result)
+    return result
+
+
+def validate_org_write(object_type: str, action_type: str, payload: dict) -> GuardrailResult:
+    """Validate an org-level write operation against best practices.
+
+    Args:
+        object_type: The object type being written (e.g. "wlans", "rftemplates").
+        action_type: The action type ("create", "update", "delete").
+        payload: The JSON payload for the operation.
+
+    Returns:
+        GuardrailResult with any warnings and suggestions.
+    """
+    result = GuardrailResult()
+    _check_hardcoded_radius(object_type, payload, result)
+    _check_fixed_rf(object_type, payload, result)
+    _check_static_psk(object_type, payload, result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Private validation checks
+# ---------------------------------------------------------------------------
+
+
+def _check_site_wlan_creation(object_type: str, action_type: str, result: GuardrailResult) -> None:
+    """Warn when creating a site-level WLAN instead of using an org-level template."""
+    if object_type == "wlans" and action_type == "create":
+        result.warnings.append(
+            "BEST PRACTICE: SSIDs should be defined in org-level WLAN templates, "
+            "not as site-level WLANs. Use mist_change_org_configuration_objects "
+            "with object_type=wlans and a template_id to create the WLAN in an "
+            "org-level template, then assign the template to the site's site group."
+        )
+        result.suggestions.append(
+            "Create this WLAN as an org-level WLAN inside a WLAN template instead. "
+            "Site-level WLANs cannot be centrally managed and cause configuration drift."
+        )
+
+
+def _check_site_level_override(object_type: str, action_type: str, result: GuardrailResult) -> None:
+    """Warn when creating site-level config that should be at org level."""
+    if object_type in ("wxrules", "wxtags") and action_type == "create":
+        result.suggestions.append(
+            f"Consider defining {object_type} at the org level and applying via "
+            "templates rather than creating site-level overrides."
+        )
+
+
+def _check_hardcoded_radius(object_type: str, payload: dict, result: GuardrailResult) -> None:
+    """Warn when WLAN payloads contain hardcoded RADIUS server IPs."""
+    if object_type != "wlans":
+        return
+    for server_list_key in ("auth_servers", "acct_servers"):
+        servers = payload.get(server_list_key, [])
+        if not isinstance(servers, list):
+            continue
+        for server in servers:
+            if not isinstance(server, dict):
+                continue
+            host = server.get("host", "")
+            if _IP_PATTERN.match(str(host)) and not _TEMPLATE_VAR_PATTERN.match(str(host)):
+                result.warnings.append(
+                    f"BEST PRACTICE: RADIUS server IP '{host}' is hardcoded in "
+                    f"{server_list_key}. Use template variables like "
+                    "{{auth_srv1}} so the same WLAN template can resolve to "
+                    "different RADIUS servers per site."
+                )
+                return  # One warning is enough
+
+
+def _check_fixed_rf(object_type: str, payload: dict, result: GuardrailResult) -> None:
+    """Warn when RF templates have fixed channels or TX power."""
+    if object_type != "rftemplates":
+        return
+    for band_key in ("band_24", "band_5", "band_6", "band_24_usage"):
+        band = payload.get(band_key)
+        if not isinstance(band, dict):
+            continue
+        if isinstance(band.get("channels"), list) and band["channels"]:
+            result.warnings.append(
+                f"BEST PRACTICE: RF template has fixed channels for {band_key}. "
+                "Mist AI RRM should manage channel selection automatically. "
+                "Only override with explicit justification."
+            )
+            return  # One warning is enough
+        if isinstance(band.get("power"), (int, float)):
+            result.warnings.append(
+                f"BEST PRACTICE: RF template has fixed TX power for {band_key}. "
+                "Mist AI RRM should manage power levels automatically. "
+                "Only override with explicit justification."
+            )
+            return
+
+
+def _check_static_psk(object_type: str, payload: dict, result: GuardrailResult) -> None:
+    """Warn when using static shared PSK instead of Cloud PSK."""
+    if object_type != "psks":
+        return
+    if payload.get("passphrase") and payload.get("usage") != "multi":
+        result.suggestions.append(
+            "Consider using Cloud PSK (per-user unique passphrase with VLAN "
+            "assignment) instead of a static shared PSK. Cloud PSK allows "
+            "individual key rotation and per-device VLAN segmentation."
+        )

--- a/src/hpe_networking_mcp/platforms/mist/tools/prompts.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/prompts.py
@@ -1,0 +1,106 @@
+"""Mist guided prompts for site provisioning workflows."""
+
+
+def register(mcp):
+
+    @mcp.prompt
+    def provision_site_from_template(
+        source_site_name: str,
+        target_site_name: str,
+        target_address: str,
+    ) -> str:
+        """Provision a new Mist site cloned from an existing site using templates."""
+        return f"""
+Provision a new site "{target_site_name}" at "{target_address}" based \
+on the configuration of "{source_site_name}":
+
+1. Call `mist_get_self(action_type=account_info)` to get the org_id.
+2. Call `mist_get_configuration_objects(org_id=<org_id>, \
+object_type=org_sites, name="{source_site_name}")` to get the source \
+site config. Note the rftemplate_id, sitetemplate_id, \
+networktemplate_id, gatewaytemplate_id, secpolicy_id, \
+alarmtemplate_id, and sitegroup_ids.
+3. Call `mist_get_configuration_objects(org_id=<org_id>, \
+object_type=site_wlans, site_id=<source_site_id>, computed=true)` to \
+get all WLANs at the source site.
+4. For each WLAN returned: check if it has a `template_id` field. \
+If yes, it comes from an org-level WLAN template (good — no action \
+needed). If no `template_id`, it is a site-level WLAN that should be \
+migrated to an org-level template.
+5. For any site-level WLANs found: check \
+`mist_get_configuration_objects(org_id=<org_id>, \
+object_type=org_wlantemplates)` for an existing template containing \
+a WLAN with the same SSID. If none exists, create a new org-level \
+WLAN template using `mist_change_org_configuration_objects(\
+action_type=create, object_type=wlantemplates, payload=...)` and \
+then create the WLAN inside it with object_type=wlans and the \
+template_id of the new template. Assign the template to the same \
+site groups as the source site.
+6. Create the new site: `mist_change_org_configuration_objects(\
+action_type=create, object_type=sites, payload={{name: \
+"{target_site_name}", address: "{target_address}", \
+rftemplate_id: <from_source>, sitetemplate_id: <from_source>, \
+networktemplate_id: <from_source>, timezone: <from_source>, \
+country_code: <from_source>}})`.
+7. Add the new site to the same site groups as the source site. For \
+each sitegroup_id: call `mist_get_configuration_objects(org_id=\
+<org_id>, object_type=org_sitegroups, object_id=<sitegroup_id>)`, \
+add the new site_id to the site_ids list, then call \
+`mist_change_org_configuration_objects(action_type=update, \
+object_type=sitegroups, object_id=<sitegroup_id>, \
+payload=<updated_sitegroup>)`.
+8. Do NOT create any site-level WLANs on the new site. Templates \
+assigned via site groups will deliver all SSIDs automatically.
+9. Report: site created, site groups assigned, templates applied, \
+and whether any site-level WLANs from the source were migrated to \
+org-level templates.
+        """.strip()
+
+    @mcp.prompt
+    def bulk_provision_sites(
+        source_site_name: str,
+        site_list_description: str,
+    ) -> str:
+        """Provision multiple sites cloned from an existing site using templates."""
+        return f"""
+Bulk provision sites based on "{source_site_name}" configuration. \
+Sites to create: {site_list_description}
+
+PHASE 1 — Analyze source (do this ONCE):
+1. Call `mist_get_self(action_type=account_info)` to get the org_id.
+2. Call `mist_get_configuration_objects(org_id=<org_id>, \
+object_type=org_sites, name="{source_site_name}")` to get the source \
+site config. Note rftemplate_id, sitetemplate_id, \
+networktemplate_id, gatewaytemplate_id, secpolicy_id, \
+alarmtemplate_id, and sitegroup_ids.
+3. Call `mist_get_configuration_objects(org_id=<org_id>, \
+object_type=site_wlans, site_id=<source_site_id>, computed=true)` to \
+get all WLANs. Identify which are template-based (have template_id) \
+vs site-level (no template_id).
+4. For any site-level WLANs: check if an equivalent org-level WLAN \
+template already exists (match by SSID). If not, create one using \
+`mist_change_org_configuration_objects` with object_type=\
+wlantemplates and then object_type=wlans. Assign the template to \
+the source site's site groups. This step ensures all SSIDs are \
+template-based before cloning.
+
+PHASE 2 — Create each site (loop):
+For each site in the list:
+5. Create the site: `mist_change_org_configuration_objects(\
+action_type=create, object_type=sites, payload={{name: <site_name>, \
+address: <site_address>, rftemplate_id: <from_source>, \
+sitetemplate_id: <from_source>, networktemplate_id: <from_source>, \
+timezone: <from_source>, country_code: <from_source>}})`.
+6. Add the new site to the same site groups as the source. Update \
+each site group's site_ids list to include the new site_id.
+7. Do NOT create any site-level WLANs. Templates applied via site \
+groups deliver all SSIDs automatically.
+
+PHASE 3 — Report:
+8. Present a summary table with columns: Site Name, Status \
+(Created/Failed), Site Groups Assigned, Templates Applied.
+9. Note any site-level WLANs from the source that were migrated to \
+org-level templates in Phase 1.
+10. Confirm: "All SSIDs are delivered via org-level WLAN templates \
+assigned through site groups. No site-level WLANs were created."
+        """.strip()

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -30,6 +30,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.tools.guardrails import validate_org_write
 
 
 class Object_type(Enum):
@@ -152,11 +153,17 @@ async def update_org_configuration_objects(
     if object_id:
         action_wording = "update an existing"
 
+    guardrails = validate_org_write(object_type.value, "update" if object_id else "create", payload)
+    guardrail_notice = ""
+    if guardrails.warnings:
+        guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
+
     if ctx:
         try:
             elicitation_response = await elicitation_handler(
                 message=(
-                    f"The LLM wants to {action_wording} {object_type.value}. Do you accept to trigger the API call?"
+                    f"The LLM wants to {action_wording} {object_type.value}. "
+                    f"Do you accept to trigger the API call?{guardrail_notice}"
                 ),
                 ctx=ctx,
             )
@@ -571,4 +578,7 @@ async def update_org_configuration_objects(
     except Exception as _exc:
         await handle_network_error(_exc)
 
-    return format_response(response, response_format)
+    result = format_response(response, response_format)
+    if guardrails.suggestions and isinstance(result, dict):
+        result["_best_practice_suggestions"] = guardrails.suggestions
+    return result

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
@@ -30,6 +30,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.tools.guardrails import validate_site_write
 
 
 class Object_type(Enum):
@@ -126,11 +127,17 @@ async def update_site_configuration_objects(
     if object_id:
         action_wording = "update an existing"
 
+    guardrails = validate_site_write(object_type.value, "update" if object_id else "create", payload)
+    guardrail_notice = ""
+    if guardrails.warnings:
+        guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
+
     if ctx:
         try:
             elicitation_response = await elicitation_handler(
                 message=(
-                    f"The LLM wants to {action_wording} {object_type.value}. Do you accept to trigger the API call?"
+                    f"The LLM wants to {action_wording} {object_type.value}. "
+                    f"Do you accept to trigger the API call?{guardrail_notice}"
                 ),
                 ctx=ctx,
             )
@@ -283,4 +290,7 @@ async def update_site_configuration_objects(
     except Exception as _exc:
         await handle_network_error(_exc)
 
-    return format_response(response, response_format)
+    result = format_response(response, response_format)
+    if guardrails.suggestions and isinstance(result, dict):
+        result["_best_practice_suggestions"] = guardrails.suggestions
+    return result

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -1,0 +1,134 @@
+"""Unit tests for Mist best-practice guardrails."""
+
+import pytest
+
+from hpe_networking_mcp.platforms.mist.tools.guardrails import (
+    validate_org_write,
+    validate_site_write,
+)
+
+
+@pytest.mark.unit
+class TestSiteWlanCreation:
+    def test_site_wlan_create_warns(self):
+        result = validate_site_write("wlans", "create", {})
+        assert len(result.warnings) == 1
+        assert "org-level WLAN templates" in result.warnings[0]
+        assert len(result.suggestions) == 1
+
+    def test_site_wlan_update_no_warn(self):
+        result = validate_site_write("wlans", "update", {})
+        assert len(result.warnings) == 0
+
+    def test_site_wlan_delete_no_warn(self):
+        result = validate_site_write("wlans", "delete", {})
+        assert len(result.warnings) == 0
+
+    def test_org_wlan_create_no_warn(self):
+        result = validate_org_write("wlans", "create", {})
+        assert len(result.warnings) == 0
+
+
+@pytest.mark.unit
+class TestHardcodedRadius:
+    def test_hardcoded_ip_warns(self):
+        payload = {"auth_servers": [{"host": "10.0.0.1", "port": 1812}]}
+        result = validate_site_write("wlans", "update", payload)
+        assert any("RADIUS" in w for w in result.warnings)
+
+    def test_template_variable_no_warn(self):
+        payload = {"auth_servers": [{"host": "{{auth_srv1}}", "port": 1812}]}
+        result = validate_site_write("wlans", "update", payload)
+        assert not any("RADIUS" in w for w in result.warnings)
+
+    def test_acct_servers_also_checked(self):
+        payload = {"acct_servers": [{"host": "192.168.1.100"}]}
+        result = validate_org_write("wlans", "create", payload)
+        assert any("RADIUS" in w for w in result.warnings)
+
+    def test_non_wlan_type_not_checked(self):
+        payload = {"auth_servers": [{"host": "10.0.0.1"}]}
+        result = validate_site_write("webhooks", "create", payload)
+        assert len(result.warnings) == 0
+
+    def test_empty_auth_servers_no_warn(self):
+        payload = {"auth_servers": []}
+        result = validate_org_write("wlans", "create", payload)
+        assert not any("RADIUS" in w for w in result.warnings)
+
+
+@pytest.mark.unit
+class TestFixedRf:
+    def test_fixed_channels_warns(self):
+        payload = {"band_24": {"channels": [1, 6, 11]}}
+        result = validate_org_write("rftemplates", "create", payload)
+        assert any("fixed channels" in w for w in result.warnings)
+
+    def test_fixed_power_warns(self):
+        payload = {"band_5": {"power": 17}}
+        result = validate_org_write("rftemplates", "create", payload)
+        assert any("fixed TX power" in w for w in result.warnings)
+
+    def test_no_overrides_no_warn(self):
+        payload = {"band_24": {"bandwidth": 20}}
+        result = validate_org_write("rftemplates", "create", payload)
+        assert len(result.warnings) == 0
+
+    def test_empty_channels_no_warn(self):
+        payload = {"band_24": {"channels": []}}
+        result = validate_org_write("rftemplates", "create", payload)
+        assert len(result.warnings) == 0
+
+    def test_non_rftemplate_not_checked(self):
+        payload = {"band_24": {"channels": [1, 6, 11]}}
+        result = validate_org_write("wlans", "create", payload)
+        assert len(result.warnings) == 0
+
+
+@pytest.mark.unit
+class TestStaticPsk:
+    def test_static_psk_suggests(self):
+        payload = {"passphrase": "my-shared-key", "ssid": "IoT"}
+        result = validate_site_write("psks", "create", payload)
+        assert any("Cloud PSK" in s for s in result.suggestions)
+
+    def test_cloud_psk_no_suggest(self):
+        payload = {"passphrase": "unique-key", "usage": "multi", "ssid": "IoT"}
+        result = validate_site_write("psks", "create", payload)
+        assert not any("Cloud PSK" in s for s in result.suggestions)
+
+    def test_non_psk_not_checked(self):
+        payload = {"passphrase": "something"}
+        result = validate_site_write("wlans", "update", payload)
+        assert not any("Cloud PSK" in s for s in result.suggestions)
+
+
+@pytest.mark.unit
+class TestSiteLevelOverride:
+    def test_wxrules_create_suggests(self):
+        result = validate_site_write("wxrules", "create", {})
+        assert any("org level" in s for s in result.suggestions)
+
+    def test_wxtags_create_suggests(self):
+        result = validate_site_write("wxtags", "create", {})
+        assert any("org level" in s for s in result.suggestions)
+
+    def test_wxrules_update_no_suggest(self):
+        result = validate_site_write("wxrules", "update", {})
+        assert not any("org level" in s for s in result.suggestions)
+
+
+@pytest.mark.unit
+class TestEdgeCases:
+    def test_empty_payload_no_crash(self):
+        result = validate_site_write("wlans", "create", {})
+        assert isinstance(result.warnings, list)
+
+    def test_unrelated_object_no_warn(self):
+        result = validate_site_write("webhooks", "create", {})
+        assert len(result.warnings) == 0
+        assert len(result.suggestions) == 0
+
+    def test_org_empty_payload_no_crash(self):
+        result = validate_org_write("wlans", "create", {})
+        assert isinstance(result.warnings, list)


### PR DESCRIPTION
## Summary

- **Guardrails module** (`guardrails.py`) — pure validation functions that inspect write tool payloads and warn when operations violate Mist best practices (site-level WLAN creation, hardcoded RADIUS IPs, fixed RF channels/power, static PSKs)
- **Integrated into all 4 write tools** — warnings appear in the elicitation confirmation message, suggestions in the tool response
- **2 guided prompts** — `provision_site_from_template` (single site) and `bulk_provision_sites` (multi-site) enforce template-based config and never copy site-level WLANs
- **INSTRUCTIONS.md** — new Mist Best Practices section covering config hierarchy, WLANs, RADIUS variables, RF, PSKs, site groups, firmware
- **23 new unit tests** for guardrails (176 total)
- `.gitignore` — added `mist-best-practices.docx`

## Test plan

- [ ] CI passes (lint, format, type check, 176 tests, Docker build)
- [ ] Create a site-level WLAN via write tool — elicitation message should include best-practice warning
- [ ] Create a WLAN with hardcoded RADIUS IP — warning about template variables
- [ ] Invoke `provision_site_from_template` prompt — verify template-based workflow
- [ ] Invoke `bulk_provision_sites` prompt — verify bulk workflow