### PR TITLE
Bump version to 0.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.8.2"
+version = "0.8.3"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch version bump for source_platform guardrail and org_id validation (PR #107).