### PR TITLE
Add opmode enum docs, strengthen cross-platform sync guidance

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -916,13 +916,28 @@ No parameters. Returns a dict sorted by health score (worst first).
 #### `central_manage_wlan_profile`
 
 > Create, update, or delete a WLAN SSID profile. Requires `ENABLE_CENTRAL_WRITE_TOOLS=true`.
+>
+> **For cross-platform WLAN sync, use the sync prompts instead of calling this tool directly.**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | ssid | str | Yes | SSID name (used as identifier in API path). |
 | action_type | str | Yes | `create`, `update`, or `delete`. |
-| payload | dict | Yes | WLAN profile config. Key fields: essid, opmode, forward-mode, vlan-name. |
+| payload | dict | Yes | WLAN profile config (see valid values below). |
 | confirmed | bool | No | Set to true after user confirms update/delete in chat. |
+
+**Valid `opmode` values** (do NOT invent values — use only these):
+
+`OPEN`, `WPA2_PERSONAL`, `WPA3_SAE`, `WPA2_ENTERPRISE`, `WPA3_ENTERPRISE_CCM_128`,
+`WPA3_ENTERPRISE_GCM_256`, `WPA3_ENTERPRISE_CNSA`, `WPA_ENTERPRISE`, `WPA_PERSONAL`,
+`WPA2_MPSK_AES`, `WPA2_MPSK_LOCAL`, `ENHANCED_OPEN`, `DPP`, `WPA2_PSK_AES_DPP`,
+`WPA2_AES_DPP`, `WPA3_SAE_DPP`, `WPA3_AES_CCM_128_DPP`, `WPA3_AES_GCM_256_DPP`,
+`BOTH_WPA_WPA2_PSK`, `BOTH_WPA_WPA2_DOT1X`, `STATIC_WEP`, `DYNAMIC_WEP`
+
+**Other key enums**: `forward-mode`: `FORWARD_MODE_BRIDGE`, `FORWARD_MODE_L2` |
+`rf-band`: `BAND_ALL`, `24GHZ_5GHZ`, `5GHZ_6GHZ`, `24GHZ`, `5GHZ`, `6GHZ`, `BAND_NONE` |
+`vlan-selector`: `NAMED_VLAN` (with `vlan-name`), `VLAN_RANGES` (with `vlan-id-range`) |
+`out-of-service`: `NONE`, `UPLINK_DOWN`, `TUNNEL_DOWN`
 
 ### Aliases, Server Groups, Named VLANs
 

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -123,6 +123,9 @@ When asked to create a new site based on an existing site:
 - **WLAN Profiles**: central_get_wlan_profiles, central_manage_wlan_profile
   - Use `central_get_wlan_profiles` to read WLAN SSID profile configurations from the library
   - Use `central_manage_wlan_profile` to create, update, or delete WLAN profiles — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`
+  - **Valid opmode values**: OPEN, WPA2_PERSONAL, WPA3_SAE, WPA2_ENTERPRISE, WPA3_ENTERPRISE_CCM_128, WPA2_MPSK_AES, ENHANCED_OPEN, DPP. Note: `WPA2_PSK_AES` does NOT exist — use `WPA2_PERSONAL` for WPA2 PSK.
+  - **Mist-to-Central opmode mapping**: Mist psk → `WPA2_PERSONAL`, Mist psk+wpa3 → `WPA3_SAE`, Mist eap → `WPA2_ENTERPRISE`, Mist eap+wpa3+wpa2 → `WPA3_ENTERPRISE_CCM_128`
+  - **NEVER call this tool directly for cross-platform WLAN sync** — use the sync prompts instead
 - **Aliases, Server Groups, Named VLANs**: central_get_aliases, central_get_server_groups, central_get_named_vlans
   - Use `central_get_aliases` to resolve alias names used in WLAN profiles (SSID aliases, PSK aliases), server groups, and VLANs. Aliases can be scoped per-site.
   - Use `central_get_server_groups` to resolve a server group name (from auth-server-group) to actual RADIUS server addresses (FQDN or IP), ports, and settings
@@ -131,14 +134,24 @@ When asked to create a new site based on an existing site:
   - **Site creation payload**: All fields must use full names, no abbreviations (e.g. "Indiana" not "IN", "United States" not "US"). The `timezone` object is required and must include `timezoneName` (e.g. "Eastern Standard Time"), `timezoneId` (e.g. "America/Indiana/Indianapolis"), and `rawOffset` in milliseconds (e.g. -18000000 for EST). Determine the correct timezone from the address.
 
 ## Cross-Platform WLAN Sync (shared prompts — requires both Mist and Central)
-When asked to add, copy, sync, or port a WLAN from one platform to another — **ALWAYS use the sync prompts**. Do NOT call write tools directly for cross-platform WLAN operations.
+
+**MANDATORY**: When the user asks to add, copy, sync, port, migrate, or create a WLAN that involves BOTH platforms (e.g. "add this Mist WLAN to Central", "copy SSID X from Central to Mist", "sync WLANs"), you MUST use the sync prompts below. Do NOT call `central_manage_wlan_profile` or `mist_change_org_configuration_objects` directly for cross-platform WLAN operations. Doing so will produce incorrect configurations because:
+1. Opmode values differ between platforms and require translation
+2. RADIUS server groups, aliases, and template variables need resolution
+3. VLAN names vs IDs need mapping
+4. Template/scope assignments must be checked and replicated
+5. Data rate profiles need translation
+
+**Prompts**:
 - Use `sync_wlans_mist_to_central` to sync Mist WLANs to Central
 - Use `sync_wlans_central_to_mist` to sync Central WLANs to Mist
 - Use `sync_wlans_bidirectional` to compare and sync both directions
+
+**Rules**:
 - Only sync bridged (non-tunneled) SSIDs. Skip tunneled SSIDs automatically.
-- From Mist: only sync WLANs that are in templates (not site-level)
+- From Mist: only sync WLANs that are in templates (not site-level). Always look up which template the WLAN belongs to and which site groups the template is assigned to.
 - From Central: deduplicate — if same SSID appears in multiple scopes, create only one Mist WLAN
-- Assignment mapping: Global→org, site collection→site group, specific sites→specific sites
+- Assignment mapping: Global→org, site collection→site group, specific sites→specific sites. Always check and replicate assignments — do not just create the profile without assigning it.
 
 ### Resolution Workflows
 The sync prompts handle these resolution steps automatically:

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -73,10 +73,29 @@ async def central_manage_wlan_profile(
         dict,
         Field(
             description=(
-                "WLAN SSID profile payload. For create/update: the full or partial "
-                "profile configuration. Key fields include essid.name, opmode, "
-                "forward-mode, vlan-name, personal-security, dot1x, rf-band. "
-                "For delete: payload is ignored."
+                "WLAN SSID profile payload. For delete: payload is ignored. "
+                "For create/update, key fields and their valid values:\n"
+                "- essid: {name: str} or {alias: str, use-alias: true}\n"
+                "- opmode (REQUIRED): OPEN, WPA2_PERSONAL, WPA3_SAE, "
+                "WPA2_ENTERPRISE, WPA3_ENTERPRISE_CCM_128, WPA3_ENTERPRISE_GCM_256, "
+                "WPA3_ENTERPRISE_CNSA, WPA_ENTERPRISE, WPA_PERSONAL, WPA2_MPSK_AES, "
+                "WPA2_MPSK_LOCAL, ENHANCED_OPEN, DPP, WPA2_PSK_AES_DPP, "
+                "WPA2_AES_DPP, WPA3_SAE_DPP, WPA3_AES_CCM_128_DPP, "
+                "WPA3_AES_GCM_256_DPP, BOTH_WPA_WPA2_PSK, BOTH_WPA_WPA2_DOT1X, "
+                "STATIC_WEP, DYNAMIC_WEP. "
+                "For PSK WLANs use WPA2_PERSONAL (not WPA2_PSK_AES which is invalid). "
+                "For WPA3 PSK use WPA3_SAE. "
+                "For WPA3+WPA2 transition use WPA3_SAE with wpa3-transition-mode-enable: true\n"
+                "- personal-security: {passphrase-format: 'STRING', wpa-passphrase: str}\n"
+                "- forward-mode: FORWARD_MODE_BRIDGE, FORWARD_MODE_L2\n"
+                "- rf-band: BAND_ALL, 24GHZ_5GHZ, 5GHZ_6GHZ, 24GHZ_6GHZ, "
+                "24GHZ, 5GHZ, 6GHZ, BAND_NONE\n"
+                "- vlan-selector: NAMED_VLAN (with vlan-name) or VLAN_RANGES "
+                "(with vlan-id-range: [str])\n"
+                "- out-of-service: NONE, UPLINK_DOWN, TUNNEL_DOWN\n"
+                "- broadcast-filter-ipv4: BCAST_FILTER_ARP, FILTER_NONE\n"
+                "- See existing profiles via central_get_wlan_profiles for "
+                "complete field reference."
             )
         ),
     ],
@@ -91,18 +110,24 @@ async def central_manage_wlan_profile(
     """
     Create, update, or delete a WLAN SSID profile in Central's library.
 
-    The SSID name is the identifier — it appears in the API path.
-    Profiles created here are added to the Central WLAN library.
-    They must be assigned to scopes (Global, site collections, or sites)
-    separately to take effect on APs.
+    **STOP — CHECK BEFORE CALLING**: If the user asked to add, copy, sync,
+    port, or migrate a WLAN from Mist to Central (or vice versa), you MUST
+    use the sync prompts instead of calling this tool directly:
+    - sync_wlans_mist_to_central
+    - sync_wlans_central_to_mist
+    - sync_wlans_bidirectional
+    Those prompts handle field translation, opmode mapping, alias resolution,
+    server group mapping, template variable creation, VLAN resolution, and
+    scope assignment automatically. Calling this tool directly for cross-
+    platform operations will produce incorrect configurations.
 
-    IMPORTANT: When creating a WLAN from Mist data or when asked to
-    add/copy/sync a WLAN between platforms, use the sync_wlans_mist_to_central
-    or sync_wlans_central_to_mist prompts instead of calling this tool
-    directly. Those prompts handle field translation, alias resolution,
-    server group mapping, and VLAN resolution automatically.
-
-    Do not sync tunneled SSIDs (forward-mode != FORWARD_MODE_BRIDGE).
+    When calling this tool directly (for Central-only operations):
+    - The SSID name is the identifier — it appears in the API path.
+    - Profiles are added to the Central WLAN library.
+    - They must be assigned to scopes (Global, site collections, or sites)
+      separately to take effect on APs.
+    - Do not create tunneled SSIDs (forward-mode != FORWARD_MODE_BRIDGE)
+      unless explicitly requested.
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")


### PR DESCRIPTION
## Summary

Fixes issues found during real-world WLAN sync testing where the AI:
1. Used invalid opmode `WPA2_PSK_AES` (doesn't exist) instead of `WPA2_PERSONAL`
2. Ignored sync prompts and called `central_manage_wlan_profile` directly
3. Never checked Mist template assignments for scope replication
4. Failed 4 times before guessing a valid opmode

### Changes

**Tool description (`central_manage_wlan_profile`)**:
- Payload Field now lists all 22 valid opmode values with explicit note that `WPA2_PSK_AES` is invalid
- Valid values for `rf-band`, `forward-mode`, `vlan-selector`, `out-of-service`, `broadcast-filter-ipv4`
- Docstring starts with "STOP — CHECK BEFORE CALLING" redirecting cross-platform operations to sync prompts

**INSTRUCTIONS.md**:
- Cross-platform sync section changed from "ALWAYS" to "MANDATORY" with 5 numbered reasons why direct tool calls fail
- Added opmode mapping table (Mist psk → WPA2_PERSONAL, etc.) to WLAN Profiles section
- Added "NEVER call this tool directly for cross-platform WLAN sync"
- Added rule to always check and replicate template/scope assignments

**TOOLS.md**:
- Full opmode enum reference added to `central_manage_wlan_profile` entry
- Key enum values for other fields documented

## Test plan

- [ ] CI passes
- [ ] Re-test "Add ADAMS-TEST WLAN to Central from Mist" — AI should invoke sync prompt
- [ ] AI should use WPA2_PERSONAL (not WPA2_PSK_AES) for PSK WLANs
- [ ] AI should check template assignment in Mist before creating in Central