### PR TITLE
Add unofficial / community-driven disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/ci.yml)
 [![Security](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/security.yml)
 
+> **Unofficial / community project.** This repository is an independent, community-driven project. It is not affiliated with, endorsed by, sponsored by, or supported by Hewlett Packard Enterprise, Aruba Networks, or Juniper Networks. "HPE", "Aruba", "Aruba Central", "Aruba ClearPass", "HPE GreenLake", "Juniper", and "Juniper Mist" are trademarks of their respective owners and are used here only to describe what this software interoperates with. Please direct support and licensing questions about those products to the respective vendors.
+
 A unified [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that brings **Juniper Mist**, **Aruba Central**, **HPE GreenLake**, and **Aruba ClearPass** together into a single, deployable service. One container. One endpoint. All your HPE networking tools.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hpe-networking-mcp"
 version = "0.9.2.1"
-description = "Unified MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass"
+description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Adds a top-of-README notice stating the project is independent and community-driven, with no affiliation to HPE, Aruba, or Juniper, and acknowledging their trademarks.
- Mirrors the same in the `pyproject.toml` `description` field so the disclaimer travels with the package metadata.

## Why
The project name and docs lean heavily on "HPE", "Aruba", "Juniper Mist", etc. Without an explicit notice, a casual reader could reasonably assume this is an HPE/Aruba-endorsed tool — that creates trademark-misuse exposure and risks users filing vendor support tickets against vendor tools for issues caused by this code.

This matches the standard practice used by similar community projects (unofficial vendor SDK wrappers, community Terraform providers, etc.).

## Scope
Docs only. No version bump, no tag, no release per the project rule that patch bumps are for code changes.

## Test plan
- [ ] Skim the rendered README — the notice should appear as a blockquote between the CI badges and the "A unified MCP server..." intro paragraph
- [ ] Confirm the wording reads correctly and covers all vendors named in the code (HPE, Aruba, Aruba Central, Aruba ClearPass, HPE GreenLake, Juniper, Juniper Mist)