### PR TITLE
Fix ClearPass 403 errors from expired OAuth2 tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.0.1] - 2026-04-17
+
+### Fixed
+- **ClearPass tools returning 403 after ~8 hours** (#130) — OAuth2 access tokens
+  issued via `client_credentials` expire after 8 hours, but the server cached the
+  startup token indefinitely. After the token aged out every `clearpass_*` tool
+  returned `403 Forbidden` even for Super Administrator clients. Replaced the
+  single-shot cache with a pycentral-style reactive refresh: on any 401/403 the
+  token is invalidated, a fresh one is fetched from `/oauth`, and the original
+  request is replayed once. Implemented as a class-level patch on
+  `ClearPassAPILogin._send_request` since pyclearpass methods bypass
+  instance-level overrides.
+
 ## [v0.9.0.0] - 2026-04-16
 
 ### Added — Aruba ClearPass Platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.9.0.0"
+version = "0.9.0.1"
 description = "Unified MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/client.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/client.py
@@ -76,9 +76,7 @@ class ClearPassTokenManager:
             raise ClearPassAuthError(f"ClearPass OAuth2 request failed: {e}") from e
 
         if response.status_code != 200:
-            raise ClearPassAuthError(
-                f"ClearPass OAuth2 failed with HTTP {response.status_code}: {response.text[:200]}"
-            )
+            raise ClearPassAuthError(f"ClearPass OAuth2 failed with HTTP {response.status_code}: {response.text[:200]}")
 
         try:
             data = response.json()
@@ -108,7 +106,7 @@ def _is_auth_error(response: Any) -> bool:
     return isinstance(status, int) and status in _AUTH_ERROR_STATUSES
 
 
-_TOKEN_MANAGER_ATTR = "_hpe_token_manager"
+_TOKEN_MANAGER_ATTR = "_hpe_token_manager"  # nosec B105 — attribute name, not a credential
 _PATCH_MARKER = "_hpe_auth_retry_patched"
 
 

--- a/src/hpe_networking_mcp/platforms/clearpass/client.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/client.py
@@ -3,12 +3,19 @@
 Unlike pycentral (single connection object), pyclearpass requires instantiating
 each API class independently — every class inherits ClearPassAPILogin.
 
-We acquire an OAuth2 token once at lifespan init and pass it via ``api_token=``
-to skip re-authentication on every tool call.
+ClearPass OAuth2 tokens expire after 8 hours (28800s). pyclearpass only
+re-auths when its cached ``api_token`` is empty, so once the token ages out
+every subsequent call returns 403 Forbidden. We fix that by wrapping
+``_send_request`` on each API instance with a pycentral-style retry: on an
+auth failure, invalidate the cached token, fetch a fresh one, and replay the
+original request exactly once.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
+import httpx
 from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
 from loguru import logger
@@ -17,21 +24,167 @@ from pyclearpass.common import ClearPassAPILogin
 from hpe_networking_mcp.config import ClearPassSecrets
 from hpe_networking_mcp.utils.logging import mask_secret
 
+# ClearPass returns both 401 (invalid token) and 403 (insufficient perms /
+# expired client-credentials token). We retry on either since a stale token
+# surfaces as 403 in practice.
+_AUTH_ERROR_STATUSES = frozenset({401, 403})
 
-def create_api_client[T: ClearPassAPILogin](api_class: type[T], config: ClearPassSecrets, token: str) -> T:
-    """Create a pyclearpass API class instance with a shared cached token.
+
+class ClearPassAuthError(RuntimeError):
+    """Raised when OAuth2 client-credentials authentication fails."""
+
+
+class ClearPassTokenManager:
+    """Acquires and caches ClearPass OAuth2 access tokens.
+
+    The token is held until :meth:`invalidate` is called, at which point the
+    next :meth:`get_token` will fetch a fresh one from ``/oauth``.
+    """
+
+    def __init__(self, config: ClearPassSecrets) -> None:
+        self._config = config
+        self._token: str | None = None
+
+    def get_token(self) -> str:
+        """Return the cached token, fetching a new one if none is held."""
+        if self._token is None:
+            self._refresh()
+        assert self._token is not None
+        return self._token
+
+    def invalidate(self) -> None:
+        """Drop the cached token so the next ``get_token`` refreshes."""
+        self._token = None
+
+    def _refresh(self) -> None:
+        """Acquire a fresh access token via the client-credentials grant."""
+        url = f"{self._config.server}/oauth"
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": self._config.client_id,
+            "client_secret": self._config.client_secret,
+        }
+        logger.info("ClearPass: requesting new OAuth2 access token")
+        try:
+            response = httpx.post(
+                url,
+                json=payload,
+                verify=self._config.verify_ssl,
+                timeout=30.0,
+            )
+        except httpx.HTTPError as e:
+            raise ClearPassAuthError(f"ClearPass OAuth2 request failed: {e}") from e
+
+        if response.status_code != 200:
+            raise ClearPassAuthError(
+                f"ClearPass OAuth2 failed with HTTP {response.status_code}: {response.text[:200]}"
+            )
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise ClearPassAuthError(f"ClearPass OAuth2 returned non-JSON body: {response.text[:200]}") from e
+
+        token = data.get("access_token")
+        if not token:
+            detail = data.get("detail") or data.get("error_description") or data
+            raise ClearPassAuthError(f"ClearPass OAuth2 response missing access_token: {detail}")
+
+        self._token = token
+        logger.info("ClearPass: obtained token {}", mask_secret(token))
+
+
+def _is_auth_error(response: Any) -> bool:
+    """Detect a 401/403 auth-failure payload from pyclearpass.
+
+    pyclearpass returns decoded dicts for JSON responses and raw text/bytes
+    otherwise. Error bodies look like::
+
+        {"type": "...", "title": "Forbidden", "status": 403, "detail": "Forbidden"}
+    """
+    if not isinstance(response, dict):
+        return False
+    status = response.get("status")
+    return isinstance(status, int) and status in _AUTH_ERROR_STATUSES
+
+
+_TOKEN_MANAGER_ATTR = "_hpe_token_manager"
+_PATCH_MARKER = "_hpe_auth_retry_patched"
+
+
+def _install_class_auth_retry() -> None:
+    """Patch :meth:`ClearPassAPILogin._send_request` once with refresh-on-auth-error.
+
+    pyclearpass API methods invoke ``ClearPassAPILogin._send_request(self, ...)``
+    directly against the class rather than the instance, so instance-level
+    monkey-patches never fire. We wrap the class method once at import time;
+    the wrapper looks up the token manager attached to each instance by
+    :func:`create_api_client` and uses it to refresh on 401/403.
+    """
+    if getattr(ClearPassAPILogin, _PATCH_MARKER, False):
+        return
+
+    original = ClearPassAPILogin._send_request
+
+    def send_with_retry(
+        self: ClearPassAPILogin,
+        url: str,
+        method: str,
+        query: str = "",
+        content_response_type: str = "application/json",
+    ) -> Any:
+        response = original(self, url, method, query, content_response_type)
+        if not _is_auth_error(response):
+            return response
+
+        token_manager: ClearPassTokenManager | None = getattr(self, _TOKEN_MANAGER_ATTR, None)
+        if token_manager is None:
+            return response
+
+        logger.info(
+            "ClearPass: auth error on {} {} — refreshing token and retrying once",
+            method.upper(),
+            url,
+        )
+        token_manager.invalidate()
+        try:
+            self.api_token = token_manager.get_token()
+        except ClearPassAuthError as e:
+            logger.warning("ClearPass: token refresh failed — {}", e)
+            return response
+        return original(self, url, method, query, content_response_type)
+
+    ClearPassAPILogin._send_request = send_with_retry  # type: ignore[method-assign]
+    ClearPassAPILogin._hpe_auth_retry_patched = True  # type: ignore[attr-defined]
+
+
+_install_class_auth_retry()
+
+
+def create_api_client[T: ClearPassAPILogin](
+    api_class: type[T],
+    config: ClearPassSecrets,
+    token_manager: ClearPassTokenManager,
+) -> T:
+    """Create a pyclearpass API client wired up with the shared token manager.
+
+    The returned instance:
+      * uses the token manager's currently cached token
+      * honours ``config.verify_ssl`` (pyclearpass hardcodes ``False``)
+      * automatically refreshes the token and retries once on 401/403
+        (via the class-level :func:`_install_class_auth_retry` patch)
 
     Args:
         api_class: Any pyclearpass API class (e.g. ``ApiIdentities``).
         config: ClearPass connection details from Docker secrets.
-        token: Pre-acquired OAuth2 access token.
+        token_manager: Shared token manager for refresh-on-auth-error.
 
     Returns:
         Configured API class instance ready for calls.
     """
-    instance = api_class(server=config.server, api_token=token)
-    # pyclearpass hardcodes verify_ssl=False in __init__ — override it
+    instance = api_class(server=config.server, api_token=token_manager.get_token())
     instance.verify_ssl = config.verify_ssl
+    setattr(instance, _TOKEN_MANAGER_ATTR, token_manager)
     return instance
 
 
@@ -48,16 +201,16 @@ async def get_clearpass_session[T: ClearPassAPILogin](api_class: type[T]) -> T:
         api_class: The pyclearpass API class to instantiate.
 
     Returns:
-        Configured API client instance.
+        Configured API client instance with auth-retry installed.
 
     Raises:
-        ToolError: If ClearPass is not configured or token is missing.
+        ToolError: If ClearPass is not configured or token acquisition fails.
     """
     ctx = get_context()
     config: ClearPassSecrets | None = ctx.lifespan_context.get("clearpass_config")
-    token: str | None = ctx.lifespan_context.get("clearpass_token")
+    token_manager: ClearPassTokenManager | None = ctx.lifespan_context.get("clearpass_token_manager")
 
-    if config is None or token is None:
+    if config is None or token_manager is None:
         raise ToolError(
             {
                 "status_code": 503,
@@ -65,9 +218,19 @@ async def get_clearpass_session[T: ClearPassAPILogin](api_class: type[T]) -> T:
             }
         )
 
+    try:
+        token = token_manager.get_token()
+    except ClearPassAuthError as e:
+        raise ToolError(
+            {
+                "status_code": 503,
+                "message": f"ClearPass token refresh failed: {e}",
+            }
+        ) from e
+
     logger.debug(
         "ClearPass API request — server: {}, token: {}",
         config.server,
         mask_secret(token),
     )
-    return create_api_client(api_class, config, token)
+    return create_api_client(api_class, config, token_manager)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -107,34 +107,22 @@ async def lifespan(server: FastMCP):
     # --- ClearPass ---
     if config.clearpass:
         try:
-            from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
+            from hpe_networking_mcp.platforms.clearpass.client import ClearPassTokenManager
 
-            test_client = ApiLocalServerConfiguration(
-                server=config.clearpass.server,
-                granttype="client_credentials",
-                clientid=config.clearpass.client_id,
-                clientsecret=config.clearpass.client_secret,
-            )
-            test_client.verify_ssl = config.clearpass.verify_ssl
-            version_info = test_client.get_server_version()
-            # Check if auth failed — pyclearpass returns error dicts instead of raising
-            if not test_client.api_token:
-                error_detail = (
-                    version_info.get("detail", "unknown error") if isinstance(version_info, dict) else str(version_info)
-                )
-                raise RuntimeError(f"OAuth2 authentication failed: {error_detail}")
-            # Cache token for reuse across all tool calls
-            context["clearpass_token"] = test_client.api_token
+            token_manager = ClearPassTokenManager(config.clearpass)
+            # Acquire an initial token so bad credentials fail loudly at startup
+            # instead of on the first tool call.
+            token_manager.get_token()
+            context["clearpass_token_manager"] = token_manager
             context["clearpass_config"] = config.clearpass
-            version_str = version_info.get("app_major_version", "unknown") if isinstance(version_info, dict) else "?"
-            logger.info("ClearPass: connection verified (version: {})", version_str)
+            logger.info("ClearPass: connection verified")
         except Exception as e:
             logger.warning("ClearPass: failed to initialize — {}", e)
             context["clearpass_config"] = None
-            context["clearpass_token"] = None
+            context["clearpass_token_manager"] = None
     else:
         context["clearpass_config"] = None
-        context["clearpass_token"] = None
+        context["clearpass_token_manager"] = None
 
     try:
         yield context


### PR DESCRIPTION
## Summary
- Fixes #130 — `clearpass_*` tools returning 403 Forbidden after ~8 hours because the server cached a single OAuth2 token indefinitely past its 8h lifetime.
- Replaces the single-shot cache with a pycentral-style reactive refresh: on any 401/403 response the token is invalidated, a fresh one is fetched via `/oauth`, and the original request is replayed once.
- Implemented as a class-level patch on `ClearPassAPILogin._send_request` because pyclearpass methods invoke `ClearPassAPILogin._send_request(self, ...)` directly against the class, bypassing any instance-level override.

## Test plan
- [x] Container starts cleanly: `ClearPass: connection verified` with fresh token
- [x] Live MCP calls return real data: `clearpass_test_connection`, `clearpass_get_network_devices`, `clearpass_get_api_clients`, `clearpass_get_sessions`
- [x] Manual retry verification: setting `instance.api_token = "deadbeef_invalid"` → detected 403 → refresh → retry → success; token on the instance was swapped to the newly fetched one
- [ ] CI: lint, format, type check, tests, Docker build