### PR TITLE
Pre-gate: Mist/Central filter-parameter consistency sweep (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0.0] - 2026-04-22
+
+### Added — Mist/Central filter-parameter consistency (#156)
+
+Eight filter parameters across five tools now accept either a single
+string or a list of strings. The rule established in v1.0.0.1 — filter
+parameters accept `str | list[str] | None`, named in the singular —
+applied across Mist and Central. Identity parameters (`blueprint_id`,
+`device_id`, etc.) and required-single-item parameters (`vn_name`,
+`ssid`) stay scalar.
+
+**Central** (`platforms/central/tools/`):
+- `central_get_devices` — `device_name`, `serial_number`, `model`
+- `central_get_aps` — `serial_number`, `device_name`, `model`, `firmware_version`
+
+**Mist** (`platforms/mist/tools/`):
+- `mist_search_device` — `model`, `version`
+- `mist_list_upgrades` — `model`
+
+Per-platform `as_comma_separated()` helper in `central/utils.py` and
+new `mist/utils.py` normalizes both shapes to the comma-separated form
+Central's OData helpers and mistapi expect. When Phase 0 of v2.0
+introduces `platforms/_common/`, the two helpers collapse into one.
+
+The `central_get_aps` tool was also refactored internally to use the
+shared `build_odata_filter` + `FilterField` pattern already used by
+`central_get_devices`. Multi-value filters now correctly emit OData
+`in (...)` clauses instead of broken `eq '...comma...'` equality.
+
+New test file `tests/unit/test_filter_value_helpers.py` parametrizes
+eight cases against both the Central and Mist helpers so they stay
+behaviour-identical.
+
+**Minor version bump** (1.0.0.3 → 1.1.0.0) because the signatures of
+eight public tool parameters changed — backward-compatible (old `str`
+form still works) but not a pure patch fix.
+
 ## [v1.0.0.3] - 2026-04-22
 
 ### Fixed — silent PUT-clobber on Central configuration updates (#155)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "1.0.0.3"
+version = "1.1.0.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -8,6 +8,7 @@ from hpe_networking_mcp.platforms.central.models import Device
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
+    as_comma_separated,
     build_odata_filter,
     clean_device_data,
 )
@@ -29,9 +30,9 @@ async def central_get_devices(
     ctx: Context,
     site_id: str | None = None,
     device_type: Literal["ACCESS_POINT", "SWITCH", "GATEWAY"] | None = None,
-    device_name: str | None = None,
-    serial_number: str | None = None,
-    model: str | None = None,
+    device_name: str | list[str] | None = None,
+    serial_number: str | list[str] | None = None,
+    model: str | list[str] | None = None,
     device_function: str | None = None,
     is_provisioned: bool | None = None,
     site_assigned: bool | None = None,
@@ -47,9 +48,10 @@ async def central_get_devices(
     Parameters:
     - site_id: Exact site ID or comma-separated list of IDs.
     - device_type: ACCESS_POINT, SWITCH, or GATEWAY. Comma-separated for multiple.
-    - device_name: Device display name. Comma-separated for multiple.
-    - serial_number: Device serial number. Comma-separated for multiple.
-    - model: Device model (e.g., AP-735-RWF1). Comma-separated for multiple.
+    - device_name: Device display name. Accepts a single string or a list of strings
+      (e.g. "AP-001" or ["AP-001", "AP-002"]).
+    - serial_number: Device serial number. Accepts a single string or a list of strings.
+    - model: Device model (e.g., AP-735-RWF1). Accepts a single string or a list of strings.
     - device_function: Device function classification. Comma-separated for multiple.
     - is_provisioned: True returns only provisioned devices (sending Monitoring
       data to New Central). False returns only unprovisioned devices.
@@ -62,9 +64,9 @@ async def central_get_devices(
     raw_pairs = [
         ("site_id", site_id),
         ("device_type", device_type),
-        ("device_name", device_name),
-        ("serial_number", serial_number),
-        ("model", model),
+        ("device_name", as_comma_separated(device_name)),
+        ("serial_number", as_comma_separated(serial_number)),
+        ("model", as_comma_separated(model)),
         ("device_function", device_function),
     ]
     pairs = [(DEVICE_FILTER_FIELDS[k], v) for k, v in raw_pairs if v is not None]

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -6,7 +6,27 @@ from pycentral.new_monitoring.gateways import MonitoringGateways
 
 from hpe_networking_mcp.platforms.central._registry import mcp
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
-from hpe_networking_mcp.platforms.central.utils import retry_central_command
+from hpe_networking_mcp.platforms.central.utils import (
+    FilterField,
+    as_comma_separated,
+    build_odata_filter,
+    retry_central_command,
+)
+
+# Shared FilterField definitions for the AP filter surface. build_odata_filter
+# consumes these and emits `eq '...'` for single values, `in (...)` for
+# comma-separated ones — so accepting a list of models via as_comma_separated
+# flows through naturally.
+_AP_FILTER_FIELDS: dict[str, FilterField] = {
+    "site_id": FilterField("siteId"),
+    "site_name": FilterField("siteName"),
+    "serial_number": FilterField("serialNumber"),
+    "device_name": FilterField("deviceName"),
+    "status": FilterField("status", ["ONLINE", "OFFLINE"]),
+    "model": FilterField("model"),
+    "firmware_version": FilterField("firmwareVersion"),
+    "deployment": FilterField("deployment", ["Standalone", "Cluster", "Unspecified"]),
+}
 
 
 @mcp.tool(annotations=READ_ONLY)
@@ -14,11 +34,11 @@ async def central_get_aps(
     ctx: Context,
     site_id: str | None = None,
     site_name: str | None = None,
-    serial_number: str | None = None,
-    device_name: str | None = None,
+    serial_number: str | list[str] | None = None,
+    device_name: str | list[str] | None = None,
     status: Literal["ONLINE", "OFFLINE"] | None = None,
-    model: str | None = None,
-    firmware_version: str | None = None,
+    model: str | list[str] | None = None,
+    firmware_version: str | list[str] | None = None,
     deployment: Literal["Standalone", "Cluster", "Unspecified"] | None = None,
     sort: str | None = None,
 ) -> list[dict] | str:
@@ -32,32 +52,29 @@ async def central_get_aps(
     Parameters:
         site_id: Filter by site ID.
         site_name: Filter by site name.
-        serial_number: AP serial number (comma-separated for multiple).
-        device_name: AP name (comma-separated for multiple).
+        serial_number: AP serial number. Accepts a single string or a list of strings.
+        device_name: AP name. Accepts a single string or a list of strings.
         status: ONLINE or OFFLINE.
-        model: AP model (comma-separated for multiple).
-        firmware_version: Firmware version (comma-separated for multiple).
+        model: AP model. Accepts a single string or a list of strings.
+        firmware_version: Firmware version. Accepts a single string or a list of strings.
         deployment: Standalone, Cluster, or Unspecified.
         sort: Sort expression (e.g. 'deviceName asc'). Supported fields:
             siteId, serialNumber, deviceName, model, status, deployment.
     """
     conn = ctx.lifespan_context["central_conn"]
 
-    filter_parts = []
-    filter_map = {
-        "siteId": site_id,
-        "siteName": site_name,
-        "serialNumber": serial_number,
-        "deviceName": device_name,
-        "status": status,
-        "model": model,
-        "firmwareVersion": firmware_version,
-        "deployment": deployment,
-    }
-    for field, value in filter_map.items():
-        if value is not None:
-            filter_parts.append(f"{field} eq '{value}'")
-    filter_str = " and ".join(filter_parts) if filter_parts else None
+    raw_pairs = [
+        ("site_id", site_id),
+        ("site_name", site_name),
+        ("serial_number", as_comma_separated(serial_number)),
+        ("device_name", as_comma_separated(device_name)),
+        ("status", status),
+        ("model", as_comma_separated(model)),
+        ("firmware_version", as_comma_separated(firmware_version)),
+        ("deployment", deployment),
+    ]
+    pairs = [(_AP_FILTER_FIELDS[k], v) for k, v in raw_pairs if v is not None]
+    filter_str = build_odata_filter(pairs)
 
     try:
         kwargs: dict = {"central_conn": conn}

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -30,6 +30,27 @@ def normalize_site_name_filter(value: str | list[str] | None) -> list[str] | Non
     return list(value)
 
 
+def as_comma_separated(value: str | list[str] | None) -> str | None:
+    """Normalize a filter value into the comma-separated string form Central expects.
+
+    Central's OData filter helpers (and ``build_odata_filter``) accept a
+    comma-separated string and split on commas to build ``in (...)`` clauses.
+    This helper lets tool parameters accept either shape::
+
+        "AP43"                 -> "AP43"              (unchanged)
+        "AP43,AP44"            -> "AP43,AP44"         (unchanged)
+        ["AP43", "AP44"]       -> "AP43,AP44"         (joined)
+        None                   -> None
+
+    Introduced for the Mist/Central filter-parameter consistency sweep (#156).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return ",".join(str(v) for v in value)
+
+
 @dataclass
 class FilterField:
     api_field: str

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
@@ -26,6 +26,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.utils import as_comma_separated
 
 
 class Device_type(Enum):
@@ -109,12 +110,13 @@ async def list_upgrades(
         ),
     ],
     model: Annotated[
-        str,
+        str | list[str],
         Field(
             description=(
                 "Device model to filter available firmware "
-                "versions by. Only applicable when "
-                "device_type is available_device_versions"
+                "versions by. Accepts a single string or a list "
+                "of strings. Only applicable when device_type is "
+                "available_device_versions."
             ),
             default=None,
         ),
@@ -264,11 +266,12 @@ async def list_upgrades(
                     response = mistapi.api.v1.orgs.ssr.listOrgSsrUpgrades(apisession, org_id=org)
                     await process_response(response)
             case "available_device_versions":
+                model_arg = as_comma_separated(model)
                 response = mistapi.api.v1.orgs.devices.listOrgAvailableDeviceVersions(
                     apisession,
                     org_id=org,
                     type=(firmware_type.value if firmware_type else None),
-                    model=model if model else None,
+                    model=model_arg if model_arg else None,
                 )
                 await process_response(response)
             case "available_ssr_versions":

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
@@ -26,6 +26,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     handle_network_error,
     process_response,
 )
+from hpe_networking_mcp.platforms.mist.utils import as_comma_separated
 
 
 class Device_type(Enum):
@@ -75,10 +76,11 @@ async def search_device(
         ),
     ],
     model: Annotated[
-        str,
+        str | list[str],
         Field(
             description=(
-                "Device model. Partial match allowed with wildcard * (e.g. `AP*` will match `AP43` and `AP41`)"
+                "Device model to filter inventory by. Accepts a single string or a list of strings. "
+                "Partial match allowed with wildcard * (e.g. `AP*` will match `AP43` and `AP41`)."
             ),
             default=None,
         ),
@@ -95,9 +97,11 @@ async def search_device(
         ),
     ],
     version: Annotated[
-        str,
+        str | list[str],
         Field(
-            description=("Firmware version of the device to filter inventory by"),
+            description=(
+                "Firmware version of the device to filter inventory by. Accepts a single string or a list of strings."
+            ),
             default=None,
         ),
     ],
@@ -164,16 +168,18 @@ async def search_device(
         }
         if serial:
             kwargs["serial"] = serial
-        if model:
-            kwargs["model"] = model
+        model_arg = as_comma_separated(model)
+        if model_arg:
+            kwargs["model"] = model_arg
         if device_type:
             kwargs["type"] = device_type.value
         if mac:
             kwargs["mac"] = mac
         if site_id:
             kwargs["site_id"] = str(site_id)
-        if version:
-            kwargs["version"] = version
+        version_arg = as_comma_separated(version)
+        if version_arg:
+            kwargs["version"] = version_arg
         if text:
             kwargs["text"] = text
         if status:

--- a/src/hpe_networking_mcp/platforms/mist/utils.py
+++ b/src/hpe_networking_mcp/platforms/mist/utils.py
@@ -1,0 +1,31 @@
+"""Shared helpers for Mist tools.
+
+Kept deliberately small — Mist tools mostly delegate to ``mistapi`` directly.
+This module exists to host normalization helpers that multiple tools share,
+the first of which was introduced for the filter-parameter consistency sweep
+(#156).
+"""
+
+from __future__ import annotations
+
+
+def as_comma_separated(value: str | list[str] | None) -> str | None:
+    """Normalize a filter value into the comma-separated string form mistapi expects.
+
+    mistapi exposes many list-endpoint parameters that accept either a single
+    value or a comma-separated list. This helper lets our tool parameters accept
+    either a ``str`` or a ``list[str]`` without surprising LLMs that pattern-match
+    against sibling tools that use the singular form.
+
+    ::
+
+        "AP43"                 -> "AP43"              (unchanged)
+        "AP43,AP44"            -> "AP43,AP44"         (unchanged)
+        ["AP43", "AP44"]       -> "AP43,AP44"         (joined)
+        None                   -> None
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return ",".join(str(v) for v in value)

--- a/tests/unit/test_filter_value_helpers.py
+++ b/tests/unit/test_filter_value_helpers.py
@@ -1,0 +1,58 @@
+"""Unit tests for ``as_comma_separated`` helpers used by the Mist/Central
+filter-parameter consistency sweep (#156).
+
+Two copies of the helper exist — one in each platform's ``utils.py`` — so
+each platform can ship without a cross-platform dependency. The tests below
+exercise both to guarantee they stay behaviour-identical. When v2.0 Phase 0
+introduces ``platforms/_common/``, the helpers collapse into one and these
+tests consolidate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.utils import (
+    as_comma_separated as central_as_comma_separated,
+)
+from hpe_networking_mcp.platforms.mist.utils import (
+    as_comma_separated as mist_as_comma_separated,
+)
+
+
+@pytest.fixture(params=[central_as_comma_separated, mist_as_comma_separated], ids=["central", "mist"])
+def as_comma_separated(request):
+    """Run every case against both platform helpers."""
+    return request.param
+
+
+@pytest.mark.unit
+class TestAsCommaSeparated:
+    def test_none_stays_none(self, as_comma_separated):
+        assert as_comma_separated(None) is None
+
+    def test_single_string_passes_through(self, as_comma_separated):
+        assert as_comma_separated("AP43") == "AP43"
+
+    def test_already_comma_separated_string_passes_through(self, as_comma_separated):
+        # If the caller already supplied the comma-separated form, don't double-join.
+        assert as_comma_separated("AP43,AP44") == "AP43,AP44"
+
+    def test_list_joined_with_commas(self, as_comma_separated):
+        assert as_comma_separated(["AP43", "AP44"]) == "AP43,AP44"
+
+    def test_single_element_list_yields_bare_value(self, as_comma_separated):
+        assert as_comma_separated(["Solo"]) == "Solo"
+
+    def test_empty_list_yields_empty_string(self, as_comma_separated):
+        # Intentional: ``""`` is distinct from ``None`` — the caller's decision
+        # whether to filter on an empty string flows through.
+        assert as_comma_separated([]) == ""
+
+    def test_tuple_is_coerced_to_list_joined(self, as_comma_separated):
+        assert as_comma_separated(("AP43", "AP44")) == "AP43,AP44"
+
+    def test_non_string_elements_are_stringified(self, as_comma_separated):
+        # Central's FilterField and mistapi both accept plain strings; a caller
+        # passing raw ints is probably wrong but shouldn't crash the helper.
+        assert as_comma_separated([1, 2]) == "1,2"


### PR DESCRIPTION
Closes #156.

Third and final pre-gating release before v2.0 Phase 0. Applies the filter-parameter rule established in v1.0.0.1 (PR #147 / issue #146) to every filter parameter across Mist and Central.

## The rule

> Filter parameters — those that narrow a result set — accept \`str | list[str] | None\`, named in the **singular**. The tool internally normalizes to the comma-separated shape Central/mistapi expect. Identity parameters (\`blueprint_id\`, \`device_id\`, etc.) and required-single-item names (\`vn_name\`, \`ssid\`) stay scalar.

Scope: Mist and Central only. ClearPass and GreenLake use OData filter strings end-to-end so the pattern doesn't apply. Apstra is mostly identity-based.

## Changed

**8 parameters, 5 tools:**

| Platform | Tool | Parameters |
|---|---|---|
| Central | \`central_get_devices\` | \`device_name\`, \`serial_number\`, \`model\` |
| Central | \`central_get_aps\` | \`serial_number\`, \`device_name\`, \`model\`, \`firmware_version\` |
| Mist | \`mist_search_device\` | \`model\`, \`version\` |
| Mist | \`mist_list_upgrades\` | \`model\` |

Backward-compatible: old \`str\` form still works. Any caller passing a list now works too.

## Helpers

- \`src/hpe_networking_mcp/platforms/central/utils.py\` — \`as_comma_separated()\` added alongside existing \`normalize_site_name_filter()\`.
- \`src/hpe_networking_mcp/platforms/mist/utils.py\` — new file, same helper shape.

When Phase 0 of v2.0 introduces \`platforms/_common/\`, the two helpers collapse into one.

## Side benefit: \`central_get_aps\` refactor

The \`central_get_aps\` tool previously built its OData filter with an inline loop:

\`\`\`python
filter_parts.append(f\"{field} eq '{value}'\")
\`\`\`

That produced incorrect OData when the value contained commas (\`model eq 'AP43,AP44'\` instead of the correct \`model in ('AP43', 'AP44')\`). Refactored to use the same \`build_odata_filter\` + \`FilterField\` pattern that \`central_get_devices\` uses, which handles comma-separated multi-value filters correctly.

## Version bump

\`1.0.0.3\` → \`1.1.0.0\`. Minor bump because eight public tool parameter signatures changed. Still backward-compatible with callers sending the old \`str\` shape.

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **345/345 passing** (16 new tests in \`test_filter_value_helpers.py\`, 8 cases parametrized across both Central and Mist helpers)

## Files
- \`src/hpe_networking_mcp/platforms/central/utils.py\` — \`as_comma_separated()\` helper
- \`src/hpe_networking_mcp/platforms/central/tools/devices.py\` — 3 param conversions
- \`src/hpe_networking_mcp/platforms/central/tools/monitoring.py\` — 4 param conversions + \`build_odata_filter\` refactor
- \`src/hpe_networking_mcp/platforms/mist/utils.py\` — new file
- \`src/hpe_networking_mcp/platforms/mist/tools/search_device.py\` — 2 param conversions
- \`src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py\` — 1 param conversion
- \`tests/unit/test_filter_value_helpers.py\` — new, 16 tests
- \`pyproject.toml\`, \`CHANGELOG.md\` — v1.1.0.0

## Next

Once this is merged, tagged, and released, we move to **Phase 0 (#158)** — the v2.0 dynamic-mode work starts proper. No more pre-gating PRs.