### PR TITLE
Add AP monitoring tools, WLAN stats, integration test scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --frozen 2>/dev/null || uv sync
-      - name: Run unit tests
+      - name: Run tests
         run: uv run pytest tests/unit -v --tb=short
-      - name: Run integration tests
-        run: uv run pytest tests/integration -v --tb=short
 
   docker:
     name: Docker Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.1.0] - 2026-04-15
+
+### Added — New Central Monitoring Tools
+- `central_get_aps` — filtered AP listing with AP-specific filters (status, model, firmware, deployment type, cluster, site). Uses `MonitoringAPs.get_all_aps()` with OData filters.
+- `central_get_ap_wlans` — get WLANs currently active on a specific AP by serial number. Uses `MonitoringAPs.get_ap_wlans()`. Supports optional `wlan_name` filter.
+- `central_get_wlan_stats` — WLAN throughput trends (tx/rx time-series in bps) over a time window. Uses `GET /network-monitoring/v1/wlans/{name}/throughput-trends`. Supports predefined time ranges and custom RFC 3339 start/end.
+- Central tool count: 53 → 56
+
+### Added — Integration Test Scaffolding
+- `tests/integration/conftest.py` — live API fixtures using Docker secrets. Creates real Central connection, skips gracefully if credentials missing.
+- `tests/integration/test_ap_monitoring_live.py` — 6 live tests for AP listing, details, and WLAN-per-AP tools
+- `tests/integration/test_wlans_live.py` — 5 live tests for WLAN listing, throughput stats, and time window filtering
+
+### Added — Utility Functions
+- `format_rfc3339()` — format datetime as RFC 3339 string with millisecond precision
+- `resolve_time_window()` — resolve predefined time ranges or pass-through custom start/end times
+
+### Changed — Versioning
+- Moved to 4-digit versioning: `v0.MAJOR.MINOR.PATCH`
+
+[v0.8.1.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.8.1.0
+
 ## [v0.8.7] - 2026-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling t
 | **Scope & Configuration Hierarchy** | — | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — |
 | **Dynamic API Discovery** | — | — | ✅ |
-| **Tools** | **35 + 2 prompts** | **53 + 12 prompts** | **3 or 10** |
+| **Tools** | **35 + 2 prompts** | **56 + 12 prompts** | **3 or 10** |
 | **Cross-Platform** | **1 tool + 3 prompts** | **1 tool + 3 prompts** | — |
 
 > **GreenLake tool count**: 3 tools in **dynamic mode** (default) — a meta-tool system that can discover and invoke any GreenLake API endpoint. 10 tools in **static mode** — dedicated tools for each endpoint. Set via `MCP_TOOL_MODE` environment variable.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,7 +9,7 @@ and `greenlake_*` (HPE GreenLake).
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
-| Aruba Central | 48 | 5 | 12 | 65 |
+| Aruba Central | 51 | 5 | 12 | 68 |
 | Cross-Platform | -- | 1 | 3 | 4 |
 | HPE GreenLake (static mode) | 10 | -- | -- | 10 |
 | HPE GreenLake (dynamic mode) | 3 | -- | -- | 3 |
@@ -503,7 +503,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Aruba Central (53 tools + 12 prompts)
+## Aruba Central (56 tools + 12 prompts)
 
 ### Sites
 
@@ -558,6 +558,33 @@ No parameters. Returns a dict sorted by health score (worst first).
 |-----------|------|----------|-------------|
 | serial_number | str | No | Device serial number (preferred). |
 | device_name | str | No | Device display name. Provide only one identifier. |
+
+### AP Monitoring
+
+#### `central_get_aps`
+
+> List access points with AP-specific filters (status, model, firmware, deployment, cluster, site).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| site_id | str | No | Filter by site ID. |
+| site_name | str | No | Filter by site name. |
+| serial_number | str | No | AP serial (comma-separated for multiple). |
+| device_name | str | No | AP name (comma-separated for multiple). |
+| status | str | No | `ONLINE` or `OFFLINE`. |
+| model | str | No | AP model (comma-separated). |
+| firmware_version | str | No | Firmware version (comma-separated). |
+| deployment | str | No | `Standalone`, `Cluster`, or `Unspecified`. |
+| sort | str | No | Sort expression (e.g. `deviceName asc`). |
+
+#### `central_get_ap_wlans`
+
+> Get WLANs currently active on a specific AP. Useful for troubleshooting which SSIDs an AP is broadcasting.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | Yes | AP serial number. |
+| wlan_name | str | No | Filter by exact WLAN name (client-side). |
 
 ### Device Monitoring
 
@@ -672,6 +699,17 @@ No parameters. Returns a dict sorted by health score (worst first).
 | filter | str | No | OData filter string. |
 | sort | str | No | Sort expression (e.g. `essid asc`). |
 | limit | int | No | Default: 100. |
+
+#### `central_get_wlan_stats`
+
+> Get throughput trend data (tx/rx time-series in bps) for a specific WLAN over a time window.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| wlan_name | str | Yes | WLAN name (SSID) to get stats for. |
+| time_range | str | No | `last_1h` (default), `last_6h`, `last_24h`, `last_7d`, `last_30d`, `today`, `yesterday`. |
+| start_time | str | No | RFC 3339 format. Overrides time_range when combined with end_time. |
+| end_time | str | No | RFC 3339 format. |
 
 ### Audit Logs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.8.7"
+version = "0.8.1.0"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -102,6 +102,9 @@ When asked to create a new site based on an existing site:
 - **Sites**: central_get_sites, central_get_site_health, central_get_site_name_id_mapping
   - Use `central_get_sites` for site configuration data (address, timezone, scopeName). Supports OData filter on scopeName, address, city, state, country, zipcode, collectionName.
   - Use `central_get_site_health` for health metrics and device/client counts. Pass site_names to filter.
+- **AP Monitoring**: central_get_aps, central_get_ap_wlans
+  - Use `central_get_aps` for filtered AP listing (status, model, firmware, deployment, site). More AP-specific filters than `central_get_devices`.
+  - Use `central_get_ap_wlans` to see which WLANs a specific AP is broadcasting (by serial number).
 - **Devices**: central_get_devices, central_find_device, central_get_ap_details, central_get_switch_details, central_get_gateway_details
 - **Device Stats**: central_get_ap_stats, central_get_ap_utilization, central_get_gateway_stats, central_get_gateway_utilization, central_get_gateway_wan_availability, central_get_tunnel_health
 - **Switch PoE & Trends**: central_get_switch_hardware_trends, central_get_switch_poe
@@ -113,7 +116,9 @@ When asked to create a new site based on an existing site:
   - Use `central_get_effective_config` to see what configuration a device inherits and from where — pass `include_details=true` for full resource configuration data
   - Use `central_get_scope_diagram` to generate a Mermaid flowchart of the scope hierarchy — render it directly, the string is pre-built
   - **Presenting scope data**: Each scope node includes `persona_count`, `resource_count`, and per-persona `categories` (e.g. policy, vlan, profile). Present as an indented hierarchy with counts at each level. Group resources by category, not as flat lists. For effective config, show the `inheritance_path` first (Global → Collection → Site), then group resources by origin scope to show what each level contributes. Use the `scope_configuration_overview` or `scope_effective_config` prompts for guided workflows.
-- **WLANs**: central_get_wlans
+- **WLANs**: central_get_wlans, central_get_wlan_stats
+  - Use `central_get_wlan_stats` for throughput trends (tx/rx time-series) for a specific SSID over a time window
+  - Use `central_get_ap_wlans` (in AP Monitoring) to see which WLANs a specific AP is broadcasting
 - **Clients**: central_get_clients, central_find_client
 - **Alerts**: central_get_alerts
 - **Events**: central_get_events, central_get_events_count

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -15,11 +15,13 @@ TOOLS = {
     "alerts": ["central_get_alerts"],
     "events": ["central_get_events", "central_get_events_count"],
     "monitoring": [
+        "central_get_aps",
+        "central_get_ap_wlans",
         "central_get_ap_details",
         "central_get_switch_details",
         "central_get_gateway_details",
     ],
-    "wlans": ["central_get_wlans"],
+    "wlans": ["central_get_wlans", "central_get_wlan_stats"],
     "audit_logs": ["central_get_audit_logs", "central_get_audit_log_detail"],
     "stats": [
         "central_get_ap_stats",

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastmcp import Context
 from pycentral.new_monitoring.aps import MonitoringAPs
 from pycentral.new_monitoring.gateways import MonitoringGateways
@@ -5,6 +7,106 @@ from pycentral.new_monitoring.gateways import MonitoringGateways
 from hpe_networking_mcp.platforms.central._registry import mcp
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_aps(
+    ctx: Context,
+    site_id: str | None = None,
+    site_name: str | None = None,
+    serial_number: str | None = None,
+    device_name: str | None = None,
+    status: Literal["ONLINE", "OFFLINE"] | None = None,
+    model: str | None = None,
+    firmware_version: str | None = None,
+    deployment: Literal["Standalone", "Cluster", "Unspecified"] | None = None,
+    sort: str | None = None,
+) -> list[dict] | str:
+    """
+    List access points with AP-specific filters.
+
+    Returns AP name, serial, model, status, firmware, site, IP,
+    radio info, and deployment type. Supports filtering by site,
+    status, model, firmware, and deployment type.
+
+    Parameters:
+        site_id: Filter by site ID.
+        site_name: Filter by site name.
+        serial_number: AP serial number (comma-separated for multiple).
+        device_name: AP name (comma-separated for multiple).
+        status: ONLINE or OFFLINE.
+        model: AP model (comma-separated for multiple).
+        firmware_version: Firmware version (comma-separated for multiple).
+        deployment: Standalone, Cluster, or Unspecified.
+        sort: Sort expression (e.g. 'deviceName asc'). Supported fields:
+            siteId, serialNumber, deviceName, model, status, deployment.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+
+    filter_parts = []
+    filter_map = {
+        "siteId": site_id,
+        "siteName": site_name,
+        "serialNumber": serial_number,
+        "deviceName": device_name,
+        "status": status,
+        "model": model,
+        "firmwareVersion": firmware_version,
+        "deployment": deployment,
+    }
+    for field, value in filter_map.items():
+        if value is not None:
+            filter_parts.append(f"{field} eq '{value}'")
+    filter_str = " and ".join(filter_parts) if filter_parts else None
+
+    try:
+        kwargs: dict = {"central_conn": conn}
+        if filter_str:
+            kwargs["filter_str"] = filter_str
+        if sort:
+            kwargs["sort"] = sort
+        aps = MonitoringAPs.get_all_aps(**kwargs)
+    except Exception as e:
+        return f"Error fetching access points: {e}"
+
+    if not aps:
+        return "No access points found matching the specified criteria."
+    return aps
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_ap_wlans(
+    ctx: Context,
+    serial_number: str,
+    wlan_name: str | None = None,
+) -> list[dict] | str:
+    """
+    Get WLANs currently active on a specific AP.
+
+    Returns the WLANs being broadcast by the AP identified by serial
+    number. Useful for troubleshooting — "which SSIDs is this AP
+    broadcasting?" Use central_find_device to get the serial number.
+
+    Parameters:
+        serial_number: AP serial number (required).
+        wlan_name: Filter by exact WLAN name (SSID). Applied client-side.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+    try:
+        resp = MonitoringAPs.get_ap_wlans(
+            central_conn=conn,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        return f"Error fetching AP WLANs: {e}"
+
+    items = resp.get("items", []) if isinstance(resp, dict) else []
+    if wlan_name:
+        items = [w for w in items if w.get("wlanName") == wlan_name]
+
+    if not items:
+        return f"No WLANs found for AP '{serial_number}'."
+    return items
 
 
 @mcp.tool(annotations=READ_ONLY)

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -1,8 +1,11 @@
+from typing import Literal
+
 from fastmcp import Context
 from pycentral.new_monitoring.aps import MonitoringAPs
 
 from hpe_networking_mcp.platforms.central._registry import mcp
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import resolve_time_window, retry_central_command
 
 
 @mcp.tool(annotations=READ_ONLY)
@@ -56,3 +59,74 @@ async def central_get_wlans(
     if isinstance(resp, list):
         return resp if resp else "No WLANs found."
     return "No WLANs found."
+
+
+TIME_RANGE = Literal["last_1h", "last_6h", "last_24h", "last_7d", "last_30d", "today", "yesterday"]
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_wlan_stats(
+    ctx: Context,
+    wlan_name: str,
+    time_range: TIME_RANGE = "last_1h",
+    start_time: str | None = None,
+    end_time: str | None = None,
+) -> list[dict] | str:
+    """
+    Get throughput trend data for a specific WLAN over a time window.
+
+    Returns a time-series of throughput samples with timestamp, tx
+    (transmitted) and rx (received) values in bits per second. Use
+    this to analyze WLAN performance trends over time.
+
+    Parameters:
+        wlan_name: WLAN name (SSID) to get stats for (required).
+        time_range: Predefined time window. Allowed: last_1h, last_6h,
+            last_24h, last_7d, last_30d, today, yesterday.
+            Ignored if both start_time and end_time are provided.
+        start_time: Start of time window in RFC 3339 format
+            (e.g. "2026-04-15T00:00:00.000Z"). Overrides time_range
+            when combined with end_time.
+        end_time: End of time window in RFC 3339 format.
+            Overrides time_range when combined with start_time.
+    """
+    start_at, end_at = resolve_time_window(time_range, start_time, end_time)
+    conn = ctx.lifespan_context["central_conn"]
+
+    try:
+        response = retry_central_command(
+            central_conn=conn,
+            api_method="GET",
+            api_path=f"network-monitoring/v1/wlans/{wlan_name}/throughput-trends",
+            api_params={"filter": f"timestamp gt {start_at} and timestamp lt {end_at}"},
+        )
+    except Exception as e:
+        return f"Error fetching WLAN statistics: {e}"
+
+    code = response.get("code", 0)
+    if not (200 <= code < 300):
+        return f"Error fetching WLAN stats (HTTP {code}): {response.get('msg')}"
+
+    # Flatten the graph structure into a list of samples
+    msg = response.get("msg", {})
+    graph = msg.get("graph", {}) if isinstance(msg, dict) else {}
+    keys = graph.get("keys", [])
+    samples = graph.get("samples", [])
+
+    result = []
+    for sample in samples:
+        data = sample.get("data", [])
+        values = dict(zip(keys, data, strict=False))
+        if all(v is None for v in values.values()):
+            continue
+        result.append(
+            {
+                "timestamp": sample.get("timestamp"),
+                "tx": values.get("tx"),
+                "rx": values.get("rx"),
+            }
+        )
+
+    if not result:
+        return f"No throughput data found for WLAN '{wlan_name}'."
+    return result

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -553,3 +553,24 @@ def compute_time_window(
         raise ValueError("Invalid time_range")
 
     return start, now
+
+
+def format_rfc3339(dt: datetime) -> str:
+    """Format a datetime as an RFC 3339 string with millisecond precision."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def resolve_time_window(
+    time_range: str,
+    start_time: str | None,
+    end_time: str | None,
+) -> tuple[str, str]:
+    """Return (start_at, end_at) as RFC 3339 strings.
+
+    If both start_time and end_time are provided, use them as-is.
+    Otherwise compute the window from the time_range preset.
+    """
+    if start_time and end_time:
+        return start_time, end_time
+    start_dt, end_dt = compute_time_window(time_range)
+    return format_rfc3339(start_dt), format_rfc3339(end_dt)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,63 @@
+"""Integration test fixtures using Docker secrets for live API access.
+
+These tests run against real Mist and Central APIs. They require
+Docker secrets to be available at SECRETS_DIR (default: ./secrets/).
+Tests skip gracefully if credentials are missing.
+
+Run via Docker:
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
+        hpe-networking-mcp sh -c "uv run pytest tests/integration/ -m integration -v"
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _read_secret(name: str) -> str | None:
+    """Read a secret file from SECRETS_DIR, matching config.py behavior."""
+    secrets_dir = os.environ.get("SECRETS_DIR", "/run/secrets")
+    path = Path(secrets_dir) / name
+    if path.is_file():
+        return path.read_text().strip()
+    return None
+
+
+@pytest.fixture(scope="session")
+def central_conn():
+    """Create a live Central connection from Docker secrets.
+
+    Skips all tests if Central credentials are not available.
+    """
+    base_url = _read_secret("central_base_url")
+    client_id = _read_secret("central_client_id")
+    client_secret = _read_secret("central_client_secret")
+
+    if not all([base_url, client_id, client_secret]):
+        pytest.skip("Central credentials not found — skipping live tests")
+
+    from pycentral import NewCentralBase
+
+    conn = NewCentralBase(
+        token_info={
+            "new_central": {
+                "base_url": base_url,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            }
+        }
+    )
+    return conn
+
+
+@pytest.fixture(scope="session")
+def live_ctx(central_conn):
+    """Create a mock Context with a live Central connection.
+
+    Mimics the lifespan context that tools receive at runtime.
+    """
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": central_conn}
+    return ctx

--- a/tests/integration/test_ap_monitoring_live.py
+++ b/tests/integration/test_ap_monitoring_live.py
@@ -1,0 +1,75 @@
+"""Integration tests for AP monitoring tools against live Central API."""
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools.monitoring import (
+    central_get_ap_details,
+    central_get_ap_wlans,
+    central_get_aps,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_get_aps_no_filter(live_ctx):
+    """Verify central_get_aps returns a list of APs."""
+    result = await central_get_aps(live_ctx)
+    assert isinstance(result, (list, str))
+    if isinstance(result, list):
+        assert len(result) > 0
+        assert all(isinstance(ap, dict) for ap in result)
+
+
+async def test_get_aps_online_filter(live_ctx):
+    """Verify filtering by ONLINE status."""
+    result = await central_get_aps(live_ctx, status="ONLINE")
+    assert isinstance(result, (list, str))
+
+
+async def test_get_aps_offline_filter(live_ctx):
+    """Verify filtering by OFFLINE status."""
+    result = await central_get_aps(live_ctx, status="OFFLINE")
+    assert isinstance(result, (list, str))
+
+
+async def test_get_ap_details_for_known_ap(live_ctx):
+    """Get details for the first AP found."""
+    aps = await central_get_aps(live_ctx)
+    if isinstance(aps, str) or not aps:
+        pytest.skip("No APs available")
+    serial = aps[0].get("serialNumber", aps[0].get("serial_number"))
+    if not serial:
+        pytest.skip("AP has no serial number")
+    result = await central_get_ap_details(live_ctx, serial_number=serial)
+    assert isinstance(result, (dict, str))
+
+
+async def test_get_ap_wlans_for_known_ap(live_ctx):
+    """Get WLANs for the first online AP."""
+    aps = await central_get_aps(live_ctx, status="ONLINE")
+    if isinstance(aps, str) or not aps:
+        pytest.skip("No online APs available")
+    serial = aps[0].get("serialNumber", aps[0].get("serial_number"))
+    if not serial:
+        pytest.skip("AP has no serial number")
+    result = await central_get_ap_wlans(live_ctx, serial_number=serial)
+    assert isinstance(result, (list, str))
+
+
+async def test_get_ap_wlans_name_filter(live_ctx):
+    """Verify wlan_name filter works client-side."""
+    aps = await central_get_aps(live_ctx, status="ONLINE")
+    if isinstance(aps, str) or not aps:
+        pytest.skip("No online APs available")
+    serial = aps[0].get("serialNumber", aps[0].get("serial_number"))
+    if not serial:
+        pytest.skip("AP has no serial number")
+
+    all_wlans = await central_get_ap_wlans(live_ctx, serial_number=serial)
+    if isinstance(all_wlans, str) or not all_wlans:
+        pytest.skip("No WLANs on this AP")
+
+    target = all_wlans[0].get("wlanName")
+    filtered = await central_get_ap_wlans(live_ctx, serial_number=serial, wlan_name=target)
+    assert isinstance(filtered, list)
+    assert all(w.get("wlanName") == target for w in filtered)

--- a/tests/integration/test_wlans_live.py
+++ b/tests/integration/test_wlans_live.py
@@ -1,0 +1,65 @@
+"""Integration tests for WLAN tools against live Central API."""
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools.wlans import (
+    central_get_wlan_stats,
+    central_get_wlans,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_get_wlans_returns_results(live_ctx):
+    """Verify central_get_wlans returns WLAN data."""
+    result = await central_get_wlans(live_ctx)
+    assert isinstance(result, (list, str))
+    if isinstance(result, list):
+        assert len(result) > 0
+
+
+async def test_get_wlans_all_have_name(live_ctx):
+    """Verify all returned WLANs have a name field."""
+    result = await central_get_wlans(live_ctx)
+    if isinstance(result, str):
+        pytest.skip("No WLANs available")
+    assert all(w.get("wlanName") or w.get("essid") for w in result)
+
+
+async def test_get_wlan_stats_for_known_wlan(live_ctx):
+    """Get throughput stats for the first WLAN found."""
+    wlans = await central_get_wlans(live_ctx)
+    if isinstance(wlans, str) or not wlans:
+        pytest.skip("No WLANs available")
+    wlan_name = wlans[0].get("wlanName") or wlans[0].get("essid")
+    if not wlan_name:
+        pytest.skip("WLAN has no name")
+
+    result = await central_get_wlan_stats(live_ctx, wlan_name=wlan_name)
+    assert isinstance(result, (list, str))
+    if isinstance(result, list):
+        assert all("timestamp" in s for s in result)
+
+
+async def test_get_wlan_stats_custom_time_window(live_ctx):
+    """Verify custom start/end time overrides time_range."""
+    wlans = await central_get_wlans(live_ctx)
+    if isinstance(wlans, str) or not wlans:
+        pytest.skip("No WLANs available")
+    wlan_name = wlans[0].get("wlanName") or wlans[0].get("essid")
+    if not wlan_name:
+        pytest.skip("WLAN has no name")
+
+    result = await central_get_wlan_stats(
+        live_ctx,
+        wlan_name=wlan_name,
+        start_time="2026-04-14T00:00:00.000Z",
+        end_time="2026-04-14T23:59:59.999Z",
+    )
+    assert isinstance(result, (list, str))
+
+
+async def test_get_wlan_stats_unknown_wlan(live_ctx):
+    """Verify unknown WLAN returns a descriptive string."""
+    result = await central_get_wlan_stats(live_ctx, wlan_name="__nonexistent_wlan__")
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary

3 new Central monitoring tools ported from the upstream central-mcp-server, plus integration test scaffolding for live API testing.

### New Tools
- **`central_get_aps`** — filtered AP listing with AP-specific filters: status (ONLINE/OFFLINE), model, firmware, deployment type (Standalone/Cluster), cluster, site. Uses `MonitoringAPs.get_all_aps()`.
- **`central_get_ap_wlans`** — WLANs currently active on a specific AP by serial number. Uses `MonitoringAPs.get_ap_wlans()`. Supports optional `wlan_name` filter.
- **`central_get_wlan_stats`** — WLAN throughput trends (tx/rx time-series in bps) over a time window. Uses `GET /network-monitoring/v1/wlans/{name}/throughput-trends`. Supports predefined time ranges and custom RFC 3339 start/end.

### Integration Tests
- `tests/integration/conftest.py` — live API fixtures using Docker secrets (not .env). Creates real Central connection, skips gracefully if credentials missing.
- `tests/integration/test_ap_monitoring_live.py` — 6 tests for AP listing, details, WLAN-per-AP
- `tests/integration/test_wlans_live.py` — 5 tests for WLAN listing, throughput stats, time windows

Run integration tests via Docker:
```
docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
  hpe-networking-mcp sh -c "SECRETS_DIR=/run/secrets uv run pytest tests/integration/ -m integration -v"
```

### Versioning
- Moved to 4-digit versioning: `v0.MAJOR.MINOR.PATCH`
- This release: v0.8.1.0
- Central tool count: 53 → 56

## Test plan
- [ ] CI passes (unit tests + lint)
- [ ] Integration tests pass against live Central API
- [ ] `central_get_aps` returns APs with status filter
- [ ] `central_get_ap_wlans` returns WLANs for a specific AP
- [ ] `central_get_wlan_stats` returns throughput data