### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.8.0"
+version = "0.8.1"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch version bump for opmode enum docs and cross-platform sync guidance fix (PR #103).