### PR TITLE
Add central_recommend_firmware with LSR-preferred upgrade policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.2.0] - 2026-04-20
+
+### Added — Central firmware recommendation tool
+- New `central_recommend_firmware` tool that reads Central's
+  `/network-services/v1/firmware-details` endpoint and applies an
+  LSR-preferred upgrade policy on top of Central's built-in
+  `recommendedVersion`.
+- Classifies each AP or Gateway's current AOS 10 train as LSR or SSR using
+  a hand-maintained mapping (`AOS10_AP_GW_RELEASE_TYPES`, currently
+  covering 10.3–10.8). Switches and AOS 8 devices are passed through with
+  Central's recommendation — the LSR/SSR concept doesn't apply to them.
+- Output includes per-device current train, release type, current version,
+  Central's recommended version, our recommended version or next LSR
+  train, a rationale string, and a fleet-level count breakdown (on LSR,
+  on SSR, on AOS 8, unknown train, needs action).
+- Filters by `serial_number`, `device_type`, `site_id`, or `site_name`
+  (server-side OData). Defaults to omitting devices that are already on
+  Central's recommended version to keep the report actionable.
+- Update `AOS10_AP_GW_RELEASE_TYPES` in
+  `src/hpe_networking_mcp/platforms/central/tools/firmware.py` when Aruba
+  designates a new LSR train.
+
 ## [v0.9.1.1] - 2026-04-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Certificates** | — | — | — | ✅ |
 | **Guided Prompts** | ✅ | ✅ | — | — |
 | **Dynamic API Discovery** | — | — | ✅ | — |
-| **Tools** | **35 + 2 prompts** | **72 + 12 prompts** | **3 or 10** | **127** |
+| **Tools** | **35 + 2 prompts** | **73 + 12 prompts** | **3 or 10** | **127** |
 | **Cross-Platform** | **2 tools + 3 prompts** | **2 tools + 3 prompts** | — | **1 tool** |
 
 > **GreenLake tool count**: 3 tools in **dynamic mode** (default) — a meta-tool system that can discover and invoke any GreenLake API endpoint. 10 tools in **static mode** — dedicated tools for each endpoint. Set via `MCP_TOOL_MODE` environment variable.
@@ -331,7 +331,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 │  ┌──────────┐ ┌──────────┐ ┌──────────────┐ ┌──────────────────┐  │
 │  │   Mist   │ │ Central  │ │  GreenLake   │ │    ClearPass     │  │
 │  │  mist_*  │ │central_* │ │ greenlake_*  │ │   clearpass_*    │  │
-│  │35+2 prmt │ │48+15 prmt│ │  3/10 tools  │ │   127 tools      │  │
+│  │35+2 prmt │ │73+12 prmt│ │  3/10 tools  │ │   127 tools      │  │
 │  └────┬─────┘ └────┬─────┘ └──────┬───────┘ └────────┬─────────┘  │
 │       │            │              │                   │             │
 └───────┼────────────┼──────────────┼───────────────────┼─────────────┘
@@ -437,7 +437,7 @@ hpe-networking-mcp/
 │   ├── middleware/              # Elicitation and null-strip middleware
 │   └── platforms/
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
-│       ├── central/             # 72 Central tools + 12 prompts + API client
+│       ├── central/             # 73 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 3 dynamic or 10 static tools + OAuth2 client
 │       ├── clearpass/           # 127 ClearPass tools + pyclearpass SDK client
 │       ├── manage_wlan.py       # Cross-platform WLAN management tool

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,7 +9,7 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
-| Aruba Central | 59 | 13 | 12 | 84 |
+| Aruba Central | 60 | 13 | 12 | 85 |
 | Aruba ClearPass | 55 | 72 | -- | 127 |
 | Cross-Platform | 1 | 1 | 3 | 5 |
 | HPE GreenLake (static mode) | 10 | -- | -- | 10 |
@@ -505,7 +505,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 ---
 
-## Aruba Central (72 tools + 12 prompts)
+## Aruba Central (73 tools + 12 prompts)
 
 ### Sites
 
@@ -1121,6 +1121,29 @@ and optional `scope_id` + `device_function` for local (scoped) objects.
 #### `central_get_role_gpids` / `central_manage_role_gpid`
 
 > Role GPIDs — map roles to policy group IDs. Controls which policy group is assigned to each role.
+
+### Firmware
+
+#### `central_recommend_firmware`
+
+> Applies an LSR-preferred upgrade policy on top of Central's built-in `recommendedVersion`. For APs and Gateways running AOS 10, classifies the current train as LSR or SSR using a hand-maintained mapping and recommends accordingly: LSR trains get Central's latest-in-train version; SSR trains are recommended to move to the next LSR train. Switches and legacy AOS 8 devices pass Central's recommendation through unchanged.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial_number | str | No | Narrow to one device. |
+| device_type | str | No | `ACCESS_POINT`, `SWITCH`, or `GATEWAY`. LSR/SSR policy only applies to the first two. |
+| site_id | str | No | Limit to a site by ID. |
+| site_name | str | No | Limit to a site by exact name. |
+| include_up_to_date | bool | No | If True, include devices already on Central's recommended version. Default False. |
+| max_pages | int | No | Safety cap on paginated fetches (1000 items × max_pages). Default 10. |
+
+**Returned report:**
+
+- `lsr_train_reference` — the LSR/SSR mapping the tool used, for transparency.
+- `total_devices_scanned`, `up_to_date`, `on_lsr_train`, `on_ssr_train`, `on_aos8`, `unknown_train`, `needs_action` — fleet-level counts.
+- `recommendations[]` — per-device records: current version/train, release type, Central's recommendation, our recommendation, action (`upgrade_in_place`, `move_to_lsr_train`, `follow_central`, `up_to_date`, `unknown`), and a rationale string.
+
+**Mapping source of truth:** Aruba's supported-devices-AOS10 documentation. When a new LSR train is designated, update `AOS10_AP_GW_RELEASE_TYPES` in [src/hpe_networking_mcp/platforms/central/tools/firmware.py](../src/hpe_networking_mcp/platforms/central/tools/firmware.py).
 
 ### Guided Prompts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.9.1.1"
+version = "0.9.2.0"
 description = "Unified MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass"
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -150,6 +150,10 @@ When asked to create a new site based on an existing site:
   - Use `central_manage_config_assignment` to assign or remove a profile at a scope. Required for WLAN sync — assigns the profile after creating it. Parameters: scope_id (from `central_get_scope_tree`), device_function (`CAMPUS_AP`), profile_type (`wlan-ssids`), profile_instance (SSID name).
 - **Configuration (Write)**: central_manage_site, central_manage_site_collection, central_manage_device_group — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`
   - **Site creation payload**: All fields must use full names, no abbreviations (e.g. "Indiana" not "IN", "United States" not "US"). The `timezone` object is required and must include `timezoneName` (e.g. "Eastern Standard Time"), `timezoneId` (e.g. "America/Indiana/Indianapolis"), and `rawOffset` in milliseconds (e.g. -18000000 for EST). Determine the correct timezone from the address.
+- **Firmware Recommendations**: central_recommend_firmware
+  - Use when the user asks what firmware version a device or fleet should be on, whether any devices need upgrades, or for a firmware audit. The tool applies an LSR-preferred upgrade policy on top of Central's built-in `recommendedVersion`: APs and Gateways on an SSR train are recommended to move to the next LSR train, rather than staying on SSR as Central would suggest.
+  - Filter with `device_type`, `site_id`, `site_name`, or `serial_number`. Default behavior omits devices already on Central's recommended version; pass `include_up_to_date=True` to see them too.
+  - The `release_type` field on each recommendation indicates LSR, SSR, AOS8, or UNKNOWN. LSR/SSR classification only covers AOS 10 APs and Gateways — switches and AOS 8 devices fall back to Central's recommendation with a pass-through action.
 
 ## Cross-Platform WLAN Management
 

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -95,6 +95,7 @@ TOOLS = {
         "central_manage_site_collection",
         "central_manage_device_group",
     ],
+    "firmware": ["central_recommend_firmware"],
 }
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware.py
@@ -196,7 +196,7 @@ def _recommend(
             (
                 f"On SSR train {train}. Recommending move to next LSR train {next_lsr} — "
                 f"Central's suggestion was '{central_recommended}'. "
-                "Select the latest available build in that train from Central's firmware catalog."
+                "Pick the latest available build in that train from Central's firmware catalog."
             ),
         )
 

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware.py
@@ -1,0 +1,411 @@
+"""Firmware recommendation tool.
+
+Reads `/network-services/v1/firmware-details` and applies an LSR-preferred
+upgrade policy on top of Central's built-in `recommendedVersion`:
+
+- APs and Gateways on an LSR train → trust Central's recommendation
+  (latest in the same major.minor train).
+- APs and Gateways on an SSR train → override Central and recommend moving
+  to the next LSR train (Central will happily keep you on SSR otherwise).
+- Legacy AOS 8 devices → pass Central's recommendation through unchanged.
+- Switches and unknown trains → pass Central's recommendation through with
+  a note, since the LSR/SSR concept in the bundled mapping only covers
+  AP and Gateway AOS 10 trains.
+
+LSR/SSR mapping is hand-maintained per Aruba's supported-devices-AOS10
+documentation. Update `AOS10_AP_GW_RELEASE_TYPES` when new trains are
+designated.
+"""
+
+import re
+from typing import Annotated, Literal
+
+from fastmcp import Context
+from pydantic import BaseModel, Field
+
+from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+# AOS 10 release-type mapping for Access Points and Gateways.
+# Source: Aruba supported-devices-AOS10 documentation. Switches and
+# controllers have separate cadences not covered here.
+AOS10_AP_GW_RELEASE_TYPES: dict[str, Literal["LSR", "SSR"]] = {
+    "10.3": "SSR",
+    "10.4": "LSR",
+    "10.5": "SSR",
+    "10.6": "SSR",
+    "10.7": "SSR",
+    "10.8": "LSR",
+}
+
+_AOS10_VERSION_RE = re.compile(r"^10\.(\d+)\.")
+_AOS8_VERSION_RE = re.compile(r"^8\.\d+\.")
+
+
+class FirmwareRecommendation(BaseModel):
+    serial_number: str
+    device_name: str
+    device_type: str  # ACCESS_POINT, SWITCH, GATEWAY
+    site_name: str | None = None
+    current_version: str
+    current_train: str | None = None  # major.minor, e.g. "10.8"
+    release_type: Literal["LSR", "SSR", "AOS8", "UNKNOWN"]
+    central_recommended_version: str | None = None
+    our_recommended_version: str | None = None
+    action: Literal[
+        "up_to_date",
+        "upgrade_in_place",
+        "move_to_lsr_train",
+        "follow_central",
+        "unknown",
+    ]
+    rationale: str
+
+
+class FirmwareRecommendationReport(BaseModel):
+    lsr_train_reference: dict[str, str]
+    total_devices_scanned: int
+    up_to_date: int
+    on_lsr_train: int
+    on_ssr_train: int
+    on_aos8: int
+    unknown_train: int
+    needs_action: int
+    recommendations: list[FirmwareRecommendation]
+
+
+def _parse_train(version: str | None) -> tuple[str | None, Literal["LSR", "SSR", "AOS8", "UNKNOWN"]]:
+    """Return (major_minor_train, release_type) for a firmware version.
+
+    Examples:
+      "10.8.1010"        -> ("10.8", "LSR")
+      "10.5.0.1_80123"   -> ("10.5", "SSR")
+      "8.5.2.0_59123"    -> ("8.5", "AOS8")
+      "garbage"          -> (None, "UNKNOWN")
+    """
+    if not version:
+        return (None, "UNKNOWN")
+    m = _AOS10_VERSION_RE.match(version)
+    if m:
+        train = f"10.{m.group(1)}"
+        return (train, AOS10_AP_GW_RELEASE_TYPES.get(train, "UNKNOWN"))
+    if _AOS8_VERSION_RE.match(version):
+        # Grab "major.minor" for AOS 8 — LSR/SSR concept doesn't apply
+        parts = version.split(".")
+        return (f"{parts[0]}.{parts[1]}", "AOS8")
+    return (None, "UNKNOWN")
+
+
+def _next_lsr_train(current_train: str | None) -> str | None:
+    """Return the next LSR train at or above the current train, or None."""
+    if not current_train:
+        return None
+    # Sort trains by their minor number (we're inside AOS 10 here)
+    try:
+        current_minor = int(current_train.split(".")[1])
+    except (IndexError, ValueError):
+        return None
+    lsr_trains = sorted(
+        (t for t, rt in AOS10_AP_GW_RELEASE_TYPES.items() if rt == "LSR"),
+        key=lambda t: int(t.split(".")[1]),
+    )
+    for train in lsr_trains:
+        if int(train.split(".")[1]) >= current_minor:
+            return train
+    return None
+
+
+def _recommend(
+    device_type: str,
+    current_version: str,
+    central_recommended: str | None,
+    upgrade_status: str | None,
+) -> tuple[
+    Literal["LSR", "SSR", "AOS8", "UNKNOWN"],
+    str | None,
+    str | None,
+    Literal["up_to_date", "upgrade_in_place", "move_to_lsr_train", "follow_central", "unknown"],
+    str,
+]:
+    """Apply the recommendation policy to one device's firmware status.
+
+    Returns: (release_type, current_train, our_recommended_version, action, rationale)
+    """
+    train, release_type = _parse_train(current_version)
+    already_up_to_date = (upgrade_status or "").strip().lower() == "up to date"
+
+    if device_type not in ("ACCESS_POINT", "GATEWAY"):
+        # LSR/SSR mapping only applies to AP/GW; pass through Central's view.
+        if already_up_to_date:
+            return (release_type, train, None, "up_to_date", "Already on Central's recommended version.")
+        return (
+            release_type,
+            train,
+            central_recommended,
+            "follow_central",
+            f"{device_type} is outside the LSR/SSR mapping — deferring to Central's recommendation.",
+        )
+
+    if release_type == "AOS8":
+        if already_up_to_date:
+            return (release_type, train, None, "up_to_date", "Legacy AOS 8 device already on Central's recommendation.")
+        return (
+            release_type,
+            train,
+            central_recommended,
+            "follow_central",
+            "Legacy AOS 8 device — LSR/SSR classification only applies to AOS 10. Deferring to Central.",
+        )
+
+    if release_type == "LSR":
+        if already_up_to_date:
+            return (
+                release_type,
+                train,
+                None,
+                "up_to_date",
+                f"On LSR train {train} and current with Central's recommended version.",
+            )
+        return (
+            release_type,
+            train,
+            central_recommended,
+            "upgrade_in_place",
+            (f"On LSR train {train}. Upgrade to latest in the same LSR train ({central_recommended})."),
+        )
+
+    if release_type == "SSR":
+        next_lsr = _next_lsr_train(train)
+        if next_lsr is None:
+            return (
+                release_type,
+                train,
+                central_recommended,
+                "follow_central",
+                (
+                    f"On SSR train {train} and no newer LSR train is known in the bundled "
+                    "mapping. Following Central's recommendation until the mapping is updated."
+                ),
+            )
+        return (
+            release_type,
+            train,
+            f"{next_lsr}.x (latest LSR build)",
+            "move_to_lsr_train",
+            (
+                f"On SSR train {train}. Recommending move to next LSR train {next_lsr} — "
+                f"Central's suggestion was '{central_recommended}'. "
+                "Select the latest available build in that train from Central's firmware catalog."
+            ),
+        )
+
+    # UNKNOWN — either garbage version string or an AOS 10 train beyond the
+    # bundled mapping. Defer but flag loudly.
+    if already_up_to_date:
+        return (
+            release_type,
+            train,
+            None,
+            "up_to_date",
+            (
+                "Current version isn't in the LSR/SSR mapping but Central considers it up to date. "
+                "Update AOS10_AP_GW_RELEASE_TYPES if this train should be classified."
+            ),
+        )
+    return (
+        release_type,
+        train,
+        central_recommended,
+        "unknown",
+        (
+            f"Current train {train} is not in the bundled LSR/SSR mapping. "
+            "Update AOS10_AP_GW_RELEASE_TYPES to classify this train and re-run."
+        ),
+    )
+
+
+def _build_filter(
+    serial_number: str | None,
+    device_type: str | None,
+    site_id: str | None,
+    site_name: str | None,
+) -> str | None:
+    """Build an OData 4.0 filter for firmware-details (eq and and only)."""
+    parts: list[str] = []
+    if serial_number:
+        parts.append(f"serialNumber eq '{serial_number}'")
+    if device_type:
+        parts.append(f"deviceType eq '{device_type}'")
+    if site_id:
+        parts.append(f"siteId eq '{site_id}'")
+    if site_name:
+        parts.append(f"siteName eq '{site_name}'")
+    return " and ".join(parts) if parts else None
+
+
+@mcp.tool(annotations=READ_ONLY)
+async def central_recommend_firmware(
+    ctx: Context,
+    serial_number: Annotated[
+        str | None,
+        Field(
+            description="Optional — recommend only for this device serial.",
+            default=None,
+        ),
+    ] = None,
+    device_type: Annotated[
+        Literal["ACCESS_POINT", "SWITCH", "GATEWAY"] | None,
+        Field(
+            description=(
+                "Optional — limit to a single device type. The LSR/SSR policy "
+                "only applies to ACCESS_POINT and GATEWAY; SWITCH entries are "
+                "passed through with Central's recommendation."
+            ),
+            default=None,
+        ),
+    ] = None,
+    site_id: Annotated[
+        str | None,
+        Field(description="Optional — limit to devices at this site.", default=None),
+    ] = None,
+    site_name: Annotated[
+        str | None,
+        Field(description="Optional — limit to devices at this site name.", default=None),
+    ] = None,
+    include_up_to_date: Annotated[
+        bool,
+        Field(
+            description=(
+                "If True, include devices already on Central's recommended version "
+                "in the recommendations list. Default False keeps the output focused "
+                "on actionable items."
+            ),
+            default=False,
+        ),
+    ] = False,
+    max_pages: Annotated[
+        int,
+        Field(
+            description=(
+                "Safety cap on paginated fetches. 1000 items per page × max_pages "
+                "is the hard ceiling on devices scanned."
+            ),
+            default=10,
+            ge=1,
+            le=50,
+        ),
+    ] = 10,
+) -> FirmwareRecommendationReport:
+    """Apply an LSR-preferred upgrade policy to every device's firmware.
+
+    Central's built-in `recommendedVersion` will happily keep a device on an
+    SSR train. This tool fetches `/network-services/v1/firmware-details` for
+    every device, classifies the current version as LSR, SSR, AOS 8, or
+    unknown, and returns a concrete recommendation:
+
+    - On LSR → upgrade to Central's recommended version (latest in same train)
+    - On SSR → move to the next LSR train at or above the current train
+    - On AOS 8 or non-AP/GW → pass Central's recommendation through
+    - Unknown train → flag the device so the user can extend the bundled
+      LSR/SSR mapping (`AOS10_AP_GW_RELEASE_TYPES` in this module)
+
+    The report includes counts by state and the LSR/SSR mapping used, so the
+    user can see at a glance whether their fleet needs an LSR shift and which
+    trains are classified.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+
+    filter_str = _build_filter(serial_number, device_type, site_id, site_name)
+
+    all_items: list[dict] = []
+    next_cursor: str | None = None
+    pages = 0
+
+    while pages < max_pages:
+        params: dict = {"limit": 1000}
+        if filter_str:
+            params["filter"] = filter_str
+        if next_cursor:
+            params["next"] = next_cursor
+
+        resp = retry_central_command(
+            central_conn=conn,
+            api_method="GET",
+            api_path="network-services/v1/firmware-details",
+            api_params=params,
+        )
+        msg = resp.get("msg", {}) if isinstance(resp, dict) else {}
+        items = msg.get("items", []) if isinstance(msg, dict) else []
+        all_items.extend(items)
+
+        next_cursor = msg.get("next") if isinstance(msg, dict) else None
+        pages += 1
+        if not next_cursor:
+            break
+
+    recommendations: list[FirmwareRecommendation] = []
+    counts = {
+        "up_to_date": 0,
+        "on_lsr_train": 0,
+        "on_ssr_train": 0,
+        "on_aos8": 0,
+        "unknown_train": 0,
+    }
+
+    for item in all_items:
+        current_version = str(item.get("firmwareVersion", ""))
+        central_rec = item.get("recommendedVersion") or None
+        upgrade_status = item.get("upgradeStatus")
+        dtype = str(item.get("deviceType", ""))
+
+        release_type, train, our_rec, action, rationale = _recommend(
+            dtype,
+            current_version,
+            central_rec,
+            upgrade_status,
+        )
+
+        if action == "up_to_date":
+            counts["up_to_date"] += 1
+        if release_type == "LSR":
+            counts["on_lsr_train"] += 1
+        elif release_type == "SSR":
+            counts["on_ssr_train"] += 1
+        elif release_type == "AOS8":
+            counts["on_aos8"] += 1
+        elif release_type == "UNKNOWN":
+            counts["unknown_train"] += 1
+
+        if action == "up_to_date" and not include_up_to_date:
+            continue
+
+        recommendations.append(
+            FirmwareRecommendation(
+                serial_number=str(item.get("serialNumber", "")),
+                device_name=str(item.get("deviceName", "")),
+                device_type=dtype,
+                site_name=item.get("siteName"),
+                current_version=current_version,
+                current_train=train,
+                release_type=release_type,
+                central_recommended_version=central_rec,
+                our_recommended_version=our_rec,
+                action=action,
+                rationale=rationale,
+            )
+        )
+
+    needs_action = sum(1 for r in recommendations if r.action != "up_to_date")
+
+    return FirmwareRecommendationReport(
+        lsr_train_reference={k: v for k, v in AOS10_AP_GW_RELEASE_TYPES.items()},
+        total_devices_scanned=len(all_items),
+        up_to_date=counts["up_to_date"],
+        on_lsr_train=counts["on_lsr_train"],
+        on_ssr_train=counts["on_ssr_train"],
+        on_aos8=counts["on_aos8"],
+        unknown_train=counts["unknown_train"],
+        needs_action=needs_action,
+        recommendations=recommendations,
+    )


### PR DESCRIPTION
## Summary
- New `central_recommend_firmware` tool that reads `/network-services/v1/firmware-details` and overlays an LSR-preferred upgrade policy on top of Central's built-in `recommendedVersion`.
- Central's default behavior will keep an AP or Gateway on an SSR train indefinitely if a newer version in the same SSR train exists. This tool classifies each device's current AOS 10 train as LSR or SSR using a hand-maintained mapping and recommends moving to the next LSR train when the device is on SSR.
- Legacy AOS 8 devices and `SWITCH` entries fall back to Central's recommendation with a pass-through action — the bundled LSR/SSR mapping only covers AOS 10 APs and Gateways.

## Policy rules applied
| Current state | Recommendation |
|---|---|
| AP/GW on LSR train, up to date | `up_to_date` |
| AP/GW on LSR train, newer in same train | `upgrade_in_place` to Central's recommended version |
| AP/GW on SSR train | `move_to_lsr_train` — target is the next LSR train at or above current |
| AP/GW on AOS 8 | `follow_central` — LSR/SSR doesn't apply |
| Switch, any version | `follow_central` |
| AP/GW on unclassified AOS 10 train (e.g. 10.16) | `unknown` — flag to extend the mapping |

## LSR/SSR mapping source of truth
`AOS10_AP_GW_RELEASE_TYPES` in [src/hpe_networking_mcp/platforms/central/tools/firmware.py](src/hpe_networking_mcp/platforms/central/tools/firmware.py) currently covers 10.3 through 10.8. Based on Aruba's supported-devices-AOS10 documentation:

```python
"10.3": "SSR",
"10.4": "LSR",
"10.5": "SSR",
"10.6": "SSR",
"10.7": "SSR",
"10.8": "LSR",
```

Update this constant when Aruba designates new trains.

## API details
- Endpoint: `GET /network-services/v1/firmware-details`
- Filters (server-side OData `eq` and `in`): `serial_number`, `device_type`, `site_id`, `site_name`
- Pagination: `next` cursor, `limit` max 1000 per page, tool loops up to `max_pages` (default 10 = 10,000 devices)
- `include_up_to_date` parameter controls whether already-current devices appear in the list (default: False, keeps output focused)

## Version
Bumped 0.9.1.1 → 0.9.2.0 (minor bump, new feature). Central tool count 72 → 73.

## Test plan
- [ ] Rebuild container: `docker compose up -d --build` after merge + tag
- [ ] Call `central_recommend_firmware()` with no arguments — confirm the report counts total devices, breaks down by LSR/SSR/AOS8/unknown, and lists only devices needing action by default
- [ ] Call with `device_type="ACCESS_POINT"` and `site_name="<your site>"` — verify server-side filter narrows result
- [ ] Confirm an AP on a 10.5 or 10.7 SSR is recommended to move to 10.8 LSR
- [ ] Confirm an AP on 10.4 LSR with a newer 10.4.x available gets an `upgrade_in_place` recommendation
- [ ] Confirm an AP on AOS 8 gets `follow_central` with Central's suggestion passed through
- [ ] Call with `include_up_to_date=True` and spot-check that up-to-date devices appear in the list

## Smoke test
Helper logic was validated in Docker against six representative cases (AP on SSR → next LSR, AP on LSR up-to-date, AP on LSR newer-available, Gateway on SSR, AOS 8 AP, switch on unknown train). All six produced the expected rationale and action.