### PR TITLE
Pre-gate: fix Central PUT-clobber on site/site-collection/device-group updates (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0.3] - 2026-04-22
+
+### Fixed — silent PUT-clobber on Central configuration updates (#155)
+
+Audited every `central_manage_*` write tool for the silent-clobber
+pattern that v0.9.2.2 fixed in `central_manage_wlan_profile`. Three
+tools shared the same bug via a common helper:
+
+- `central_manage_site`
+- `central_manage_site_collection`
+- `central_manage_device_group`
+
+All three called `_execute_config_action` in
+`platforms/central/tools/configuration.py`, which hard-coded `PUT`
+for updates. Central treats `PUT` as full-resource replacement, so
+partial-update payloads silently dropped every field not included.
+Exact same class of bug Zach reported in #141, same fix shape as PR
+#142.
+
+Updates now issue `PATCH` by default (Central merges the payload
+server-side, preserving untouched fields). All three tools gain a
+`replace_existing: bool = False` parameter that opts back into the
+old `PUT` behavior for callers deliberately sending a full-resource
+replacement. The elicitation prompt now warns when
+`replace_existing=True` is in play.
+
+Ten other `central_manage_*` tools already used `PATCH` via shared
+helpers and were not affected.
+
+New unit test file `tests/unit/test_central_configuration.py` covers
+method selection for create / update-default / update-replace-existing /
+delete and the resource-id validation paths.
+
+### Changed — test fixture scope (internal)
+
+The `_install_registry_stubs()` helper introduced in v1.0.0.2
+(`tests/integration/conftest.py`) was lifted up to `tests/conftest.py`
+so both unit and integration tests can import from tool modules
+without tripping the `_registry.mcp is None` decorator error.
+`tests/integration/conftest.py` keeps its integration-specific
+fixtures. No behavior change at runtime.
+
 ## [v1.0.0.2] - 2026-04-22
 
 ### Fixed — test/dev infrastructure (pre-gate for v2.0 work)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "1.0.0.2"
+version = "1.0.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -81,6 +81,17 @@ async def central_manage_site(
             default=False,
         ),
     ],
+    replace_existing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Only used on update. When false (default) the update is a PATCH — Central merges the payload "
+                "with the existing site, preserving fields you don't specify. Set true to issue a PUT that "
+                "replaces the entire site; any field absent from the payload is dropped. Use with care."
+            ),
+            default=False,
+        ),
+    ],
 ) -> dict | str:
     """Create, update, or delete a site in Aruba Central."""
     return await _execute_config_action(
@@ -91,6 +102,7 @@ async def central_manage_site(
         resource_id=site_id,
         payload=payload,
         confirmed=confirmed,
+        replace_existing=replace_existing,
     )
 
 
@@ -138,6 +150,18 @@ async def central_manage_site_collection(
             default=False,
         ),
     ],
+    replace_existing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Only used on update. When false (default) the update is a PATCH — Central merges the payload "
+                "with the existing collection, preserving fields you don't specify. Set true to issue a PUT that "
+                "replaces the entire collection; any field absent from the payload is dropped. "
+                "This flag does not apply to add_sites / remove_sites."
+            ),
+            default=False,
+        ),
+    ],
 ) -> dict | str:
     """Create, update, delete, or manage sites within a site collection."""
     if action_type == CollectionActionType.ADD_SITES:
@@ -156,6 +180,7 @@ async def central_manage_site_collection(
         resource_id=collection_id,
         payload=payload,
         confirmed=confirmed,
+        replace_existing=replace_existing,
     )
 
 
@@ -196,6 +221,17 @@ async def central_manage_device_group(
             default=False,
         ),
     ],
+    replace_existing: Annotated[
+        bool,
+        Field(
+            description=(
+                "Only used on update. When false (default) the update is a PATCH — Central merges the payload "
+                "with the existing device group, preserving fields you don't specify. Set true to issue a PUT "
+                "that replaces the entire device group; any field absent from the payload is dropped. Use with care."
+            ),
+            default=False,
+        ),
+    ],
 ) -> dict | str:
     """Create, update, or delete a device group in Aruba Central."""
     return await _execute_config_action(
@@ -206,6 +242,7 @@ async def central_manage_device_group(
         resource_id=group_id,
         payload=payload,
         confirmed=confirmed,
+        replace_existing=replace_existing,
     )
 
 
@@ -222,12 +259,20 @@ async def _execute_config_action(
     resource_id: str | None,
     payload: dict,
     confirmed: bool = False,
+    replace_existing: bool = False,
 ) -> dict | str:
     """Execute a configuration CRUD action with confirmation and error handling.
 
     Central API patterns:
     - CREATE: POST to base path, payload as JSON body
-    - UPDATE: PUT to base path, payload includes scopeId to identify resource
+    - UPDATE (default): PATCH — Central merges the payload with the existing
+      resource server-side. Callers pass only the fields they want to change;
+      untouched fields are preserved.
+    - UPDATE (replace_existing=True): PUT — full-resource replacement. Every
+      field missing from the payload is dropped. Use only when the caller
+      has fetched the current resource and is deliberately sending a
+      complete replacement. This path reproduces the pre-v0.9.2.2 behavior
+      that silently clobbered fields in partial updates (#141, #155).
     - DELETE: DELETE to {path}/bulk, body is {"items": [{"id": "..."}]}
     """
     if action_type in (ActionType.UPDATE, ActionType.DELETE) and not resource_id:
@@ -241,8 +286,17 @@ async def _execute_config_action(
 
     # Confirm with user for update and delete only (skip if already confirmed)
     if action_type != ActionType.CREATE and not confirmed:
+        if action_type == ActionType.UPDATE and replace_existing:
+            warning = (
+                " NOTE: replace_existing=True — this is a full-resource PUT. Any "
+                "field not in the payload will be dropped from the stored resource."
+            )
+        else:
+            warning = ""
         elicitation_response = await elicitation_handler(
-            message=(f"The LLM wants to {action_wording} {resource_name}. Do you accept to trigger the API call?"),
+            message=(
+                f"The LLM wants to {action_wording} {resource_name}.{warning} Do you accept to trigger the API call?"
+            ),
             ctx=ctx,
         )
         if elicitation_response.action == "decline":
@@ -266,7 +320,7 @@ async def _execute_config_action(
         full_path = api_path
         api_data = payload
     elif action_type == ActionType.UPDATE:
-        api_method = "PUT"
+        api_method = "PUT" if replace_existing else "PATCH"
         full_path = api_path
         api_data = {**payload, "scopeId": resource_id}
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,47 @@
 """Shared fixtures for HPE Networking MCP Server tests."""
 
+import importlib
+from unittest.mock import MagicMock
+
 import pytest
+
+
+def _install_registry_stubs() -> None:
+    """Stub ``_registry.mcp`` for each platform so tool modules import cleanly.
+
+    Every ``@mcp.tool(...)`` at import time reads ``_registry.mcp``. In a test
+    run, nothing has called ``register_tools()``, so the attribute is ``None``
+    and any test that imports from a tool module fails collection with
+    ``AttributeError: 'NoneType' object has no attribute 'tool'``. Installing
+    a pass-through ``MagicMock`` at conftest load lets tool modules import
+    and leaves the decorated functions intact as regular callables.
+
+    Introduced at ``tests/integration/conftest.py`` for #153 and lifted here
+    (for #155) when a new unit test under ``tests/unit/`` needed the same
+    stubbing. Scoped to both unit and integration tests; idempotent.
+    """
+    platform_registries = (
+        "hpe_networking_mcp.platforms.apstra._registry",
+        "hpe_networking_mcp.platforms.central._registry",
+        "hpe_networking_mcp.platforms.clearpass._registry",
+        "hpe_networking_mcp.platforms.greenlake._registry",
+        "hpe_networking_mcp.platforms.mist._registry",
+    )
+
+    mock_mcp = MagicMock()
+    mock_mcp.tool = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
+    mock_mcp.prompt = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
+
+    for module_path in platform_registries:
+        try:
+            reg = importlib.import_module(module_path)
+        except ImportError:
+            continue
+        if getattr(reg, "mcp", None) is None:
+            reg.mcp = mock_mcp
+
+
+_install_registry_stubs()
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,54 +15,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
-def _install_registry_stubs() -> None:
-    """Stub ``_registry.mcp`` for each platform so tool modules can be imported.
-
-    Live integration tests (e.g. ``test_ap_monitoring_live.py``) import tool
-    functions directly from ``hpe_networking_mcp.platforms.*.tools.*``. Each
-    tool module calls ``@mcp.tool(...)`` at import time against
-    ``_registry.mcp`` — which is ``None`` until ``register_tools()`` runs.
-    Since integration tests don't spin up a FastMCP server (they exercise the
-    tool functions against live vendor APIs), ``register_tools()`` never runs
-    and the imports fail at collection with ``AttributeError: 'NoneType'
-    object has no attribute 'tool'``.
-
-    This fixture installs a ``MagicMock`` whose ``.tool(...)`` and
-    ``.prompt(...)`` return pass-through decorators, so decorated functions
-    remain intact as regular callables. Idempotent — skips platforms whose
-    registry is already populated (e.g. when running unit + integration in
-    the same session and a prior fixture set one up).
-
-    Only runs for the ``tests/integration`` tree; ``tests/unit`` does not need
-    the stubbing because unit tests import from utils/models/client modules
-    rather than from the tool modules.
-    """
-    platform_registries = (
-        "hpe_networking_mcp.platforms.apstra._registry",
-        "hpe_networking_mcp.platforms.central._registry",
-        "hpe_networking_mcp.platforms.clearpass._registry",
-        "hpe_networking_mcp.platforms.greenlake._registry",
-        "hpe_networking_mcp.platforms.mist._registry",
-    )
-
-    mock_mcp = MagicMock()
-    mock_mcp.tool = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
-    mock_mcp.prompt = MagicMock(side_effect=lambda *_a, **_kw: lambda fn: fn)
-
-    for module_path in platform_registries:
-        try:
-            import importlib
-
-            reg = importlib.import_module(module_path)
-        except ImportError:
-            # Platform module not yet available (e.g. during scaffolding).
-            continue
-        if getattr(reg, "mcp", None) is None:
-            reg.mcp = mock_mcp
-
-
-_install_registry_stubs()
+# Note: the `_install_registry_stubs` call that allowed integration tests to
+# import tool modules at collection time used to live here. It was lifted to
+# tests/conftest.py for #155 so unit tests can also exercise tool-module-level
+# imports. pytest auto-loads the parent conftest before this one, so the
+# stubs are already in place by the time anything here runs.
 
 
 def _read_secret(name: str) -> str | None:

--- a/tests/unit/test_central_configuration.py
+++ b/tests/unit/test_central_configuration.py
@@ -1,0 +1,173 @@
+"""Unit tests for central configuration CRUD helper.
+
+Covers the PUT-clobber fix for #155 — ``_execute_config_action`` now uses
+PATCH for updates by default (server-side merge) and only issues PUT when
+the caller opts into full-resource replacement via ``replace_existing=True``.
+This mirrors the v0.9.2.2 fix applied to ``central_manage_wlan_profile`` and
+closes the same class of silent-clobber bug for sites, site collections, and
+device groups.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools.configuration import (
+    ActionType,
+    _execute_config_action,
+)
+
+
+def _fake_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    ctx.get_state = AsyncMock(return_value="prompt")
+    return ctx
+
+
+def _ok_response() -> dict:
+    return {"code": 200, "msg": {"ok": True}}
+
+
+@pytest.mark.unit
+class TestExecuteConfigActionMethodSelection:
+    """Asserts the helper picks the right HTTP method for each action_type."""
+
+    @pytest.mark.asyncio
+    @patch("hpe_networking_mcp.platforms.central.tools.configuration.retry_central_command")
+    async def test_create_uses_post(self, mock_retry):
+        mock_retry.return_value = _ok_response()
+        ctx = _fake_ctx()
+
+        result = await _execute_config_action(
+            ctx=ctx,
+            action_type=ActionType.CREATE,
+            resource_name="site",
+            api_path="network-config/v1/sites",
+            resource_id=None,
+            payload={"name": "HQ"},
+            confirmed=True,
+        )
+
+        assert result["status"] == "success"
+        assert mock_retry.call_args.kwargs["api_method"] == "POST"
+        assert mock_retry.call_args.kwargs["api_path"] == "network-config/v1/sites"
+
+    @pytest.mark.asyncio
+    @patch("hpe_networking_mcp.platforms.central.tools.configuration.retry_central_command")
+    async def test_update_default_uses_patch(self, mock_retry):
+        """The whole point of the fix: default update must be PATCH, not PUT."""
+        mock_retry.return_value = _ok_response()
+        ctx = _fake_ctx()
+
+        await _execute_config_action(
+            ctx=ctx,
+            action_type=ActionType.UPDATE,
+            resource_name="site",
+            api_path="network-config/v1/sites",
+            resource_id="site-123",
+            payload={"timezone": "UTC"},
+            confirmed=True,  # skip elicitation
+        )
+
+        assert mock_retry.call_args.kwargs["api_method"] == "PATCH"
+        # Body still carries scopeId to identify the target resource
+        assert mock_retry.call_args.kwargs["api_data"]["scopeId"] == "site-123"
+        assert mock_retry.call_args.kwargs["api_data"]["timezone"] == "UTC"
+
+    @pytest.mark.asyncio
+    @patch("hpe_networking_mcp.platforms.central.tools.configuration.retry_central_command")
+    async def test_update_with_replace_existing_uses_put(self, mock_retry):
+        """Escape hatch: replace_existing=True opts into full-replacement PUT."""
+        mock_retry.return_value = _ok_response()
+        ctx = _fake_ctx()
+
+        await _execute_config_action(
+            ctx=ctx,
+            action_type=ActionType.UPDATE,
+            resource_name="site",
+            api_path="network-config/v1/sites",
+            resource_id="site-123",
+            payload={"name": "HQ", "address": "123 Main"},
+            confirmed=True,
+            replace_existing=True,
+        )
+
+        assert mock_retry.call_args.kwargs["api_method"] == "PUT"
+
+    @pytest.mark.asyncio
+    @patch("hpe_networking_mcp.platforms.central.tools.configuration.retry_central_command")
+    async def test_delete_uses_delete_at_bulk_path(self, mock_retry):
+        mock_retry.return_value = _ok_response()
+        ctx = _fake_ctx()
+
+        await _execute_config_action(
+            ctx=ctx,
+            action_type=ActionType.DELETE,
+            resource_name="site",
+            api_path="network-config/v1/sites",
+            resource_id="site-123",
+            payload={},
+            confirmed=True,
+        )
+
+        assert mock_retry.call_args.kwargs["api_method"] == "DELETE"
+        assert mock_retry.call_args.kwargs["api_path"] == "network-config/v1/sites/bulk"
+        assert mock_retry.call_args.kwargs["api_data"] == {"items": [{"id": "site-123"}]}
+
+
+@pytest.mark.unit
+class TestExecuteConfigActionRequiredIds:
+    """Update and delete require a resource_id; the helper raises without one."""
+
+    @pytest.mark.asyncio
+    async def test_update_without_resource_id_raises(self):
+        from fastmcp.exceptions import ToolError
+
+        ctx = _fake_ctx()
+        with pytest.raises(ToolError):
+            await _execute_config_action(
+                ctx=ctx,
+                action_type=ActionType.UPDATE,
+                resource_name="site",
+                api_path="network-config/v1/sites",
+                resource_id=None,
+                payload={"name": "x"},
+                confirmed=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_without_resource_id_raises(self):
+        from fastmcp.exceptions import ToolError
+
+        ctx = _fake_ctx()
+        with pytest.raises(ToolError):
+            await _execute_config_action(
+                ctx=ctx,
+                action_type=ActionType.DELETE,
+                resource_name="site",
+                api_path="network-config/v1/sites",
+                resource_id=None,
+                payload={},
+                confirmed=True,
+            )
+
+    @pytest.mark.asyncio
+    @patch("hpe_networking_mcp.platforms.central.tools.configuration.retry_central_command")
+    async def test_create_without_resource_id_is_fine(self, mock_retry):
+        """Create doesn't need an existing resource_id."""
+        mock_retry.return_value = _ok_response()
+        ctx = _fake_ctx()
+
+        result = await _execute_config_action(
+            ctx=ctx,
+            action_type=ActionType.CREATE,
+            resource_name="site",
+            api_path="network-config/v1/sites",
+            resource_id=None,
+            payload={"name": "HQ"},
+            confirmed=True,
+        )
+        assert result["status"] == "success"


### PR DESCRIPTION
Closes #155.

Pre-gating release before the v2.0 dynamic-mode work begins. Audit of every \`central_manage_*\` tool for the silent-clobber pattern that v0.9.2.2 fixed for \`central_manage_wlan_profile\` in PR #142.

## Findings

Of 13 \`central_manage_*\` tools, **10 were already safe** (using PATCH via shared security-policy helpers); **3 were suspect** (shared the same \`_execute_config_action\` helper that hard-coded PUT for updates):

- \`central_manage_site\`
- \`central_manage_site_collection\`
- \`central_manage_device_group\`

## Fix

Single location in \`src/hpe_networking_mcp/platforms/central/tools/configuration.py\`:

- \`_execute_config_action\` now issues **PATCH** for updates by default (Central's merge semantics). PUT only when the caller explicitly opts in via \`replace_existing=True\`.
- Each of the 3 tools gains a \`replace_existing: bool = False\` parameter, threaded through to the helper.
- Elicitation prompt warns the user when \`replace_existing=True\` is in play.

Behavior for creates / deletes is unchanged (POST / DELETE-bulk).

## Side fix

\`_install_registry_stubs()\` was lifted from \`tests/integration/conftest.py\` (where v1.0.0.2 placed it for #153) up to \`tests/conftest.py\`. The new \`test_central_configuration.py\` imports from a tool module, and integration-scoped stubbing didn't reach unit tests. This is the natural home for the helper going forward.

## Version bump

\`1.0.0.2\` → \`1.0.0.3\`. Pre-gating release per umbrella #157.

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **329/329 passing** (7 new tests for method selection + resource-id validation)

## Files
- \`src/hpe_networking_mcp/platforms/central/tools/configuration.py\` — helper + 3 tools
- \`tests/conftest.py\` — stub helper (lifted from integration)
- \`tests/integration/conftest.py\` — pointer comment
- \`tests/unit/test_central_configuration.py\` — new, 7 tests
- \`pyproject.toml\`, \`CHANGELOG.md\` — v1.0.0.3