### PR TITLE
Remove source_platform from platform tools, fix workflow messages

### DIFF
--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -99,19 +99,6 @@ async def central_manage_wlan_profile(
             )
         ),
     ],
-    source_platform: Annotated[
-        str,
-        Field(
-            description=(
-                "Where is this WLAN coming from? Set to 'new' if creating a "
-                "brand new SSID that does not exist on any platform. Set to "
-                "'mist' if the SSID already exists in Mist and is being added, "
-                "copied, ported, or synced to Central. Set to 'central' if "
-                "this is a Central-only modification."
-            ),
-            default="new",
-        ),
-    ],
     confirmed: Annotated[
         bool,
         Field(
@@ -129,28 +116,6 @@ async def central_manage_wlan_profile(
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
-
-    # Redirect cross-platform operations to the sync workflow
-    if source_platform == "mist":
-        return {
-            "status": "redirect",
-            "message": (
-                "This SSID is being synced from Mist. Do NOT call this tool "
-                "directly for cross-platform operations. Instead, follow the "
-                "sync_wlans_mist_to_central workflow:\n"
-                "1. Call mist_get_self(action_type=account_info) to get org_id\n"
-                "2. Call mist_get_configuration_objects(org_id=<org_id>, "
-                "object_type=org_wlans, name=<ssid>) to get the full WLAN config\n"
-                "3. Note the template_id, then look up the template to find "
-                "sitegroup_ids and site_ids for assignment mapping\n"
-                "4. Translate fields: Mist auth.type=psk → Central opmode=WPA2_PERSONAL, "
-                "Mist auth.type=eap → Central opmode=WPA2_ENTERPRISE, "
-                "Mist bands → Central rf-band, Mist vlan_id → Central vlan-id-range\n"
-                "5. Create the profile with correctly mapped fields\n"
-                "6. Report which Central scopes to assign the profile to "
-                "based on the Mist template assignment"
-            ),
-        }
 
     # Validate opmode on create/update to catch cross-platform translation errors
     if action_type in ("create", "update") and "opmode" in payload:

--- a/src/hpe_networking_mcp/platforms/manage_wlan.py
+++ b/src/hpe_networking_mcp/platforms/manage_wlan.py
@@ -51,12 +51,17 @@ opmode="WPA3_ENTERPRISE_CCM_128"
 - roam_mode="11r" → dot11r=true
 
 **STEP 5** — Call `central_manage_wlan_profile(ssid="{ssid}", \
-action_type="create", source_platform="central", payload=<mapped>)` \
-to create the profile.
+action_type="create", payload=<mapped>)` to create the profile.
 
-**STEP 6** — Report assignment: "In Mist, this WLAN is in template \
-'<name>' assigned to site groups: <list> and/or sites: <list>. In \
-Central, assign the profile to matching site collections and/or sites."
+**STEP 6 — Assignment (REQUIRED — do not skip):**
+Report to the user where this WLAN is assigned in Mist and where it \
+needs to be assigned in Central:
+- "In Mist, this WLAN is in template '<name>' assigned to site groups: \
+<list> and/or sites: <list>."
+- "In Central, assign the profile to matching site collections: <list> \
+and/or sites: <list>."
+If a matching Central site collection does not exist, tell the user it \
+needs to be created first.
 """
 
 # Central → Mist sync workflow returned when SSID exists in Central
@@ -89,11 +94,16 @@ the correct Mist org_id.
 - Use template variables ({{auth_srv1}}) for RADIUS, never hardcode IPs
 - Define resolved addresses in site vars
 
-**STEP 5** — Create a Mist WLAN template, then create the WLAN inside \
-it using `mist_change_org_configuration_objects`.
+**STEP 5** — Create a Mist WLAN template using \
+`mist_change_org_configuration_objects(action_type="create", \
+object_type="wlantemplates", payload=...)`, then create the WLAN \
+inside it with `object_type="wlans"` and the new template_id.
 
-**STEP 6** — Check Central scope assignment and assign the Mist \
-template to matching site groups.
+**STEP 6 — Assignment (REQUIRED — do not skip):**
+Check what scope/site collection the Central WLAN is assigned to. \
+Assign the Mist WLAN template to matching site groups. Report: \
+"In Central, this WLAN is assigned to scope: <scope>. In Mist, \
+assign the template to site group: <matching group>."
 """
 
 # Both platforms have it

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -148,20 +148,6 @@ async def change_org_configuration_objects(
         ),
     ],
     ctx: Context,
-    source_platform: Annotated[
-        str,
-        Field(
-            description=(
-                "Where is this configuration coming from? Set to 'new' if "
-                "creating a brand new object. Set to 'central' if the WLAN "
-                "already exists in Aruba Central and is being added, copied, "
-                "ported, or synced to Mist. Set to 'mist' for Mist-only "
-                "modifications. Only relevant when object_type is 'wlans' "
-                "or 'wlantemplates'."
-            ),
-            default="new",
-        ),
-    ],
     confirmed: Annotated[
         bool,
         Field(
@@ -180,28 +166,6 @@ async def change_org_configuration_objects(
         payload,
         object_id,
     )
-
-    # Redirect cross-platform WLAN operations to the sync workflow
-    if source_platform == "central" and object_type.value in ("wlans", "wlantemplates"):
-        return {
-            "status": "redirect",
-            "message": (
-                "This WLAN is being synced from Central. Do NOT call this tool "
-                "directly for cross-platform operations. Instead, follow the "
-                "sync_wlans_central_to_mist workflow:\n"
-                "1. Call central_get_wlan_profiles to get the full WLAN config\n"
-                "2. Resolve Central aliases (SSID, PSK) via central_get_aliases\n"
-                "3. Resolve server groups via central_get_server_groups\n"
-                "4. Resolve named VLANs via central_get_named_vlans\n"
-                "5. Translate fields: Central opmode=WPA2_PERSONAL → Mist "
-                "auth.type=psk, Central rf-band → Mist bands array, etc.\n"
-                "6. Use template variables ({{auth_srv1}}) for RADIUS servers, "
-                "never hardcode IPs\n"
-                "7. Create the WLAN template, then create the WLAN inside it\n"
-                "8. Check Central scope assignment and assign the Mist template "
-                "to matching site groups"
-            ),
-        }
 
     apisession, response_format = await get_apisession()
 


### PR DESCRIPTION
## Summary

The `source_platform` redirect on `central_manage_wlan_profile` conflicted with the unified `manage_wlan_profile` tool. The AI followed the workflow from `manage_wlan_profile` correctly, did the field translation, but when it called `central_manage_wlan_profile` to actually create the profile, the `source_platform="mist"` redirect blocked it.

### Changes
- Remove `source_platform` parameter and redirect logic from `central_manage_wlan_profile` and `mist_change_org_configuration_objects`
- Remove `source_platform` references from `manage_wlan.py` workflow messages
- Make Step 6 (assignment) more prominent: "REQUIRED — do not skip" in both workflow directions

### Why
The `source_platform` guardrail was a stopgap from before `manage_wlan_profile` existed. Now that the unified tool handles cross-platform detection, the platform-specific tools should just execute — they're called as part of the workflow, not as the entry point.

## Test plan
- [ ] CI passes
- [ ] Test "Add ADAMS-TEST from Mist to Central" — manage_wlan_profile returns workflow, AI follows steps, central_manage_wlan_profile creates successfully
- [ ] AI reports assignment mapping in Step 6