### PR TITLE
Fix central_get_site_health parameter name mismatch (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0.1] - 2026-04-22
+
+### Fixed — `central_get_site_health` parameter name mismatch (#146)
+- Reported by Zach Jennings. The tool used `site_names: list[str]`
+  (plural) while every other single-site Central tool and prompt uses
+  `site_name` (singular). Local LLMs pattern-matching against the
+  Central surface consistently guessed `site_name=...` and hit
+  "must NOT have additional properties" from the FastMCP JSON-schema
+  validator — a framework-level error that told the model nothing about
+  which parameter name was actually correct, causing reasoning loops
+  and no successful tool call.
+- Signature is now `site_name: str | list[str] | None = None`. Accepts
+  either a single name string (`site_name="Owls Nest"`) or a list
+  (`site_name=["A", "B"]`). Batch callers keep working; single-site
+  callers match peer tools.
+- Normalization extracted into `_normalize_site_name_filter` helper with
+  unit tests covering str, list, tuple, empty-list, and None inputs.
+- Updated docstrings, guided prompt bodies, INSTRUCTIONS.md, and
+  docs/TOOLS.md to reference the new shape.
+
 ## [v1.0.0.0] - 2026-04-22
 
 ### Added — Juniper Apstra platform (21 tools), v1.0 milestone

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -528,7 +528,7 @@ GreenLake supports two mutually exclusive tool modes controlled by
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| site_names | list[str] | No | Site names to filter by (exact match). Omit for all sites. |
+| site_name | str \| list[str] | No | One site name or a list of site names to filter by (exact match). Omit for all sites. |
 
 #### `central_get_site_name_id_mapping`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "1.0.0.0"
+version = "1.0.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -97,13 +97,13 @@ When asked to create a new site based on an existing site:
 
 ## Starting a Central Session
 1. `central_get_site_name_id_mapping` → lightweight overview of all sites with health scores
-2. `central_get_site_health(site_names=[...])` → detailed health metrics for specific sites
+2. `central_get_site_health(site_name=...)` → detailed health metrics (accepts a single name string or a list)
 3. `central_get_sites` → site configuration data (address, timezone, etc.) from network-config API
 
 ## Tool Categories
 - **Sites**: central_get_sites, central_get_site_health, central_get_site_name_id_mapping
   - Use `central_get_sites` for site configuration data (address, timezone, scopeName). Supports OData filter on scopeName, address, city, state, country, zipcode, collectionName.
-  - Use `central_get_site_health` for health metrics and device/client counts. Pass site_names to filter.
+  - Use `central_get_site_health` for health metrics and device/client counts. Pass `site_name` (string or list) to filter.
 - **AP Monitoring**: central_get_aps, central_get_ap_wlans
   - Use `central_get_aps` for filtered AP listing (status, model, firmware, deployment, site). More AP-specific filters than `central_get_devices`.
   - Use `central_get_ap_wlans` to see which WLANs a specific AP is broadcasting (by serial number).
@@ -208,7 +208,7 @@ After reading the report, drill down into specific issues using the exact tool c
 
 ## Guidelines
 - ALWAYS start with `central_get_site_name_id_mapping` for a lightweight overview.
-- Call `central_get_site_health` with a `site_names` filter for health data — never without a filter unless explicitly requested.
+- Call `central_get_site_health` with a `site_name` filter (string or list) for health data — never without a filter unless explicitly requested.
 - Recommendations must be based strictly on API response data.
 - Direct users to HPE Aruba Networking Central for authoritative view and remediation.
 

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -35,7 +35,7 @@ async def central_get_alerts(
     cursor: int | None = None,
 ) -> PaginatedAlerts | str:
     """
-    REQUIRES site_id — call central_get_site_health(site_names=["<site name>"]) and extract
+    REQUIRES site_id — call central_get_site_health(site_name="<site name>") and extract
     site_id from the returned SiteData. Do NOT call this tool without a site_id; it will
     fail validation.
 
@@ -51,7 +51,7 @@ async def central_get_alerts(
 
     Parameters:
         - site_id: Site identifier. Obtain by calling
-          central_get_site_health(site_names=["<name>"]) and reading site_id from the result.
+          central_get_site_health(site_name="<name>") and reading site_id from the result.
         - status: "Active" (default) for unresolved alerts, "Cleared" for resolved ones.
         - device_type: Narrow to a device class — "Access Point", "Gateway", "Switch",
           or "Bridge".

--- a/src/hpe_networking_mcp/platforms/central/tools/prompts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/prompts.py
@@ -25,7 +25,7 @@ Troubleshoot the site "{site_name}" by following these steps:
 
 1. Call `central_get_site_name_id_mapping` to verify the site name and get its \
 site_id and current health score.
-2. Call `central_get_site_health` with site_names=["{site_name}"] to get detailed site \
+2. Call `central_get_site_health` with site_name="{site_name}" to get detailed site \
 metrics.
 3. Call `central_get_alerts` with the site_id and status="Active" to get all \
 active alerts. Prioritize by severity (Critical > High > Medium > Low).
@@ -173,7 +173,7 @@ Compare health across sites: {sites_str}
 
 1. Call `central_get_site_name_id_mapping` to verify all site names and get \
 their site_ids and health scores.
-2. Call `central_get_site_health` with site_names={list(site_names)} to get \
+2. Call `central_get_site_health` with site_name={list(site_names)} to get \
 detailed metrics for each site.
 3. For each site, call `central_get_alerts` with the site_id and \
 status="Active" to get active alert counts by severity.

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -7,6 +7,7 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     fetch_site_data_parallel,
     groups_to_map,
+    normalize_site_name_filter,
     retry_central_command,
 )
 
@@ -57,14 +58,14 @@ async def central_get_sites(
 @mcp.tool(annotations=READ_ONLY)
 async def central_get_site_health(
     ctx: Context,
-    site_names: list[str] | None = None,
+    site_name: str | list[str] | None = None,
 ) -> list[SiteData]:
     """
     Returns health metrics and device/client counts for sites.
 
     For site configuration data (address, timezone, etc.), use central_get_sites.
 
-    Prefer calling with a site_names filter targeting only the sites you care about.
+    Prefer calling with a site_name filter targeting only the sites you care about.
     Do NOT call without a filter unless the user explicitly requests data for all
     sites — returning all sites is expensive and consumes significant context.
 
@@ -74,12 +75,14 @@ async def central_get_site_health(
     this tool with those specific site names.
 
     Parameters:
-        site_names: One or more site names to filter by (exact match).
-            If omitted, all sites are returned (use sparingly).
+        site_name: One site name or a list of site names to filter by (exact match).
+            Accepts either a single string (e.g. "Owls Nest") or a list of strings
+            (e.g. ["Owls Nest", "HQ"]). If omitted, all sites are returned (use sparingly).
     """
+    wanted = normalize_site_name_filter(site_name)
     sites_data = fetch_site_data_parallel(ctx.lifespan_context["central_conn"])
-    if site_names:
-        return [sites_data[name] for name in site_names if name in sites_data]
+    if wanted:
+        return [sites_data[name] for name in wanted if name in sites_data]
     return list(sites_data.values())
 
 

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -16,6 +16,20 @@ from hpe_networking_mcp.platforms.central.models import (
 )
 
 
+def normalize_site_name_filter(value: str | list[str] | None) -> list[str] | None:
+    """Accept a single site name, a list, or None; return a canonical list or None.
+
+    Exists so tool parameters named ``site_name`` can accept either shape
+    without surprising LLMs that pattern-match against the singular-string
+    convention used by peer Central tools. Introduced for issue #146.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
 @dataclass
 class FilterField:
     api_field: str

--- a/tests/unit/test_central_sites.py
+++ b/tests/unit/test_central_sites.py
@@ -1,0 +1,39 @@
+"""Unit tests for central sites tool helpers.
+
+Covers the ``normalize_site_name_filter`` helper introduced for issue #146:
+the ``central_get_site_health`` tool accepts either a single string or a list
+of strings so LLMs pattern-matching against peer Central tools (which all use
+singular ``site_name``) don't get tripped up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.utils import normalize_site_name_filter
+
+
+@pytest.mark.unit
+class TestNormalizeSiteNameFilter:
+    def test_none_stays_none(self):
+        assert normalize_site_name_filter(None) is None
+
+    def test_single_string_wraps_in_list(self):
+        assert normalize_site_name_filter("Owls Nest") == ["Owls Nest"]
+
+    def test_single_string_with_special_chars_preserved(self):
+        assert normalize_site_name_filter("Owls Nest New Central") == ["Owls Nest New Central"]
+
+    def test_list_passes_through_as_list(self):
+        assert normalize_site_name_filter(["A", "B"]) == ["A", "B"]
+
+    def test_single_element_list_stays_list(self):
+        assert normalize_site_name_filter(["Solo"]) == ["Solo"]
+
+    def test_empty_list_returns_empty_list(self):
+        # An empty list is not None — caller decides whether to return all sites
+        # or no sites. The helper preserves that distinction.
+        assert normalize_site_name_filter([]) == []
+
+    def test_tuple_coerced_to_list(self):
+        assert normalize_site_name_filter(("A", "B")) == ["A", "B"]


### PR DESCRIPTION
Closes #146.

## Summary

- Signature of \`central_get_site_health\` changes from \`site_names: list[str] | None\` to \`site_name: str | list[str] | None\`, aligning with every other single-site Central tool and prompt.
- Normalization extracted to \`normalize_site_name_filter\` in \`central/utils.py\` so it's testable without triggering the \`@mcp.tool\` decorator at import time.
- Local LLMs pattern-matching against the Central surface were consistently guessing \`site_name=...\` and hitting FastMCP's framework-level "must NOT have additional properties" validation error, which gave no hint about the correct parameter name and caused reasoning loops. Reported by Zach Jennings with gpt-oss:20b.

## Behavior

- \`site_name="Owls Nest"\` — works (new, matches peer tools)
- \`site_name=["A", "B"]\` — works (preserves batch capability)
- \`site_name=None\` — works (returns all sites, same as before)

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **322/322 passing** (7 new tests for \`normalize_site_name_filter\`)

## Files touched
- \`src/hpe_networking_mcp/platforms/central/tools/sites.py\` — signature + normalization
- \`src/hpe_networking_mcp/platforms/central/utils.py\` — new \`normalize_site_name_filter\` helper
- \`src/hpe_networking_mcp/platforms/central/tools/alerts.py\` — docstring references
- \`src/hpe_networking_mcp/platforms/central/tools/prompts.py\` — prompt bodies
- \`src/hpe_networking_mcp/INSTRUCTIONS.md\` — 3 references updated
- \`docs/TOOLS.md\` — parameter table row rewritten
- \`CHANGELOG.md\` — v1.0.0.1 entry
- \`pyproject.toml\` — version bumped to 1.0.0.1
- \`tests/unit/test_central_sites.py\` — new test file

## Out of scope

The broader Mist/Central parameter-consistency sweep (apply \`str | list[str]\` to every filter parameter across both platforms) is deferred to a separate PR. This change is scoped narrowly to the one tool Zach hit.