### PR TITLE
Fix Central write tools API path: v1 -> v1alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.18] - 2026-04-14
+
+### Fixed
+- Central write tools using wrong API version (`v1` instead of `v1alpha1`) for sites, site-collections, and device-groups endpoints, causing DNS resolution failures
+
+[v0.7.18]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.18
+
 ## [v0.7.17] - 2026-04-14
 
 ### Changed — Write Tool Confirmation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.17"
+version = "0.7.18"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -76,7 +76,7 @@ async def central_manage_site(
         ctx=ctx,
         action_type=action_type,
         resource_name="site",
-        api_path="network-config/v1/sites",
+        api_path="network-config/v1alpha1/sites",
         resource_id=site_id,
         payload=payload,
     )
@@ -118,7 +118,7 @@ async def central_manage_site_collection(
         ctx=ctx,
         action_type=action_type,
         resource_name="site collection",
-        api_path="network-config/v1/site-collections",
+        api_path="network-config/v1alpha1/site-collections",
         resource_id=collection_id,
         payload=payload,
     )
@@ -160,7 +160,7 @@ async def central_manage_device_group(
         ctx=ctx,
         action_type=action_type,
         resource_name="device group",
-        api_path="network-config/v1/device-groups",
+        api_path="network-config/v1alpha1/device-groups",
         resource_id=group_id,
         payload=payload,
     )
@@ -185,7 +185,7 @@ async def _execute_config_action(
         ctx: MCP context with lifespan_context containing central_conn.
         action_type: CREATE, UPDATE, or DELETE.
         resource_name: Human-readable name for elicitation messages.
-        api_path: Base API path (e.g. "network-config/v1/sites").
+        api_path: Base API path (e.g. "network-config/v1alpha1/sites").
         resource_id: Resource ID for update/delete operations.
         payload: Request payload for create/update.
 


### PR DESCRIPTION
Central network-config endpoints use v1alpha1. The v1 path caused pycentral to route to a hostname that failed DNS resolution. Bump to 0.7.18.