### PR TITLE
Bump version to 0.9.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.9.0.1] - 2026-04-17
+## [v0.9.0.2] - 2026-04-17
 
 ### Fixed
 - **ClearPass tools returning 403 after ~8 hours** (#130) — OAuth2 access tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.9.0.1"
+version = "0.9.0.2"
 description = "Unified MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- The previous PR (#131) shipped with version `0.9.0.1`, but that tag was already released earlier today for the prior ClearPass auth validation fix (#129). Bumps `pyproject.toml` to `0.9.0.2` and retitles the CHANGELOG entry so the next release tag is uniquely `v0.9.0.2`.

## Test plan
- [x] `pyproject.toml` version is `0.9.0.2`
- [x] Top CHANGELOG entry header is `## [v0.9.0.2] - 2026-04-17`
- [ ] CI passes