### PR TITLE
[v2.0 Phase 3] ClearPass dynamic-mode migration + confirm_write consolidation complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v2.0 Phases 0-3
+
+### Added — ClearPass dynamic-mode migration (#161) + `confirm_write` consolidation complete (#148)
+
+Fourth platform onto the dynamic-mode infrastructure. ClearPass is the
+largest single platform by tool count (127 across 31 files). With
+`MCP_TOOL_MODE=dynamic`, ClearPass exposes exactly three meta-tools
+(`clearpass_list_tools`, `clearpass_get_tool_schema`,
+`clearpass_invoke_tool`) and hides the 127 underlying tools via the
+shared `Visibility(dynamic_managed)` transform. Static mode unchanged.
+
+- `platforms/clearpass/_registry.py` rewritten as a `tool()` decorator
+  shim mirroring Apstra / Mist / Central.
+- All 31 ClearPass tool files under `platforms/clearpass/tools/*.py`
+  swapped from `@mcp.tool(...)` to `@tool(...)`.
+- `platforms/clearpass/__init__.py` — always imports every category;
+  calls `build_meta_tools("clearpass", mcp)` when
+  `tool_mode == "dynamic"`. Dropped the `WRITE_CATEGORIES` skip logic
+  since Visibility + `is_tool_enabled` now handle gating uniformly.
+
+### Changed — finishes `#148` confirm_write consolidation
+
+All 15 ClearPass write-tool files (the 14 `_confirm_write` helpers plus
+one inline copy in `manage_endpoints.py`) replaced with calls to the
+shared `middleware.elicitation.confirm_write()` helper. The local
+helper names are preserved as thin wrappers so existing call sites
+don't change; the actual elicitation/decline/cancel decision logic
+lives in the middleware. Same treatment Apstra got in Phase 0 PR B —
+**#148 is now fully closed** (Apstra + ClearPass both consolidated).
+
+### Tests
+- 6 new integration-style tests in `test_clearpass_dynamic_mode.py`.
+  Total suite: 415/415 passing.
+
+### Boot verification
+- `MCP_TOOL_MODE=static` + ClearPass configured → 127 `clearpass_*`
+  tools visible.
+- `MCP_TOOL_MODE=dynamic` + all four migrated platforms configured →
+  12 meta-tools total (3 per platform × 4 platforms) + cross-platform
+  `health` tool. Every underlying tool hidden.
+
 ## [Unreleased] — v2.0 Phases 0-2
 
 ### Added — Central dynamic-mode migration (#160)

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -37,7 +37,7 @@ AI agents that hard-coded these names will get "tool not found" on v2.0.
 - [x] Phase 0 PR B — Apstra migrates to dynamic mode (pilot); `apstra_health` and `apstra_formatting_guidelines` removed
 - [x] Phase 1 — Mist migrates
 - [x] Phase 2 — Central migrates
-- [ ] Phase 3 — ClearPass migrates
+- [x] Phase 3 — ClearPass migrates
 - [ ] Phase 4 — GreenLake dynamic mode generalizes to the new meta-tool pattern
 - [ ] Phase 5 — local-LLM validation
 - [ ] Phase 6 — `MCP_TOOL_MODE=dynamic` becomes the default; tag `v2.0.0.0`

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -40,7 +40,7 @@ Dynamic-mode migration status (phased per [#157](https://github.com/nowireless4u
 | Juniper Apstra | ✅ yes (Phase 0) |
 | Juniper Mist | ✅ yes (Phase 1) |
 | Aruba Central | ✅ yes (Phase 2) |
-| Aruba ClearPass | pending (Phase 3) |
+| Aruba ClearPass | ✅ yes (Phase 3) |
 | HPE GreenLake | yes (already dynamic via the legacy endpoint-dispatch meta-tools; unified in Phase 4) |
 
 When a platform that has **not** migrated yet runs under `MCP_TOOL_MODE=dynamic`,

--- a/src/hpe_networking_mcp/platforms/clearpass/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/__init__.py
@@ -197,28 +197,37 @@ TOOLS: dict[str, list[str]] = {
     ],
 }
 
-# Write categories are skipped when write tools are disabled
-WRITE_CATEGORIES = {k for k in TOOLS if k.startswith("manage_")}
-
 
 def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
-    """Dynamically load and register all ClearPass tool modules. Returns count of loaded tools."""
+    """Load all ClearPass tool modules and register them with FastMCP.
+
+    Always imports every category so ``REGISTRIES["clearpass"]`` is fully
+    populated; runtime write-gating is handled by the Visibility transform
+    (static mode) and ``is_tool_enabled`` (dynamic mode, via the meta-tools).
+
+    Returns the count of individual underlying tools that registered.
+    """
+    from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
     from hpe_networking_mcp.platforms.clearpass import _registry
 
     _registry.mcp = mcp
 
-    write_enabled = config.enable_clearpass_write_tools
     loaded: list[str] = []
-
     for category, tool_names in TOOLS.items():
-        if category in WRITE_CATEGORIES and not write_enabled:
-            logger.info("ClearPass: write tools disabled, skipping {} ({} tools)", category, len(tool_names))
-            continue
         try:
             importlib.import_module(f"hpe_networking_mcp.platforms.clearpass.tools.{category}")
             loaded.extend(tool_names)
             logger.debug("ClearPass: loaded module {}", category)
         except Exception as e:
             logger.warning("ClearPass: failed to load module {} -- {}", category, e)
+
+    if config.tool_mode == "dynamic":
+        build_meta_tools("clearpass", mcp)
+        logger.info(
+            "ClearPass: {} underlying tools + 3 meta-tools registered (dynamic mode)",
+            len(loaded),
+        )
+    else:
+        logger.info("ClearPass: {} tools registered (static mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/clearpass/_registry.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/_registry.py
@@ -1,6 +1,62 @@
-"""ClearPass tool registry -- holds the FastMCP instance that tools register against."""
+"""ClearPass tool registry -- module-level FastMCP holder + shared-registry shim.
+
+Tool modules under ``platforms/clearpass/tools/`` decorate their functions with
+``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
+The shim mirrors the Apstra, Mist, and Central patterns: delegate to the real
+FastMCP decorator, merge the ``dynamic_managed`` tag so dynamic-mode
+``Visibility`` can hide individual tools, and record a ``ToolSpec`` into
+``REGISTRIES["clearpass"]`` so the three ClearPass meta-tools can dispatch by
+name at runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
 
 from fastmcp import FastMCP
 
-# Set by platforms.clearpass.register_tools() before tool modules are imported
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    DYNAMIC_MANAGED_TAG,
+    ToolSpec,
+    record_tool,
+)
+
+# Set by platforms.clearpass.register_tools() before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
+
+_PLATFORM = "clearpass"
+
+
+def _derive_category(func: Callable[..., Any]) -> str:
+    """Short module name as the registry category (e.g. ``sessions``)."""
+    module = getattr(func, "__module__", "")
+    return module.rsplit(".", 1)[-1] if "." in module else module
+
+
+def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
+        resolved_name: str = tool_kwargs.get("name") or func.__name__
+        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
+
+        record_tool(
+            ToolSpec(
+                name=resolved_name,
+                func=func,
+                platform=_PLATFORM,
+                category=_derive_category(func),
+                description=resolved_description,
+                tags=supplied_tags,
+            )
+        )
+
+        if mcp is None:
+            return func
+
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        return mcp.tool(**effective_kwargs)(func)
+
+    return decorator

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_audit_logs(
     ctx: Context,
     username: str,
@@ -56,7 +56,7 @@ async def clearpass_get_audit_logs(
         return f"Error fetching audit logs: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_system_events(
     ctx: Context,
     filter: str | None = None,
@@ -84,7 +84,7 @@ async def clearpass_get_system_events(
         return f"Error fetching system events: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_insight_alerts(
     ctx: Context,
     alert_id: str | None = None,
@@ -121,7 +121,7 @@ async def clearpass_get_insight_alerts(
         return f"Error fetching insight alerts: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_insight_reports(
     ctx: Context,
     report_id: str | None = None,
@@ -158,7 +158,7 @@ async def clearpass_get_insight_reports(
         return f"Error fetching insight reports: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_endpoint_insights(
     ctx: Context,
     mac: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_auth_sources(
     ctx: Context,
     auth_source_id: str | None = None,
@@ -52,7 +52,7 @@ async def clearpass_get_auth_sources(
         return f"Error fetching auth sources: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_auth_source_status(
     ctx: Context,
     auth_source_id: str,
@@ -74,7 +74,7 @@ async def clearpass_get_auth_source_status(
         return f"Error fetching auth source status: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_test_auth_source(
     ctx: Context,
     auth_source_id: str,
@@ -102,7 +102,7 @@ async def clearpass_test_auth_source(
         return f"Error fetching auth source for testing: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_auth_methods(
     ctx: Context,
     auth_method_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_trust_list(
     ctx: Context,
     cert_trust_list_id: str | None = None,
@@ -77,7 +77,7 @@ async def clearpass_get_trust_list(
         return f"Error fetching trust list: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_client_certificates(
     ctx: Context,
     client_cert_id: str | None = None,
@@ -110,7 +110,7 @@ async def clearpass_get_client_certificates(
         return f"Error fetching client certificates: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_server_certificates(
     ctx: Context,
     service_id: str | None = None,
@@ -144,7 +144,7 @@ async def clearpass_get_server_certificates(
         return f"Error fetching server certificates: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_service_certificates(
     ctx: Context,
     service_cert_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_endpoints(
     ctx: Context,
     endpoint_id: str | None = None,
@@ -52,7 +52,7 @@ async def clearpass_get_endpoints(
         return f"Error fetching endpoints: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_endpoint_profiler(
     ctx: Context,
     mac_or_ip: str,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_enforcement_policies(
     ctx: Context,
     policy_id: str | None = None,
@@ -55,7 +55,7 @@ async def clearpass_get_enforcement_policies(
         return f"Error fetching enforcement policies: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_enforcement_profiles(
     ctx: Context,
     profile_id: str | None = None,
@@ -101,7 +101,7 @@ async def clearpass_get_enforcement_profiles(
         return f"Error fetching enforcement profiles: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_profile_templates(
     ctx: Context,
 ) -> dict | str:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -25,7 +25,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_pass_templates(
     ctx: Context,
     template_id: str | None = None,
@@ -58,7 +58,7 @@ async def clearpass_get_pass_templates(
         return f"Error fetching pass templates: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_print_templates(
     ctx: Context,
     template_id: str | None = None,
@@ -91,7 +91,7 @@ async def clearpass_get_print_templates(
         return f"Error fetching print templates: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_weblogin_pages(
     ctx: Context,
     page_id: str | None = None,
@@ -128,7 +128,7 @@ async def clearpass_get_weblogin_pages(
         return f"Error fetching web login pages: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_guest_auth_settings(
     ctx: Context,
 ) -> dict | str:
@@ -146,7 +146,7 @@ async def clearpass_get_guest_auth_settings(
         return f"Error fetching guest authentication settings: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_guest_manager_settings(
     ctx: Context,
 ) -> dict | str:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_guest_users(
     ctx: Context,
     guest_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_api_clients(
     ctx: Context,
     client_id: str | None = None,
@@ -68,7 +68,7 @@ async def clearpass_get_api_clients(
         return f"Error fetching API clients: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_local_users(
     ctx: Context,
     local_user_id: str | None = None,
@@ -106,7 +106,7 @@ async def clearpass_get_local_users(
         return f"Error fetching local users: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_static_host_lists(
     ctx: Context,
     static_host_list_id: str | None = None,
@@ -145,7 +145,7 @@ async def clearpass_get_static_host_lists(
         return f"Error fetching static host lists: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_devices(
     ctx: Context,
     device_id: str | None = None,
@@ -182,7 +182,7 @@ async def clearpass_get_devices(
         return f"Error fetching devices: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_deny_listed_users(
     ctx: Context,
     deny_listed_users_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_extensions(
     ctx: Context,
     extension_id: str | None = None,
@@ -73,7 +73,7 @@ async def clearpass_get_extensions(
         return f"Error fetching extensions: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_syslog_targets(
     ctx: Context,
     syslog_target_id: str | None = None,
@@ -106,7 +106,7 @@ async def clearpass_get_syslog_targets(
         return f"Error fetching syslog targets: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_syslog_export_filters(
     ctx: Context,
     syslog_export_filter_id: str | None = None,
@@ -141,7 +141,7 @@ async def clearpass_get_syslog_export_filters(
         return f"Error fetching syslog export filters: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_event_sources(
     ctx: Context,
     event_sources_id: str | None = None,
@@ -174,7 +174,7 @@ async def clearpass_get_event_sources(
         return f"Error fetching event sources: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_context_servers(
     ctx: Context,
     context_server_action_id: str | None = None,
@@ -209,7 +209,7 @@ async def clearpass_get_context_servers(
         return f"Error fetching context server actions: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_endpoint_context_servers(
     ctx: Context,
     endpoint_context_server_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_access_controls(
     ctx: Context,
     server_uuid: str,
@@ -38,7 +38,7 @@ async def clearpass_get_access_controls(
         return f"Error fetching access controls: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_ad_domains(
     ctx: Context,
     server_uuid: str,
@@ -67,7 +67,7 @@ async def clearpass_get_ad_domains(
         return f"Error fetching AD domains: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_server_version(
     ctx: Context,
     uuid: str | None = None,
@@ -94,7 +94,7 @@ async def clearpass_get_server_version(
         return f"Error fetching server version: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_fips_status(
     ctx: Context,
 ) -> dict | str:
@@ -111,7 +111,7 @@ async def clearpass_get_fips_status(
         return f"Error fetching FIPS status: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_server_services(
     ctx: Context,
     server_uuid: str,
@@ -140,7 +140,7 @@ async def clearpass_get_server_services(
         return f"Error fetching server services: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_server_snmp(
     ctx: Context,
     server_uuid: str,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -17,36 +17,17 @@ _REPORT_ACTIONS = ("create", "delete", "enable", "disable", "run")
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive audit actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_insight_alert(
     ctx: Context,
     action_type: Annotated[
@@ -116,7 +97,7 @@ def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str
     return f"Unhandled action_type: {action_type}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_insight_report(
     ctx: Context,
     action_type: Annotated[
@@ -182,7 +163,7 @@ def _execute_report_action(client, action_type: str, payload: dict, report_id: s
     return f"Unhandled action_type: {action_type}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_create_system_event(
     ctx: Context,
     source: Annotated[str, Field(description="Event source (e.g. 'MCP Server', 'Admin').")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,36 +16,17 @@ _SOURCE_ACTIONS = ("create", "update", "delete", "configure_backup", "configure_
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive auth actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID or name for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_auth_source(
     ctx: Context,
     action_type: Annotated[
@@ -129,7 +110,7 @@ def _execute_auth_source_action(
     return client._send_request(f"/auth-source/name/{name}", "patch", query=payload)
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_auth_method(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -22,36 +22,17 @@ _CERT_ACTIONS = (
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive certificate actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} certificate '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of certificate '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} certificate '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_certificate(
     ctx: Context,
     action_type: Annotated[
@@ -158,7 +139,7 @@ def _execute_cert_action(
     return f"Unhandled action_type: {action_type}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_create_csr(
     ctx: Context,
     payload: Annotated[

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
@@ -7,13 +7,13 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_endpoint(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -43,21 +43,9 @@ async def clearpass_manage_endpoint(
 
     if action_type != "create" and not confirmed:
         identifier = endpoint_id or mac_address or "unknown"
-        elicit = await elicitation_handler(
-            message=f"ClearPass: {action_type} endpoint '{identifier}'. Confirm?",
-            ctx=ctx,
-        )
-        if elicit.action == "decline":
-            mode = await ctx.get_state("elicitation_mode")
-            if mode == "chat_confirm":
-                return {
-                    "status": "confirmation_required",
-                    "message": f"Please confirm {action_type} of endpoint '{identifier}'. "
-                    "Call this tool again with confirmed=true after the user confirms.",
-                }
-            return {"message": "Action declined by user."}
-        elif elicit.action == "cancel":
-            return {"message": "Action canceled by user."}
+        decline = await confirm_write(ctx, f"ClearPass: {action_type} endpoint '{identifier}'. Confirm?")
+        if decline:
+            return decline
 
     try:
         from pyclearpass.api_identities import ApiIdentities

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
@@ -7,43 +7,24 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive enforcement actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID or name for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_enforcement_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -93,7 +74,7 @@ async def clearpass_manage_enforcement_policy(
         return f"Error managing enforcement policy: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_enforcement_profile(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
@@ -7,43 +7,24 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive guest config actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID or name for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} guest config '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} guest config '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_pass_template(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -88,7 +69,7 @@ async def clearpass_manage_pass_template(
         return f"Error managing pass template: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_print_template(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -132,7 +113,7 @@ async def clearpass_manage_print_template(
         return f"Error managing print template: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_weblogin_page(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -181,7 +162,7 @@ async def clearpass_manage_weblogin_page(
         return f"Error managing weblogin page: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_guest_settings(
     ctx: Context,
     setting_type: Annotated[str, Field(description="Setting type: 'authentication' or 'manager'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -7,43 +7,24 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive guest actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Guest ID or username for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} guest '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of guest '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} guest '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_guest_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -90,7 +71,7 @@ async def clearpass_manage_guest_user(
         return f"Error managing guest user: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_send_guest_credentials(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to send credentials for.")],
@@ -121,7 +102,7 @@ async def clearpass_send_guest_credentials(
         return f"Error sending guest credentials: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_generate_guest_pass(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to generate pass for.")],
@@ -153,7 +134,7 @@ async def clearpass_generate_guest_pass(
         return f"Error generating guest pass: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_process_sponsor_action(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to process sponsor action for.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,40 +16,17 @@ from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 async def _confirm_write(
     ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
 ) -> dict | None:
-    """Handle confirmation for destructive actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        resource: Resource type name for display.
-        identifier: Resource ID or name for display.
-        confirmed: Whether the user already confirmed.
-
-    Returns:
-        Error dict if declined/canceled, None if confirmed.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
-    if action_type == "create" or confirmed:
-        return None
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} {resource} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of {resource} '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_api_client(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -85,7 +62,7 @@ async def clearpass_manage_api_client(
         return f"Error managing API client: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_local_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -126,7 +103,7 @@ async def clearpass_manage_local_user(
         return f"Error managing local user: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_static_host_list(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -171,7 +148,7 @@ async def clearpass_manage_static_host_list(
         return f"Error managing static host list: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_device(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -212,7 +189,7 @@ async def clearpass_manage_device(
         return f"Error managing device: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_deny_listed_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create' or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,40 +16,17 @@ from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 async def _confirm_write(
     ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
 ) -> dict | None:
-    """Handle confirmation for destructive actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        resource: Resource type name for display.
-        identifier: Resource ID or name for display.
-        confirmed: Whether the user already confirmed.
-
-    Returns:
-        Error dict if declined/canceled, None if confirmed.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
-    if confirmed:
-        return None
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} {resource} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of {resource} '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_extension(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'start', 'stop', 'restart', or 'delete'.")],
@@ -84,7 +61,7 @@ async def clearpass_manage_extension(
         return f"Error managing extension: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_syslog_target(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -125,7 +102,7 @@ async def clearpass_manage_syslog_target(
         return f"Error managing syslog target: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_syslog_export_filter(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -174,7 +151,7 @@ async def clearpass_manage_syslog_export_filter(
         return f"Error managing syslog export filter: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_endpoint_context_server(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', or 'trigger_poll'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,40 +16,17 @@ from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 async def _confirm_write(
     ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
 ) -> dict | None:
-    """Handle confirmation for destructive actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        resource: Resource type name for display.
-        identifier: Resource ID or name for display.
-        confirmed: Whether the user already confirmed.
-
-    Returns:
-        Error dict if declined/canceled, None if confirmed.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
-    if confirmed:
-        return None
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} {resource} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of {resource} '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_access_control(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'update' or 'delete'.")],
@@ -85,7 +62,7 @@ async def clearpass_manage_access_control(
         return f"Error managing access control: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_ad_domain(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'join', 'leave', or 'configure_password_servers'.")],
@@ -128,7 +105,7 @@ async def clearpass_manage_ad_domain(
         return f"Error managing AD domain: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_cluster_server(
     ctx: Context,
     server_uuid: Annotated[str, Field(description="Server UUID to update.")],
@@ -154,7 +131,7 @@ async def clearpass_manage_cluster_server(
         return f"Error managing cluster server: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_server_service(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'start' or 'stop'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -45,37 +45,17 @@ async def _resolve_device_id(client, device_id: str | None, name: str | None) ->
 
 
 async def _confirm_action(ctx: Context, action_type: str, device_id: str | None, name: str | None) -> dict | None:
-    """Request user confirmation for destructive actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        device_id: Device ID for display.
-        name: Device name for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     identifier = device_id or name or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} network device '{identifier}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of network device '{identifier}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} network device '{identifier}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_network_device(
     ctx: Context,
     action_type: Annotated[

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,40 +16,17 @@ from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 async def _confirm_write(
     ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
 ) -> dict | None:
-    """Handle confirmation for destructive actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        resource: Resource type name for display.
-        identifier: Resource ID or name for display.
-        confirmed: Whether the user already confirmed.
-
-    Returns:
-        Error dict if declined/canceled, None if confirmed.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
-    if action_type == "create" or confirmed:
-        return None
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} {resource} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of {resource} '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_service(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', 'enable', or 'disable'.")],
@@ -100,7 +77,7 @@ async def clearpass_manage_service(
         return f"Error managing service: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_device_group(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -149,7 +126,7 @@ async def clearpass_manage_device_group(
         return f"Error managing device group: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_posture_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -192,7 +169,7 @@ async def clearpass_manage_posture_policy(
         return f"Error managing posture policy: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_proxy_target(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -233,7 +210,7 @@ async def clearpass_manage_proxy_target(
         return f"Error managing proxy target: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_radius_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', 'enable', or 'disable'.")],
@@ -294,7 +271,7 @@ async def clearpass_manage_radius_dictionary(
         return f"Error managing RADIUS dictionary: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_tacacs_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -341,7 +318,7 @@ async def clearpass_manage_tacacs_dictionary(
         return f"Error managing TACACS dictionary: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_application_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
@@ -7,43 +7,24 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Request user confirmation for destructive role actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation being performed.
-        identifier: Item ID or name for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} of '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_role(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -94,7 +75,7 @@ async def clearpass_manage_role(
         return f"Error managing role: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_role_mapping(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,40 +16,17 @@ from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 async def _confirm_write(
     ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
 ) -> dict | None:
-    """Handle confirmation for update/delete actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action_type: The operation being performed.
-        resource: Resource type name for display.
-        identifier: Resource ID or name for display.
-        confirmed: Whether the user already confirmed.
-
-    Returns:
-        Error dict if declined/canceled, None if confirmed.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
-    if action_type == "create" or confirmed:
-        return None
     label = identifier or "unknown"
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action_type} {resource} '{label}'. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action_type} of {resource} '{label}'. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_admin_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -82,7 +59,7 @@ async def clearpass_manage_admin_user(
         return f"Error managing admin user: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_admin_privilege(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -115,7 +92,7 @@ async def clearpass_manage_admin_privilege(
         return f"Error managing admin privilege: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_operator_profile(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -152,7 +129,7 @@ async def clearpass_manage_operator_profile(
         return f"Error managing operator profile: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_license(
     ctx: Context,
     action_type: Annotated[
@@ -186,7 +163,7 @@ async def clearpass_manage_license(
         return f"Error managing license: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_cluster_params(
     ctx: Context,
     payload: Annotated[dict, Field(description="Cluster parameters config payload.")],
@@ -205,7 +182,7 @@ async def clearpass_manage_cluster_params(
         return f"Error managing cluster parameters: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_password_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'update_admin' or 'update_local'.")],
@@ -229,7 +206,7 @@ async def clearpass_manage_password_policy(
         return f"Error managing password policy: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_attribute(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -262,7 +239,7 @@ async def clearpass_manage_attribute(
         return f"Error managing attribute: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_data_filter(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -295,7 +272,7 @@ async def clearpass_manage_data_filter(
         return f"Error managing data filter: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_file_backup_server(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -336,7 +313,7 @@ async def clearpass_manage_file_backup_server(
         return f"Error managing file backup server: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_messaging_setup(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -362,7 +339,7 @@ async def clearpass_manage_messaging_setup(
         return f"Error managing messaging setup: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_snmp_trap_receiver(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -403,7 +380,7 @@ async def clearpass_manage_snmp_trap_receiver(
         return f"Error managing SNMP trap receiver: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_manage_policy_manager_zone(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
 
@@ -16,37 +16,17 @@ _VALID_TARGETS = ("session_id", "username", "mac", "ip", "bulk")
 
 
 async def _confirm_session_action(ctx: Context, action: str, target_type: str, target: str | None) -> dict | None:
-    """Request user confirmation for session control actions.
+    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
 
-    Args:
-        ctx: FastMCP context.
-        action: The operation (disconnect or CoA).
-        target_type: Target type (session_id, username, mac, ip, bulk).
-        target: Target value for display.
-
-    Returns:
-        Error dict if declined/canceled, None if accepted.
+    Kept as a local helper so existing call sites don't change; the
+    shared elicitation/decline/cancel logic now lives in the middleware
+    (#148).
     """
     label = f"{target_type}={target}" if target else target_type
-    elicit = await elicitation_handler(
-        message=f"ClearPass: {action} session for {label}. Confirm?",
-        ctx=ctx,
-    )
-    if elicit.action == "decline":
-        mode = await ctx.get_state("elicitation_mode")
-        if mode == "chat_confirm":
-            return {
-                "status": "confirmation_required",
-                "message": f"Please confirm {action} for {label}. "
-                "Call this tool again with confirmed=true after the user confirms.",
-            }
-        return {"message": "Action declined by user."}
-    elif elicit.action == "cancel":
-        return {"message": "Action canceled by user."}
-    return None
+    return await confirm_write(ctx, f"ClearPass: {action} session for {label}. Confirm?")
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_disconnect_session(
     ctx: Context,
     target_type: Annotated[str, Field(description="Target type: 'session_id', 'username', 'mac', 'ip', or 'bulk'.")],
@@ -104,7 +84,7 @@ async def clearpass_disconnect_session(
         return f"Error disconnecting session: {e}"
 
 
-@mcp.tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
 async def clearpass_perform_coa(
     ctx: Context,
     target_type: Annotated[str, Field(description="Target type: 'session_id', 'username', 'mac', 'ip', or 'bulk'.")],

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_network_devices(
     ctx: Context,
     device_id: str | None = None,
@@ -72,7 +72,7 @@ async def clearpass_get_network_devices(
         return f"Error fetching network devices: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_network_device_stats(
     ctx: Context,
     device_id: str,
@@ -94,7 +94,7 @@ async def clearpass_get_network_device_stats(
         return f"Error fetching network device stats: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_test_device_connectivity(
     ctx: Context,
     device_id: str,
@@ -121,7 +121,7 @@ async def clearpass_test_device_connectivity(
         return f"Error fetching device for connectivity review: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_validate_device_config(
     ctx: Context,
     device_id: str,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_services(
     ctx: Context,
     config_service_id: str | None = None,
@@ -72,7 +72,7 @@ async def clearpass_get_services(
         return f"Error fetching services: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_posture_policies(
     ctx: Context,
     posture_policy_id: str | None = None,
@@ -109,7 +109,7 @@ async def clearpass_get_posture_policies(
         return f"Error fetching posture policies: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_device_groups(
     ctx: Context,
     network_device_group_id: str | None = None,
@@ -148,7 +148,7 @@ async def clearpass_get_device_groups(
         return f"Error fetching device groups: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_proxy_targets(
     ctx: Context,
     proxy_target_id: str | None = None,
@@ -185,7 +185,7 @@ async def clearpass_get_proxy_targets(
         return f"Error fetching proxy targets: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_radius_dictionaries(
     ctx: Context,
     radius_dictionary_id: str | None = None,
@@ -224,7 +224,7 @@ async def clearpass_get_radius_dictionaries(
         return f"Error fetching RADIUS dictionaries: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_tacacs_dictionaries(
     ctx: Context,
     tacacs_service_dictionary_id: str | None = None,
@@ -263,7 +263,7 @@ async def clearpass_get_tacacs_dictionaries(
         return f"Error fetching TACACS+ dictionaries: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_application_dictionaries(
     ctx: Context,
     application_dictionary_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_roles(
     ctx: Context,
     role_id: str | None = None,
@@ -52,7 +52,7 @@ async def clearpass_get_roles(
         return f"Error fetching roles: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_role_mappings(
     ctx: Context,
     role_mapping_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
@@ -35,7 +35,7 @@ def _build_query_string(
     return "?" + "&".join(p for p in params if p)
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_admin_users(
     ctx: Context,
     admin_user_id: str | None = None,
@@ -68,7 +68,7 @@ async def clearpass_get_admin_users(
         return f"Error fetching admin users: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_admin_privileges(
     ctx: Context,
     admin_privilege_id: str | None = None,
@@ -103,7 +103,7 @@ async def clearpass_get_admin_privileges(
         return f"Error fetching admin privileges: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_operator_profiles(
     ctx: Context,
     filter: str | None = None,
@@ -131,7 +131,7 @@ async def clearpass_get_operator_profiles(
         return f"Error fetching operator profiles: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_licenses(
     ctx: Context,
     license_id: str | None = None,
@@ -155,7 +155,7 @@ async def clearpass_get_licenses(
         return f"Error fetching licenses: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_cluster_params(
     ctx: Context,
 ) -> dict | str:
@@ -173,7 +173,7 @@ async def clearpass_get_cluster_params(
         return f"Error fetching cluster parameters: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_password_policies(
     ctx: Context,
 ) -> dict | str:
@@ -195,7 +195,7 @@ async def clearpass_get_password_policies(
         return f"Error fetching password policies: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_attributes(
     ctx: Context,
     attribute_id: str | None = None,
@@ -228,7 +228,7 @@ async def clearpass_get_attributes(
         return f"Error fetching attributes: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_data_filters(
     ctx: Context,
     data_filter_id: str | None = None,
@@ -261,7 +261,7 @@ async def clearpass_get_data_filters(
         return f"Error fetching data filters: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_file_backup_servers(
     ctx: Context,
     file_backup_server_id: str | None = None,
@@ -296,7 +296,7 @@ async def clearpass_get_file_backup_servers(
         return f"Error fetching file backup servers: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_messaging_setup(
     ctx: Context,
 ) -> dict | str:
@@ -314,7 +314,7 @@ async def clearpass_get_messaging_setup(
         return f"Error fetching messaging setup: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_snmp_trap_receivers(
     ctx: Context,
     snmp_trap_receiver_id: str | None = None,
@@ -349,7 +349,7 @@ async def clearpass_get_snmp_trap_receivers(
         return f"Error fetching SNMP trap receivers: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_policy_manager_zones(
     ctx: Context,
     policy_manager_zones_id: str | None = None,
@@ -384,7 +384,7 @@ async def clearpass_get_policy_manager_zones(
         return f"Error fetching Policy Manager zones: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_oauth_privileges(
     ctx: Context,
 ) -> dict | str:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_sessions(
     ctx: Context,
     session_id: str | None = None,
@@ -48,7 +48,7 @@ async def clearpass_get_sessions(
         return f"Error fetching sessions: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_session_action_status(
     ctx: Context,
     action_id: str,
@@ -70,7 +70,7 @@ async def clearpass_get_session_action_status(
         return f"Error fetching session action status: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_get_reauth_profiles(
     ctx: Context,
     session_id: str,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from fastmcp import Context
 
-from hpe_networking_mcp.platforms.clearpass._registry import mcp
+from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_generate_random_password(
     ctx: Context,
     type: str = "password",
@@ -33,7 +33,7 @@ async def clearpass_generate_random_password(
         return f"Error generating random password: {e}"
 
 
-@mcp.tool(annotations=READ_ONLY)
+@tool(annotations=READ_ONLY)
 async def clearpass_test_connection(
     ctx: Context,
 ) -> dict | str:

--- a/tests/unit/test_clearpass_dynamic_mode.py
+++ b/tests/unit/test_clearpass_dynamic_mode.py
@@ -1,0 +1,66 @@
+"""Integration-style unit tests for the ClearPass dynamic-mode migration (#161).
+
+Mirrors the Apstra / Mist / Central tests. Imports every ClearPass tool module
+against the stubbed mcp (installed in ``tests/conftest.py``) and asserts the
+shared registry ends up populated with the expected specs.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, clear_registry
+
+
+@pytest.fixture
+def clearpass_registry_populated():
+    """Import every ClearPass tool module so ``REGISTRIES['clearpass']`` is full."""
+    clear_registry("clearpass")
+    from hpe_networking_mcp.platforms.clearpass import TOOLS
+
+    for category in TOOLS:
+        module = importlib.import_module(f"hpe_networking_mcp.platforms.clearpass.tools.{category}")
+        importlib.reload(module)
+    yield REGISTRIES["clearpass"]
+    clear_registry("clearpass")
+
+
+@pytest.mark.unit
+class TestClearPassRegistryPopulation:
+    def test_registry_contains_all_tools(self, clearpass_registry_populated):
+        """Every ClearPass tool listed in platforms.clearpass.TOOLS registers cleanly."""
+        from hpe_networking_mcp.platforms.clearpass import TOOLS
+
+        expected = {name for names in TOOLS.values() for name in names}
+        actual = set(clearpass_registry_populated.keys())
+        assert actual == expected, f"Mismatch — missing: {expected - actual}, extra: {actual - expected}"
+
+    def test_expected_surface_size(self, clearpass_registry_populated):
+        """ClearPass is the largest single platform (>= 125 tools)."""
+        assert len(clearpass_registry_populated) >= 125
+
+    def test_write_tools_carry_write_delete_tag(self, clearpass_registry_populated):
+        """Spot-check: key destructive tools carry the gating tag."""
+        for name in (
+            "clearpass_manage_role",
+            "clearpass_disconnect_session",
+            "clearpass_perform_coa",
+            "clearpass_manage_endpoint",
+        ):
+            assert "clearpass_write_delete" in clearpass_registry_populated[name].tags
+
+    def test_read_tool_has_no_write_tag(self, clearpass_registry_populated):
+        read = clearpass_registry_populated["clearpass_get_sessions"]
+        assert "clearpass_write_delete" not in read.tags
+
+    def test_categories_derived_from_module_names(self, clearpass_registry_populated):
+        assert clearpass_registry_populated["clearpass_get_sessions"].category == "sessions"
+        assert clearpass_registry_populated["clearpass_manage_role"].category == "manage_roles"
+        assert clearpass_registry_populated["clearpass_get_endpoints"].category == "endpoints"
+        assert clearpass_registry_populated["clearpass_test_connection"].category == "utilities"
+
+    def test_descriptions_are_populated(self, clearpass_registry_populated):
+        for name, spec in clearpass_registry_populated.items():
+            assert spec.description, f"{name} has empty description"


### PR DESCRIPTION
Part of umbrella [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157). **Closes [#161](https://github.com/nowireless4u/hpe-networking-mcp/issues/161) and [#148](https://github.com/nowireless4u/hpe-networking-mcp/issues/148)** (ClearPass half of confirm_write; Apstra half landed in Phase 0 PR B).

Fourth and **largest** platform migrated to dynamic mode — ClearPass's 127 tools across 31 files collapse to 3 meta-tools. Same pattern as Apstra, Mist, Central. No tag, no release per the Phase-PR release strategy.

## User impact

- **Static mode (default):** no change. All 127 \`clearpass_*\` tools remain visible.
- **Dynamic mode (\`MCP_TOOL_MODE=dynamic\`):** ClearPass's tool surface collapses to **3 meta-tools** (\`clearpass_list_tools\`, \`clearpass_get_tool_schema\`, \`clearpass_invoke_tool\`). Underlying tools remain dispatchable via the meta-tools; they're hidden from the model's direct tool list by the shared \`Visibility\` transform.

## Changes

- [\`clearpass/_registry.py\`](src/hpe_networking_mcp/platforms/clearpass/_registry.py) rewritten as a \`tool()\` decorator shim mirroring the other three platforms.
- 31 tool files under \`clearpass/tools/\` — mechanical \`@mcp.tool(...)\` → \`@tool(...)\` swap.
- [\`clearpass/__init__.py\`](src/hpe_networking_mcp/platforms/clearpass/__init__.py) — always imports every category; calls \`build_meta_tools\` when \`tool_mode == "dynamic"\`. Dropped the \`WRITE_CATEGORIES\` skip logic.

## `confirm_write` consolidation (finishes #148)

15 ClearPass write tools had identical or near-identical 12-line confirmation helpers. All 15 now delegate to \`middleware.elicitation.confirm_write()\` — 14 as thin named wrappers (\`_confirm_write\`, \`_confirm_session_action\`) preserving call sites, 1 inlined (\`manage_endpoints.py\`). Combined with the 3 Apstra helpers consolidated in Phase 0 PR B, the #148 work is complete — no ClearPass or Apstra file carries its own elicitation decision logic anymore.

## Boot verification (Docker)

\`\`\`
static mode:  127 clearpass_* tools visible.
dynamic mode: 3 meta-tools per platform across 4 migrated platforms (12 total)
              + cross-platform health tool. Every underlying tool hidden.
\`\`\`

## Test plan
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run ruff format --check .\` — clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — **415/415 passing** (6 new tests in \`test_clearpass_dynamic_mode.py\`)

## Files
- **Modified:** 37 files (31 tool files + registry + \`__init__.py\`, plus \`CHANGELOG.md\`, \`TOOLS.md\`, \`MIGRATING_TO_V2.md\`)
- **Created:** \`tests/unit/test_clearpass_dynamic_mode.py\`

**Net lines: +457 / -585** — the confirm_write consolidation alone removed ~190 lines of duplicated elicitation logic across ClearPass.

## Closes
- #161 — ClearPass dynamic-mode migration
- #148 — consolidate duplicated _confirm() helpers (both Apstra and ClearPass now done)

## Next
**Phase 4 (#162)** — GreenLake unification. GreenLake already has its own dynamic-mode implementation (3 endpoint-dispatch meta-tools from v0.9.x); Phase 4 unifies it with the new shared pattern.