### PR TITLE
v0.8.0: Fix Central delete/update, confirmation loop, site collection management (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.0] - 2026-04-14
+
+### Fixed — Central Write Tools (#99)
+- Central delete operations now use bulk endpoint (`DELETE {path}/bulk` with `{"items": [{"id": "..."}]}`) instead of appending ID to URL path
+- Central update operations now pass `scopeId` in request body instead of URL path
+- Confirmation loop fix: added `confirmed` parameter to all write tools (Mist + Central). When `confirmed=true`, skips re-prompting. The AI sets this after the user confirms in chat.
+
+### Added — Site Collection Management
+- `add_sites` and `remove_sites` action types for `central_manage_site_collection`
+- Uses `POST /network-config/v1/site-collection-add-sites` and `DELETE /network-config/v1/site-collection-remove-sites`
+
+[v0.8.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.8.0
+
 ## [v0.7.21] - 2026-04-14
 
 ### Added

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -916,13 +916,14 @@ No parameters. Returns a dict sorted by health score (worst first).
 
 #### `central_manage_site_collection`
 
-> Create, update, or delete a site collection in Aruba Central. Requires `ENABLE_CENTRAL_WRITE_TOOLS=true`.
+> Create, update, delete, or manage sites within a site collection. Requires `ENABLE_CENTRAL_WRITE_TOOLS=true`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| action_type | str | Yes | `create`, `update`, or `delete`. |
-| payload | dict | Yes | Site collection payload. For create: `scopeName` required. Optional: `description`, `siteIds`. |
-| collection_id | str | No | Collection ID. Required for update and delete. |
+| action_type | str | Yes | `create`, `update`, `delete`, `add_sites`, or `remove_sites`. |
+| payload | dict | Yes | For create: `scopeName` required, optional `description`, `siteIds`. For add_sites/remove_sites: `siteIds` list required. |
+| collection_id | str | No | Collection ID. Required for update, delete, add_sites, remove_sites. |
+| confirmed | bool | No | Set to true after user confirms update/delete in chat. |
 
 #### `central_manage_device_group`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.7.21"
+version = "0.8.0"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -1,8 +1,8 @@
 """Aruba Central configuration write tools — sites, site collections, device groups.
 
 Provides CRUD operations for Central network configuration objects.
-All write tools are gated behind ENABLE_WRITE_TOOLS and require user
-confirmation via elicitation before executing.
+All write tools are gated behind ENABLE_CENTRAL_WRITE_TOOLS and require
+user confirmation for update/delete operations.
 """
 
 from enum import Enum
@@ -18,13 +18,6 @@ from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms.central._registry import mcp
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
-WRITE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 WRITE_DELETE = ToolAnnotations(
     readOnlyHint=False,
     destructiveHint=True,
@@ -37,6 +30,14 @@ class ActionType(Enum):
     CREATE = "create"
     UPDATE = "update"
     DELETE = "delete"
+
+
+class CollectionActionType(Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+    ADD_SITES = "add_sites"
+    REMOVE_SITES = "remove_sites"
 
 
 # ------------------------------------------------------------------
@@ -73,6 +74,13 @@ async def central_manage_site(
             default=None,
         ),
     ],
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | str:
     """Create, update, or delete a site in Aruba Central."""
     return await _execute_config_action(
@@ -82,6 +90,7 @@ async def central_manage_site(
         api_path="network-config/v1/sites",
         resource_id=site_id,
         payload=payload,
+        confirmed=confirmed,
     )
 
 
@@ -94,8 +103,14 @@ async def central_manage_site(
 async def central_manage_site_collection(
     ctx: Context,
     action_type: Annotated[
-        ActionType,
-        Field(description="Action to perform: create, update, or delete."),
+        CollectionActionType,
+        Field(
+            description=(
+                "Action to perform: create, update, delete, add_sites, or remove_sites. "
+                "Use add_sites to add sites to an existing collection. "
+                "Use remove_sites to remove sites from a collection."
+            )
+        ),
     ],
     payload: Annotated[
         dict,
@@ -103,7 +118,8 @@ async def central_manage_site_collection(
             description=(
                 "Site collection payload. For create: 'scopeName' is required. "
                 "Optional: 'description', 'siteIds' (list of site IDs to include). "
-                "For update: include only fields to change. "
+                "For update: include fields to change plus 'scopeId'. "
+                "For add_sites/remove_sites: provide 'scopeId' and 'siteIds' list. "
                 "For delete: payload is ignored."
             )
         ),
@@ -111,19 +127,35 @@ async def central_manage_site_collection(
     collection_id: Annotated[
         str | None,
         Field(
-            description=("Site collection ID. Required for update and delete. Obtain from central_get_scope_tree."),
+            description=("Site collection ID. Required for update, delete, add_sites, remove_sites."),
             default=None,
         ),
     ],
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | str:
-    """Create, update, or delete a site collection in Aruba Central."""
+    """Create, update, delete, or manage sites within a site collection."""
+    if action_type == CollectionActionType.ADD_SITES:
+        return await _execute_collection_site_action(
+            ctx=ctx, action="add", collection_id=collection_id, payload=payload
+        )
+    if action_type == CollectionActionType.REMOVE_SITES:
+        return await _execute_collection_site_action(
+            ctx=ctx, action="remove", collection_id=collection_id, payload=payload
+        )
     return await _execute_config_action(
         ctx=ctx,
-        action_type=action_type,
+        action_type=ActionType(action_type.value),
         resource_name="site collection",
         api_path="network-config/v1/site-collections",
         resource_id=collection_id,
         payload=payload,
+        confirmed=confirmed,
     )
 
 
@@ -145,7 +177,7 @@ async def central_manage_device_group(
             description=(
                 "Device group payload. For create: 'scopeName' is required. "
                 "Optional: 'description'. "
-                "For update: include only fields to change. "
+                "For update: include fields to change plus 'scopeId'. "
                 "For delete: payload is ignored."
             )
         ),
@@ -157,6 +189,13 @@ async def central_manage_device_group(
             default=None,
         ),
     ],
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | str:
     """Create, update, or delete a device group in Aruba Central."""
     return await _execute_config_action(
@@ -166,11 +205,12 @@ async def central_manage_device_group(
         api_path="network-config/v1/device-groups",
         resource_id=group_id,
         payload=payload,
+        confirmed=confirmed,
     )
 
 
 # ---------------------------------------------------------------------------
-# Shared execution helper
+# Shared execution helpers
 # ---------------------------------------------------------------------------
 
 
@@ -181,19 +221,14 @@ async def _execute_config_action(
     api_path: str,
     resource_id: str | None,
     payload: dict,
+    confirmed: bool = False,
 ) -> dict | str:
-    """Execute a configuration CRUD action with elicitation and error handling.
+    """Execute a configuration CRUD action with confirmation and error handling.
 
-    Args:
-        ctx: MCP context with lifespan_context containing central_conn.
-        action_type: CREATE, UPDATE, or DELETE.
-        resource_name: Human-readable name for elicitation messages.
-        api_path: Base API path (e.g. "network-config/v1/sites").
-        resource_id: Resource ID for update/delete operations.
-        payload: Request payload for create/update.
-
-    Returns:
-        API response dict or error string.
+    Central API patterns:
+    - CREATE: POST to base path, payload as JSON body
+    - UPDATE: PUT to base path, payload includes scopeId to identify resource
+    - DELETE: DELETE to {path}/bulk, body is {"items": [{"id": "..."}]}
     """
     if action_type in (ActionType.UPDATE, ActionType.DELETE) and not resource_id:
         raise ToolError(f"Resource ID is required for {action_type.value} operations.")
@@ -204,8 +239,8 @@ async def _execute_config_action(
         ActionType.DELETE: "delete an existing",
     }[action_type]
 
-    # Confirm with user for update and delete operations only
-    if action_type != ActionType.CREATE:
+    # Confirm with user for update and delete only (skip if already confirmed)
+    if action_type != ActionType.CREATE and not confirmed:
         elicitation_response = await elicitation_handler(
             message=(f"The LLM wants to {action_wording} {resource_name}. Do you accept to trigger the API call?"),
             ctx=ctx,
@@ -217,7 +252,7 @@ async def _execute_config_action(
                     "message": (
                         f"This operation will {action_wording} {resource_name}. "
                         "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters after the user confirms."
+                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}
@@ -226,17 +261,18 @@ async def _execute_config_action(
 
     conn = ctx.lifespan_context["central_conn"]
 
-    method_map = {
-        ActionType.CREATE: "POST",
-        ActionType.UPDATE: "PUT",
-        ActionType.DELETE: "DELETE",
-    }
-    api_method = method_map[action_type]
-    full_path = f"{api_path}/{resource_id}" if resource_id else api_path
-
-    api_data: dict = {}
-    if action_type != ActionType.DELETE:
+    if action_type == ActionType.CREATE:
+        api_method = "POST"
+        full_path = api_path
         api_data = payload
+    elif action_type == ActionType.UPDATE:
+        api_method = "PUT"
+        full_path = api_path
+        api_data = {**payload, "scopeId": resource_id}
+    else:
+        api_method = "DELETE"
+        full_path = f"{api_path}/bulk"
+        api_data = {"items": [{"id": resource_id}]}
 
     logger.info("Central config: {} {} — path: {}", api_method, resource_name, full_path)
 
@@ -253,6 +289,61 @@ async def _execute_config_action(
             "status": "success",
             "action": action_type.value,
             "resource": resource_name,
+            "data": response.get("msg", {}),
+        }
+
+    return {
+        "status": "error",
+        "code": code,
+        "message": response.get("msg", "Unknown error"),
+    }
+
+
+async def _execute_collection_site_action(
+    ctx: Context,
+    action: str,
+    collection_id: str | None,
+    payload: dict,
+) -> dict | str:
+    """Add or remove sites from a site collection.
+
+    Args:
+        action: "add" or "remove".
+        collection_id: The site collection ID.
+        payload: Must contain 'siteIds' list.
+    """
+    if not collection_id:
+        raise ToolError("collection_id is required for add_sites/remove_sites.")
+
+    site_ids = payload.get("siteIds", [])
+    if not site_ids:
+        raise ToolError("payload must contain 'siteIds' list.")
+
+    conn = ctx.lifespan_context["central_conn"]
+
+    if action == "add":
+        api_method = "POST"
+        api_path = "network-config/v1/site-collection-add-sites"
+    else:
+        api_method = "DELETE"
+        api_path = "network-config/v1/site-collection-remove-sites"
+
+    api_data = {"scopeId": collection_id, "siteIds": site_ids}
+    logger.info("Central config: {} sites {} collection {}", action, len(site_ids), collection_id)
+
+    response = retry_central_command(
+        central_conn=conn,
+        api_method=api_method,
+        api_path=api_path,
+        api_data=api_data,
+    )
+
+    code = response.get("code", 0)
+    if 200 <= code < 300:
+        return {
+            "status": "success",
+            "action": f"{action}_sites",
+            "resource": "site collection",
             "data": response.get("msg", {}),
         }
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -143,6 +143,13 @@ async def change_org_configuration_objects(
         ),
     ],
     ctx: Context,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | list | str:
     """Update, create or delete configuration object for a specified org."""
 
@@ -183,7 +190,7 @@ async def change_org_configuration_objects(
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
     # Confirm with user for update and delete operations only
-    if action_type != Action_type.CREATE:
+    if action_type != Action_type.CREATE and not confirmed:
         elicitation_response = await elicitation_handler(
             message=(
                 f"The LLM wants to {action_wording} {object_type.value}. "
@@ -198,7 +205,7 @@ async def change_org_configuration_objects(
                     "message": (
                         f"This operation will {action_wording} {object_type.value}. "
                         "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters after the user confirms."
+                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
@@ -120,6 +120,13 @@ async def change_site_configuration_objects(
         ),
     ],
     ctx: Context,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | list | str:
     """Update, create or delete a configuration object for a specified site."""
 
@@ -160,7 +167,7 @@ async def change_site_configuration_objects(
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
     # Confirm with user for update and delete operations only
-    if action_type != Action_type.CREATE:
+    if action_type != Action_type.CREATE and not confirmed:
         elicitation_response = await elicitation_handler(
             message=(
                 f"The LLM wants to {action_wording} {object_type.value}. "
@@ -175,7 +182,7 @@ async def change_site_configuration_objects(
                     "message": (
                         f"This operation will {action_wording} {object_type.value}. "
                         "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters after the user confirms."
+                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -135,6 +135,13 @@ async def update_org_configuration_objects(
         ),
     ],
     ctx: Context,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | list | str:
     """Update or create configuration object for a specified org."""
 
@@ -159,7 +166,7 @@ async def update_org_configuration_objects(
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
     # Confirm with user for update operations only (object_id present = update)
-    if object_id:
+    if object_id and not confirmed:
         elicitation_response = await elicitation_handler(
             message=(
                 f"The LLM wants to {action_wording} {object_type.value}. "
@@ -174,7 +181,7 @@ async def update_org_configuration_objects(
                     "message": (
                         f"This operation will {action_wording} {object_type.value}. "
                         "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters after the user confirms."
+                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
@@ -109,6 +109,13 @@ async def update_site_configuration_objects(
         ),
     ],
     ctx: Context,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            default=False,
+        ),
+    ],
 ) -> dict | list | str:
     """Update or create config object for a specified site."""
 
@@ -133,7 +140,7 @@ async def update_site_configuration_objects(
         guardrail_notice = "\n\n" + "\n".join(guardrails.warnings[:3])
 
     # Confirm with user for update operations only (object_id present = update)
-    if object_id:
+    if object_id and not confirmed:
         elicitation_response = await elicitation_handler(
             message=(
                 f"The LLM wants to {action_wording} {object_type.value}. "
@@ -148,7 +155,7 @@ async def update_site_configuration_objects(
                     "message": (
                         f"This operation will {action_wording} {object_type.value}. "
                         "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters after the user confirms."
+                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}


### PR DESCRIPTION
## Summary (closes #99)

### Fixed
- **Central delete** — now uses bulk endpoint (`DELETE {path}/bulk` with `{"items": [{"id": "..."}]}`)
- **Central update** — passes `scopeId` in request body instead of URL path
- **Confirmation loop** — added `confirmed` parameter to all 5 write tools (4 Mist + 1 Central). AI sets `confirmed=true` after user confirms in chat, breaking the loop.

### Added
- `add_sites` and `remove_sites` action types for `central_manage_site_collection`

### Files Changed
- `central/tools/configuration.py` — rewritten `_execute_config_action` + new `_execute_collection_site_action`
- 4 Mist write tools — added `confirmed` param + updated elicitation check
- CHANGELOG.md, TOOLS.md, pyproject.toml

## Test plan

- [ ] CI passes
- [ ] Delete a site in Central → bulk delete succeeds
- [ ] Delete a site collection → bulk delete succeeds
- [ ] Update a site collection → PUT with scopeId in body succeeds
- [ ] Delete with `DISABLE_ELICITATION=false` → AI asks, user confirms, AI calls with `confirmed=true` → succeeds
- [ ] Add sites to a collection via `add_sites` action
- [ ] Mist delete still works as before