### PR TITLE
Bump version to 0.7.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.12"
+version = "0.7.13"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for best-practice guardrails and site provisioning prompts.