### PR TITLE
[v2.0 Phase 0 PR A] Shared tool-registry infrastructure + cross-platform health tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v2.0 Phase 0 infrastructure
+
+### Added — shared tool-registry and meta-tool infrastructure (#158 part A)
+
+Groundwork for the v2.0.0.0 dynamic-tool-mode default flip. No user-visible
+changes in this release: individual platform tool surfaces are unchanged and
+`MCP_TOOL_MODE=static` remains the default. The infrastructure lands first so
+each per-platform migration PR (Apstra, Mist, Central, ClearPass, GreenLake)
+is a small, mechanical swap.
+
+- `src/hpe_networking_mcp/platforms/_common/` package:
+  - `tool_registry.py` — `ToolSpec` dataclass and `REGISTRIES` dict populated
+    by each platform's `@tool(...)` shim (PR B onward). Includes
+    `is_tool_enabled()` gating honoring `ENABLE_*_WRITE_TOOLS` flags.
+  - `meta_tools.py` — `build_meta_tools(platform, mcp)` factory that
+    registers three meta-tools per platform: `<platform>_list_tools`,
+    `<platform>_get_tool_schema`, `<platform>_invoke_tool`.
+- `src/hpe_networking_mcp/platforms/health.py` — new cross-platform `health`
+  tool replacing the per-platform `apstra_health` and
+  `clearpass_test_connection`. Accepts `platform: str | list[str] | None`
+  following the filter-parameter rule from v1.0.0.1. Per-platform probe
+  helpers (`_probe_mist`, `_probe_central`, `_probe_greenlake`,
+  `_probe_clearpass`, `_probe_apstra`) report `ok` / `degraded` /
+  `unavailable` with platform-specific detail. The existing
+  `apstra_health` and `clearpass_test_connection` tools remain in place in
+  this release; they are removed in Phase 0 PR B and Phase 3 respectively.
+- `src/hpe_networking_mcp/middleware/elicitation.py` — `confirm_write(ctx, message)`
+  helper consolidating the 17 duplicated `_confirm` helpers from individual
+  write tool files (#148). Write tools convert to it in subsequent phases.
+
+### Changed
+
+- `ServerConfig.greenlake_tool_mode` is now a read-only property aliasing
+  `ServerConfig.tool_mode` (#151). Internal field renamed; `MCP_TOOL_MODE`
+  env-var name unchanged. Alias slated for removal in v2.1.
+
+### Tests
+- 46 new unit tests (`test_tool_registry.py`, `test_meta_tools.py`,
+  `test_health.py`). Total suite: 391/391 passing.
+
 ## [v1.1.0.0] - 2026-04-22
 
 ### Added — Mist/Central filter-parameter consistency (#156)

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -1,0 +1,45 @@
+# Migrating to v2.0.0.0
+
+Work in progress. This document lands its final form in the v2.0.0.0 default-flip PR (umbrella [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157)). Today it exists as a stub so later phases have a canonical place to accumulate migration notes.
+
+---
+
+## What v2.0 changes
+
+The default tool-exposure surface drops from 261 static tools to ~18. Every per-platform tool becomes discoverable via three meta-tools per platform (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus three cross-platform static tools (`health`, `site_health_check`, `manage_wlan_profile`). Driven by the context-budget problem on small local LLMs (Zach Jennings' original report).
+
+## What stays
+
+- Every tool's **behavior** and **return shape** is unchanged when invoked.
+- Every env var you configure in `docker-compose.yml` (`ENABLE_*_WRITE_TOOLS`, `DISABLE_ELICITATION`, etc.) keeps its meaning.
+- Write-tool elicitation prompts you the same way.
+- Secrets, Docker image tagging, and deployment workflow are unchanged.
+
+## Opt out
+
+Set `MCP_TOOL_MODE=static` in your `docker-compose.yml` to restore v1.x behavior. The env var name is unchanged from v1.x (where it used to apply to GreenLake only); in v2.0 it applies to every platform.
+
+## Removed tools
+
+_(Finalized in the v2.0 default-flip PR. The list below is what the plan calls for; treat it as advisory until v2.0.0.0 ships.)_
+
+| Removed in v2.0 | Replacement |
+|---|---|
+| `apstra_health` | `health(platform="apstra")` |
+| `clearpass_test_connection` | `health(platform="clearpass")` |
+| `apstra_formatting_guidelines` | Content migrates into `src/hpe_networking_mcp/INSTRUCTIONS.md` under the Juniper Apstra section |
+
+AI agents that hard-coded these names will get "tool not found" on v2.0.
+
+## Progress tracker
+
+- [x] Phase 0 PR A — shared `_common/` infrastructure, cross-platform `health` tool, `tool_mode` config
+- [ ] Phase 0 PR B — Apstra migrates to dynamic mode (pilot); removed tools from above actually removed
+- [ ] Phase 1 — Mist migrates
+- [ ] Phase 2 — Central migrates
+- [ ] Phase 3 — ClearPass migrates
+- [ ] Phase 4 — GreenLake dynamic mode generalizes to the new meta-tool pattern
+- [ ] Phase 5 — local-LLM validation
+- [ ] Phase 6 — `MCP_TOOL_MODE=dynamic` becomes the default; tag `v2.0.0.0`
+
+See [issue #157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157) for the live status.

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -94,8 +94,13 @@ class ServerConfig:
     debug: bool = False
     log_file: str | None = None
 
-    # GreenLake tool mode: "static" (10 dedicated tools) or "dynamic" (3 meta-tools)
-    greenlake_tool_mode: str = "static"
+    # Tool exposure mode (generalized from GreenLake's original setting, #151).
+    # "static"  — every tool registers with FastMCP individually; all visible.
+    # "dynamic" — the per-platform 3 meta-tools (list / schema / invoke) are
+    #             exposed; the underlying tools are hidden via a Visibility
+    #             transform. Added in v1.1.0.0+ as opt-in; becomes default in
+    #             v2.0.0.0.
+    tool_mode: str = "static"
 
     # Platform secrets — None means platform is disabled
     mist: MistSecrets | None = None
@@ -103,6 +108,11 @@ class ServerConfig:
     greenlake: GreenLakeSecrets | None = None
     clearpass: ClearPassSecrets | None = None
     apstra: ApstraSecrets | None = None
+
+    @property
+    def greenlake_tool_mode(self) -> str:
+        """Deprecated alias for :attr:`tool_mode`. Removed in v2.0 (#151)."""
+        return self.tool_mode
 
     @property
     def enabled_platforms(self) -> list[str]:
@@ -330,8 +340,13 @@ def load_config() -> ServerConfig:
     debug = os.getenv("DEBUG", "false").lower() in ("true", "1", "yes")
     log_file = os.getenv("LOG_FILE") or None
 
-    # GreenLake tool mode: "static" or "dynamic"
-    greenlake_tool_mode = os.getenv("MCP_TOOL_MODE", "static").lower().strip()
+    # Tool exposure mode — MCP_TOOL_MODE env var. Same env-var name as the
+    # old GreenLake-specific setting; the internal config field is now just
+    # ``tool_mode`` because every platform honors it in v2.0.
+    tool_mode = os.getenv("MCP_TOOL_MODE", "static").lower().strip()
+    if tool_mode not in ("static", "dynamic"):
+        logger.warning("Ignoring unknown MCP_TOOL_MODE={!r}, defaulting to 'static'", tool_mode)
+        tool_mode = "static"
 
     # Load platform credentials from Docker secrets
     mist = _load_mist()
@@ -351,7 +366,7 @@ def load_config() -> ServerConfig:
         disable_elicitation=disable_elicit,
         debug=debug,
         log_file=log_file,
-        greenlake_tool_mode=greenlake_tool_mode,
+        tool_mode=tool_mode,
         mist=mist,
         central=central,
         greenlake=greenlake,
@@ -367,6 +382,6 @@ def load_config() -> ServerConfig:
         raise SystemExit(1)
 
     logger.info("Enabled platforms: {}", ", ".join(config.enabled_platforms))
-    if greenlake_tool_mode != "static":
-        logger.info("GreenLake tool mode: {}", greenlake_tool_mode)
+    if tool_mode != "static":
+        logger.info("Tool mode: {}", tool_mode)
     return config

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -93,6 +93,50 @@ class ElicitationMiddleware(Middleware):
         return result  # type: ignore[return-value]
 
 
+async def confirm_write(
+    ctx: Context,
+    message: str,
+    *,
+    chat_confirm_hint: str | None = None,
+) -> dict | None:
+    """High-level write-tool confirmation helper.
+
+    Most write tools were carrying nearly-identical ``_confirm`` helpers that
+    wrapped :func:`elicitation_handler` and turned the returned action into the
+    canonical ``{"status": ..., "message": ...}`` dict shape. This helper
+    consolidates that boilerplate (#148).
+
+    Args:
+        ctx: FastMCP context.
+        message: Human-readable description of what the tool is about to do.
+            Passed verbatim to the elicitation prompt.
+        chat_confirm_hint: Optional replacement for the default "call again
+            with confirmed=true" message returned when the client cannot
+            present an elicitation prompt. Useful for tools whose parameter
+            name isn't ``confirmed``.
+
+    Returns:
+        ``None`` if the user accepted (or elicitation is disabled) — caller
+        proceeds. A dict with ``status`` of ``confirmation_required``,
+        ``declined``, or ``cancelled`` if not — caller should return the dict
+        as the tool result.
+    """
+    result = await elicitation_handler(message=message, ctx=ctx)
+    if result.action == "accept":
+        return None
+    if result.action == "cancel":
+        return {"status": "cancelled", "message": "Action cancelled by user."}
+    # decline
+    mode = await ctx.get_state("elicitation_mode")
+    if mode == "chat_confirm":
+        hint = chat_confirm_hint or (
+            f"{message} — please confirm with the user before proceeding, then "
+            "call this tool again with confirmed=true."
+        )
+        return {"status": "confirmation_required", "message": hint}
+    return {"status": "declined", "message": "Action declined by user."}
+
+
 async def elicitation_handler(message: str, ctx: Context) -> ElicitResult:
     """Get user confirmation before a write operation.
 

--- a/src/hpe_networking_mcp/platforms/_common/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_common/__init__.py
@@ -1,0 +1,16 @@
+"""Shared infrastructure for the dynamic tool-mode refactor (v2.0, #157).
+
+Modules:
+    tool_registry  — ``ToolSpec``, ``REGISTRIES``, ``record_tool``,
+                     ``is_tool_enabled``, ``clear_registry``.
+    meta_tools     — ``build_meta_tools(platform, mcp, registry)`` factory
+                     that returns ``<platform>_list_tools`` /
+                     ``<platform>_get_tool_schema`` /
+                     ``<platform>_invoke_tool``.
+
+The goal: keep the single-PR blast radius small for the per-platform
+migration PRs (Phases 1-3, 5). The registry and meta-tool factory are
+added here once; each platform then swaps its ``@mcp.tool(...)`` decorators
+for the thin ``tool()`` shim in its ``_registry.py`` and gains three
+meta-tools for free.
+"""

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -1,0 +1,256 @@
+"""Per-platform meta-tool factory for dynamic tool mode.
+
+Every platform exposes exactly three tools when ``MCP_TOOL_MODE=dynamic``:
+
+* ``<platform>_list_tools(filter, category)`` — names + summaries for every
+  tool the platform has registered (minus anything currently write-gated).
+* ``<platform>_get_tool_schema(name)`` — full parameter schema, pulled from
+  the FastMCP instance so we don't duplicate Pydantic's schema generation.
+* ``<platform>_invoke_tool(name, params)`` — validates and dispatches.
+
+Write gating, elicitation, and error shapes match the direct-call path
+exactly; only the invocation surface changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from loguru import logger
+from mcp.types import ToolAnnotations
+
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    REGISTRIES,
+    ToolSpec,
+    is_tool_enabled,
+)
+
+_META_ANNOTATIONS_READONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+# ``<platform>_invoke_tool`` dispatches to any registered tool, including
+# destructive ones, so advertise that it can do anything.
+_META_ANNOTATIONS_INVOKE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+
+def _tool_summary(spec: ToolSpec, max_len: int = 200) -> str:
+    """Extract a short, model-friendly summary from a tool's description."""
+    desc = (spec.description or "").strip()
+    if not desc:
+        return ""
+    # Take the first non-empty paragraph, trim to max_len
+    first_para = desc.split("\n\n", 1)[0].strip()
+    if len(first_para) > max_len:
+        return first_para[: max_len - 1].rstrip() + "…"
+    return first_para
+
+
+def build_meta_tools(platform: str, mcp: FastMCP) -> None:
+    """Register the three meta-tools for a platform on the FastMCP server.
+
+    Called from each platform's ``register_tools`` when ``tool_mode`` is
+    ``"dynamic"``. The per-platform ``_registry.tool()`` shim has already
+    populated ``REGISTRIES[platform]`` with ``ToolSpec`` entries by the time
+    this runs.
+    """
+    if platform not in REGISTRIES:
+        raise ValueError(f"Unknown platform: {platform}")
+
+    registry_ref = REGISTRIES[platform]  # reference, not a copy
+
+    # ---- <platform>_list_tools -----------------------------------------
+
+    @mcp.tool(
+        name=f"{platform}_list_tools",
+        description=(
+            f"List every tool registered for the {platform} platform. "
+            f"Pass an optional `filter` substring to narrow by name or "
+            f"description, and an optional `category` to restrict to one "
+            f"module (use this tool with no arguments first to discover "
+            f"available categories). Returns an array of "
+            f"{{name, category, summary}} records — call "
+            f"`{platform}_get_tool_schema(name=...)` next to fetch the "
+            f"full parameter schema for any tool you want to invoke."
+        ),
+        annotations=_META_ANNOTATIONS_READONLY,
+        tags={f"{platform}_meta"},
+    )
+    async def _list_tools(
+        ctx: Context,
+        filter: str | None = None,
+        category: str | None = None,
+    ) -> dict[str, Any]:
+        config = ctx.lifespan_context.get("config")
+        substring = (filter or "").lower().strip()
+        category_filter = (category or "").strip() or None
+
+        matches: list[dict[str, str]] = []
+        for name, spec in registry_ref.items():
+            if not is_tool_enabled(spec, config):
+                continue
+            if category_filter and spec.category != category_filter:
+                continue
+            if substring:
+                haystack = f"{name} {spec.description}".lower()
+                if substring not in haystack:
+                    continue
+            matches.append(
+                {
+                    "name": name,
+                    "category": spec.category,
+                    "summary": _tool_summary(spec),
+                }
+            )
+
+        matches.sort(key=lambda m: (m["category"], m["name"]))
+        categories = sorted({spec.category for spec in registry_ref.values() if is_tool_enabled(spec, config)})
+        return {
+            "platform": platform,
+            "total": len(matches),
+            "categories": categories,
+            "tools": matches,
+        }
+
+    # ---- <platform>_get_tool_schema -------------------------------------
+
+    @mcp.tool(
+        name=f"{platform}_get_tool_schema",
+        description=(
+            f"Fetch the full parameter schema for a single {platform} tool. "
+            f"Use `{platform}_list_tools` first to find the tool name you "
+            f"want to call, then call this to get the parameter types, "
+            f"descriptions, required/optional markers, and enums. The "
+            f"returned `input_schema` is the JSON schema that "
+            f"`{platform}_invoke_tool` will validate `params` against."
+        ),
+        annotations=_META_ANNOTATIONS_READONLY,
+        tags={f"{platform}_meta"},
+    )
+    async def _get_tool_schema(
+        ctx: Context,
+        name: str,
+    ) -> dict[str, Any]:
+        spec = registry_ref.get(name)
+        if spec is None:
+            return {
+                "status": "not_found",
+                "message": f"{platform} has no tool named {name!r}.",
+                "hint": f"Call {platform}_list_tools to see available tools.",
+            }
+        config = ctx.lifespan_context.get("config")
+        if not is_tool_enabled(spec, config):
+            return {
+                "status": "forbidden",
+                "message": (
+                    f"Tool {name!r} is a write tool and writes are disabled for {platform}. "
+                    f"Set ENABLE_{platform.upper()}_WRITE_TOOLS=true to expose it."
+                ),
+            }
+
+        try:
+            fm_tool = await mcp.get_tool(name)
+        except Exception as exc:
+            logger.warning(
+                "{}_get_tool_schema: failed to resolve tool {!r} from FastMCP — {}",
+                platform,
+                name,
+                exc,
+            )
+            return {
+                "status": "error",
+                "message": f"Could not resolve tool schema: {exc}",
+            }
+
+        input_schema = getattr(fm_tool, "parameters", None) or getattr(fm_tool, "input_schema", None)
+        annotations = getattr(fm_tool, "annotations", None)
+        return {
+            "status": "ok",
+            "name": name,
+            "category": spec.category,
+            "description": spec.description,
+            "tags": sorted(spec.tags),
+            "annotations": _annotations_to_dict(annotations),
+            "input_schema": input_schema,
+        }
+
+    # ---- <platform>_invoke_tool -----------------------------------------
+
+    @mcp.tool(
+        name=f"{platform}_invoke_tool",
+        description=(
+            f"Invoke any registered {platform} tool by name with a `params` "
+            f"dict matching the schema from `{platform}_get_tool_schema`. "
+            f"Destructive tools still prompt for user confirmation via "
+            f"elicitation — the confirmation path is identical to calling "
+            f"the tool directly in static mode."
+        ),
+        annotations=_META_ANNOTATIONS_INVOKE,
+        tags={f"{platform}_meta"},
+    )
+    async def _invoke_tool(
+        ctx: Context,
+        name: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        spec = registry_ref.get(name)
+        if spec is None:
+            return {
+                "status": "not_found",
+                "message": f"{platform} has no tool named {name!r}.",
+                "hint": f"Call {platform}_list_tools to see available tools.",
+            }
+        config = ctx.lifespan_context.get("config")
+        if not is_tool_enabled(spec, config):
+            return {
+                "status": "forbidden",
+                "message": (
+                    f"Tool {name!r} is a write tool and writes are disabled for {platform}. "
+                    f"Set ENABLE_{platform.upper()}_WRITE_TOOLS=true to expose it."
+                ),
+            }
+
+        safe_params = params or {}
+        logger.info(
+            "{}_invoke_tool: dispatching {} with {} param(s)",
+            platform,
+            name,
+            len(safe_params),
+        )
+        try:
+            return await spec.func(ctx, **safe_params)
+        except TypeError as exc:
+            # Usually "unexpected keyword argument" — the caller sent a
+            # param that the tool doesn't accept. Mirror the shape
+            # Pydantic-validation errors use so clients can handle them
+            # uniformly.
+            return {
+                "status": "invalid_params",
+                "message": str(exc),
+                "hint": f"Call {platform}_get_tool_schema(name={name!r}) for the exact parameter shape.",
+            }
+
+    logger.info("{}: registered 3 meta-tools (dynamic mode)", platform)
+
+
+def _annotations_to_dict(annotations: Any) -> dict[str, Any]:
+    """Best-effort serialization of FastMCP tool annotations."""
+    if annotations is None:
+        return {}
+    if hasattr(annotations, "model_dump"):
+        try:
+            return annotations.model_dump(exclude_none=True)
+        except Exception:
+            pass
+    if hasattr(annotations, "__dict__"):
+        return {k: v for k, v in annotations.__dict__.items() if v is not None}
+    return {}

--- a/src/hpe_networking_mcp/platforms/_common/tool_registry.py
+++ b/src/hpe_networking_mcp/platforms/_common/tool_registry.py
@@ -1,0 +1,116 @@
+"""Per-platform tool registry for dynamic tool mode.
+
+Populated as a side effect of each tool module's import — the ``tool()``
+decorator in each platform's ``_registry.py`` wraps ``@mcp.tool(...)`` so
+the function is both registered with the FastMCP instance (for static mode)
+and recorded here (for dynamic mode's meta-tool dispatch).
+
+Write-gating is honored uniformly via ``is_tool_enabled``: ``list_tools``
+filters gated tools out of its results and ``invoke_tool`` refuses them
+with a 403-shaped response.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolSpec:
+    """Everything the meta-tools need to know about one registered tool.
+
+    The FastMCP instance holds the full JSON schema — we retrieve it at
+    invocation time via ``mcp.get_tool(name)`` rather than duplicating the
+    schema extraction here.
+    """
+
+    name: str
+    func: Callable[..., Any]
+    platform: str
+    category: str
+    description: str = ""
+    tags: set[str] = field(default_factory=set)
+
+
+# One dict per platform, keyed by tool name. Populated by each platform's
+# ``tool()`` shim when tool modules import.
+REGISTRIES: dict[str, dict[str, ToolSpec]] = {
+    "apstra": {},
+    "central": {},
+    "clearpass": {},
+    "greenlake": {},
+    "mist": {},
+}
+
+
+# Tag indicating "this tool is registered as individual FastMCP tool AND is
+# discoverable via the platform's list_tools meta-tool." In dynamic mode a
+# Visibility transform uses this tag to hide the individual tools from the
+# model's tool list, leaving only the three meta-tools exposed.
+DYNAMIC_MANAGED_TAG = "dynamic_managed"
+
+
+# Maps each platform to its write-tool tags. When a tool carries one of
+# these tags and the corresponding ENABLE_X_WRITE_TOOLS flag is false,
+# the tool is invisible to ``list_tools`` and refused by ``invoke_tool``.
+_WRITE_TAG_BY_PLATFORM: dict[str, set[str]] = {
+    "apstra": {"apstra_write", "apstra_write_delete"},
+    "central": {"central_write_delete"},
+    "clearpass": {"clearpass_write_delete"},
+    "greenlake": set(),  # GreenLake is read-only today.
+    "mist": {"mist_write", "mist_write_delete"},
+}
+
+_GATE_CONFIG_ATTR: dict[str, str | None] = {
+    "apstra": "enable_apstra_write_tools",
+    "central": "enable_central_write_tools",
+    "clearpass": "enable_clearpass_write_tools",
+    "greenlake": None,
+    "mist": "enable_mist_write_tools",
+}
+
+
+def record_tool(spec: ToolSpec) -> None:
+    """Register a tool into the platform-scoped registry (idempotent)."""
+    if spec.platform not in REGISTRIES:
+        raise ValueError(f"Unknown platform: {spec.platform}")
+    REGISTRIES[spec.platform][spec.name] = spec
+
+
+def clear_registry(platform: str | None = None) -> None:
+    """Clear one or all platform registries. Used by tests.
+
+    Without an argument, clears every platform — useful when a test needs
+    a clean slate because two prior tests both populated the same registry.
+    """
+    if platform is None:
+        for reg in REGISTRIES.values():
+            reg.clear()
+        return
+    if platform not in REGISTRIES:
+        raise ValueError(f"Unknown platform: {platform}")
+    REGISTRIES[platform].clear()
+
+
+def is_tool_enabled(spec: ToolSpec, config: Any) -> bool:
+    """Decide whether a tool is currently callable given the server config.
+
+    Args:
+        spec: The tool's registry entry.
+        config: A ``ServerConfig`` (or any object exposing the
+            ``enable_<platform>_write_tools`` attribute).
+
+    Returns:
+        ``True`` if the tool is reachable right now. Read-only tools always
+        return ``True``. Write tools return ``True`` only when their
+        platform's write-enable flag is truthy.
+    """
+    write_tags = _WRITE_TAG_BY_PLATFORM.get(spec.platform, set())
+    if not (spec.tags & write_tags):
+        return True
+    gate_attr = _GATE_CONFIG_ATTR.get(spec.platform)
+    if gate_attr is None:
+        return True
+    return bool(getattr(config, gate_attr, False))

--- a/src/hpe_networking_mcp/platforms/health.py
+++ b/src/hpe_networking_mcp/platforms/health.py
@@ -1,0 +1,226 @@
+"""Cross-platform ``health`` tool and per-platform probe helpers.
+
+The ``health`` tool replaces the per-platform ``apstra_health`` /
+``clearpass_test_connection`` surface with a single entry point that
+reports every configured platform's reachability in one call. Accepts a
+``platform`` filter (``str | list[str] | None``) matching the rule
+established in v1.0.0.1 (#146): omit for all, pass one name for one,
+pass a list for several.
+
+The same ``_probe_<platform>()`` helpers are called by
+``server.py:lifespan()`` at startup so there's a single source of truth
+for "is this platform reachable" — no divergence between what startup
+logs say and what the tool reports.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from loguru import logger
+from mcp.types import ToolAnnotations
+
+_PROBE_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+_ALL_PLATFORMS: tuple[str, ...] = ("mist", "central", "greenlake", "clearpass", "apstra")
+
+
+def _normalize_platform_filter(
+    value: str | list[str] | None,
+    enabled: list[str],
+) -> list[str]:
+    """Resolve the ``platform`` argument to a list of platform names to probe.
+
+    - ``None`` -> every enabled platform
+    - ``"apstra"`` -> ``["apstra"]``
+    - ``["apstra", "clearpass"]`` -> the list as-is
+
+    Unknown names are dropped with a warning; the probe dict will simply
+    omit them. Platforms that are not configured are skipped silently
+    (they appear in the result dict as ``unavailable``).
+    """
+    if value is None:
+        return list(enabled)
+    candidates = [value] if isinstance(value, str) else [str(v) for v in value]
+
+    wanted: list[str] = []
+    for name in candidates:
+        name = name.strip().lower()
+        if name in _ALL_PLATFORMS:
+            wanted.append(name)
+        else:
+            logger.warning("health(platform={!r}) — unknown platform name, skipping", name)
+    return wanted
+
+
+# ---------------------------------------------------------------------------
+# Per-platform probes
+#
+# Each probe returns a dict with at minimum: status ("ok"/"degraded"/"unavailable")
+# plus a message string. Additional keys may carry platform-specific detail.
+# ---------------------------------------------------------------------------
+
+
+async def _probe_mist(ctx: Context) -> dict[str, Any]:
+    import mistapi
+
+    session = ctx.lifespan_context.get("mist_session")
+    if session is None:
+        return {"status": "unavailable", "message": "Mist is not configured or failed to initialize"}
+    try:
+        resp = mistapi.api.v1.self.self.getSelf(session)
+        if resp.status_code == 200 and resp.data:
+            privileges = resp.data.get("privileges", [])
+            org_count = sum(1 for p in privileges if p.get("scope") == "org")
+            return {"status": "ok", "message": "Mist API session active", "org_count": org_count}
+        return {
+            "status": "degraded",
+            "message": f"Unexpected response from Mist self endpoint (HTTP {resp.status_code})",
+        }
+    except Exception as e:
+        return {"status": "degraded", "message": f"Mist probe failed: {e}"}
+
+
+async def _probe_central(ctx: Context) -> dict[str, Any]:
+    conn = ctx.lifespan_context.get("central_conn")
+    if conn is None:
+        return {"status": "unavailable", "message": "Central is not configured or failed to initialize"}
+    try:
+        resp = conn.command(
+            "GET",
+            "network-monitoring/v1/sites-health",
+            api_params={"limit": 1},
+        )
+        code = resp.get("code", 0)
+        if 200 <= code < 300:
+            return {"status": "ok", "message": "Central REST API reachable", "http_status": code}
+        return {
+            "status": "degraded",
+            "message": f"Central verification returned HTTP {code}",
+            "body": resp.get("msg", {}),
+        }
+    except Exception as e:
+        return {"status": "degraded", "message": f"Central probe failed: {e}"}
+
+
+async def _probe_greenlake(ctx: Context) -> dict[str, Any]:
+    tm = ctx.lifespan_context.get("greenlake_token_manager")
+    if tm is None:
+        return {"status": "unavailable", "message": "GreenLake is not configured or failed to initialize"}
+    try:
+        token = tm.get_raw_token() if hasattr(tm, "get_raw_token") else None
+        if not token and hasattr(tm, "get_auth_headers"):
+            # Force a refresh by asking for headers, then re-read the token
+            tm.get_auth_headers()
+            token = tm.get_raw_token() if hasattr(tm, "get_raw_token") else None
+        if token:
+            return {"status": "ok", "message": "GreenLake access token available"}
+        return {"status": "degraded", "message": "GreenLake token manager returned empty token"}
+    except Exception as e:
+        return {"status": "degraded", "message": f"GreenLake probe failed: {e}"}
+
+
+async def _probe_clearpass(ctx: Context) -> dict[str, Any]:
+    tm = ctx.lifespan_context.get("clearpass_token_manager")
+    if tm is None:
+        return {"status": "unavailable", "message": "ClearPass is not configured or failed to initialize"}
+    try:
+        token = tm.get_token()
+        if token:
+            return {"status": "ok", "message": "ClearPass OAuth2 token active"}
+        return {"status": "degraded", "message": "ClearPass token manager returned empty token"}
+    except Exception as e:
+        return {"status": "degraded", "message": f"ClearPass probe failed: {e}"}
+
+
+async def _probe_apstra(ctx: Context) -> dict[str, Any]:
+    client = ctx.lifespan_context.get("apstra_client")
+    if client is None:
+        return {"status": "unavailable", "message": "Apstra is not configured or failed to initialize"}
+    try:
+        await client.health_check()
+        return {"status": "ok", "message": "Apstra API reachable", "server": client.server}
+    except Exception as e:
+        return {"status": "degraded", "message": f"Apstra probe failed: {e}"}
+
+
+_PROBES = {
+    "mist": _probe_mist,
+    "central": _probe_central,
+    "greenlake": _probe_greenlake,
+    "clearpass": _probe_clearpass,
+    "apstra": _probe_apstra,
+}
+
+
+async def run_probes(ctx: Context, platforms: list[str]) -> dict[str, dict[str, Any]]:
+    """Run each requested platform's probe and collect results.
+
+    Exposed separately from the ``health`` tool so ``server.py:lifespan``
+    can reuse the same probe logic at startup.
+    """
+    results: dict[str, dict[str, Any]] = {}
+    for name in platforms:
+        probe = _PROBES.get(name)
+        if probe is None:
+            continue
+        try:
+            results[name] = await probe(ctx)
+        except Exception as e:  # pragma: no cover — defensive; individual probes already catch
+            logger.warning("health probe for {} raised unexpectedly — {}", name, e)
+            results[name] = {"status": "degraded", "message": f"probe raised: {e}"}
+    return results
+
+
+def _overall_status(results: dict[str, dict[str, Any]]) -> str:
+    """Summarize per-platform statuses into a single top-level value.
+
+    - ``ok`` if every probe returned ``ok``.
+    - ``degraded`` if at least one probe reports ``degraded`` or ``unavailable``.
+    - ``ok`` (trivially) for an empty result set.
+    """
+    if not results:
+        return "ok"
+    values = {r.get("status", "unknown") for r in results.values()}
+    if values <= {"ok"}:
+        return "ok"
+    return "degraded"
+
+
+def register(mcp: FastMCP) -> None:
+    """Register the cross-platform ``health`` tool on the FastMCP server."""
+
+    @mcp.tool(
+        name="health",
+        description=(
+            "Report health of enabled HPE networking platforms in a single call. "
+            "Accepts an optional platform filter: omit for every enabled platform, "
+            "pass one name as a string (e.g. 'apstra'), or pass a list "
+            "(['apstra', 'clearpass']). Replaces the per-platform health tools "
+            "that existed in v1.x (apstra_health, clearpass_test_connection)."
+        ),
+        annotations=_PROBE_ANNOTATIONS,
+    )
+    async def health(
+        ctx: Context,
+        platform: str | list[str] | None = None,
+    ) -> dict[str, Any]:
+        config = ctx.lifespan_context.get("config")
+        enabled = config.enabled_platforms if config is not None else list(_ALL_PLATFORMS)
+        wanted = _normalize_platform_filter(platform, enabled)
+        results = await run_probes(ctx, wanted)
+        return {
+            "status": _overall_status(results),
+            "service": "hpe-networking-mcp",
+            "timestamp": time.time(),
+            "platforms": results,
+        }
+
+    logger.info("Cross-platform: registered health tool")

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -196,6 +196,11 @@ def create_server(config: ServerConfig) -> FastMCP:
     if config.mist or config.central:
         _register_site_health_check(mcp, config)
 
+    # --- Cross-platform `health` tool (always registered; unaffected by tool_mode) ---
+    from hpe_networking_mcp.platforms.health import register as _register_health
+
+    _register_health(mcp)
+
     # --- Write tool visibility (per-platform) ---
     from fastmcp.server.transforms import Visibility
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,137 @@
+"""Unit tests for the cross-platform ``health`` tool (#158)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hpe_networking_mcp.config import ApstraSecrets, ServerConfig
+from hpe_networking_mcp.platforms.health import (
+    _normalize_platform_filter,
+    _overall_status,
+    run_probes,
+)
+
+
+def _config_with(**flags) -> ServerConfig:
+    defaults = {}
+    defaults.update(flags)
+    return ServerConfig(**defaults)
+
+
+def _apstra_secrets() -> ApstraSecrets:
+    return ApstraSecrets(server="apstra.test", username="u", password="p")
+
+
+@pytest.mark.unit
+class TestNormalizePlatformFilter:
+    def test_none_returns_all_enabled(self):
+        assert _normalize_platform_filter(None, ["mist", "apstra"]) == ["mist", "apstra"]
+
+    def test_single_string(self):
+        assert _normalize_platform_filter("apstra", ["mist", "apstra"]) == ["apstra"]
+
+    def test_list_preserves_order(self):
+        assert _normalize_platform_filter(["apstra", "mist"], ["mist", "apstra"]) == ["apstra", "mist"]
+
+    def test_case_insensitive(self):
+        assert _normalize_platform_filter("APSTRA", ["apstra"]) == ["apstra"]
+
+    def test_unknown_platform_silently_dropped(self):
+        # Logs a warning but doesn't crash — caller sees an empty result for the bad name.
+        assert _normalize_platform_filter("azure", ["mist", "apstra"]) == []
+
+    def test_mixed_list_drops_unknowns(self):
+        assert _normalize_platform_filter(["apstra", "azure", "mist"], ["mist", "apstra"]) == ["apstra", "mist"]
+
+
+@pytest.mark.unit
+class TestOverallStatus:
+    def test_empty_is_ok(self):
+        assert _overall_status({}) == "ok"
+
+    def test_all_ok(self):
+        assert _overall_status({"apstra": {"status": "ok"}, "mist": {"status": "ok"}}) == "ok"
+
+    def test_one_degraded(self):
+        assert _overall_status({"apstra": {"status": "ok"}, "mist": {"status": "degraded"}}) == "degraded"
+
+    def test_unavailable_counts_as_degraded(self):
+        assert _overall_status({"apstra": {"status": "ok"}, "mist": {"status": "unavailable"}}) == "degraded"
+
+
+@pytest.mark.unit
+class TestRunProbes:
+    async def test_apstra_ok_when_client_healthy(self):
+        apstra_client = MagicMock()
+        apstra_client.server = "apstra.test:443"
+        apstra_client.health_check = AsyncMock(return_value=True)
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"apstra_client": apstra_client}
+
+        results = await run_probes(ctx, ["apstra"])
+        assert results["apstra"]["status"] == "ok"
+        assert results["apstra"]["server"] == "apstra.test:443"
+
+    async def test_apstra_degraded_when_health_check_raises(self):
+        apstra_client = MagicMock()
+        apstra_client.health_check = AsyncMock(side_effect=RuntimeError("401 bad creds"))
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"apstra_client": apstra_client}
+
+        results = await run_probes(ctx, ["apstra"])
+        assert results["apstra"]["status"] == "degraded"
+        assert "401" in results["apstra"]["message"]
+
+    async def test_apstra_unavailable_when_not_configured(self):
+        ctx = MagicMock()
+        ctx.lifespan_context = {"apstra_client": None}
+
+        results = await run_probes(ctx, ["apstra"])
+        assert results["apstra"]["status"] == "unavailable"
+
+    async def test_clearpass_ok_when_token_returns(self):
+        tm = MagicMock()
+        tm.get_token = MagicMock(return_value="fake-token-abc")
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"clearpass_token_manager": tm}
+
+        results = await run_probes(ctx, ["clearpass"])
+        assert results["clearpass"]["status"] == "ok"
+
+    async def test_clearpass_degraded_on_refresh_failure(self):
+        tm = MagicMock()
+        tm.get_token = MagicMock(side_effect=RuntimeError("OAuth2 rejected"))
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"clearpass_token_manager": tm}
+
+        results = await run_probes(ctx, ["clearpass"])
+        assert results["clearpass"]["status"] == "degraded"
+        assert "OAuth2" in results["clearpass"]["message"]
+
+    async def test_filter_runs_only_requested_platforms(self):
+        apstra_client = MagicMock()
+        apstra_client.server = "x:443"
+        apstra_client.health_check = AsyncMock(return_value=True)
+
+        mist_session = MagicMock()  # would fail the probe if it ran
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {
+            "apstra_client": apstra_client,
+            "mist_session": mist_session,
+        }
+
+        results = await run_probes(ctx, ["apstra"])
+        assert set(results.keys()) == {"apstra"}
+
+    async def test_unknown_platform_silently_skipped(self):
+        ctx = MagicMock()
+        ctx.lifespan_context = {}
+        results = await run_probes(ctx, ["acme"])
+        assert results == {}

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -1,0 +1,232 @@
+"""Unit tests for the shared meta-tool factory (v2.0 Phase 0, #158).
+
+Verifies the three meta-tools installed by ``build_meta_tools`` against a
+real FastMCP instance with stub ``ToolSpec`` entries. Integration with real
+platform tool bodies is exercised in PR B (Phase 0 Apstra pilot).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from hpe_networking_mcp.config import ServerConfig
+from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    REGISTRIES,
+    ToolSpec,
+    clear_registry,
+)
+
+READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True)
+WRITE_DELETE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.fixture
+def stub_apstra_registry():
+    """Populate REGISTRIES['apstra'] with a few handcrafted ToolSpecs.
+
+    The funcs are AsyncMocks so invoke_tool can dispatch to them and we can
+    assert on call args without hitting any real vendor API.
+    """
+    get_blueprints = AsyncMock(return_value={"items": [{"id": "bp1", "label": "HQ"}]})
+    get_blueprints.__name__ = "apstra_get_blueprints"  # type: ignore[attr-defined]
+    create_vn = AsyncMock(return_value={"status": "created"})
+    create_vn.__name__ = "apstra_create_virtual_network"  # type: ignore[attr-defined]
+
+    REGISTRIES["apstra"]["apstra_get_blueprints"] = ToolSpec(
+        name="apstra_get_blueprints",
+        func=get_blueprints,
+        platform="apstra",
+        category="blueprints",
+        description="List every Apstra datacenter blueprint.",
+        tags=set(),
+    )
+    REGISTRIES["apstra"]["apstra_create_virtual_network"] = ToolSpec(
+        name="apstra_create_virtual_network",
+        func=create_vn,
+        platform="apstra",
+        category="manage_networks",
+        description="Create a VXLAN or VLAN virtual network.",
+        tags={"apstra_write"},
+    )
+    return {"get_blueprints": get_blueprints, "create_vn": create_vn}
+
+
+@pytest.fixture
+def mcp_with_meta_tools(stub_apstra_registry):
+    mcp = FastMCP(name="test-server")
+    build_meta_tools("apstra", mcp)
+    return mcp
+
+
+def _fake_ctx(config: ServerConfig) -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"config": config}
+    return ctx
+
+
+@pytest.mark.unit
+class TestBuildMetaTools:
+    def test_registers_three_tools(self, mcp_with_meta_tools):
+        """Exactly the three meta-tools appear on the FastMCP instance."""
+        import asyncio
+
+        tools = asyncio.run(mcp_with_meta_tools.list_tools())
+        names = sorted(t.name for t in tools)
+        assert names == [
+            "apstra_get_tool_schema",
+            "apstra_invoke_tool",
+            "apstra_list_tools",
+        ]
+
+    def test_unknown_platform_raises(self):
+        mcp = FastMCP(name="test")
+        with pytest.raises(ValueError, match="Unknown platform"):
+            build_meta_tools("acme", mcp)
+
+
+@pytest.mark.unit
+class TestListTools:
+    async def test_returns_read_tools_and_hides_write_when_disabled(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        config = ServerConfig()  # writes disabled
+        ctx = _fake_ctx(config)
+
+        result = await tool.fn(ctx)
+        names = [t["name"] for t in result["tools"]]
+        assert "apstra_get_blueprints" in names
+        assert "apstra_create_virtual_network" not in names
+        assert result["total"] == 1
+
+    async def test_returns_write_tools_when_enabled(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        config = ServerConfig(enable_apstra_write_tools=True)
+        ctx = _fake_ctx(config)
+
+        result = await tool.fn(ctx)
+        names = [t["name"] for t in result["tools"]]
+        assert "apstra_get_blueprints" in names
+        assert "apstra_create_virtual_network" in names
+        assert result["total"] == 2
+
+    async def test_filter_narrows_results(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        config = ServerConfig(enable_apstra_write_tools=True)
+
+        result = await tool.fn(_fake_ctx(config), filter="blueprints")
+        names = [t["name"] for t in result["tools"]]
+        assert names == ["apstra_get_blueprints"]
+
+    async def test_category_filter(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        config = ServerConfig(enable_apstra_write_tools=True)
+
+        result = await tool.fn(_fake_ctx(config), category="blueprints")
+        names = [t["name"] for t in result["tools"]]
+        assert names == ["apstra_get_blueprints"]
+
+    async def test_returns_categories_list(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        config = ServerConfig(enable_apstra_write_tools=True)
+
+        result = await tool.fn(_fake_ctx(config))
+        assert sorted(result["categories"]) == ["blueprints", "manage_networks"]
+
+
+@pytest.mark.unit
+class TestGetToolSchema:
+    async def test_returns_schema_for_known_tool(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_get_tool_schema")
+        config = ServerConfig(enable_apstra_write_tools=True)
+
+        result = await tool.fn(_fake_ctx(config), name="apstra_get_blueprints")
+        assert result["status"] == "ok"
+        assert result["name"] == "apstra_get_blueprints"
+        assert result["category"] == "blueprints"
+        assert "description" in result
+
+    async def test_not_found(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_get_tool_schema")
+        config = ServerConfig()
+
+        result = await tool.fn(_fake_ctx(config), name="apstra_nonexistent")
+        assert result["status"] == "not_found"
+
+    async def test_forbidden_when_write_gated(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_get_tool_schema")
+        config = ServerConfig()  # writes disabled
+
+        result = await tool.fn(_fake_ctx(config), name="apstra_create_virtual_network")
+        assert result["status"] == "forbidden"
+
+
+@pytest.mark.unit
+class TestInvokeTool:
+    async def test_dispatches_to_registered_function(self, mcp_with_meta_tools, stub_apstra_registry):
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+        ctx = _fake_ctx(config)
+
+        result = await tool.fn(ctx, name="apstra_get_blueprints")
+        assert result == {"items": [{"id": "bp1", "label": "HQ"}]}
+        stub_apstra_registry["get_blueprints"].assert_awaited_once()
+
+    async def test_forwards_params_as_kwargs(self, mcp_with_meta_tools, stub_apstra_registry):
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig(enable_apstra_write_tools=True)
+        ctx = _fake_ctx(config)
+
+        await tool.fn(
+            ctx,
+            name="apstra_create_virtual_network",
+            params={"blueprint_id": "bp1", "vn_name": "test"},
+        )
+        stub_apstra_registry["create_vn"].assert_awaited_once_with(
+            ctx,
+            blueprint_id="bp1",
+            vn_name="test",
+        )
+
+    async def test_not_found(self, mcp_with_meta_tools):
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        result = await tool.fn(_fake_ctx(config), name="apstra_does_not_exist")
+        assert result["status"] == "not_found"
+
+    async def test_forbidden_when_write_gated(self, mcp_with_meta_tools, stub_apstra_registry):
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()  # writes disabled
+
+        result = await tool.fn(
+            _fake_ctx(config),
+            name="apstra_create_virtual_network",
+            params={"blueprint_id": "bp1"},
+        )
+        assert result["status"] == "forbidden"
+        stub_apstra_registry["create_vn"].assert_not_awaited()
+
+    async def test_invalid_params_reports_shape(self, mcp_with_meta_tools, stub_apstra_registry):
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        # Configure the stub to raise TypeError (simulating wrong kwarg)
+        stub_apstra_registry["get_blueprints"].side_effect = TypeError("unexpected keyword argument 'bogus'")
+        result = await tool.fn(
+            _fake_ctx(config),
+            name="apstra_get_blueprints",
+            params={"bogus": "yes"},
+        )
+        assert result["status"] == "invalid_params"
+        assert "bogus" in result["message"]

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -1,0 +1,122 @@
+"""Unit tests for the shared tool registry (v2.0 Phase 0, #158)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.config import ServerConfig
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    REGISTRIES,
+    ToolSpec,
+    clear_registry,
+    is_tool_enabled,
+    record_tool,
+)
+
+
+def _fn() -> None:
+    """Stub for ``ToolSpec.func``."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Every test starts with empty registries and leaves them empty."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.mark.unit
+class TestRecordTool:
+    def test_records_into_the_right_platform(self):
+        spec = ToolSpec(name="apstra_get_blueprints", func=_fn, platform="apstra", category="blueprints")
+        record_tool(spec)
+        assert REGISTRIES["apstra"]["apstra_get_blueprints"] is spec
+
+    def test_record_does_not_leak_to_other_platforms(self):
+        spec = ToolSpec(name="apstra_x", func=_fn, platform="apstra", category="x")
+        record_tool(spec)
+        assert REGISTRIES["mist"] == {}
+        assert REGISTRIES["central"] == {}
+
+    def test_same_name_overwrites(self):
+        first = ToolSpec(name="t", func=_fn, platform="apstra", category="a")
+        second = ToolSpec(name="t", func=_fn, platform="apstra", category="b")
+        record_tool(first)
+        record_tool(second)
+        assert REGISTRIES["apstra"]["t"] is second
+
+    def test_unknown_platform_raises(self):
+        spec = ToolSpec(name="t", func=_fn, platform="acme", category="x")
+        with pytest.raises(ValueError, match="Unknown platform"):
+            record_tool(spec)
+
+
+@pytest.mark.unit
+class TestClearRegistry:
+    def test_clear_all(self):
+        record_tool(ToolSpec(name="a", func=_fn, platform="apstra", category="x"))
+        record_tool(ToolSpec(name="b", func=_fn, platform="mist", category="x"))
+        clear_registry()
+        assert REGISTRIES["apstra"] == {}
+        assert REGISTRIES["mist"] == {}
+
+    def test_clear_one_platform(self):
+        record_tool(ToolSpec(name="a", func=_fn, platform="apstra", category="x"))
+        record_tool(ToolSpec(name="b", func=_fn, platform="mist", category="x"))
+        clear_registry("apstra")
+        assert REGISTRIES["apstra"] == {}
+        assert REGISTRIES["mist"] == {"b": REGISTRIES["mist"]["b"]}
+
+    def test_clear_unknown_platform_raises(self):
+        with pytest.raises(ValueError, match="Unknown platform"):
+            clear_registry("acme")
+
+
+@pytest.mark.unit
+class TestIsToolEnabled:
+    def _make_config(self, **overrides) -> ServerConfig:
+        return ServerConfig(**overrides)
+
+    def test_read_only_tool_always_enabled(self):
+        spec = ToolSpec(name="apstra_get_blueprints", func=_fn, platform="apstra", category="r", tags=set())
+        assert is_tool_enabled(spec, self._make_config()) is True
+
+    def test_write_tool_disabled_by_default(self):
+        spec = ToolSpec(name="apstra_deploy", func=_fn, platform="apstra", category="w", tags={"apstra_write_delete"})
+        assert is_tool_enabled(spec, self._make_config()) is False
+
+    def test_write_tool_enabled_when_flag_set(self):
+        spec = ToolSpec(name="apstra_deploy", func=_fn, platform="apstra", category="w", tags={"apstra_write_delete"})
+        assert is_tool_enabled(spec, self._make_config(enable_apstra_write_tools=True)) is True
+
+    def test_apstra_write_non_delete_tag_also_respects_gate(self):
+        spec = ToolSpec(
+            name="apstra_create_virtual_network",
+            func=_fn,
+            platform="apstra",
+            category="w",
+            tags={"apstra_write"},
+        )
+        assert is_tool_enabled(spec, self._make_config()) is False
+        assert is_tool_enabled(spec, self._make_config(enable_apstra_write_tools=True)) is True
+
+    def test_central_write_gate(self):
+        spec = ToolSpec(
+            name="central_manage_site",
+            func=_fn,
+            platform="central",
+            category="w",
+            tags={"central_write_delete"},
+        )
+        assert is_tool_enabled(spec, self._make_config()) is False
+        assert is_tool_enabled(spec, self._make_config(enable_central_write_tools=True)) is True
+
+    def test_greenlake_has_no_write_gate(self):
+        """GreenLake is read-only today — any tool registered under it is always enabled."""
+        spec = ToolSpec(name="greenlake_get_devices", func=_fn, platform="greenlake", category="r", tags=set())
+        assert is_tool_enabled(spec, self._make_config()) is True
+
+    def test_unrelated_tag_does_not_gate(self):
+        spec = ToolSpec(name="t", func=_fn, platform="apstra", category="c", tags={"random_tag"})
+        assert is_tool_enabled(spec, self._make_config()) is True


### PR DESCRIPTION
Part of umbrella [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157). First half of [Phase 0 (#158)](https://github.com/nowireless4u/hpe-networking-mcp/issues/158) — the **infrastructure** half, split out from the Apstra pilot so this can be reviewed independently. Apstra migration lands in PR B next session.

## Goal

Install the shared scaffolding that every v2.0 platform migration PR will build on:

- **Tool registry** — per-platform dicts of \`ToolSpec\` entries populated by each platform's decorator shim (PR B and later).
- **Meta-tool factory** — \`build_meta_tools(platform, mcp)\` registers the three discovery tools per platform.
- **Cross-platform \`health\` tool** — replaces the per-platform health probes with one call, filterable by platform. Lives alongside the v1 tools for this release; the v1 tools are removed in PR B / Phase 3.
- **\`confirm_write()\` helper** — consolidates the 17 duplicated \`_confirm\` helpers from the write-tool files (#148 groundwork).
- **Config rename** — \`greenlake_tool_mode\` → \`tool_mode\` with a deprecated alias property (#151).

## User impact

**None.** Zero user-visible surface changes:

- Individual tool lists are unchanged.
- \`MCP_TOOL_MODE=static\` is still the default.
- No new required config.
- No version bump (\`pyproject.toml\` stays at \`1.1.0.0\`).
- No tag, no GitHub release, no image publish per the [release strategy](https://github.com/nowireless4u/hpe-networking-mcp/issues/157#issuecomment-4300881024).

CHANGELOG entry is under \`## [Unreleased]\`, to be stamped \`## [v2.0.0.0]\` at Phase 6.

## Not in this PR

- Apstra tool file swaps (\`@mcp.tool\` → \`@tool\`) — PR B
- Removal of \`apstra_health\`, \`apstra_formatting_guidelines\`, \`clearpass_test_connection\` — PR B and Phase 3
- \`server.py:lifespan\` refactor to share probe helpers — PR B (lands with the Apstra migration that actually needs it)
- \`docs/TOOLS.md\` dynamic-mode preamble — PR B (so the first documented example is a real migration)
- Any behavioral change to existing tools

## Files

**Created (8):**
- \`src/hpe_networking_mcp/platforms/_common/__init__.py\`
- \`src/hpe_networking_mcp/platforms/_common/tool_registry.py\`
- \`src/hpe_networking_mcp/platforms/_common/meta_tools.py\`
- \`src/hpe_networking_mcp/platforms/health.py\`
- \`docs/MIGRATING_TO_V2.md\` (skeleton)
- \`tests/unit/test_tool_registry.py\` (15 tests)
- \`tests/unit/test_meta_tools.py\` (13 tests — \`build_meta_tools\` validation, \`list_tools\` read/write/filter/category paths, \`get_tool_schema\` not-found/forbidden, \`invoke_tool\` dispatch/forbidden/invalid-params)
- \`tests/unit/test_health.py\` (18 tests — \`_normalize_platform_filter\`, \`_overall_status\`, per-platform probes with ok/degraded/unavailable states)

**Modified:**
- \`src/hpe_networking_mcp/config.py\` — \`tool_mode\` field + \`greenlake_tool_mode\` alias
- \`src/hpe_networking_mcp/server.py\` — register \`health\` tool
- \`src/hpe_networking_mcp/middleware/elicitation.py\` — \`confirm_write()\` helper
- \`CHANGELOG.md\` — new \`## [Unreleased]\` entry

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **391/391 passing** (46 new)

## Sequence

1. This PR merges → main has the infrastructure.
2. **PR B** (next session) — Apstra migrates to dynamic mode, removes \`apstra_health\` and \`apstra_formatting_guidelines\`, refactors lifespan to share probes, closes #158.
3. Phases 1-5, 6 (the v2.0.0.0 cut), 7 follow.