### PR TITLE
Add config-assignment tool, fix manage_wlan workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ CLAUDE.md
 # Reference documents
 mist-best-practices.docx
 mist-central-wlan-api
+api-endpoints/

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -62,6 +62,10 @@ TOOLS = {
         "central_get_wlan_profiles",
         "central_manage_wlan_profile",
     ],
+    "config_assignments": [
+        "central_get_config_assignments",
+        "central_manage_config_assignment",
+    ],
     "configuration": [
         "central_manage_site",
         "central_manage_site_collection",

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -1,0 +1,296 @@
+"""Aruba Central configuration assignment tools.
+
+Provides tools to assign, read, and remove configuration profiles
+(WLAN SSIDs, roles, policies, etc.) at specific scopes in the
+Central hierarchy. This is how profiles created in the library
+get applied to Global, site collections, sites, device groups,
+or individual devices.
+
+API: POST/GET/DELETE /network-config/v1alpha1/config-assignments
+"""
+
+from typing import Annotated
+
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from loguru import logger
+from pydantic import Field
+
+from hpe_networking_mcp.middleware.elicitation import elicitation_handler
+from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+WRITE_DELETE = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": False,
+    "openWorldHint": True,
+}
+
+# Valid device-function values from the API schema
+VALID_DEVICE_FUNCTIONS = {
+    "CAMPUS_AP",
+    "MICROBRANCH_AP",
+    "ACCESS_SWITCH",
+    "CORE_SWITCH",
+    "AGG_SWITCH",
+    "AOSS_ACCESS_SWITCH",
+    "AOSS_CORE_SWITCH",
+    "AOSS_AGG_SWITCH",
+    "BRANCH_GW",
+    "MOBILITY_GW",
+    "VPNC",
+    "ALL",
+    "SERVICE_PERSONA",
+    "BRIDGE",
+    "IOT",
+    "HYBRID_NAC",
+}
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_config_assignments(
+    ctx: Context,
+    scope_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Scope ID to filter assignments. Get scope IDs from "
+                "central_get_scope_tree. If omitted, returns all assignments."
+            ),
+            default=None,
+        ),
+    ],
+    device_function: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Device function filter. For WLAN profiles use 'CAMPUS_AP'. "
+                "Valid values: CAMPUS_AP, ACCESS_SWITCH, BRANCH_GW, "
+                "MOBILITY_GW, CORE_SWITCH, AGG_SWITCH, ALL, etc."
+            ),
+            default=None,
+        ),
+    ],
+) -> dict | list | str:
+    """
+    Get configuration assignments from Aruba Central.
+
+    Shows which configuration profiles are assigned to which scopes
+    and device functions. Use this to check where a WLAN profile,
+    role, or policy is currently assigned in the hierarchy.
+
+    Parameters:
+        scope_id: Filter by scope ID. Get IDs from central_get_scope_tree.
+        device_function: Filter by device function (e.g. CAMPUS_AP for WLANs).
+
+    Returns:
+        List of config-assignment entries with scope-id, device-function,
+        profile-type, profile-instance, scope-name, and scope-type.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+
+    api_params: dict = {}
+    if scope_id:
+        api_params["scope-id"] = scope_id
+    if device_function:
+        api_params["device-function"] = device_function
+
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path="network-config/v1alpha1/config-assignments",
+        api_params=api_params,
+    )
+    return response.get("msg", {})
+
+
+@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_config_assignment(
+    ctx: Context,
+    action_type: Annotated[
+        str,
+        Field(
+            description="Action to perform: 'assign' or 'remove'.",
+        ),
+    ],
+    scope_id: Annotated[
+        str,
+        Field(
+            description=(
+                "Scope ID where the profile should be assigned/removed. "
+                "Get scope IDs from central_get_scope_tree. Examples: "
+                "Global scope ID, a site collection ID, or a site ID."
+            ),
+        ),
+    ],
+    device_function: Annotated[
+        str,
+        Field(
+            description=(
+                "Device function for the assignment. For WLAN profiles "
+                "use 'CAMPUS_AP'. Valid values: CAMPUS_AP, ACCESS_SWITCH, "
+                "BRANCH_GW, MOBILITY_GW, CORE_SWITCH, AGG_SWITCH, ALL, "
+                "MICROBRANCH_AP, VPNC, SERVICE_PERSONA, BRIDGE, IOT, "
+                "HYBRID_NAC, AOSS_ACCESS_SWITCH, AOSS_CORE_SWITCH, "
+                "AOSS_AGG_SWITCH."
+            ),
+        ),
+    ],
+    profile_type: Annotated[
+        str,
+        Field(
+            description=(
+                "Type of profile to assign. For WLAN SSIDs use 'wlan-ssids'. "
+                "Other examples: 'roles', 'policies', 'auth-server-groups', "
+                "'named-vlans', 'aliases'."
+            ),
+        ),
+    ],
+    profile_instance: Annotated[
+        str,
+        Field(
+            description=(
+                "Name of the specific profile to assign. For WLAN SSIDs "
+                "this is the SSID name (e.g. 'ADAMS-TEST'). For roles "
+                "this is the role name, etc."
+            ),
+        ),
+    ],
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation.",
+            default=False,
+        ),
+    ],
+) -> dict | str:
+    """
+    Assign or remove a configuration profile at a scope in Central's hierarchy.
+
+    This is how profiles created in the library (WLAN SSIDs, roles,
+    policies, etc.) get applied to scopes in the hierarchy. For example,
+    to make a WLAN profile active at a site, assign it with:
+    - scope_id = the site's scope ID (from central_get_scope_tree)
+    - device_function = "CAMPUS_AP"
+    - profile_type = "wlan-ssids"
+    - profile_instance = "ADAMS-TEST"
+
+    To find the scope_id, call central_get_scope_tree and look up the
+    target scope (Global, site collection, or site) by name.
+    """
+    if action_type not in ("assign", "remove"):
+        raise ToolError(f"Invalid action_type: {action_type}. Must be 'assign' or 'remove'.")
+
+    if device_function not in VALID_DEVICE_FUNCTIONS:
+        raise ToolError(
+            f"Invalid device_function: {device_function}. Valid values: {', '.join(sorted(VALID_DEVICE_FUNCTIONS))}"
+        )
+
+    conn = ctx.lifespan_context["central_conn"]
+
+    if action_type == "assign":
+        action_wording = f"assign profile '{profile_instance}' ({profile_type}) to scope '{scope_id}'"
+
+        if not confirmed:
+            elicitation_response = await elicitation_handler(
+                message=f"The LLM wants to {action_wording}. Do you accept?",
+                ctx=ctx,
+            )
+            if elicitation_response.action == "decline":
+                if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                    return {
+                        "status": "confirmation_required",
+                        "message": (
+                            f"This operation will {action_wording}. "
+                            "Please confirm with the user before proceeding. "
+                            "Call this tool again with confirmed=true after the user confirms."
+                        ),
+                    }
+                return {"message": "Action declined by user."}
+            elif elicitation_response.action == "cancel":
+                return {"message": "Action canceled by user."}
+
+        payload = {
+            "config-assignment": [
+                {
+                    "scope-id": scope_id,
+                    "device-function": device_function,
+                    "profile-type": profile_type,
+                    "profile-instance": profile_instance,
+                }
+            ]
+        }
+
+        logger.info(
+            "Central config-assignment: assign '{}' ({}) to scope '{}' as {}",
+            profile_instance,
+            profile_type,
+            scope_id,
+            device_function,
+        )
+
+        response = retry_central_command(
+            central_conn=conn,
+            api_method="POST",
+            api_path="network-config/v1alpha1/config-assignments",
+            api_data=payload,
+        )
+
+    else:  # remove
+        action_wording = f"remove profile '{profile_instance}' ({profile_type}) from scope '{scope_id}'"
+
+        if not confirmed:
+            elicitation_response = await elicitation_handler(
+                message=f"The LLM wants to {action_wording}. Do you accept?",
+                ctx=ctx,
+            )
+            if elicitation_response.action == "decline":
+                if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                    return {
+                        "status": "confirmation_required",
+                        "message": (
+                            f"This operation will {action_wording}. "
+                            "Please confirm with the user before proceeding. "
+                            "Call this tool again with confirmed=true after the user confirms."
+                        ),
+                    }
+                return {"message": "Action declined by user."}
+            elif elicitation_response.action == "cancel":
+                return {"message": "Action canceled by user."}
+
+        base = "network-config/v1alpha1/config-assignments"
+        api_path = f"{base}/{scope_id}/{device_function}/{profile_type}/{profile_instance}"
+
+        logger.info(
+            "Central config-assignment: remove '{}' ({}) from scope '{}' as {}",
+            profile_instance,
+            profile_type,
+            scope_id,
+            device_function,
+        )
+
+        response = retry_central_command(
+            central_conn=conn,
+            api_method="DELETE",
+            api_path=api_path,
+        )
+
+    code = response.get("code", 0)
+    if 200 <= code < 300:
+        return {
+            "status": "success",
+            "action": action_type,
+            "scope_id": scope_id,
+            "device_function": device_function,
+            "profile_type": profile_type,
+            "profile_instance": profile_instance,
+            "data": response.get("msg", {}),
+        }
+
+    return {
+        "status": "error",
+        "code": code,
+        "message": response.get("msg", "Unknown error"),
+    }

--- a/src/hpe_networking_mcp/platforms/manage_wlan.py
+++ b/src/hpe_networking_mcp/platforms/manage_wlan.py
@@ -53,15 +53,17 @@ opmode="WPA3_ENTERPRISE_CCM_128"
 **STEP 5** — Call `central_manage_wlan_profile(ssid="{ssid}", \
 action_type="create", payload=<mapped>)` to create the profile.
 
-**STEP 6 — Assignment (REQUIRED — do not skip):**
-Report to the user where this WLAN is assigned in Mist and where it \
-needs to be assigned in Central:
-- "In Mist, this WLAN is in template '<name>' assigned to site groups: \
-<list> and/or sites: <list>."
-- "In Central, assign the profile to matching site collections: <list> \
-and/or sites: <list>."
-If a matching Central site collection does not exist, tell the user it \
-needs to be created first.
+**STEP 6 — Assign the profile to a scope (REQUIRED — do not skip):**
+a. Call `central_get_scope_tree(view="committed")` to find the scope \
+that matches the Mist template assignment from Step 3.
+b. Match Mist site groups → Central site collections by name. Match \
+Mist sites → Central sites by name. Note the `scope_id` for each match.
+c. For each matching scope, call `central_manage_config_assignment(\
+action_type="assign", scope_id=<scope_id>, \
+device_function="CAMPUS_AP", profile_type="wlan-ssids", \
+profile_instance="{ssid}")` to assign the WLAN profile.
+d. Report: "In Mist, this WLAN is in template '<name>' assigned to \
+site groups: <list>. In Central, assigned to scopes: <list>."
 """
 
 # Central → Mist sync workflow returned when SSID exists in Central
@@ -99,30 +101,32 @@ the correct Mist org_id.
 object_type="wlantemplates", payload=...)`, then create the WLAN \
 inside it with `object_type="wlans"` and the new template_id.
 
-**STEP 6 — Assignment (REQUIRED — do not skip):**
-Check what scope/site collection the Central WLAN is assigned to. \
-Assign the Mist WLAN template to matching site groups. Report: \
-"In Central, this WLAN is assigned to scope: <scope>. In Mist, \
-assign the template to site group: <matching group>."
+**STEP 6 — Assign the template to site groups (REQUIRED — do not skip):**
+a. Call `central_get_config_assignments(device_function="CAMPUS_AP")` \
+to find where the Central WLAN is assigned. Look for entries with \
+profile_instance="{ssid}" to find the scope.
+b. Match Central scopes → Mist site groups by name.
+c. For each matching site group, update the site group to include the \
+new template using `mist_change_org_configuration_objects`.
+d. Report: "In Central, this WLAN is assigned to scope: <scope>. In \
+Mist, assigned template to site groups: <list>."
 """
 
 # Both platforms have it
 _BOTH_PLATFORMS_WORKFLOW = """
-This SSID exists on BOTH platforms:
-- **Mist**: {mist_status}
-- **Central**: {central_status}
+This SSID "{ssid}" exists on BOTH platforms. The full configs from \
+each platform are included in this response under `mist_wlan` and \
+`central_profile`.
 
-Compare the configurations and ask the user:
-1. "Use Mist as source" (update Central to match Mist)
-2. "Use Central as source" (update Mist to match Central)
-3. "Skip — leave both as-is"
+You MUST ask the user which source to use before making any changes:
+1. "Use Mist as source" → update Central to match Mist
+2. "Use Central as source" → update Mist to match Central
+3. "Leave both as-is"
 
-To compare, retrieve the full config from both platforms:
-- Call `mist_get_configuration_objects(org_id=<org_id>, \
-object_type=org_wlans, name="{ssid}")` for Mist config
-- The Central config is: {central_status}
+Show a comparison table of key fields (auth type, PSK, VLAN, bands, \
+etc.) so the user can see the differences before deciding.
 
-Then show a side-by-side table of differences.
+Do NOT proceed with any create or update until the user chooses.
 """
 
 


### PR DESCRIPTION
## Summary

Adds the missing piece for complete WLAN sync: the ability to assign configuration profiles to scopes in Central's hierarchy.

### New tools
- **`central_get_config_assignments`** — read which profiles are assigned to which scopes (`GET /network-config/v1alpha1/config-assignments`). Filter by scope_id and device_function.
- **`central_manage_config_assignment`** — assign or remove a profile at a scope (`POST`/`DELETE /network-config/v1alpha1/config-assignments`). Parameters: scope_id, device_function (CAMPUS_AP for WLANs), profile_type (wlan-ssids), profile_instance (SSID name).

### manage_wlan.py workflow fixes
- **Mist→Central Step 6**: now calls `central_get_scope_tree` to find the matching scope, then `central_manage_config_assignment` to assign the WLAN profile — no more "tell the user to do it manually"
- **Central→Mist Step 6**: calls `central_get_config_assignments` to find where the Central WLAN is assigned, then maps to Mist site groups
- **Both-platforms**: returns full configs in the response and requires user to choose a source before proceeding

### Other
- `.gitignore`: added `api-endpoints/`
- Central tool count: 51 → 53

## Test plan
- [ ] CI passes
- [ ] Test "Add ADAMS-TEST from Mist to Central" — profile created AND assigned to scope
- [ ] Test with SSID on both platforms — shows comparison, asks user to choose
- [ ] `central_get_config_assignments` returns current assignments