### PR TITLE
Add source_platform guardrail and org_id validation

### DIFF
--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -99,6 +99,19 @@ async def central_manage_wlan_profile(
             )
         ),
     ],
+    source_platform: Annotated[
+        str,
+        Field(
+            description=(
+                "Where is this WLAN coming from? Set to 'new' if creating a "
+                "brand new SSID that does not exist on any platform. Set to "
+                "'mist' if the SSID already exists in Mist and is being added, "
+                "copied, ported, or synced to Central. Set to 'central' if "
+                "this is a Central-only modification."
+            ),
+            default="new",
+        ),
+    ],
     confirmed: Annotated[
         bool,
         Field(
@@ -110,27 +123,70 @@ async def central_manage_wlan_profile(
     """
     Create, update, or delete a WLAN SSID profile in Central's library.
 
-    **STOP — CHECK BEFORE CALLING**: If the user asked to add, copy, sync,
-    port, or migrate a WLAN from Mist to Central (or vice versa), you MUST
-    use the sync prompts instead of calling this tool directly:
-    - sync_wlans_mist_to_central
-    - sync_wlans_central_to_mist
-    - sync_wlans_bidirectional
-    Those prompts handle field translation, opmode mapping, alias resolution,
-    server group mapping, template variable creation, VLAN resolution, and
-    scope assignment automatically. Calling this tool directly for cross-
-    platform operations will produce incorrect configurations.
-
-    When calling this tool directly (for Central-only operations):
-    - The SSID name is the identifier — it appears in the API path.
-    - Profiles are added to the Central WLAN library.
-    - They must be assigned to scopes (Global, site collections, or sites)
-      separately to take effect on APs.
-    - Do not create tunneled SSIDs (forward-mode != FORWARD_MODE_BRIDGE)
-      unless explicitly requested.
+    The SSID name is the identifier — it appears in the API path.
+    Profiles are added to the Central WLAN library and must be assigned
+    to scopes (Global, site collections, or sites) separately.
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+
+    # Redirect cross-platform operations to the sync workflow
+    if source_platform == "mist":
+        return {
+            "status": "redirect",
+            "message": (
+                "This SSID is being synced from Mist. Do NOT call this tool "
+                "directly for cross-platform operations. Instead, follow the "
+                "sync_wlans_mist_to_central workflow:\n"
+                "1. Call mist_get_self(action_type=account_info) to get org_id\n"
+                "2. Call mist_get_configuration_objects(org_id=<org_id>, "
+                "object_type=org_wlans, name=<ssid>) to get the full WLAN config\n"
+                "3. Note the template_id, then look up the template to find "
+                "sitegroup_ids and site_ids for assignment mapping\n"
+                "4. Translate fields: Mist auth.type=psk → Central opmode=WPA2_PERSONAL, "
+                "Mist auth.type=eap → Central opmode=WPA2_ENTERPRISE, "
+                "Mist bands → Central rf-band, Mist vlan_id → Central vlan-id-range\n"
+                "5. Create the profile with correctly mapped fields\n"
+                "6. Report which Central scopes to assign the profile to "
+                "based on the Mist template assignment"
+            ),
+        }
+
+    # Validate opmode on create/update to catch cross-platform translation errors
+    if action_type in ("create", "update") and "opmode" in payload:
+        valid_opmodes = {
+            "OPEN",
+            "WPA2_PERSONAL",
+            "WPA2_ENTERPRISE",
+            "ENHANCED_OPEN",
+            "WPA3_SAE",
+            "WPA3_ENTERPRISE_CCM_128",
+            "WPA3_ENTERPRISE_GCM_256",
+            "WPA3_ENTERPRISE_CNSA",
+            "WPA_ENTERPRISE",
+            "WPA_PERSONAL",
+            "WPA2_MPSK_AES",
+            "WPA2_MPSK_LOCAL",
+            "DPP",
+            "WPA2_PSK_AES_DPP",
+            "WPA2_AES_DPP",
+            "WPA3_SAE_DPP",
+            "WPA3_AES_CCM_128_DPP",
+            "WPA3_AES_GCM_256_DPP",
+            "BOTH_WPA_WPA2_PSK",
+            "BOTH_WPA_WPA2_DOT1X",
+            "STATIC_WEP",
+            "DYNAMIC_WEP",
+        }
+        opmode = payload["opmode"]
+        if opmode not in valid_opmodes:
+            raise ToolError(
+                f"Invalid opmode '{opmode}'. "
+                "If you are syncing a WLAN from Mist, use the "
+                "sync_wlans_mist_to_central prompt instead of calling this "
+                "tool directly — it handles opmode translation automatically. "
+                f"Valid opmodes: {', '.join(sorted(valid_opmodes))}"
+            )
 
     api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}"
 

--- a/src/hpe_networking_mcp/platforms/mist/client.py
+++ b/src/hpe_networking_mcp/platforms/mist/client.py
@@ -43,6 +43,30 @@ async def get_apisession() -> tuple[mistapi.APISession, str]:
     return session, "json"
 
 
+def validate_org_id(org_id: str) -> str:
+    """Validate an org_id against the token's actual org_id.
+
+    If the org_id doesn't match the token's org, raises a ToolError
+    with the correct org_id so the AI can self-correct without an
+    extra API call.
+
+    Args:
+        org_id: The org_id provided by the AI.
+
+    Returns:
+        The validated org_id (may be corrected).
+    """
+    ctx = get_context()
+    correct_org_id = ctx.lifespan_context.get("mist_org_id")
+    if correct_org_id and str(org_id) != str(correct_org_id):
+        raise ToolError(
+            f"Wrong org_id '{org_id}'. The correct org_id for this "
+            f"API token is '{correct_org_id}'. Use this org_id for "
+            f"all Mist API calls."
+        )
+    return str(org_id)
+
+
 async def process_response(response: APIResponse) -> None:
     """Validate an API response and raise ToolError on failure."""
     if response.status_code is None:

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -148,6 +148,20 @@ async def change_org_configuration_objects(
         ),
     ],
     ctx: Context,
+    source_platform: Annotated[
+        str,
+        Field(
+            description=(
+                "Where is this configuration coming from? Set to 'new' if "
+                "creating a brand new object. Set to 'central' if the WLAN "
+                "already exists in Aruba Central and is being added, copied, "
+                "ported, or synced to Mist. Set to 'mist' for Mist-only "
+                "modifications. Only relevant when object_type is 'wlans' "
+                "or 'wlantemplates'."
+            ),
+            default="new",
+        ),
+    ],
     confirmed: Annotated[
         bool,
         Field(
@@ -166,6 +180,28 @@ async def change_org_configuration_objects(
         payload,
         object_id,
     )
+
+    # Redirect cross-platform WLAN operations to the sync workflow
+    if source_platform == "central" and object_type.value in ("wlans", "wlantemplates"):
+        return {
+            "status": "redirect",
+            "message": (
+                "This WLAN is being synced from Central. Do NOT call this tool "
+                "directly for cross-platform operations. Instead, follow the "
+                "sync_wlans_central_to_mist workflow:\n"
+                "1. Call central_get_wlan_profiles to get the full WLAN config\n"
+                "2. Resolve Central aliases (SSID, PSK) via central_get_aliases\n"
+                "3. Resolve server groups via central_get_server_groups\n"
+                "4. Resolve named VLANs via central_get_named_vlans\n"
+                "5. Translate fields: Central opmode=WPA2_PERSONAL → Mist "
+                "auth.type=psk, Central rf-band → Mist bands array, etc.\n"
+                "6. Use template variables ({{auth_srv1}}) for RADIUS servers, "
+                "never hardcode IPs\n"
+                "7. Create the WLAN template, then create the WLAN inside it\n"
+                "8. Check Central scope assignment and assign the Mist template "
+                "to matching site groups"
+            ),
+        }
 
     apisession, response_format = await get_apisession()
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
@@ -27,6 +27,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     get_apisession,
     handle_network_error,
     process_response,
+    validate_org_id,
 )
 
 
@@ -229,6 +230,7 @@ async def get_configuration_objects(
         limit,
     )
 
+    validate_org_id(str(org_id))
     apisession, response_format = await get_apisession()
 
     response = None

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
@@ -13,6 +13,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     get_apisession,
     handle_network_error,
     process_response,
+    validate_org_id,
 )
 
 
@@ -49,6 +50,7 @@ async def get_wlans(
         site_id,
     )
 
+    validate_org_id(str(org_id))
     apisession, response_format = await get_apisession()
 
     try:

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -31,6 +31,17 @@ async def lifespan(server: FastMCP):
             if hasattr(mist_session, "set_verbose"):
                 mist_session.set_verbose(False)
             context["mist_session"] = mist_session
+            # Resolve org_id from API token at startup
+            try:
+                self_resp = mistapi.api.v1.self.self.getSelf(mist_session)
+                if self_resp.status_code == 200 and self_resp.data:
+                    privileges = self_resp.data.get("privileges", [])
+                    org_privs = [p for p in privileges if p.get("scope") == "org"]
+                    if org_privs:
+                        context["mist_org_id"] = org_privs[0]["org_id"]
+                        logger.info("Mist: resolved org_id={}", context["mist_org_id"])
+            except Exception as e:
+                logger.warning("Mist: failed to resolve org_id at startup — {}", e)
             logger.info("Mist: API session initialized")
         except Exception as e:
             logger.warning("Mist: failed to initialize — {}", e)


### PR DESCRIPTION
## Summary

Two code-level fixes for issues where instruction-based guidance failed to change AI behavior:

### 1. source_platform parameter (sync workflow redirect)
Added `source_platform` parameter to both WLAN write tools:
- **`central_manage_wlan_profile`**: accepts `"new"` (default), `"mist"`, or `"central"`. When `source_platform="mist"`, the tool returns a redirect response with step-by-step sync workflow instructions instead of creating the profile.
- **`mist_change_org_configuration_objects`**: same pattern. When `source_platform="central"` and object_type is `wlans`/`wlantemplates`, returns redirect with Central→Mist sync workflow.

The AI naturally fills in `source_platform` from the user's request context (e.g. "add from Mist" → `source_platform="mist"`), making this more reliable than instruction-based guidance.

### 2. org_id validation
The AI consistently fabricates Mist org_ids instead of calling `mist_get_self` first. Fix:
- Resolve the real org_id from `mist_get_self` at server startup and store in lifespan context
- `validate_org_id()` in `mist/client.py` checks every call — if wrong, returns immediate error with the correct org_id
- Added to `mist_get_wlans` and `mist_get_configuration_objects`

## Test plan

- [ ] CI passes
- [ ] Test "Add ADAMS-TEST from Mist to Central" — AI sets source_platform="mist", gets redirect
- [ ] Test with wrong org_id — gets immediate correction without 403 round-trip
- [ ] Test creating a new SSID (source_platform="new") — proceeds normally