### PR TITLE
Pre-gate: fix integration-test collection + dev compose rw (#153, #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0.2] - 2026-04-22
+
+### Fixed — test/dev infrastructure (pre-gate for v2.0 work)
+
+- **Integration-test collection failure (#153)** — `tests/integration/test_ap_monitoring_live.py` and `test_wlans_live.py` import tool modules directly, and those modules call `@mcp.tool(...)` at import time against a `_registry.mcp` that is `None` outside of a running server. Collection aborted with `AttributeError: 'NoneType' object has no attribute 'tool'`. `tests/integration/conftest.py` now installs a `MagicMock` on each platform's `_registry.mcp` at conftest load, so tool modules import cleanly for collection. Unit tests unaffected (they don't import from tool modules). Test collection now discovers 353 tests (previously short-circuited at 322).
+- **Dev compose read-only src mount (#154)** — `docker-compose.dev.yml` mounted `./src` as read-only, which broke `uv run ruff format` inside the container. Flipped to read-write in the dev overlay only; production `docker-compose.yml` does not mount `./src` at all, so end users are unaffected. Saves a per-PR papercut.
+
+No user-facing code changes. Published image is functionally identical to v1.0.0.1.
+
 ## [v1.0.0.1] - 2026-04-22
 
 ### Fixed — `central_get_site_health` parameter name mismatch (#146)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,9 @@ services:
   hpe-networking-mcp:
     build: .
     volumes:
-      - ./src:/app/src:ro
+      # Read-write so in-container formatters (ruff format) can rewrite source.
+      # Production docker-compose.yml does not mount src at all — this does not
+      # affect end users.
+      - ./src:/app/src
       - ./tests:/app/tests
       - ./pyproject.toml:/app/pyproject.toml:ro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "1.0.0.1"
+version = "1.0.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ Docker secrets to be available at SECRETS_DIR (default: ./secrets/).
 Tests skip gracefully if credentials are missing.
 
 Run via Docker:
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm \\
         hpe-networking-mcp sh -c "uv run pytest tests/integration/ -m integration -v"
 """
 
@@ -14,6 +14,55 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+
+def _install_registry_stubs() -> None:
+    """Stub ``_registry.mcp`` for each platform so tool modules can be imported.
+
+    Live integration tests (e.g. ``test_ap_monitoring_live.py``) import tool
+    functions directly from ``hpe_networking_mcp.platforms.*.tools.*``. Each
+    tool module calls ``@mcp.tool(...)`` at import time against
+    ``_registry.mcp`` — which is ``None`` until ``register_tools()`` runs.
+    Since integration tests don't spin up a FastMCP server (they exercise the
+    tool functions against live vendor APIs), ``register_tools()`` never runs
+    and the imports fail at collection with ``AttributeError: 'NoneType'
+    object has no attribute 'tool'``.
+
+    This fixture installs a ``MagicMock`` whose ``.tool(...)`` and
+    ``.prompt(...)`` return pass-through decorators, so decorated functions
+    remain intact as regular callables. Idempotent — skips platforms whose
+    registry is already populated (e.g. when running unit + integration in
+    the same session and a prior fixture set one up).
+
+    Only runs for the ``tests/integration`` tree; ``tests/unit`` does not need
+    the stubbing because unit tests import from utils/models/client modules
+    rather than from the tool modules.
+    """
+    platform_registries = (
+        "hpe_networking_mcp.platforms.apstra._registry",
+        "hpe_networking_mcp.platforms.central._registry",
+        "hpe_networking_mcp.platforms.clearpass._registry",
+        "hpe_networking_mcp.platforms.greenlake._registry",
+        "hpe_networking_mcp.platforms.mist._registry",
+    )
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
+    mock_mcp.prompt = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
+
+    for module_path in platform_registries:
+        try:
+            import importlib
+
+            reg = importlib.import_module(module_path)
+        except ImportError:
+            # Platform module not yet available (e.g. during scaffolding).
+            continue
+        if getattr(reg, "mcp", None) is None:
+            reg.mcp = mock_mcp
+
+
+_install_registry_stubs()
 
 
 def _read_secret(name: str) -> str | None:


### PR DESCRIPTION
Closes #153. Closes #154.

Two small test/dev infrastructure fixes that every subsequent PR on the road to v2.0 benefits from. Neither affects the published image or any end-user behavior.

## Summary

### #153 — Integration-test collection
\`tests/integration/conftest.py\` now stubs \`_registry.mcp\` for every platform at conftest import. Integration test modules that import tool functions directly no longer blow up collection with \`AttributeError: 'NoneType' object has no attribute 'tool'\`.

Before: collection aborted at 322 tests (the first integration module to fail took the rest with it).
After: **353 tests collected** cleanly. Integration tests skip gracefully when credentials aren't present (fixture already handled that).

### #154 — Dev compose src mount
\`docker-compose.dev.yml\`: \`./src:/app/src:ro\` → \`./src:/app/src\`. Lets in-container formatters (\`uv run ruff format\`) rewrite source files. Production \`docker-compose.yml\` does not mount \`./src\` at all, so end users are unaffected. Added a comment at the mount site explaining the dev-vs-prod scope.

## Version bump

\`1.0.0.1\` → \`1.0.0.2\`. Pre-gating release per the strategy documented on umbrella #157.

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **322/322 passing**
- [x] \`pytest --collect-only\` reports 353 tests (includes integration) without errors

## Files
- \`tests/integration/conftest.py\` — \`_install_registry_stubs()\` helper + module-level call
- \`docker-compose.dev.yml\` — rw mount with clarifying comment
- \`pyproject.toml\` — version bump to 1.0.0.2
- \`CHANGELOG.md\` — \`[v1.0.0.2]\` entry

## Not in scope
No production image changes. No user-facing behavior changes. Pure dev/test improvement.