### PR TITLE
Skip confirmation on create, require on update and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.17] - 2026-04-14
+
+### Changed — Write Tool Confirmation
+- Create operations now execute immediately without confirmation
+- Update and delete operations require user confirmation (via elicitation prompt or AI chat confirmation)
+- Matches the expected behavior: creates are safe, updates/deletes need approval
+
+[v0.7.17]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.17
+
 ## [v0.7.16] - 2026-04-14
 
 ### Fixed — Write Tool Confirmation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.16"
+version = "0.7.17"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -201,23 +201,25 @@ async def _execute_config_action(
         ActionType.DELETE: "delete an existing",
     }[action_type]
 
-    elicitation_response = await elicitation_handler(
-        message=(f"The LLM wants to {action_wording} {resource_name}. Do you accept to trigger the API call?"),
-        ctx=ctx,
-    )
-    if elicitation_response.action == "decline":
-        if await ctx.get_state("elicitation_mode") == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": (
-                    f"This operation will {action_wording} {resource_name}. "
-                    "Please confirm with the user before proceeding. "
-                    "Call this tool again with the same parameters after the user confirms."
-                ),
-            }
-        return {"message": "Action declined by user."}
-    elif elicitation_response.action == "cancel":
-        return {"message": "Action canceled by user."}
+    # Confirm with user for update and delete operations only
+    if action_type != ActionType.CREATE:
+        elicitation_response = await elicitation_handler(
+            message=(f"The LLM wants to {action_wording} {resource_name}. Do you accept to trigger the API call?"),
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} {resource_name}. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with the same parameters after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
 
     conn = ctx.lifespan_context["central_conn"]
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -182,26 +182,28 @@ async def change_org_configuration_objects(
     if guardrails.warnings:
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
-    elicitation_response = await elicitation_handler(
-        message=(
-            f"The LLM wants to {action_wording} {object_type.value}. "
-            f"Do you accept to trigger the API call?{guardrail_notice}"
-        ),
-        ctx=ctx,
-    )
-    if elicitation_response.action == "decline":
-        if await ctx.get_state("elicitation_mode") == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": (
-                    f"This operation will {action_wording} {object_type.value}. "
-                    "Please confirm with the user before proceeding. "
-                    "Call this tool again with the same parameters after the user confirms."
-                ),
-            }
-        return {"message": "Action declined by user."}
-    elif elicitation_response.action == "cancel":
-        return {"message": "Action canceled by user."}
+    # Confirm with user for update and delete operations only
+    if action_type != Action_type.CREATE:
+        elicitation_response = await elicitation_handler(
+            message=(
+                f"The LLM wants to {action_wording} {object_type.value}. "
+                f"Do you accept to trigger the API call?{guardrail_notice}"
+            ),
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} {object_type.value}. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with the same parameters after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
 
     org = str(org_id)
     obj = str(object_id)

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
@@ -159,26 +159,28 @@ async def change_site_configuration_objects(
     if guardrails.warnings:
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
-    elicitation_response = await elicitation_handler(
-        message=(
-            f"The LLM wants to {action_wording} {object_type.value}. "
-            f"Do you accept to trigger the API call?{guardrail_notice}"
-        ),
-        ctx=ctx,
-    )
-    if elicitation_response.action == "decline":
-        if await ctx.get_state("elicitation_mode") == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": (
-                    f"This operation will {action_wording} {object_type.value}. "
-                    "Please confirm with the user before proceeding. "
-                    "Call this tool again with the same parameters after the user confirms."
-                ),
-            }
-        return {"message": "Action declined by user."}
-    elif elicitation_response.action == "cancel":
-        return {"message": "Action canceled by user."}
+    # Confirm with user for update and delete operations only
+    if action_type != Action_type.CREATE:
+        elicitation_response = await elicitation_handler(
+            message=(
+                f"The LLM wants to {action_wording} {object_type.value}. "
+                f"Do you accept to trigger the API call?{guardrail_notice}"
+            ),
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} {object_type.value}. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with the same parameters after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
 
     site = str(site_id)
     obj = str(object_id)

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -158,26 +158,28 @@ async def update_org_configuration_objects(
     if guardrails.warnings:
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
-    elicitation_response = await elicitation_handler(
-        message=(
-            f"The LLM wants to {action_wording} {object_type.value}. "
-            f"Do you accept to trigger the API call?{guardrail_notice}"
-        ),
-        ctx=ctx,
-    )
-    if elicitation_response.action == "decline":
-        if await ctx.get_state("elicitation_mode") == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": (
-                    f"This operation will {action_wording} {object_type.value}. "
-                    "Please confirm with the user before proceeding. "
-                    "Call this tool again with the same parameters after the user confirms."
-                ),
-            }
-        return {"message": "Action declined by user."}
-    elif elicitation_response.action == "cancel":
-        return {"message": "Action canceled by user."}
+    # Confirm with user for update operations only (object_id present = update)
+    if object_id:
+        elicitation_response = await elicitation_handler(
+            message=(
+                f"The LLM wants to {action_wording} {object_type.value}. "
+                f"Do you accept to trigger the API call?{guardrail_notice}"
+            ),
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} {object_type.value}. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with the same parameters after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
 
     org = str(org_id)
     obj = str(object_id) if object_id else None

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
@@ -132,26 +132,28 @@ async def update_site_configuration_objects(
     if guardrails.warnings:
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
-    elicitation_response = await elicitation_handler(
-        message=(
-            f"The LLM wants to {action_wording} {object_type.value}. "
-            f"Do you accept to trigger the API call?{guardrail_notice}"
-        ),
-        ctx=ctx,
-    )
-    if elicitation_response.action == "decline":
-        if await ctx.get_state("elicitation_mode") == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": (
-                    f"This operation will {action_wording} {object_type.value}. "
-                    "Please confirm with the user before proceeding. "
-                    "Call this tool again with the same parameters after the user confirms."
-                ),
-            }
-        return {"message": "Action declined by user."}
-    elif elicitation_response.action == "cancel":
-        return {"message": "Action canceled by user."}
+    # Confirm with user for update operations only (object_id present = update)
+    if object_id:
+        elicitation_response = await elicitation_handler(
+            message=(
+                f"The LLM wants to {action_wording} {object_type.value}. "
+                f"Do you accept to trigger the API call?{guardrail_notice}"
+            ),
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} {object_type.value}. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with the same parameters after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
 
     site = str(site_id)
     obj = str(object_id) if object_id else None


### PR DESCRIPTION
## Summary

- Create operations execute immediately without confirmation
- Update and delete operations require user confirmation (elicitation prompt or AI chat confirm)
- Applied to all 5 write tool files (4 Mist + 1 Central)
- Troubleshooting tools unaffected
- Version bump to 0.7.17

## Test plan

- [ ] CI passes
- [ ] Create a site in Central → executes immediately, no confirmation prompt
- [ ] Update a site → AI asks user to confirm before proceeding
- [ ] Delete a site → AI asks user to confirm before proceeding