### PR TITLE
Fix Docker publish for 4-digit versioning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The docker/metadata-action type=semver pattern cannot parse 4-digit versions (v0.8.3.0). Switched to type=ref,event=tag which uses the git tag as-is. Also adds latest tag.