### PR TITLE
[v2.0 Phase 1] Mist dynamic-mode migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v2.0 Phases 0-1
+
+### Added — Mist dynamic-mode migration (#159)
+
+Second platform onto the dynamic-mode infrastructure. With
+`MCP_TOOL_MODE=dynamic`, Mist exposes exactly three meta-tools
+(`mist_list_tools`, `mist_get_tool_schema`, `mist_invoke_tool`) and hides
+the 35 underlying Mist tools via the shared `Visibility(dynamic_managed)`
+transform. Static mode is unchanged.
+
+- `platforms/mist/_registry.py` rewritten as a `tool()` decorator shim
+  mirroring Apstra's — delegates to `mcp.tool(...)`, adds the
+  `dynamic_managed` tag, and records into `REGISTRIES["mist"]`.
+- All 35 Mist tool files under `platforms/mist/tools/*.py` swapped from
+  `@mcp.tool(...)` to `@tool(...)` (import path updated to match).
+- `platforms/mist/__init__.py` — always imports every tool file so the
+  registry is complete regardless of `ENABLE_MIST_WRITE_TOOLS`; calls
+  `build_meta_tools("mist", mcp)` when `tool_mode == "dynamic"`.
+- Mist prompts (`@mcp.prompt` in `prompts.py`) are unaffected — prompts
+  are a different MCP primitive than tools and aren't part of the
+  dynamic-mode meta-tool surface.
+
+### Tests
+- 6 new integration-style tests in `test_mist_dynamic_mode.py`. Total
+  suite: 403/403 passing.
+
+### Boot verification
+- `MCP_TOOL_MODE=static` + Mist configured → 35 `mist_*` tools visible.
+- `MCP_TOOL_MODE=dynamic` + Mist + Apstra configured → 3 Mist meta-tools
+  + 3 Apstra meta-tools + cross-platform `health` tool; every underlying
+  tool hidden.
+
 ## [Unreleased] — v2.0 Phase 0
 
 ### Added — Apstra dynamic-mode pilot (#158 part B)

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -35,7 +35,7 @@ AI agents that hard-coded these names will get "tool not found" on v2.0.
 
 - [x] Phase 0 PR A — shared `_common/` infrastructure, cross-platform `health` tool, `tool_mode` config
 - [x] Phase 0 PR B — Apstra migrates to dynamic mode (pilot); `apstra_health` and `apstra_formatting_guidelines` removed
-- [ ] Phase 1 — Mist migrates
+- [x] Phase 1 — Mist migrates
 - [ ] Phase 2 — Central migrates
 - [ ] Phase 3 — ClearPass migrates
 - [ ] Phase 4 — GreenLake dynamic mode generalizes to the new meta-tool pattern

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -38,7 +38,7 @@ Dynamic-mode migration status (phased per [#157](https://github.com/nowireless4u
 | Platform | Dynamic mode available |
 |---|---|
 | Juniper Apstra | ✅ yes (Phase 0) |
-| Juniper Mist | pending (Phase 1) |
+| Juniper Mist | ✅ yes (Phase 1) |
 | Aruba Central | pending (Phase 2) |
 | Aruba ClearPass | pending (Phase 3) |
 | HPE GreenLake | yes (already dynamic via the legacy endpoint-dispatch meta-tools; unified in Phase 4) |

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -61,19 +61,21 @@ TOOLS = {
 
 
 def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
-    """Dynamically load and register all Mist tool modules. Returns count of loaded tools."""
-    # Inject the FastMCP instance into the registry so tool modules can import it
+    """Load all Mist tool modules and register them with FastMCP.
+
+    Always imports every tool file so ``REGISTRIES["mist"]`` is fully populated;
+    runtime write-gating is handled by the Visibility transform (static mode)
+    and ``is_tool_enabled`` (dynamic mode, via the meta-tools).
+
+    Returns the count of individual underlying tools that registered.
+    """
+    from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
     from hpe_networking_mcp.platforms.mist import _registry
 
     _registry.mcp = mcp
 
-    write_enabled = config.enable_mist_write_tools
     loaded: list[str] = []
-
     for _category, tool_names in TOOLS.items():
-        if _category in ("write", "write_delete") and not write_enabled:
-            logger.info("Mist: write tools disabled, skipping {} tools", len(tool_names))
-            continue
         for tool_name in tool_names:
             if tool_name in loaded:
                 continue
@@ -86,7 +88,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             except Exception as e:
                 logger.warning("Mist: failed to load tool {} -- {}", tool_name, e)
 
-    # Register prompts (not in TOOLS dict — prompts don't follow mist_* naming)
+    # Register prompts (not in TOOLS dict — prompts are a different MCP primitive
+    # and aren't part of the dynamic-mode meta-tool surface).
     try:
         from hpe_networking_mcp.platforms.mist.tools import prompts as mist_prompts
 
@@ -94,5 +97,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         logger.debug("Mist: loaded prompts")
     except Exception as e:
         logger.warning("Mist: failed to load prompts -- {}", e)
+
+    if config.tool_mode == "dynamic":
+        build_meta_tools("mist", mcp)
+        logger.info(
+            "Mist: {} underlying tools + 3 meta-tools registered (dynamic mode)",
+            len(loaded),
+        )
+    else:
+        logger.info("Mist: {} tools registered (static mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/mist/_registry.py
+++ b/src/hpe_networking_mcp/platforms/mist/_registry.py
@@ -1,15 +1,71 @@
-"""Mist tool registry -- holds the FastMCP instance that tools register against.
+"""Mist tool registry -- module-level FastMCP holder + shared-registry shim.
 
-The ``mcp`` attribute is set by :func:`platforms.mist.register_tools` *before*
-any tool module is imported, so that ``@mcp.tool()`` decorators work correctly.
+Tool modules under ``platforms/mist/tools/`` decorate their functions with
+``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
+The shim mirrors the Apstra pattern: delegate to the real FastMCP decorator,
+merge the ``dynamic_managed`` tag so dynamic-mode ``Visibility`` can hide
+individual tools, and record a ``ToolSpec`` into ``REGISTRIES["mist"]`` so the
+three Mist meta-tools can dispatch by name at runtime.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any
 
-if TYPE_CHECKING:
-    from fastmcp import FastMCP
+from fastmcp import FastMCP
 
-# Set by platforms.mist.register_tools() before tool modules are imported
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    DYNAMIC_MANAGED_TAG,
+    ToolSpec,
+    record_tool,
+)
+
+# Set by platforms.mist.register_tools() before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
+
+_PLATFORM = "mist"
+
+
+def _derive_category(func: Callable[..., Any]) -> str:
+    """Short module name as the registry category (e.g. ``search_device``)."""
+    module = getattr(func, "__module__", "")
+    return module.rsplit(".", 1)[-1] if "." in module else module
+
+
+def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry.
+
+    Accepts every keyword ``FastMCP.tool`` accepts — forwards them unchanged
+    except for ``tags``, which gets ``dynamic_managed`` merged in so the
+    Visibility transform in ``server.py`` can hide these tools when the
+    server runs in dynamic mode.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
+        resolved_name: str = tool_kwargs.get("name") or func.__name__
+        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
+
+        record_tool(
+            ToolSpec(
+                name=resolved_name,
+                func=func,
+                platform=_PLATFORM,
+                category=_derive_category(func),
+                description=resolved_description,
+                tags=supplied_tags,
+            )
+        )
+
+        if mcp is None:
+            # register_tools() not yet called — likely an import during test
+            # collection before the platform is wired. Leave the function
+            # undecorated; tests that need FastMCP registration set up a real
+            # mcp first (see tests/conftest.py stubs).
+            return func
+
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        return mcp.tool(**effective_kwargs)(func)
+
+    return decorator

--- a/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     get_apisession,
     handle_network_error,
@@ -92,7 +92,7 @@ def _check_mist_ports(
     return safe_ports, skipped
 
 
-@mcp.tool(
+@tool(
     name="mist_bounce_switch_port",
     description=(
         "Bounce ports on a Juniper EX switch. Safety checks are "

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -21,7 +21,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -63,7 +63,7 @@ class Action_type(Enum):
     DELETE = "delete"
 
 
-@mcp.tool(
+@tool(
     name="mist_change_org_configuration_objects",
     description=(
         "Update, create or delete configuration object for a specified org.\n"

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
@@ -21,7 +21,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -47,7 +47,7 @@ class Action_type(Enum):
     DELETE = "delete"
 
 
-@mcp.tool(
+@tool(
     name="mist_change_site_configuration_objects",
     description=(
         "Update, create or delete a configuration object for a "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_ap_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_ap_details.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -16,7 +16,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_ap_details",
     description=(
         "Get detailed information for a specific AP including model, firmware, radio configuration, IP, and status."

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import get_apisession
 from hpe_networking_mcp.platforms.mist.tools import (
     schemas_data as _schemas_data_module,
@@ -77,7 +77,7 @@ def _compact_schema(schema: dict) -> dict:
     return result
 
 
-@mcp.tool(
+@tool(
     name="mist_get_configuration_object_schema",
     description=(
         "Retrieve the JSON schema for a Mist configuration object "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
@@ -21,7 +21,7 @@ from mistapi.__api_response import APIResponse as _APIResponse
 from pydantic import Field
 from requests.structures import CaseInsensitiveDict
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -105,7 +105,7 @@ def _name_id_list(data: list) -> list:
     return [{"name": item.get("name"), "id": item.get("id")} for item in data if item.get("name")]
 
 
-@mcp.tool(
+@tool(
     name="mist_get_configuration_objects",
     description=(
         "Use this tool to retrieve configuration objects "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
@@ -18,7 +18,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -41,7 +41,7 @@ class Object_type(Enum):
     NAC_EVENTS = "nac_events"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_constants",
     description=(
         "Retrieve Mist platform constants including insight "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_gateway_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_gateway_details.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -16,7 +16,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_gateway_details",
     description=(
         "Get detailed information for a specific gateway including "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -37,7 +37,7 @@ class Object_type(Enum):
     SWITCH = "switch"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_insight_metrics",
     description="Get insight metrics for a given object",
     tags={"sites_insights"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_next_page.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_next_page.py
@@ -16,7 +16,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -25,7 +25,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_next_page",
     description=("Retrieve the next page of results using the '_next' URL returned by a previous tool call."),
     tags={"info"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_licenses.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_licenses.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -34,7 +34,7 @@ class Response_type(Enum):
     SUMMARY = "summary"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_org_licenses",
     description=("This tool can be used to retrieve information about the licenses of an org"),
     tags={"orgs"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -33,7 +33,7 @@ class Info_type(Enum):
     SITE = "site"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_org_or_site_info",
     description=("Search information about the organizations or sites"),
     tags={"info"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_sites_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_sites_sle.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -34,7 +34,7 @@ class Sle(Enum):
     WAN = "wan"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_org_sites_sle",
     description=("Get SLE summary for the organization sites."),
     tags={"sles"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
@@ -18,7 +18,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -27,7 +27,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_org_sle",
     description=(
         "Get Org SLEs (all/worst sites, Mx Edges, ...). "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_self.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_self.py
@@ -18,7 +18,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -33,7 +33,7 @@ class Action_type(Enum):
     LOGIN_FAILURES = "login_failures"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_self",
     description=(
         "This tool can be used to retrieve information about "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -16,7 +16,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_site_health",
     description=(
         "Get a health overview across all sites in the organization. "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -41,7 +41,7 @@ class Band(Enum):
     B6 = "6"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_site_rrm_info",
     description=(
         "Retrieve Radio Resource Management (RRM) information "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_sle.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -54,7 +54,7 @@ class Object_type(Enum):
     THRESHOLD = "threshold"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_site_sle",
     description=(
         "Provides Information about the Service Level "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_stats.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_stats.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -51,7 +51,7 @@ class Device_type(Enum):
     GATEWAY = "gateway"
 
 
-@mcp.tool(
+@tool(
     name="mist_get_stats",
     description=(
         "Use this tool to retrieve various statistics from "

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_switch_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_switch_details.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -16,7 +16,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_switch_details",
     description=(
         "Get detailed information for a specific switch including model, firmware, port configuration, IP, and status."

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
@@ -7,7 +7,7 @@ import mistapi
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -17,7 +17,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_get_wlans",
     description=(
         "List WLANs/SSIDs configured in the organization or a specific site. "

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_rogue_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_rogue_devices.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -40,7 +40,7 @@ class Rogue_ap_type(Enum):
     SPOOF = "spoof"
 
 
-@mcp.tool(
+@tool(
     name="mist_list_rogue_devices",
     description=(
         "Retrieve a list of rogue devices (APs or clients) "

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_site_sle_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_site_sle_info.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -41,7 +41,7 @@ class Scope(Enum):
     SWITCH = "switch"
 
 
-@mcp.tool(
+@tool(
     name="mist_list_site_sle_info",
     description=(
         "List SLE metadata for a site scope. Use metrics to "

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -51,7 +51,7 @@ class Channel(Enum):
     STABLE = "stable"
 
 
-@mcp.tool(
+@tool(
     name="mist_list_upgrades",
     description=(
         "Retrieve upgrade-related information for the "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_alarms.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_alarms.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -34,7 +34,7 @@ class Scope(Enum):
     SUPPRESSED = "suppressed"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_alarms",
     description=(
         "Search for raised alarms in an organization or site "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_audit_logs.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -33,7 +33,7 @@ class Scope(Enum):
     ORG = "org"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_audit_logs",
     description=("Search audit logs for the current account or an organization"),
     tags={"events"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_client.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -41,7 +41,7 @@ class Band(Enum):
     B6 = "6"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_client",
     description=(
         "Search for clients across an organization or "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -40,7 +40,7 @@ class Status(Enum):
     DISCONNECTED = "disconnected"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_device",
     description=(
         "Search a network device in the Organization "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device_config_history.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device_config_history.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -39,7 +39,7 @@ class Device_type(Enum):
     GATEWAY = "gateway"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_device_config_history",
     description=(
         "Search for entries in device config history. "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_events.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_events.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -38,7 +38,7 @@ class Event_source(Enum):
     ROGUE = "rogue"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_events",
     description=(
         "Search for events across an organization or site "

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_guest_authorization.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_guest_authorization.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -33,7 +33,7 @@ class Scope(Enum):
     SITE = "site"
 
 
-@mcp.tool(
+@tool(
     name="mist_search_guest_authorization",
     description=("Search for guest authorization entries in an organization or site"),
     tags={"clients"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_nac_user_macs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_nac_user_macs.py
@@ -18,7 +18,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -27,7 +27,7 @@ from hpe_networking_mcp.platforms.mist.client import (
 )
 
 
-@mcp.tool(
+@tool(
     name="mist_search_nac_user_macs",
     description=(
         "Search for NAC user MAC addresses in an "

--- a/src/hpe_networking_mcp/platforms/mist/tools/troubleshoot.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/troubleshoot.py
@@ -19,7 +19,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -34,7 +34,7 @@ class Troubleshoot_type(Enum):
     WIRELESS = "wireless"
 
 
-@mcp.tool(
+@tool(
     name="mist_troubleshoot",
     description=(
         "Troubleshoot sites, devices, clients, and wired "

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -23,7 +23,7 @@ from pydantic import Field
 from hpe_networking_mcp.middleware.elicitation import (
     elicitation_handler,
 )
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -59,7 +59,7 @@ class Object_type(Enum):
     WXTAGS = "wxtags"
 
 
-@mcp.tool(
+@tool(
     name="mist_update_org_configuration_objects",
     description=(
         "Update or create configuration object for a "

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
@@ -23,7 +23,7 @@ from pydantic import Field
 from hpe_networking_mcp.middleware.elicitation import (
     elicitation_handler,
 )
-from hpe_networking_mcp.platforms.mist._registry import mcp
+from hpe_networking_mcp.platforms.mist._registry import tool
 from hpe_networking_mcp.platforms.mist.client import (
     format_response,
     get_apisession,
@@ -43,7 +43,7 @@ class Object_type(Enum):
     WXTAGS = "wxtags"
 
 
-@mcp.tool(
+@tool(
     name="mist_update_site_configuration_objects",
     description=(
         "Update or create configuration object for a "

--- a/tests/unit/test_mist_dynamic_mode.py
+++ b/tests/unit/test_mist_dynamic_mode.py
@@ -1,0 +1,81 @@
+"""Integration-style unit tests for the Mist dynamic-mode migration (#159).
+
+Mirrors ``test_apstra_dynamic_mode.py`` — imports every Mist tool module
+against the stubbed mcp (installed in ``tests/conftest.py``) and asserts the
+shared registry is populated with the expected specs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, clear_registry
+
+
+@pytest.fixture
+def mist_registry_populated():
+    """Import every Mist tool module so ``REGISTRIES['mist']`` is fully populated.
+
+    Clears the registry at the start (other tests may have stubbed entries)
+    and reloads every module to force re-registration against the currently-
+    stubbed ``_registry.mcp``.
+    """
+    clear_registry("mist")
+    from hpe_networking_mcp.platforms.mist import TOOLS
+
+    module_names: list[str] = []
+    for tool_names in TOOLS.values():
+        for name in tool_names:
+            module_names.append(name.replace("mist_", ""))
+
+    for mod_short in sorted(set(module_names)):
+        module = importlib.import_module(f"hpe_networking_mcp.platforms.mist.tools.{mod_short}")
+        importlib.reload(module)
+    yield REGISTRIES["mist"]
+    clear_registry("mist")
+
+
+@pytest.mark.unit
+class TestMistRegistryPopulation:
+    def test_registry_contains_all_tools(self, mist_registry_populated):
+        """Every Mist tool listed in platforms.mist.TOOLS registers cleanly."""
+        from hpe_networking_mcp.platforms.mist import TOOLS
+
+        expected = {name for names in TOOLS.values() for name in names}
+        actual = set(mist_registry_populated.keys())
+        assert actual == expected, f"Mismatch — missing: {expected - actual}, extra: {actual - expected}"
+
+    def test_expected_surface_size(self, mist_registry_populated):
+        """Sanity: 35 tools across all categories."""
+        from hpe_networking_mcp.platforms.mist import TOOLS
+
+        expected = sum(len(names) for names in TOOLS.values())
+        assert len(mist_registry_populated) == expected
+
+    def test_write_tools_carry_write_tags(self, mist_registry_populated):
+        """Write-gating relies on tags being set on the registered specs."""
+        update_site = mist_registry_populated["mist_update_site_configuration_objects"]
+        assert "write" in update_site.tags or any(
+            t in update_site.tags for t in ("mist_write", "write", "configuration")
+        )
+
+        change_site = mist_registry_populated["mist_change_site_configuration_objects"]
+        assert "write_delete" in change_site.tags or any(
+            t in change_site.tags for t in ("mist_write_delete", "write_delete", "configuration")
+        )
+
+    def test_read_tool_has_no_write_tag(self, mist_registry_populated):
+        read = mist_registry_populated["mist_search_device"]
+        assert not (read.tags & {"mist_write", "mist_write_delete"})
+
+    def test_categories_derived_from_module_names(self, mist_registry_populated):
+        """The registry category comes from the source module's short name."""
+        assert mist_registry_populated["mist_search_device"].category == "search_device"
+        assert mist_registry_populated["mist_get_self"].category == "get_self"
+        assert mist_registry_populated["mist_bounce_switch_port"].category == "bounce_switch_port"
+
+    def test_descriptions_are_populated(self, mist_registry_populated):
+        for name, spec in mist_registry_populated.items():
+            assert spec.description, f"{name} has empty description"


### PR DESCRIPTION
Part of umbrella [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157). **Closes [#159](https://github.com/nowireless4u/hpe-networking-mcp/issues/159).**

Second platform onto the dynamic-mode infrastructure landed in Phase 0 (PRs [#169](https://github.com/nowireless4u/hpe-networking-mcp/pull/169) and [#170](https://github.com/nowireless4u/hpe-networking-mcp/pull/170)). Same pattern, larger surface (35 tools vs Apstra's 19). No tag, no release, no pyproject bump per the Phase-PR release strategy.

## User impact

- **Static mode users (default):** no change. All 35 \`mist_*\` tools remain visible.
- **Dynamic mode users (\`MCP_TOOL_MODE=dynamic\`):** Mist's tool surface collapses to **3 meta-tools** (\`mist_list_tools\`, \`mist_get_tool_schema\`, \`mist_invoke_tool\`). The 35 underlying tools remain dispatchable but are hidden from the model's tool list by the shared \`Visibility\` transform.
- Mist prompts continue to work unchanged — prompts are a different MCP primitive and aren't part of the dynamic-mode meta-tool surface.

## Changes

- [\`mist/_registry.py\`](src/hpe_networking_mcp/platforms/mist/_registry.py) rewritten as a \`tool()\` decorator shim mirroring Apstra's.
- 35 tool files under \`mist/tools/\` — mechanical \`@mcp.tool(...)\` → \`@tool(...)\` swap.
- [\`mist/__init__.py\`](src/hpe_networking_mcp/platforms/mist/__init__.py) — always imports every tool file; calls \`build_meta_tools\` when \`tool_mode == "dynamic"\`. Dropped the "skip write tools if disabled" branch — Visibility + \`is_tool_enabled\` handle gating uniformly now.

## Boot verification (Docker)

\`\`\`
static mode:  35 mist_* tools visible.
dynamic mode: 3 Mist meta-tools + 3 Apstra meta-tools + cross-platform health;
              every underlying Mist and Apstra tool hidden by Visibility.
\`\`\`

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **403/403 passing** (6 new tests in \`test_mist_dynamic_mode.py\`)
- [x] Boot test both modes — verified above

## Files
- **Modified:** 41 files (38 in \`mist/tools/\`, plus \`mist/_registry.py\`, \`mist/__init__.py\`, \`TOOLS.md\`, \`MIGRATING_TO_V2.md\`, \`CHANGELOG.md\`)
- **Created:** \`tests/unit/test_mist_dynamic_mode.py\`

## Closes
- #159

## Next
**Phase 2 (#160)** — Central migration. Largest non-ClearPass platform (~72 tools), and benefits from \`v1.0.0.3\` PUT-clobber audit + \`v1.1.0.0\` filter-param sweep having already landed.