### PR TITLE
Fix Central write tools sending payload as query params instead of body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.19] - 2026-04-14
+
+### Fixed
+- Central write tools sending payload as query params instead of JSON body — pycentral `command()` uses `api_data` for request body, not `api_params`
+- Added `api_data` parameter to `retry_central_command` for POST/PUT body support
+
+[v0.7.19]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.19
+
 ## [v0.7.18] - 2026-04-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.18"
+version = "0.7.19"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -231,9 +231,9 @@ async def _execute_config_action(
     api_method = method_map[action_type]
     full_path = f"{api_path}/{resource_id}" if resource_id else api_path
 
-    api_params: dict = {}
+    api_data: dict = {}
     if action_type != ActionType.DELETE:
-        api_params = payload
+        api_data = payload
 
     logger.info("Central config: {} {} — path: {}", api_method, resource_name, full_path)
 
@@ -241,7 +241,7 @@ async def _execute_config_action(
         central_conn=conn,
         api_method=api_method,
         api_path=full_path,
-        api_params=api_params,
+        api_data=api_data,
     )
 
     code = response.get("code", 0)

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -193,15 +193,23 @@ def retry_central_command(
     api_method: str,
     api_path: str,
     api_params: dict | None = None,
+    api_data: dict | None = None,
     max_retries: int = 5,
 ) -> dict:
     """Call central_conn.command and retry up to max_retries on transient errors.
 
-    Does not sleep between attempts. On persistent server errors (5xx) or
-    rate-limit (429) this raises an exception so the caller can abort.
+    Args:
+        central_conn: pycentral connection object.
+        api_method: HTTP method (GET, POST, PUT, DELETE).
+        api_path: API endpoint path.
+        api_params: URL query parameters.
+        api_data: Request body payload (sent as JSON for POST/PUT).
+        max_retries: Max retry attempts for transient errors.
+
     Client errors (4xx) are raised immediately.
     """
     api_params = api_params or {}
+    api_data = api_data or {}
     last_response: dict | None = None
     for attempt in range(1, max_retries + 1):
         try:
@@ -209,6 +217,7 @@ def retry_central_command(
                 api_method=api_method,
                 api_path=api_path,
                 api_params=api_params,
+                api_data=api_data,
             )
         except Exception as exc:
             central_conn.logger.error(


### PR DESCRIPTION
pycentral command() uses api_data for JSON body, not api_params (query params). This caused 400 Bad Request on site creation. Added api_data to retry_central_command. Bump to 0.7.19.