### PR TITLE
Fix ClearPass lifespan init silently accepting auth failures

### DIFF
--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -119,7 +119,9 @@ async def lifespan(server: FastMCP):
             version_info = test_client.get_server_version()
             # Check if auth failed — pyclearpass returns error dicts instead of raising
             if not test_client.api_token:
-                error_detail = version_info.get("detail", "unknown error") if isinstance(version_info, dict) else str(version_info)
+                error_detail = (
+                    version_info.get("detail", "unknown error") if isinstance(version_info, dict) else str(version_info)
+                )
                 raise RuntimeError(f"OAuth2 authentication failed: {error_detail}")
             # Cache token for reuse across all tool calls
             context["clearpass_token"] = test_client.api_token

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -117,6 +117,10 @@ async def lifespan(server: FastMCP):
             )
             test_client.verify_ssl = config.clearpass.verify_ssl
             version_info = test_client.get_server_version()
+            # Check if auth failed — pyclearpass returns error dicts instead of raising
+            if not test_client.api_token:
+                error_detail = version_info.get("detail", "unknown error") if isinstance(version_info, dict) else str(version_info)
+                raise RuntimeError(f"OAuth2 authentication failed: {error_detail}")
             # Cache token for reuse across all tool calls
             context["clearpass_token"] = test_client.api_token
             context["clearpass_config"] = config.clearpass


### PR DESCRIPTION
## Summary
- pyclearpass returns error dicts instead of raising exceptions on OAuth2 auth failure
- The lifespan init treated any dict response as success, logging `ClearPass: connection verified (version: unknown)` even when credentials were rejected with `invalid_client`
- Now checks for an empty `api_token` after the verification call and raises `RuntimeError` with the actual error detail
- This causes the init to properly log a warning and set `clearpass_config = None`, auto-disabling the platform like other platforms do on auth failure

## Test plan
- [ ] Invalid credentials: server logs `ClearPass: failed to initialize — OAuth2 authentication failed: The client credentials are invalid`
- [ ] Valid credentials: server logs `ClearPass: connection verified (version: X.Y)`
- [ ] Other platforms unaffected