### PR TITLE
Fix central_manage_wlan_profile clobbering entire profiles on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.9.2.2] - 2026-04-21
+
+### Fixed — `central_manage_wlan_profile` silently clobbered entire profiles on update (#141)
+- Reported by Zach Jennings. An update with a partial payload (e.g.
+  `{"dtim-period": 2}`) was issued to Central as a `PUT`, which is
+  full-resource replacement — every field missing from the payload was
+  dropped. Security, VLAN, QoS, and client settings on the affected
+  profiles were lost silently.
+- `action_type="update"` now issues `PATCH /network-config/v1alpha1/wlan-ssids/{ssid}`
+  and Central merges the payload with the existing profile server-side.
+  Callers pass only the fields they want to change; untouched fields are
+  preserved. One round trip, atomic on the server, uses Central's own
+  merge semantics.
+- Added `replace_existing: bool = False` parameter. When True, the tool
+  falls back to the old `PUT` full-replacement behavior. The payload
+  description and elicitation message make the consequences explicit.
+- Elicitation prompt for partial updates now fetches the current profile
+  and shows a per-field before → after diff, so the user sees exactly
+  what will change before approving. Failures in the diff lookup are
+  non-blocking — the write proceeds with a generic message if the GET
+  fails.
+
 ## [v0.9.2.1] - 2026-04-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/ci.yml)
 [![Security](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/nowireless4u/hpe-networking-mcp/actions/workflows/security.yml)
 
+> **Unofficial / community project.** This repository is an independent, community-driven project. It is not affiliated with, endorsed by, sponsored by, or supported by Hewlett Packard Enterprise, Aruba Networks, or Juniper Networks. "HPE", "Aruba", "Aruba Central", "Aruba ClearPass", "HPE GreenLake", "Juniper", and "Juniper Mist" are trademarks of their respective owners and are used here only to describe what this software interoperates with. Please direct support and licensing questions about those products to the respective vendors.
+
 A unified [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that brings **Juniper Mist**, **Aruba Central**, **HPE GreenLake**, and **Aruba ClearPass** together into a single, deployable service. One container. One endpoint. All your HPE networking tools.
 
 ---

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -963,8 +963,11 @@ No parameters. Returns a dict sorted by health score (worst first).
 |-----------|------|----------|-------------|
 | ssid | str | Yes | SSID name (used as identifier in API path). |
 | action_type | str | Yes | `create`, `update`, or `delete`. |
-| payload | dict | Yes | WLAN profile config (see valid values below). |
+| payload | dict | Yes | WLAN profile config. For `update` (default), pass only the fields you want to change — the tool issues a `PATCH` and Central merges. For `create`, pass a full profile. For `delete`, payload is ignored. |
+| replace_existing | bool | No | Destructive flag. When True, `update` issues a `PUT` that replaces the entire profile — fields not in the payload will be dropped. Default False (safe partial-patch). |
 | confirmed | bool | No | Set to true after user confirms update/delete in chat. |
+
+**Update semantics:** By default, `action_type="update"` issues `PATCH /network-config/v1alpha1/wlan-ssids/{ssid}` and the Central API merges the payload with the existing profile server-side. Pass only the fields you want to change; everything else is preserved. The elicitation prompt fetches the current profile and shows a per-field `before → after` diff before applying the change. Set `replace_existing=True` only when you have the complete profile in `payload` and genuinely want a wholesale swap (uses `PUT`).
 
 **Valid `opmode` values** (do NOT invent values — use only these):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "hpe-networking-mcp"
 version = "0.9.2.1"
-description = "Unified MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass"
+description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "0.9.2.1"
+version = "0.9.2.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -129,6 +129,8 @@ When asked to create a new site based on an existing site:
 - **WLAN Profiles**: central_get_wlan_profiles, central_manage_wlan_profile
   - Use `central_get_wlan_profiles` to read WLAN SSID profile configurations from the library
   - Use `central_manage_wlan_profile` to create, update, or delete WLAN profiles — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`
+  - **Update semantics are partial-patch by default**: when `action_type="update"`, pass only the fields you want to change. The tool issues `PATCH` and Central merges with the existing profile — untouched fields are preserved. Do NOT send a full profile copy thinking the tool will reconcile it.
+  - **Only set `replace_existing=True`** when the user explicitly wants to wholesale-swap the entire profile AND the payload contains the full desired configuration. Any field missing from the payload in that mode will be dropped. If in doubt, leave it False.
   - **Valid opmode values**: OPEN, WPA2_PERSONAL, WPA3_SAE, WPA2_ENTERPRISE, WPA3_ENTERPRISE_CCM_128, WPA2_MPSK_AES, ENHANCED_OPEN, DPP. Note: `WPA2_PSK_AES` does NOT exist — use `WPA2_PERSONAL` for WPA2 PSK.
   - **Mist-to-Central opmode mapping**: Mist psk → `WPA2_PERSONAL`, Mist psk+wpa3 → `WPA3_SAE`, Mist eap → `WPA2_ENTERPRISE`, Mist eap+wpa3+wpa2 → `WPA3_ENTERPRISE_CCM_128`
   - **NEVER call this tool directly for cross-platform WLAN sync** — use the sync prompts instead

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -73,10 +73,19 @@ async def central_manage_wlan_profile(
         dict,
         Field(
             description=(
-                "WLAN SSID profile payload. For delete: payload is ignored. "
-                "For create/update, key fields and their valid values:\n"
+                "WLAN SSID profile payload.\n\n"
+                "For 'update' (default, partial-patch): pass ONLY the fields you "
+                "want to change. The tool issues PATCH against Central, which "
+                "merges your payload with the existing profile server-side — "
+                "untouched fields are preserved.\n\n"
+                "For 'update' with replace_existing=True: payload must be the "
+                "full profile. Any field not in the payload will be dropped "
+                "from the stored profile. Use with extreme care.\n\n"
+                "For 'create': full payload required.\n\n"
+                "For 'delete': payload is ignored.\n\n"
+                "Key fields and their valid values:\n"
                 "- essid: {name: str} or {alias: str, use-alias: true}\n"
-                "- opmode (REQUIRED): OPEN, WPA2_PERSONAL, WPA3_SAE, "
+                "- opmode (REQUIRED on create): OPEN, WPA2_PERSONAL, WPA3_SAE, "
                 "WPA2_ENTERPRISE, WPA3_ENTERPRISE_CCM_128, WPA3_ENTERPRISE_GCM_256, "
                 "WPA3_ENTERPRISE_CNSA, WPA_ENTERPRISE, WPA_PERSONAL, WPA2_MPSK_AES, "
                 "WPA2_MPSK_LOCAL, ENHANCED_OPEN, DPP, WPA2_PSK_AES_DPP, "
@@ -99,13 +108,28 @@ async def central_manage_wlan_profile(
             )
         ),
     ],
+    replace_existing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Destructive flag. When False (default), 'update' issues a "
+                "PATCH that merges the payload with the existing profile — "
+                "fields you don't include are preserved. When True, 'update' "
+                "issues a PUT that replaces the entire profile — fields not in "
+                "the payload will be dropped. Only set to True when you have "
+                "the complete profile in the payload and genuinely want a "
+                "wholesale swap."
+            ),
+            default=False,
+        ),
+    ] = False,
     confirmed: Annotated[
         bool,
         Field(
             description="Set to true when the user has confirmed the operation in chat.",
             default=False,
         ),
-    ],
+    ] = False,
 ) -> dict | str:
     """
     Create, update, or delete a WLAN SSID profile in Central's library.
@@ -113,6 +137,11 @@ async def central_manage_wlan_profile(
     The SSID name is the identifier — it appears in the API path.
     Profiles are added to the Central WLAN library and must be assigned
     to scopes (Global, site collections, or sites) separately.
+
+    Update semantics (default) use PATCH for partial updates: pass only
+    the fields you want to change. Pass replace_existing=True to force a
+    PUT full-replacement — use sparingly, since any field missing from
+    the payload will be dropped from the stored profile.
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
@@ -154,17 +183,42 @@ async def central_manage_wlan_profile(
             )
 
     api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}"
+    conn = ctx.lifespan_context["central_conn"]
 
-    action_wording = {
-        "create": "create a new",
-        "update": "update an existing",
-        "delete": "delete an existing",
-    }[action_type]
+    # Method selection: update defaults to PATCH (partial merge on the
+    # server). replace_existing=True forces PUT (full replacement).
+    method_map = {
+        "create": "POST",
+        "update": "PUT" if replace_existing else "PATCH",
+        "delete": "DELETE",
+    }
+    api_method = method_map[action_type]
+
+    # Build the action summary for the elicitation prompt. For partial
+    # updates we try to diff the payload against the current profile so
+    # the user sees which fields will actually change; for full-replace
+    # updates we show a loud warning instead.
+    if action_type == "create":
+        action_wording = "create a new"
+        diff_lines: list[str] = []
+    elif action_type == "delete":
+        action_wording = "delete an existing"
+        diff_lines = []
+    elif replace_existing:
+        action_wording = "REPLACE THE ENTIRE"
+        diff_lines = [
+            "⚠️  replace_existing=True — any field not in the payload will be DROPPED.",
+            f"Payload top-level keys: {sorted(payload.keys())}",
+        ]
+    else:
+        action_wording = "patch (partial update of)"
+        diff_lines = _build_patch_diff(conn, api_path, payload)
 
     # Confirm for update and delete only
     if action_type != "create" and not confirmed:
+        diff_suffix = ("\n\nChanges:\n" + "\n".join(diff_lines)) if diff_lines else ""
         elicitation_response = await elicitation_handler(
-            message=(f"The LLM wants to {action_wording} WLAN profile '{ssid}'. Do you accept?"),
+            message=(f"The LLM wants to {action_wording} WLAN profile '{ssid}'.{diff_suffix}\n\nDo you accept?"),
             ctx=ctx,
         )
         if elicitation_response.action == "decline":
@@ -172,19 +226,15 @@ async def central_manage_wlan_profile(
                 return {
                     "status": "confirmation_required",
                     "message": (
-                        f"This operation will {action_wording} WLAN profile '{ssid}'. "
-                        "Please confirm with the user before proceeding. "
+                        f"This operation will {action_wording} WLAN profile '{ssid}'."
+                        + diff_suffix
+                        + " Please confirm with the user before proceeding. "
                         "Call this tool again with confirmed=true after the user confirms."
                     ),
                 }
             return {"message": "Action declined by user."}
         elif elicitation_response.action == "cancel":
             return {"message": "Action canceled by user."}
-
-    conn = ctx.lifespan_context["central_conn"]
-
-    method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}
-    api_method = method_map[action_type]
 
     api_data: dict = {}
     if action_type != "delete":
@@ -213,3 +263,39 @@ async def central_manage_wlan_profile(
         "code": code,
         "message": response.get("msg", "Unknown error"),
     }
+
+
+def _build_patch_diff(conn: object, api_path: str, payload: dict) -> list[str]:
+    """Compute a human-readable diff of what a PATCH will change.
+
+    Fetches the current profile and reports, per top-level key in the
+    payload, the before → after value. Failures are non-blocking — if
+    the GET fails, the caller falls back to a generic elicitation
+    message so the write isn't held up by a display-only helper.
+    """
+    try:
+        resp = retry_central_command(
+            central_conn=conn,
+            api_method="GET",
+            api_path=api_path,
+        )
+        current = resp.get("msg", {}) if isinstance(resp, dict) else {}
+        if not isinstance(current, dict):
+            current = {}
+    except Exception as e:
+        logger.warning("Central WLAN: diff lookup failed — {}", e)
+        return [f"(current profile lookup failed: {e} — patch will still apply)"]
+
+    lines: list[str] = []
+    for key, new_val in payload.items():
+        if key in current:
+            old_val = current[key]
+            if old_val == new_val:
+                lines.append(f"{key}: {old_val!r} (unchanged)")
+            else:
+                lines.append(f"{key}: {old_val!r} → {new_val!r}")
+        else:
+            lines.append(f"{key}: (new) → {new_val!r}")
+    if not lines:
+        lines.append("(empty payload — no changes)")
+    return lines


### PR DESCRIPTION
Fixes #141. Reported by Zach Jennings.

## Summary
- `central_manage_wlan_profile` update now issues a `PATCH` against Central instead of a `PUT`. A partial payload (e.g. `{"dtim-period": 2}`) no longer wipes every other field in the profile.
- Added `replace_existing: bool = False` parameter as an explicit, opt-in path to the old PUT full-replacement behavior for the rare case where the caller genuinely wants a wholesale swap.
- Elicitation prompt for partial updates now fetches the current profile and shows a per-key `before → after` diff. The user sees exactly which fields will change before approving.

## Root cause (recap)
[src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py:186-200 (pre-fix)](https://github.com/nowireless4u/hpe-networking-mcp/blob/main/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py#L186-L200) used `{"update": "PUT"}` and passed the caller's payload as the full request body. Central's `PUT /network-config/v1alpha1/wlan-ssids/{ssid}` is full-resource replacement — anything not in the body is dropped.

## Why PATCH and not client-side read-modify-write
Central's API spec ([api-endpoints/central/wlan.json:295-372](api-endpoints/central/wlan.json#L295-L372)) declares PATCH as a first-class operation on this endpoint. Server-side merge is strictly better than a client-side GET-merge-PUT:

- Single round trip
- Atomic on the server — no race window between GET and PUT
- Merge semantics come from Central's spec, not from us re-implementing them
- Smaller request bodies (only changed fields)

## Behavior matrix

| `action_type` | `replace_existing` | HTTP method | Payload must contain |
|---|---|---|---|
| `create` | (ignored) | `POST` | Full new profile |
| `update` | `False` (default) | `PATCH` | Only the fields to change |
| `update` | `True` | `PUT` | Full profile — unlisted fields are DROPPED |
| `delete` | (ignored) | `DELETE` | — |

## Elicitation example (partial update)
Before (generic, what the user used to see):
```
The LLM wants to update an existing WLAN profile 'z56'. Do you accept?
```

After (shows the actual diff):
```
The LLM wants to patch (partial update of) WLAN profile 'z56'.

Changes:
dtim-period: 1 → 2

Do you accept?
```

For `replace_existing=True` the message switches to:
```
The LLM wants to REPLACE THE ENTIRE WLAN profile 'z56'.

Changes:
⚠️  replace_existing=True — any field not in the payload will be DROPPED.
Payload top-level keys: ['dtim-period', 'essid', 'opmode', ...]

Do you accept?
```

## Test plan
- [ ] Rebuild container with 0.9.2.2 image
- [ ] On a test profile with custom security + VLAN + QoS: call `central_manage_wlan_profile(ssid="test", action_type="update", payload={"dtim-period": 2})` and confirm the elicitation message lists the dtim-period change. After accepting, verify via `central_get_wlan_profiles(ssid="test")` that all other settings are preserved.
- [ ] Repeat with a nested-field update (e.g. `{"personal-security": {"wpa-passphrase": "new"}}`) — confirm other nested fields like `passphrase-format` remain intact (Central's PATCH does the merge).
- [ ] Call with `replace_existing=True` and a full payload — confirm the elicitation message shows the big warning, and verify the profile is replaced wholesale as requested.
- [ ] Confirm create and delete paths still work (POST and DELETE unchanged).

## Follow-up
Other `central_manage_*` tools (roles, policies, aliases, server groups, named VLANs, device groups, sites) likely follow the same `{"update": "PUT"}` pattern. Will audit in a separate PR/issue per the original plan.