### PR TITLE
Fix Central site payload format and revert to v1 API path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.20] - 2026-04-14
+
+### Fixed
+- Central site creation payload: timezone is required, all field values must use full names (no abbreviations). Updated tool description, INSTRUCTIONS.md, and TOOLS.md with correct format.
+
+[v0.7.20]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.20
+
 ## [v0.7.19] - 2026-04-14
 
 ### Fixed

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -900,7 +900,7 @@ No parameters. Returns a dict sorted by health score (worst first).
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | action_type | str | Yes | `create`, `update`, or `delete`. |
-| payload | dict | Yes | Site payload. For create: `address` required (or `latitude` + `longitude`). Optional: `name`, `city`, `state`, `country`, `zipcode`, `timezone`. |
+| payload | dict | Yes | Site payload. All values must use full names (no abbreviations). For create: `address`, `name`, `city`, `state`, `country`, `zipcode`, and `timezone` (object with `timezoneName`, `timezoneId`, `rawOffset` in ms) are required. |
 | site_id | str | No | Site ID. Required for update and delete. |
 
 #### `central_manage_site_collection`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.19"
+version = "0.7.20"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -117,7 +117,8 @@ When asked to create a new site based on an existing site:
 - **Audit Logs**: central_get_audit_logs, central_get_audit_log_detail
 - **Applications**: central_get_applications
 - **Troubleshooting**: central_ping, central_traceroute, central_cable_test, central_show_commands, central_disconnect_users_ssid, central_disconnect_users_ap, central_disconnect_client_ap, central_disconnect_client_gateway, central_disconnect_clients_gateway, central_port_bounce_switch, central_poe_bounce_switch, central_port_bounce_gateway, central_poe_bounce_gateway
-- **Configuration (Write)**: central_manage_site, central_manage_site_collection, central_manage_device_group — requires `ENABLE_WRITE_TOOLS=true`
+- **Configuration (Write)**: central_manage_site, central_manage_site_collection, central_manage_device_group — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`
+  - **Site creation payload**: All fields must use full names, no abbreviations (e.g. "Indiana" not "IN", "United States" not "US"). The `timezone` object is required and must include `timezoneName` (e.g. "Eastern Standard Time"), `timezoneId` (e.g. "America/Indiana/Indianapolis"), and `rawOffset` in milliseconds (e.g. -18000000 for EST). Determine the correct timezone from the address.
 
 ## Guidelines
 - ALWAYS start with `central_get_site_name_id_mapping` for a lightweight overview.

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -55,11 +55,14 @@ async def central_manage_site(
         dict,
         Field(
             description=(
-                "Site configuration payload. For create: 'address' is required "
-                "(or 'latitude' + 'longitude'). Optional fields: name, city, state, "
-                "country, zipcode, timezone (object with timezoneName, timezoneId, "
-                "rawOffset). For update: include only fields to change. "
-                "For delete: payload is ignored."
+                "Site configuration payload. IMPORTANT: All fields must use full names, "
+                "no abbreviations (e.g. 'Indiana' not 'IN', 'United States' not 'US'). "
+                "Required fields for create: address, name, city, state, country, zipcode, "
+                "and timezone. The timezone object must include timezoneName (e.g. "
+                "'Eastern Standard Time'), timezoneId (e.g. 'America/Indiana/Indianapolis'), "
+                "and rawOffset in milliseconds (e.g. -18000000 for EST). "
+                "Determine the correct timezone based on the site address. "
+                "For update: include only fields to change. For delete: payload is ignored."
             )
         ),
     ],

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -79,7 +79,7 @@ async def central_manage_site(
         ctx=ctx,
         action_type=action_type,
         resource_name="site",
-        api_path="network-config/v1alpha1/sites",
+        api_path="network-config/v1/sites",
         resource_id=site_id,
         payload=payload,
     )
@@ -121,7 +121,7 @@ async def central_manage_site_collection(
         ctx=ctx,
         action_type=action_type,
         resource_name="site collection",
-        api_path="network-config/v1alpha1/site-collections",
+        api_path="network-config/v1/site-collections",
         resource_id=collection_id,
         payload=payload,
     )
@@ -163,7 +163,7 @@ async def central_manage_device_group(
         ctx=ctx,
         action_type=action_type,
         resource_name="device group",
-        api_path="network-config/v1alpha1/device-groups",
+        api_path="network-config/v1/device-groups",
         resource_id=group_id,
         payload=payload,
     )
@@ -188,7 +188,7 @@ async def _execute_config_action(
         ctx: MCP context with lifespan_context containing central_conn.
         action_type: CREATE, UPDATE, or DELETE.
         resource_name: Human-readable name for elicitation messages.
-        api_path: Base API path (e.g. "network-config/v1alpha1/sites").
+        api_path: Base API path (e.g. "network-config/v1/sites").
         resource_id: Resource ID for update/delete operations.
         payload: Request payload for create/update.
 


### PR DESCRIPTION
## Summary

- Timezone is required for site creation, all field values must use full names (no abbreviations)
- Updated tool description, INSTRUCTIONS.md, and TOOLS.md with correct payload format
- Reverted API path from v1alpha1 back to v1 (the v1alpha1 change was not needed — the original DNS failure was due to passing payload as query params)
- Bump to 0.7.20

## Test plan

- [ ] CI passes
- [ ] Create a site with full payload (name, address, city, state, country, zipcode, timezone) — succeeds