### PR TITLE
Add Central role management tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.8.2.0] - 2026-04-15
+
+### Added — Central Role Management
+- `central_get_roles` — read role configurations (VLAN, QoS, ACLs, bandwidth contracts, classification rules)
+- `central_manage_role` — create, update, delete roles. Supports shared (library) and local (scoped) roles via `scope_id` and `device_function` params.
+- Central tool count: 56 → 58
+
+[v0.8.2.0]: https://github.com/nowireless4u/hpe-networking-mcp/releases/tag/v0.8.2.0
+
 ## [v0.8.1.0] - 2026-04-15
 
 ### Added — New Central Monitoring Tools

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling t
 | **Scope & Configuration Hierarchy** | — | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — |
 | **Dynamic API Discovery** | — | — | ✅ |
-| **Tools** | **35 + 2 prompts** | **56 + 12 prompts** | **3 or 10** |
+| **Tools** | **35 + 2 prompts** | **58 + 12 prompts** | **3 or 10** |
 | **Cross-Platform** | **1 tool + 3 prompts** | **1 tool + 3 prompts** | — |
 
 > **GreenLake tool count**: 3 tools in **dynamic mode** (default) — a meta-tool system that can discover and invoke any GreenLake API endpoint. 10 tools in **static mode** — dedicated tools for each endpoint. Set via `MCP_TOOL_MODE` environment variable.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,7 +9,7 @@ and `greenlake_*` (HPE GreenLake).
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
-| Aruba Central | 51 | 5 | 12 | 68 |
+| Aruba Central | 52 | 6 | 12 | 70 |
 | Cross-Platform | -- | 1 | 3 | 4 |
 | HPE GreenLake (static mode) | 10 | -- | -- | 10 |
 | HPE GreenLake (dynamic mode) | 3 | -- | -- | 3 |
@@ -503,7 +503,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Aruba Central (56 tools + 12 prompts)
+## Aruba Central (58 tools + 12 prompts)
 
 ### Sites
 
@@ -1062,6 +1062,29 @@ to translate between Central's named/aliased config and Mist's inline config.
 | profile_type | str | Yes | Profile type: `wlan-ssids`, `roles`, `policies`, `auth-server-groups`, `named-vlans`, `aliases`. |
 | profile_instance | str | Yes | Profile name (e.g. the SSID name for WLAN profiles). |
 | confirmed | bool | No | Set to true after user confirms. |
+
+### Roles
+
+#### `central_get_roles`
+
+> Get role configurations. Roles define network access (VLAN, QoS, ACLs, bandwidth contracts) for clients and are used in WLAN profiles, switch ports, NAC policies, and firewall rules.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | str | No | Specific role name. If omitted, returns all roles. |
+
+#### `central_manage_role`
+
+> Create, update, or delete a role. Requires `ENABLE_CENTRAL_WRITE_TOOLS=true`. Roles can be shared (library) or local (scoped to a site/collection).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| name | str | Yes | Role name (identifier in API path). |
+| action_type | str | Yes | `create`, `update`, or `delete`. |
+| payload | dict | Yes | Role config (VLAN, ACLs, QoS, bandwidth, etc.). Empty dict for delete. |
+| scope_id | str | No | Scope ID for local roles. Omit for shared/library roles. |
+| device_function | str | No | `CAMPUS_AP`, `ACCESS_SWITCH`, `BRANCH_GW`, etc. Required with scope_id. |
+| confirmed | bool | No | Set to true after user confirms update/delete. |
 
 ### Guided Prompts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.8.1.0"
+version = "0.8.2.0"
 description = "Unified MCP server for Juniper Mist, Aruba Central, and HPE GreenLake"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -131,6 +131,11 @@ When asked to create a new site based on an existing site:
   - **Valid opmode values**: OPEN, WPA2_PERSONAL, WPA3_SAE, WPA2_ENTERPRISE, WPA3_ENTERPRISE_CCM_128, WPA2_MPSK_AES, ENHANCED_OPEN, DPP. Note: `WPA2_PSK_AES` does NOT exist — use `WPA2_PERSONAL` for WPA2 PSK.
   - **Mist-to-Central opmode mapping**: Mist psk → `WPA2_PERSONAL`, Mist psk+wpa3 → `WPA3_SAE`, Mist eap → `WPA2_ENTERPRISE`, Mist eap+wpa3+wpa2 → `WPA3_ENTERPRISE_CCM_128`
   - **NEVER call this tool directly for cross-platform WLAN sync** — use the sync prompts instead
+- **Roles**: central_get_roles, central_manage_role
+  - Use `central_get_roles` to read role configurations (VLAN, QoS, ACLs, bandwidth contracts)
+  - Use `central_manage_role` to create, update, or delete roles — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`
+  - Roles can be shared (library-level) or local (scoped to a site/collection). Use `scope_id` and `device_function` params for local roles.
+  - After creating, use `central_manage_config_assignment` to assign the role to a scope
 - **Aliases, Server Groups, Named VLANs**: central_get_aliases, central_get_server_groups, central_get_named_vlans
   - Use `central_get_aliases` to resolve alias names used in WLAN profiles (SSID aliases, PSK aliases), server groups, and VLANs. Aliases can be scoped per-site.
   - Use `central_get_server_groups` to resolve a server group name (from auth-server-group) to actual RADIUS server addresses (FQDN or IP), ports, and settings

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -64,6 +64,10 @@ TOOLS = {
         "central_get_wlan_profiles",
         "central_manage_wlan_profile",
     ],
+    "roles": [
+        "central_get_roles",
+        "central_manage_role",
+    ],
     "config_assignments": [
         "central_get_config_assignments",
         "central_manage_config_assignment",

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -1,0 +1,204 @@
+"""Aruba Central role configuration tools.
+
+Provides read and write access to Central's role system. Roles define
+network access for clients and can be assigned to WLAN profiles, switch
+ports, NAC policies, and firewall rules. Roles contain VLAN assignments,
+QoS settings, ACLs, bandwidth contracts, and classification rules.
+
+API: GET/POST/PATCH/DELETE /network-config/v1alpha1/roles
+"""
+
+from typing import Annotated
+
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from loguru import logger
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from hpe_networking_mcp.middleware.elicitation import elicitation_handler
+from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+WRITE_DELETE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_get_roles(
+    ctx: Context,
+    name: str | None = None,
+) -> dict | list | str:
+    """
+    Get role configurations from Aruba Central.
+
+    Roles define network access for clients — VLAN assignments, QoS,
+    ACLs, bandwidth contracts, and classification rules. They are used
+    in WLAN profiles (default-role, pre-auth-role), switch port configs,
+    NAC policies, and firewall rules.
+
+    Parameters:
+        name: Specific role name to retrieve. If omitted, returns all roles.
+
+    Returns:
+        Single role dict if name specified, or list of all roles.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+    api_path = f"network-config/v1alpha1/roles/{name}" if name else "network-config/v1alpha1/roles"
+
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path=api_path,
+    )
+    return response.get("msg", {})
+
+
+@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_role(
+    ctx: Context,
+    name: Annotated[
+        str,
+        Field(description="The role name. Used as the identifier in the API path."),
+    ],
+    action_type: Annotated[
+        str,
+        Field(description="Action to perform: 'create', 'update', or 'delete'."),
+    ],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Role configuration payload. For delete: pass empty dict {}. "
+                "For create/update, key fields include:\n"
+                "- vlan: VLAN assignment for the role (ID or name)\n"
+                "- access-list: ACL rules applied to this role\n"
+                "- bandwidth-contract: bandwidth limits\n"
+                "- qos: QoS settings\n"
+                "- captive-portal: captive portal profile\n"
+                "- session-timeout: session timeout in seconds\n"
+                "- description: role description (CX switches only)\n"
+                "Use central_get_roles to see existing role structures "
+                "as a reference for the payload format."
+            )
+        ),
+    ],
+    scope_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Scope ID for scoped (LOCAL) roles. If provided, creates "
+                "a local role at this scope. If omitted, creates a shared "
+                "(SHARED/library) role. Get scope IDs from central_get_scope_tree."
+            ),
+            default=None,
+        ),
+    ],
+    device_function: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Device function for scoped roles. Required when scope_id "
+                "is provided. Valid values: CAMPUS_AP, ACCESS_SWITCH, "
+                "BRANCH_GW, MOBILITY_GW, CORE_SWITCH, AGG_SWITCH, ALL."
+            ),
+            default=None,
+        ),
+    ],
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Set to true when the user has confirmed the operation in chat.",
+            default=False,
+        ),
+    ],
+) -> dict | str:
+    """
+    Create, update, or delete a role in Central.
+
+    Roles define network access for clients and are used across WLAN
+    profiles, switch ports, NAC policies, and firewall rules. The role
+    name is the identifier in the API path.
+
+    Roles can be shared (library-level, available everywhere) or local
+    (scoped to a specific site/collection/device). Use scope_id and
+    device_function to create local roles.
+
+    After creating a role, use central_manage_config_assignment to
+    assign it to a scope if needed.
+    """
+    if action_type not in ("create", "update", "delete"):
+        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+
+    api_path = f"network-config/v1alpha1/roles/{name}"
+    method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}
+    api_method = method_map[action_type]
+
+    action_wording = {
+        "create": "create a new",
+        "update": "update an existing",
+        "delete": "delete an existing",
+    }[action_type]
+
+    # Confirm for update and delete only
+    if action_type != "create" and not confirmed:
+        elicitation_response = await elicitation_handler(
+            message=f"The LLM wants to {action_wording} role '{name}'. Do you accept?",
+            ctx=ctx,
+        )
+        if elicitation_response.action == "decline":
+            if await ctx.get_state("elicitation_mode") == "chat_confirm":
+                return {
+                    "status": "confirmation_required",
+                    "message": (
+                        f"This operation will {action_wording} role '{name}'. "
+                        "Please confirm with the user before proceeding. "
+                        "Call this tool again with confirmed=true after the user confirms."
+                    ),
+                }
+            return {"message": "Action declined by user."}
+        elif elicitation_response.action == "cancel":
+            return {"message": "Action canceled by user."}
+
+    conn = ctx.lifespan_context["central_conn"]
+
+    # Build query params for scoped operations
+    api_params: dict = {}
+    if scope_id and device_function:
+        api_params["object-type"] = "LOCAL"
+        api_params["scope-id"] = scope_id
+        api_params["device-function"] = device_function
+
+    api_data: dict = {}
+    if action_type != "delete":
+        api_data = payload
+
+    logger.info("Central role: {} '{}' — path: {}", api_method, name, api_path)
+
+    response = retry_central_command(
+        central_conn=conn,
+        api_method=api_method,
+        api_path=api_path,
+        api_data=api_data if api_data else None,
+        api_params=api_params if api_params else None,
+    )
+
+    code = response.get("code", 0)
+    if 200 <= code < 300:
+        return {
+            "status": "success",
+            "action": action_type,
+            "name": name,
+            "data": response.get("msg", {}),
+        }
+
+    return {
+        "status": "error",
+        "code": code,
+        "message": response.get("msg", "Unknown error"),
+    }


### PR DESCRIPTION
## Summary

New read+write tools for Central's role system. Roles define network access for clients and are used across WLAN profiles (default-role, pre-auth-role), switch port configs, NAC policies, and firewall rules.

### New Tools
- **`central_get_roles`** — read role configurations (VLAN assignments, QoS, ACLs, bandwidth contracts, classification rules)
- **`central_manage_role`** — create, update, delete roles. Supports shared (library-level) and local (scoped) roles via `scope_id` and `device_function` parameters. Uses `PATCH` for updates (not `PUT`) per the Central API spec.

### Details
- API: `GET/POST/PATCH/DELETE /network-config/v1alpha1/roles/{name}`
- Scoped roles: pass `scope_id` + `device_function` to create LOCAL roles at a specific scope
- Central tool count: 56 → 58

## Test plan
- [ ] CI passes
- [ ] `central_get_roles` returns role list
- [ ] `central_get_roles(name="<role>")` returns specific role config
- [ ] `central_manage_role(action_type="create")` creates a role