### PR TITLE
[v2.0 Phase 2] Central dynamic-mode migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v2.0 Phases 0-2
+
+### Added — Central dynamic-mode migration (#160)
+
+Third platform onto the dynamic-mode infrastructure. With
+`MCP_TOOL_MODE=dynamic`, Central exposes exactly three meta-tools
+(`central_list_tools`, `central_get_tool_schema`, `central_invoke_tool`)
+and hides the 73 underlying Central tools via the shared
+`Visibility(dynamic_managed)` transform. Static mode is unchanged.
+
+- `platforms/central/_registry.py` rewritten as a `tool()` decorator
+  shim mirroring Apstra's and Mist's.
+- All 24 Central tool files under `platforms/central/tools/*.py`
+  swapped from `@mcp.tool(...)` to `@tool(...)`. The `prompts.py`
+  module (12 guided prompts) is unchanged — prompts are a different
+  MCP primitive and aren't part of the dynamic-mode meta-tool surface.
+- `platforms/central/__init__.py` — always imports every category so
+  the registry is complete regardless of `ENABLE_CENTRAL_WRITE_TOOLS`;
+  calls `build_meta_tools("central", mcp)` when
+  `tool_mode == "dynamic"`. Dropped the "skip configuration when write
+  disabled" branch — Visibility + `is_tool_enabled` handle gating
+  uniformly now.
+
+### Tests
+- 6 new integration-style tests in `test_central_dynamic_mode.py`.
+  Total suite: 409/409 passing.
+
+### Boot verification
+- `MCP_TOOL_MODE=static` + Central configured → 73 `central_*` tools
+  visible.
+- `MCP_TOOL_MODE=dynamic` + Central + Mist + Apstra configured → 3
+  meta-tools per migrated platform + cross-platform `health` tool;
+  every underlying tool hidden by Visibility.
+
 ## [Unreleased] — v2.0 Phases 0-1
 
 ### Added — Mist dynamic-mode migration (#159)

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -36,7 +36,7 @@ AI agents that hard-coded these names will get "tool not found" on v2.0.
 - [x] Phase 0 PR A — shared `_common/` infrastructure, cross-platform `health` tool, `tool_mode` config
 - [x] Phase 0 PR B — Apstra migrates to dynamic mode (pilot); `apstra_health` and `apstra_formatting_guidelines` removed
 - [x] Phase 1 — Mist migrates
-- [ ] Phase 2 — Central migrates
+- [x] Phase 2 — Central migrates
 - [ ] Phase 3 — ClearPass migrates
 - [ ] Phase 4 — GreenLake dynamic mode generalizes to the new meta-tool pattern
 - [ ] Phase 5 — local-LLM validation

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -39,7 +39,7 @@ Dynamic-mode migration status (phased per [#157](https://github.com/nowireless4u
 |---|---|
 | Juniper Apstra | ✅ yes (Phase 0) |
 | Juniper Mist | ✅ yes (Phase 1) |
-| Aruba Central | pending (Phase 2) |
+| Aruba Central | ✅ yes (Phase 2) |
 | Aruba ClearPass | pending (Phase 3) |
 | HPE GreenLake | yes (already dynamic via the legacy endpoint-dispatch meta-tools; unified in Phase 4) |
 

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -100,18 +100,21 @@ TOOLS = {
 
 
 def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
-    """Dynamically load and register all Central tool modules. Returns count of loaded tools."""
+    """Load all Central tool modules and register them with FastMCP.
+
+    Always imports every category so ``REGISTRIES["central"]`` is fully
+    populated; runtime write-gating is handled by the Visibility transform
+    (static mode) and ``is_tool_enabled`` (dynamic mode, via the meta-tools).
+
+    Returns the count of individual underlying tools that registered.
+    """
+    from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
     from hpe_networking_mcp.platforms.central import _registry
 
     _registry.mcp = mcp
 
-    write_enabled = config.enable_central_write_tools
     loaded: list[str] = []
-
     for category, tool_names in TOOLS.items():
-        if category == "configuration" and not write_enabled:
-            logger.info("Central: write tools disabled, skipping {} tools", len(tool_names))
-            continue
         try:
             importlib.import_module(f"hpe_networking_mcp.platforms.central.tools.{category}")
             loaded.extend(tool_names)
@@ -119,7 +122,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("Central: failed to load module {} -- {}", category, e)
 
-    # Register prompts (these use register(mcp) pattern, not _registry)
+    # Register prompts (register(mcp) pattern; prompts are a different MCP
+    # primitive and aren't part of the dynamic-mode meta-tool surface).
     try:
         from hpe_networking_mcp.platforms.central.tools import prompts
 
@@ -127,5 +131,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         logger.debug("Central: loaded prompts")
     except Exception as e:
         logger.warning("Central: failed to load prompts -- {}", e)
+
+    if config.tool_mode == "dynamic":
+        build_meta_tools("central", mcp)
+        logger.info(
+            "Central: {} underlying tools + 3 meta-tools registered (dynamic mode)",
+            len(loaded),
+        )
+    else:
+        logger.info("Central: {} tools registered (static mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/central/_registry.py
+++ b/src/hpe_networking_mcp/platforms/central/_registry.py
@@ -1,6 +1,61 @@
-"""Central tool registry -- holds the FastMCP instance that tools register against."""
+"""Central tool registry -- module-level FastMCP holder + shared-registry shim.
+
+Tool modules under ``platforms/central/tools/`` decorate their functions with
+``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
+The shim mirrors the Apstra and Mist patterns: delegate to the real FastMCP
+decorator, merge the ``dynamic_managed`` tag so dynamic-mode ``Visibility`` can
+hide individual tools, and record a ``ToolSpec`` into ``REGISTRIES["central"]``
+so the three Central meta-tools can dispatch by name at runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
 
 from fastmcp import FastMCP
 
-# Set by platforms.central.register_tools() before tool modules are imported
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    DYNAMIC_MANAGED_TAG,
+    ToolSpec,
+    record_tool,
+)
+
+# Set by platforms.central.register_tools() before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
+
+_PLATFORM = "central"
+
+
+def _derive_category(func: Callable[..., Any]) -> str:
+    """Short module name as the registry category (e.g. ``sites``)."""
+    module = getattr(func, "__module__", "")
+    return module.rsplit(".", 1)[-1] if "." in module else module
+
+
+def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
+        resolved_name: str = tool_kwargs.get("name") or func.__name__
+        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
+
+        record_tool(
+            ToolSpec(
+                name=resolved_name,
+                func=func,
+                platform=_PLATFORM,
+                category=_derive_category(func),
+                description=resolved_description,
+                tags=supplied_tags,
+            )
+        )
+
+        if mcp is None:
+            return func
+
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        return mcp.tool(**effective_kwargs)(func)
+
+    return decorator

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -4,7 +4,7 @@ from fastmcp import Context
 from mcp.types import ToolAnnotations
 from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 
 OPERATIONAL = ToolAnnotations(
     readOnlyHint=False,
@@ -44,7 +44,7 @@ def _resolve_switch_id(conn, serial_number: str) -> str:
 # ── Disconnect Tools ─────────────────────────────────────────────
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_disconnect_users_ssid(
     ctx: Context,
     serial_number: str,
@@ -80,7 +80,7 @@ async def central_disconnect_users_ssid(
     return resp
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_disconnect_users_ap(
     ctx: Context,
     serial_number: str,
@@ -112,7 +112,7 @@ async def central_disconnect_users_ap(
     return resp
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_disconnect_client_ap(
     ctx: Context,
     serial_number: str,
@@ -148,7 +148,7 @@ async def central_disconnect_client_ap(
     return resp
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_disconnect_client_gateway(
     ctx: Context,
     serial_number: str,
@@ -181,7 +181,7 @@ async def central_disconnect_client_gateway(
     return resp
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_disconnect_clients_gateway(
     ctx: Context,
     serial_number: str,
@@ -262,7 +262,7 @@ def _get_switch_ports(conn, serial_number: str) -> dict:
 # ── Port / PoE Bounce Tools ──────────────────────────────────────
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_port_bounce_switch(
     ctx: Context,
     serial_number: str,
@@ -327,7 +327,7 @@ async def central_port_bounce_switch(
     }
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_poe_bounce_switch(
     ctx: Context,
     serial_number: str,
@@ -407,7 +407,7 @@ async def central_poe_bounce_switch(
     }
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_port_bounce_gateway(
     ctx: Context,
     serial_number: str,
@@ -443,7 +443,7 @@ async def central_port_bounce_gateway(
     return resp
 
 
-@mcp.tool(annotations=OPERATIONAL)
+@tool(annotations=OPERATIONAL)
 async def central_poe_bounce_gateway(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import PaginatedAlerts
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
@@ -23,7 +23,7 @@ ALERT_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_alerts(
     ctx: Context,
     site_id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/aliases.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/aliases.py
@@ -7,12 +7,12 @@ and other configuration objects.
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_aliases(
     ctx: Context,
     alias_name: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -1,11 +1,11 @@
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_applications(
     ctx: Context,
     site_id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -1,11 +1,11 @@
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_audit_logs(
     ctx: Context,
     start_at: str,
@@ -59,7 +59,7 @@ async def central_get_audit_logs(
     return resp.get("msg", {})
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_audit_log_detail(
     ctx: Context,
     id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -3,7 +3,7 @@ from typing import Literal
 from fastmcp import Context
 from pycentral.new_monitoring.clients import Clients
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Client
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
@@ -25,7 +25,7 @@ CLIENT_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_clients(
     ctx: Context,
     site_id: str | None = None,
@@ -90,7 +90,7 @@ async def central_get_clients(
     return clean_client_data(clients)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_find_client(
     ctx: Context,
     mac_address: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -17,7 +17,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
@@ -49,7 +49,7 @@ VALID_DEVICE_FUNCTIONS = {
 }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_config_assignments(
     ctx: Context,
     scope_id: Annotated[
@@ -106,7 +106,7 @@ async def central_get_config_assignments(
     return response.get("msg", {})
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_config_assignment(
     ctx: Context,
     action_type: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -15,7 +15,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 WRITE_DELETE = ToolAnnotations(
@@ -45,7 +45,7 @@ class CollectionActionType(Enum):
 # ------------------------------------------------------------------
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_site(
     ctx: Context,
     action_type: Annotated[
@@ -111,7 +111,7 @@ async def central_manage_site(
 # ------------------------------------------------------------------
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_site_collection(
     ctx: Context,
     action_type: Annotated[
@@ -189,7 +189,7 @@ async def central_manage_site_collection(
 # ------------------------------------------------------------------
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_device_group(
     ctx: Context,
     action_type: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -3,7 +3,7 @@ from typing import Literal
 from fastmcp import Context
 from pycentral.new_monitoring import MonitoringDevices
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Device
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
@@ -25,7 +25,7 @@ DEVICE_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_devices(
     ctx: Context,
     site_id: str | None = None,
@@ -99,7 +99,7 @@ async def central_get_devices(
     return clean_device_data(devices)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_find_device(
     ctx: Context,
     serial_number: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/events.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/events.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import (
     Event,
     EventFilters,
@@ -51,7 +51,7 @@ def _resolve_time_window(
     return fmt(start_dt), fmt(end_dt)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_events(
     ctx: Context,
     context_type: CONTEXT_TYPE,
@@ -129,7 +129,7 @@ async def central_get_events(
     )
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_events_count(
     ctx: Context,
     context_type: CONTEXT_TYPE,

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware.py
@@ -23,7 +23,7 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import BaseModel, Field
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
@@ -220,7 +220,7 @@ def _build_filter(
     return " and ".join(parts) if parts else None
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_recommend_firmware(
     ctx: Context,
     serial_number: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -4,7 +4,7 @@ from fastmcp import Context
 from pycentral.new_monitoring.aps import MonitoringAPs
 from pycentral.new_monitoring.gateways import MonitoringGateways
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
@@ -29,7 +29,7 @@ _AP_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_aps(
     ctx: Context,
     site_id: str | None = None,
@@ -91,7 +91,7 @@ async def central_get_aps(
     return aps
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_ap_wlans(
     ctx: Context,
     serial_number: str,
@@ -126,7 +126,7 @@ async def central_get_ap_wlans(
     return items
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_ap_details(
     ctx: Context,
     serial_number: str,
@@ -156,7 +156,7 @@ async def central_get_ap_details(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_switch_details(
     ctx: Context,
     serial_number: str,
@@ -240,7 +240,7 @@ async def central_get_switch_details(
     return result
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_gateway_details(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/named_vlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/named_vlans.py
@@ -7,12 +7,12 @@ via an alias reference.
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_named_vlans(
     ctx: Context,
     name: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -17,7 +17,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
@@ -29,7 +29,7 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_roles(
     ctx: Context,
     name: str | None = None,
@@ -59,7 +59,7 @@ async def central_get_roles(
     return response.get("msg", {})
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_role(
     ctx: Context,
     name: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/scope.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.scope_builder import (
     build_scope_tree,
     tree_to_dict,
@@ -23,7 +23,7 @@ from hpe_networking_mcp.platforms.central.scope_queries import (
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_scope_tree(
     ctx: Context,
     view: Literal["committed", "effective"] = "committed",
@@ -51,7 +51,7 @@ async def central_get_scope_tree(
         return f"Error building scope tree: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_scope_resources(
     ctx: Context,
     scope_id: str,
@@ -111,7 +111,7 @@ async def central_get_scope_resources(
     }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_effective_config(
     ctx: Context,
     scope_id: str,
@@ -160,7 +160,7 @@ async def central_get_effective_config(
     }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_devices_in_scope(
     ctx: Context,
     scope_id: str,
@@ -200,7 +200,7 @@ async def central_get_devices_in_scope(
     }
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_scope_diagram(
     ctx: Context,
     scope_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -17,7 +17,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
@@ -139,7 +139,7 @@ _CONFIRMED_FIELD = Field(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_net_groups(
     ctx: Context,
     name: str | None = None,
@@ -159,7 +159,7 @@ async def central_get_net_groups(
     return await _get_resource(ctx, "net-groups", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_net_group(
     ctx: Context,
     name: Annotated[str, Field(description="Net-group (netdestination) name.")],
@@ -198,7 +198,7 @@ async def central_manage_net_group(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_net_services(
     ctx: Context,
     name: str | None = None,
@@ -217,7 +217,7 @@ async def central_get_net_services(
     return await _get_resource(ctx, "net-services", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_net_service(
     ctx: Context,
     name: Annotated[str, Field(description="Net-service name.")],
@@ -255,7 +255,7 @@ async def central_manage_net_service(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_object_groups(
     ctx: Context,
     name: str | None = None,
@@ -273,7 +273,7 @@ async def central_get_object_groups(
     return await _get_resource(ctx, "object-groups", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_object_group(
     ctx: Context,
     name: Annotated[str, Field(description="Object-group name.")],
@@ -311,7 +311,7 @@ async def central_manage_object_group(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_role_acls(
     ctx: Context,
     name: str | None = None,
@@ -329,7 +329,7 @@ async def central_get_role_acls(
     return await _get_resource(ctx, "role-acls", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_role_acl(
     ctx: Context,
     name: Annotated[str, Field(description="Role-ACL name.")],
@@ -367,7 +367,7 @@ async def central_manage_role_acl(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_policies(
     ctx: Context,
     name: str | None = None,
@@ -386,7 +386,7 @@ async def central_get_policies(
     return await _get_resource(ctx, "policies", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_policy(
     ctx: Context,
     name: Annotated[str, Field(description="Policy name.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
@@ -12,7 +12,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
@@ -36,7 +36,7 @@ WRITE_DELETE = ToolAnnotations(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_policy_groups(
     ctx: Context,
 ) -> dict | list | str:
@@ -51,7 +51,7 @@ async def central_get_policy_groups(
     return await _get_resource(ctx, "policy-groups", None)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_policy_group(
     ctx: Context,
     action_type: Annotated[
@@ -141,7 +141,7 @@ async def central_manage_policy_group(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_role_gpids(
     ctx: Context,
     name: str | None = None,
@@ -159,7 +159,7 @@ async def central_get_role_gpids(
     return await _get_resource(ctx, "role-gpids", name)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_role_gpid(
     ctx: Context,
     name: Annotated[str, Field(description="Role name for the GPID mapping.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/server_groups.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/server_groups.py
@@ -7,12 +7,12 @@ authentication and accounting servers.
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_server_groups(
     ctx: Context,
     name: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -1,7 +1,7 @@
 from fastmcp import Context
 from pycentral.new_monitoring import MonitoringSites
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import SiteData
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
@@ -12,7 +12,7 @@ from hpe_networking_mcp.platforms.central.utils import (
 )
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_sites(
     ctx: Context,
     filter: str | None = None,
@@ -55,7 +55,7 @@ async def central_get_sites(
     return response.get("msg", {})
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_site_health(
     ctx: Context,
     site_name: str | list[str] | None = None,
@@ -86,7 +86,7 @@ async def central_get_site_health(
     return list(sites_data.values())
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_site_name_id_mapping(ctx: Context) -> dict:
     """
     Returns a lightweight mapping of all site names to their IDs and health

--- a/src/hpe_networking_mcp/platforms/central/tools/stats.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/stats.py
@@ -4,11 +4,11 @@ from fastmcp import Context
 from pycentral.new_monitoring.aps import MonitoringAPs
 from pycentral.new_monitoring.gateways import MonitoringGateways
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_ap_stats(
     ctx: Context,
     serial_number: str,
@@ -49,7 +49,7 @@ async def central_get_ap_stats(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_ap_utilization(
     ctx: Context,
     serial_number: str,
@@ -98,7 +98,7 @@ async def central_get_ap_utilization(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_gateway_stats(
     ctx: Context,
     serial_number: str,
@@ -139,7 +139,7 @@ async def central_get_gateway_stats(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_gateway_utilization(
     ctx: Context,
     serial_number: str,
@@ -189,7 +189,7 @@ async def central_get_gateway_utilization(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_gateway_wan_availability(
     ctx: Context,
     serial_number: str,
@@ -230,7 +230,7 @@ async def central_get_gateway_wan_availability(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_tunnel_health(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
@@ -2,12 +2,12 @@
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_switch_hardware_trends(
     ctx: Context,
     serial_number: str,
@@ -93,7 +93,7 @@ async def central_get_switch_hardware_trends(
     return result
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_switch_poe(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -3,7 +3,7 @@ from typing import Literal
 from fastmcp import Context
 from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 
 
@@ -18,7 +18,7 @@ def _resolve_if_switch(conn, serial_number: str, device_type: str) -> str:
     return _resolve_switch_id(conn, serial_number)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_ping(
     ctx: Context,
     serial_number: str,
@@ -70,7 +70,7 @@ async def central_ping(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_traceroute(
     ctx: Context,
     serial_number: str,
@@ -111,7 +111,7 @@ async def central_traceroute(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_cable_test(
     ctx: Context,
     serial_number: str,
@@ -148,7 +148,7 @@ async def central_cable_test(
     return resp
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_show_commands(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -13,7 +13,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
@@ -25,7 +25,7 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_wlan_profiles(
     ctx: Context,
     ssid: str | None = None,
@@ -58,7 +58,7 @@ async def central_get_wlan_profiles(
     return response.get("msg", {})
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_wlan_profile(
     ctx: Context,
     ssid: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -3,12 +3,12 @@ from typing import Literal
 from fastmcp import Context
 from pycentral.new_monitoring.aps import MonitoringAPs
 
-from hpe_networking_mcp.platforms.central._registry import mcp
+from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import resolve_time_window, retry_central_command
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_wlans(
     ctx: Context,
     site_id: str | None = None,
@@ -64,7 +64,7 @@ async def central_get_wlans(
 TIME_RANGE = Literal["last_1h", "last_6h", "last_24h", "last_7d", "last_30d", "today", "yesterday"]
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def central_get_wlan_stats(
     ctx: Context,
     wlan_name: str,

--- a/tests/unit/test_central_dynamic_mode.py
+++ b/tests/unit/test_central_dynamic_mode.py
@@ -1,0 +1,63 @@
+"""Integration-style unit tests for the Central dynamic-mode migration (#160).
+
+Mirrors ``test_apstra_dynamic_mode.py`` and ``test_mist_dynamic_mode.py``:
+import every Central tool module against the stubbed mcp (installed in
+``tests/conftest.py``) and assert the shared registry ends up populated with
+the expected Central specs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, clear_registry
+
+
+@pytest.fixture
+def central_registry_populated():
+    """Import every Central tool module so ``REGISTRIES['central']`` is full."""
+    clear_registry("central")
+    from hpe_networking_mcp.platforms.central import TOOLS
+
+    for category in TOOLS:
+        module = importlib.import_module(f"hpe_networking_mcp.platforms.central.tools.{category}")
+        importlib.reload(module)
+    yield REGISTRIES["central"]
+    clear_registry("central")
+
+
+@pytest.mark.unit
+class TestCentralRegistryPopulation:
+    def test_registry_contains_all_tools(self, central_registry_populated):
+        """Every Central tool listed in platforms.central.TOOLS registers cleanly."""
+        from hpe_networking_mcp.platforms.central import TOOLS
+
+        expected = {name for names in TOOLS.values() for name in names}
+        actual = set(central_registry_populated.keys())
+        assert actual == expected, f"Mismatch — missing: {expected - actual}, extra: {actual - expected}"
+
+    def test_expected_surface_size(self, central_registry_populated):
+        """Sanity: the full Central tool surface is > 60 tools."""
+        assert len(central_registry_populated) > 60
+
+    def test_write_tools_carry_write_delete_tag(self, central_registry_populated):
+        """The three configuration CRUD tools are the flagship write_delete surface."""
+        for name in ("central_manage_site", "central_manage_site_collection", "central_manage_device_group"):
+            assert "central_write_delete" in central_registry_populated[name].tags
+
+    def test_read_tool_has_no_write_tag(self, central_registry_populated):
+        read = central_registry_populated["central_get_sites"]
+        assert "central_write_delete" not in read.tags
+
+    def test_categories_derived_from_module_names(self, central_registry_populated):
+        """Registry category == source module's short name."""
+        assert central_registry_populated["central_get_sites"].category == "sites"
+        assert central_registry_populated["central_get_devices"].category == "devices"
+        assert central_registry_populated["central_manage_site"].category == "configuration"
+        assert central_registry_populated["central_get_aps"].category == "monitoring"
+
+    def test_descriptions_are_populated(self, central_registry_populated):
+        for name, spec in central_registry_populated.items():
+            assert spec.description, f"{name} has empty description"


### PR DESCRIPTION
Part of umbrella [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157). **Closes [#160](https://github.com/nowireless4u/hpe-networking-mcp/issues/160).**

Third platform onto the dynamic-mode infrastructure from Phase 0 (PRs [#169](https://github.com/nowireless4u/hpe-networking-mcp/pull/169), [#170](https://github.com/nowireless4u/hpe-networking-mcp/pull/170)) and Phase 1 ([#171](https://github.com/nowireless4u/hpe-networking-mcp/pull/171)). Central's 73 tools collapse to 3 meta-tools under dynamic mode. No tag, no release per the Phase-PR release strategy.

## User impact

- **Static mode (default):** no change. All 73 \`central_*\` tools remain visible. Central's 12 guided prompts still work exactly as before.
- **Dynamic mode (\`MCP_TOOL_MODE=dynamic\`):** Central's tool surface collapses to **3 meta-tools** (\`central_list_tools\`, \`central_get_tool_schema\`, \`central_invoke_tool\`). Underlying tools remain dispatchable but are hidden from the model's tool list by the shared \`Visibility\` transform. Prompts are unaffected — they're a different MCP primitive and aren't part of the dynamic-mode meta-tool surface.

## Changes

- [\`central/_registry.py\`](src/hpe_networking_mcp/platforms/central/_registry.py) rewritten as a \`tool()\` decorator shim mirroring Apstra and Mist.
- 24 tool files under \`central/tools/\` — mechanical \`@mcp.tool(...)\` → \`@tool(...)\` swap. \`prompts.py\` is untouched.
- [\`central/__init__.py\`](src/hpe_networking_mcp/platforms/central/__init__.py) — always imports every category; calls \`build_meta_tools\` when \`tool_mode == "dynamic"\`. Dropped the "skip configuration category when write disabled" branch; gating is uniform via Visibility + \`is_tool_enabled\`.

## Boot verification (Docker)

\`\`\`
static mode:  73 central_* tools visible.
dynamic mode: 3 Central meta-tools + 3 Mist meta-tools + 3 Apstra meta-tools
              + cross-platform health; every underlying tool hidden.
\`\`\`

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **409/409 passing** (6 new tests in \`test_central_dynamic_mode.py\`)

## Files
- **Modified:** 30 files (26 in \`central/\` including tool files + registry + \`__init__.py\`, plus \`TOOLS.md\`, \`MIGRATING_TO_V2.md\`, \`CHANGELOG.md\`, one test in \`test_central_*\` unchanged)
- **Created:** \`tests/unit/test_central_dynamic_mode.py\`

## Closes
- #160

## Next
**Phase 3 (#161)** — ClearPass. Largest single platform by tool count (127 tools / 32 files) and finishes the \`confirm_write\` consolidation from #148.