### PR TITLE
Rename central_get_sites to central_get_site_health, add new central_get_sites (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.21] - 2026-04-14
+
+### Added
+- `central_get_sites` — new tool returning site configuration data (address, timezone, scopeName) from `network-config/v1/sites` with OData filter and sort support
+
+### Changed
+- Renamed old `central_get_sites` → `central_get_site_health` to accurately reflect it returns health metrics, not site config data
+- Central tool count: 45 → 46 (+ 12 prompts)
+
+### Fixed
+- `central_get_site_health` crash (`KeyError: 'name'`) when sites returned from the health API lack a `name` field (e.g. newly created sites)
+
+[v0.7.21]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.7.21
+
 ## [v0.7.20] - 2026-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling t
 | **Scope & Configuration Hierarchy** | — | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — |
 | **Dynamic API Discovery** | — | — | ✅ |
-| **Tools** | **35 + 2 prompts** | **45 + 12 prompts** | **3 or 10** |
+| **Tools** | **35 + 2 prompts** | **46 + 12 prompts** | **3 or 10** |
 
 > **GreenLake tool count**: 3 tools in **dynamic mode** (default) — a meta-tool system that can discover and invoke any GreenLake API endpoint. 10 tools in **static mode** — dedicated tools for each endpoint. Set via `MCP_TOOL_MODE` environment variable.
 
@@ -296,7 +296,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 │   ┌────────────┐ ┌────────────┐ ┌────────────────┐  │
 │   │   Mist     │ │  Central   │ │   GreenLake    │  │
 │   │  mist_*    │ │ central_*  │ │  greenlake_*   │  │
-│   │ 35+2 prmt  │ │ 45+12 prmt │ │  3/10 tools    │  │
+│   │ 35+2 prmt  │ │ 46+12 prmt │ │  3/10 tools    │  │
 │   └─────┬──────┘ └─────┬──────┘ └───────┬────────┘  │
 │         │              │                │            │
 └─────────┼──────────────┼────────────────┼────────────┘
@@ -400,7 +400,7 @@ hpe-networking-mcp/
 │   ├── middleware/              # Elicitation and null-strip middleware
 │   └── platforms/
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
-│       ├── central/             # 45 Central tools + 12 prompts + API client
+│       ├── central/             # 46 Central tools + 12 prompts + API client
 │       └── greenlake/           # 3 dynamic or 10 static tools + OAuth2 client
 ├── tests/                       # Unit and integration tests (176 tests)
 ├── docs/                        # PRD, PRP, tool reference

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,7 +9,7 @@ and `greenlake_*` (HPE GreenLake).
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
-| Aruba Central | 42 | 3 | 12 | 57 |
+| Aruba Central | 43 | 3 | 12 | 58 |
 | HPE GreenLake (static mode) | 10 | -- | -- | 10 |
 | HPE GreenLake (dynamic mode) | 3 | -- | -- | 3 |
 
@@ -502,13 +502,24 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Aruba Central (45 tools + 12 prompts)
+## Aruba Central (46 tools + 12 prompts)
 
 ### Sites
 
 #### `central_get_sites`
 
-> Returns detailed metrics for one or more sites. Prefer calling with a site_names filter.
+> Returns site configuration data (address, timezone, scopeName) from the network-config API. Use for site details. For health metrics, use `central_get_site_health`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| filter | str | No | OData 4.0 filter on scopeName, address, city, state, country, zipcode, collectionName. |
+| sort | str | No | Sort by scopeName, address, state, country, city, deviceCount, collectionName, zipcode, timezone, longitude, latitude. |
+| limit | int | No | Results per page (1-100, default 100). |
+| offset | int | No | Pagination offset (default 0). |
+
+#### `central_get_site_health`
+
+> Returns health metrics and device/client counts for sites. For site config data, use `central_get_sites`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.20"
+version = "0.7.21"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -95,10 +95,13 @@ When asked to create a new site based on an existing site:
 
 ## Starting a Central Session
 1. `central_get_site_name_id_mapping` → lightweight overview of all sites with health scores
-2. `central_get_sites(site_names=[...])` → detailed metrics for specific sites of interest
+2. `central_get_site_health(site_names=[...])` → detailed health metrics for specific sites
+3. `central_get_sites` → site configuration data (address, timezone, etc.) from network-config API
 
 ## Tool Categories
-- **Sites**: central_get_sites, central_get_site_name_id_mapping
+- **Sites**: central_get_sites, central_get_site_health, central_get_site_name_id_mapping
+  - Use `central_get_sites` for site configuration data (address, timezone, scopeName). Supports OData filter on scopeName, address, city, state, country, zipcode, collectionName.
+  - Use `central_get_site_health` for health metrics and device/client counts. Pass site_names to filter.
 - **Devices**: central_get_devices, central_find_device, central_get_ap_details, central_get_switch_details, central_get_gateway_details
 - **Device Stats**: central_get_ap_stats, central_get_ap_utilization, central_get_gateway_stats, central_get_gateway_utilization, central_get_gateway_wan_availability, central_get_tunnel_health
 - **Switch PoE & Trends**: central_get_switch_hardware_trends, central_get_switch_poe
@@ -122,7 +125,7 @@ When asked to create a new site based on an existing site:
 
 ## Guidelines
 - ALWAYS start with `central_get_site_name_id_mapping` for a lightweight overview.
-- Call `central_get_sites` with a `site_names` filter — never without a filter unless explicitly requested.
+- Call `central_get_site_health` with a `site_names` filter for health data — never without a filter unless explicitly requested.
 - Recommendations must be based strictly on API response data.
 - Direct users to HPE Aruba Networking Central for authoritative view and remediation.
 

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -9,7 +9,7 @@ from hpe_networking_mcp.config import ServerConfig
 
 # Tool categories mapped to module names and their tool names
 TOOLS = {
-    "sites": ["central_get_sites", "central_get_site_name_id_mapping"],
+    "sites": ["central_get_sites", "central_get_site_health", "central_get_site_name_id_mapping"],
     "devices": ["central_get_devices", "central_find_device"],
     "clients": ["central_get_clients", "central_find_client"],
     "alerts": ["central_get_alerts"],

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -35,7 +35,7 @@ async def central_get_alerts(
     cursor: int | None = None,
 ) -> PaginatedAlerts | str:
     """
-    REQUIRES site_id — call central_get_sites(site_names=["<site name>"]) and extract
+    REQUIRES site_id — call central_get_site_health(site_names=["<site name>"]) and extract
     site_id from the returned SiteData. Do NOT call this tool without a site_id; it will
     fail validation.
 
@@ -51,7 +51,7 @@ async def central_get_alerts(
 
     Parameters:
         - site_id: Site identifier. Obtain by calling
-          central_get_sites(site_names=["<name>"]) and reading site_id from the result.
+          central_get_site_health(site_names=["<name>"]) and reading site_id from the result.
         - status: "Active" (default) for unresolved alerts, "Cleared" for resolved ones.
         - device_type: Narrow to a device class — "Access Point", "Gateway", "Switch",
           or "Bridge".

--- a/src/hpe_networking_mcp/platforms/central/tools/prompts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/prompts.py
@@ -9,7 +9,7 @@ Provide a full network health overview by following these steps:
 1. Call `central_get_site_name_id_mapping` to get all sites with health scores, \
 device/client/alert counts.
 2. Identify sites with poor or fair health, or notably high alert counts.
-3. Call `central_get_sites` with only those site names(maximum 5) to get detailed \
+3. Call `central_get_site_health` with only those site names(maximum 5) to get detailed \
 metrics.
 4. Summarize per site: health score, device/client/alert totals, and any notable \
 issues.
@@ -25,7 +25,7 @@ Troubleshoot the site "{site_name}" by following these steps:
 
 1. Call `central_get_site_name_id_mapping` to verify the site name and get its \
 site_id and current health score.
-2. Call `central_get_sites` with site_names=["{site_name}"] to get detailed site \
+2. Call `central_get_site_health` with site_names=["{site_name}"] to get detailed site \
 metrics.
 3. Call `central_get_alerts` with the site_id and status="Active" to get all \
 active alerts. Prioritize by severity (Critical > High > Medium > Low).
@@ -173,7 +173,7 @@ Compare health across sites: {sites_str}
 
 1. Call `central_get_site_name_id_mapping` to verify all site names and get \
 their site_ids and health scores.
-2. Call `central_get_sites` with site_names={list(site_names)} to get \
+2. Call `central_get_site_health` with site_names={list(site_names)} to get \
 detailed metrics for each site.
 3. For each site, call `central_get_alerts` with the site_id and \
 status="Active" to get active alert counts by severity.

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -7,13 +7,62 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     fetch_site_data_parallel,
     groups_to_map,
+    retry_central_command,
 )
 
 
 @mcp.tool(annotations=READ_ONLY)
-async def central_get_sites(ctx: Context, site_names: list[str] | None = None) -> list[SiteData]:
+async def central_get_sites(
+    ctx: Context,
+    filter: str | None = None,
+    sort: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict | str:
     """
-    Returns detailed metrics for one or more sites.
+    Returns site configuration data from Aruba Central (address, timezone, etc.).
+
+    Use this tool when you need site details like address, city, state, country,
+    zipcode, timezone, or scopeName. For site health metrics and device/client
+    counts, use central_get_site_health instead.
+
+    Parameters:
+        filter: OData 4.0 filter string. Supports filtering on scopeName,
+            address, city, state, country, zipcode, collectionName.
+            Example: "scopeName eq 'Moms House'" or "state eq 'Indiana'"
+        sort: Sort by field. One of scopeName, address, state, country, city,
+            deviceCount, collectionName, zipcode, timezone, longitude, latitude.
+        limit: Number of sites to return (1-100, default 100).
+        offset: Offset for pagination (default 0).
+
+    Returns:
+        Dict with sites list and pagination info.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+    api_params: dict = {"limit": limit, "offset": offset}
+    if filter:
+        api_params["filter"] = filter
+    if sort:
+        api_params["sort"] = sort
+
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path="network-config/v1/sites",
+        api_params=api_params,
+    )
+    return response.get("msg", {})
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_site_health(
+    ctx: Context,
+    site_names: list[str] | None = None,
+) -> list[SiteData]:
+    """
+    Returns health metrics and device/client counts for sites.
+
+    For site configuration data (address, timezone, etc.), use central_get_sites.
 
     Prefer calling with a site_names filter targeting only the sites you care about.
     Do NOT call without a filter unless the user explicitly requests data for all
@@ -25,8 +74,8 @@ async def central_get_sites(ctx: Context, site_names: list[str] | None = None) -
     this tool with those specific site names.
 
     Parameters:
-    - site_names: One or more site name to filter by. Supports exact matches.
-      If omitted, all sites are returned (use sparingly or when explicitly requested).
+        site_names: One or more site names to filter by (exact match).
+            If omitted, all sites are returned (use sparingly).
     """
     sites_data = fetch_site_data_parallel(ctx.lifespan_context["central_conn"])
     if site_names:
@@ -42,7 +91,7 @@ async def central_get_site_name_id_mapping(ctx: Context) -> dict:
     to help quickly identify sites that may need attention. Sites with
     unknown/None health values are placed last.
 
-    Use this before calling central_get_sites or any endpoint that requires a
+    Use this before calling central_get_site_health or any endpoint that requires a
     site_id. It is especially useful when the user provides a partial or ambiguous
     site name — verify the correct name here, then pass it to the appropriate tool.
     The health score also helps identify sites with issues before drilling down

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -98,15 +98,19 @@ def process_site_health_data(
     Returns:
         dict: Dictionary of site names to SiteData objects
     """
-    processed_sites: dict[str, SiteData] = {site["name"]: transform_to_site_data(site) for site in site_health}
+    processed_sites: dict[str, SiteData] = {
+        site["name"]: transform_to_site_data(site) for site in site_health if "name" in site
+    }
 
     for site in device_health:
-        if site["name"] in processed_sites:
-            processed_sites[site["name"]].metrics.devices["Details"] = groups_to_map(site["deviceTypes"])
+        site_name = site.get("name", "")
+        if site_name in processed_sites:
+            processed_sites[site_name].metrics.devices["Details"] = groups_to_map(site["deviceTypes"])
 
     for site in client_health:
-        if site["name"] in processed_sites:
-            processed_sites[site["name"]].metrics.clients["Details"] = groups_to_map(site["clientTypes"])
+        site_name = site.get("name", "")
+        if site_name in processed_sites:
+            processed_sites[site_name].metrics.clients["Details"] = groups_to_map(site["clientTypes"])
 
     return processed_sites
 


### PR DESCRIPTION
## Summary (closes #92)

- **Rename** `central_get_sites` → `central_get_site_health` — accurately reflects it returns health metrics from the monitoring API
- **New** `central_get_sites` — returns site configuration data (address, timezone, scopeName) from `GET /network-config/v1/sites` with OData filter and sort support
- **Fix** `KeyError: 'name'` crash in `process_site_health_data` when sites lack a `name` field
- Updated all references in prompts, alerts, configuration, INSTRUCTIONS.md, TOOLS.md, README.md
- Central tool count: 45 → 46 (+ 12 prompts)
- Version bump to 0.7.21

## Test plan

- [ ] CI passes
- [ ] `central_get_sites` returns site config data with address/timezone
- [ ] `central_get_sites(filter="scopeName eq 'Moms House'")` returns filtered results
- [ ] `central_get_site_health` still returns health metrics as before
- [ ] Newly created sites don't crash `central_get_site_health`