### PR TITLE
v2.0.0.1 hotfix: thread ctx explicitly through every Mist tool (closes #179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0.1] - 2026-04-24
+
+**Hotfix for a critical v2.0.0.0 regression.** Every Mist tool invocation through `mist_invoke_tool` failed in dynamic mode with `TypeError: got multiple values for argument 'action_type'` (or the equivalent for whichever parameter was the tool's actual first positional argument). Reported separately by Seth and Zach during v2.0 live testing. Fixes [#179](https://github.com/nowireless4u/hpe-networking-mcp/issues/179).
+
+### Root cause
+
+`_common/meta_tools.py::_invoke_tool` dispatches tool calls as `spec.func(ctx, **safe_params)` — `ctx: Context` is passed positionally. Central, ClearPass, GreenLake, and Apstra tools all accept `ctx` as their first parameter, so the dispatch is correct. Mist tools, however, were ported from Thomas Munzer's upstream `mistmcp` project, which uses FastMCP's `get_context()` helper inside `get_apisession()` instead of accepting `ctx` explicitly. The wrapper's positional `ctx` collided with the tool's real first parameter.
+
+In static mode this isn't a problem because FastMCP's `@mcp.tool` decorator handles `ctx` injection internally — the bug only surfaces through the dynamic-mode meta-tool dispatch path.
+
+### Fixed
+
+- **`platforms/mist/client.py`** — `get_apisession(ctx)` and `validate_org_id(ctx, org_id)` now take `ctx: Context` explicitly. `process_response` and `handle_network_error` kept their existing signatures; the two `ctx.error()` calls in `process_response` were swapped for `logger.error` to avoid having to thread ctx through ~300 call sites just to surface identical information that's already in the raised `ToolError`. Matches Central's pattern where helpers only take ctx when they need `lifespan_context` access.
+- **35 Mist tool files** under `platforms/mist/tools/` — every `@tool(...)`-decorated `async def` now accepts `ctx: Context` as its first parameter. All `get_apisession()` and `validate_org_id(...)` call sites updated to pass `ctx`. Imports of `from fastmcp.server.dependencies import get_context` removed; imports of `from fastmcp import Context` added.
+- **New regression test** `tests/unit/test_invoke_tool_dispatch.py` — parametrized over all 5 platforms, uses `inspect.signature()` to assert every registered tool's first parameter is `ctx: Context`. This is the exact invariant `_invoke_tool` relies on. Would have caught the v2.0.0.0 bug at test time. Total suite: 458 tests passing (453 → 458, +5 new).
+
+### Deferred to a follow-up
+
+Mist still uses a different **module-organization convention** than the other four platforms (one-tool-per-file under `platforms/mist/tools/` vs. one-module-per-category elsewhere). Re-organizing those 35 files into ~15 category modules is planned for a later release — not in this hotfix so that Seth and Zach get the dispatch fix immediately.
+
+### Users affected
+
+Anyone on `v2.0.0.0` with `MCP_TOOL_MODE=dynamic` (the default) who tried to use Mist tools. Workaround until `v2.0.0.1` rolls out: set `MCP_TOOL_MODE=static` in `docker-compose.yml` to restore direct tool visibility (v1.x-style surface — every underlying tool advertised individually, avoiding the meta-tool wrapper path).
+
+Closes [#179](https://github.com/nowireless4u/hpe-networking-mcp/issues/179).
+
+---
+
 ## [2.0.0.0] - 2026-04-23
 
 **Major release.** Default tool-exposure mode flipped from `static` to `dynamic`. The exposed tool surface drops from 261 tools to 18 without removing any underlying functionality — every platform tool is still here and still invokable, but now discovered on demand via three meta-tools per platform. Resolves the context-budget problem on 32K-context local LLMs (Zach Jennings' original report, [#163](https://github.com/nowireless4u/hpe-networking-mcp/issues/163)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.0"
+version = "2.0.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/mist/client.py
+++ b/src/hpe_networking_mcp/platforms/mist/client.py
@@ -1,11 +1,20 @@
-"""Mist API client — session management, response processing, and formatting."""
+"""Mist API client — session management, response processing, and formatting.
+
+Every public helper takes ``ctx: Context`` explicitly. This matches the
+pattern used by every other platform (Central, ClearPass, GreenLake,
+Apstra) and is a hard prerequisite for dynamic-mode ``mist_invoke_tool``
+dispatch, which passes ``ctx`` positionally to the tool function.
+v2.0.0.0 shipped with Mist tools inheriting the upstream mistmcp style
+that relied on ``get_context()`` internally, which broke meta-tool
+invocation in v2.0 dynamic mode (see CHANGELOG 2.0.0.1).
+"""
 
 import contextlib
 import json
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from fastmcp.server.dependencies import get_context
 from loguru import logger
 from mistapi.__api_response import APIResponse
 
@@ -20,13 +29,15 @@ STATUS_MESSAGES = {
 }
 
 
-async def get_apisession() -> tuple[mistapi.APISession, str]:
+async def get_apisession(ctx: Context) -> tuple[mistapi.APISession, str]:
     """Get the Mist API session from the lifespan context.
+
+    Args:
+        ctx: FastMCP tool-invocation context.
 
     Returns:
         Tuple of (APISession, response_format)
     """
-    ctx = get_context()
     session = ctx.lifespan_context.get("mist_session")
     if session is None:
         raise ToolError(
@@ -43,7 +54,7 @@ async def get_apisession() -> tuple[mistapi.APISession, str]:
     return session, "json"
 
 
-def validate_org_id(org_id: str) -> str:
+def validate_org_id(ctx: Context, org_id: str) -> str:
     """Validate an org_id against the token's actual org_id.
 
     If the org_id doesn't match the token's org, raises a ToolError
@@ -51,12 +62,12 @@ def validate_org_id(org_id: str) -> str:
     extra API call.
 
     Args:
+        ctx: FastMCP tool-invocation context.
         org_id: The org_id provided by the AI.
 
     Returns:
         The validated org_id (may be corrected).
     """
-    ctx = get_context()
     correct_org_id = ctx.lifespan_context.get("mist_org_id")
     if correct_org_id and str(org_id) != str(correct_org_id):
         raise ToolError(
@@ -68,7 +79,13 @@ def validate_org_id(org_id: str) -> str:
 
 
 async def process_response(response: APIResponse) -> None:
-    """Validate an API response and raise ToolError on failure."""
+    """Validate an API response and raise ToolError on failure.
+
+    Does not take ``ctx`` — the helper doesn't need lifespan-context
+    state. Errors are surfaced to the AI via the raised ``ToolError``'s
+    message; a loguru ``logger.error`` call writes the same detail to
+    the server's stderr log for operator visibility.
+    """
     if response.status_code is None:
         raise ToolError(
             {
@@ -78,9 +95,8 @@ async def process_response(response: APIResponse) -> None:
         )
     if response.status_code == 200:
         return
-    ctx = get_context()
     if response.status_code == 403:
-        await ctx.error(f"Got HTTP{response.status_code} with details {response.data}")
+        logger.error("Mist API HTTP {} — {}", response.status_code, response.data)
         raise ToolError(
             {
                 "status_code": 403,
@@ -94,17 +110,21 @@ async def process_response(response: APIResponse) -> None:
         )
     api_error: dict = {"status_code": response.status_code, "message": ""}
     if response.data:
-        await ctx.error(f"Got HTTP{response.status_code} with details {response.data}")
+        logger.error("Mist API HTTP {} — {}", response.status_code, response.data)
         api_error["message"] = json.dumps(response.data)
     else:
         message = STATUS_MESSAGES.get(response.status_code or 0, "Unknown error")
-        await ctx.error(f"Got HTTP{response.status_code}")
+        logger.error("Mist API HTTP {}", response.status_code)
         api_error["message"] = json.dumps(message)
     raise ToolError(api_error)
 
 
 async def handle_network_error(exc: Exception) -> None:
-    """Convert network-level exceptions to clean ToolError messages."""
+    """Convert network-level exceptions to clean ToolError messages.
+
+    Does not take ``ctx`` — no lifespan-context state needed. The
+    exception type and message are embedded in the raised ``ToolError``.
+    """
     raise ToolError(
         {
             "status_code": 503,

--- a/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/bounce_switch_port.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -110,6 +111,7 @@ def _check_mist_ports(
     },
 )
 async def bounce_switch_port(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     device_id: Annotated[
         UUID,
@@ -141,7 +143,7 @@ async def bounce_switch_port(
         port_list,
     )
 
-    apisession, _response_format = await get_apisession()
+    apisession, _response_format = await get_apisession(ctx)
 
     # Safety check: verify port status before bouncing
     safe_ports, skipped = _check_mist_ports(apisession, str(site_id), str(device_id), port_list)

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_org_configuration_objects.py
@@ -104,6 +104,7 @@ class Action_type(Enum):
     },
 )
 async def change_org_configuration_objects(
+    ctx: Context,
     action_type: Annotated[
         Action_type,
         Field(
@@ -147,7 +148,6 @@ async def change_org_configuration_objects(
             default=None,
         ),
     ],
-    ctx: Context,
     confirmed: Annotated[
         bool,
         Field(
@@ -167,7 +167,7 @@ async def change_org_configuration_objects(
         object_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     action_wording = "create a new"
     if action_type == Action_type.UPDATE:

--- a/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/change_site_configuration_objects.py
@@ -76,6 +76,7 @@ class Action_type(Enum):
     },
 )
 async def change_site_configuration_objects(
+    ctx: Context,
     action_type: Annotated[
         Action_type,
         Field(
@@ -119,7 +120,6 @@ async def change_site_configuration_objects(
             default=None,
         ),
     ],
-    ctx: Context,
     confirmed: Annotated[
         bool,
         Field(
@@ -139,7 +139,7 @@ async def change_site_configuration_objects(
         object_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     action_wording = "create a new"
     if action_type == Action_type.UPDATE:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_ap_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_ap_details.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -31,6 +32,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_ap_details(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     device_id: Annotated[
         UUID,
@@ -48,7 +50,7 @@ async def get_ap_details(
         device_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.sites.devices.getSiteDevice(

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
@@ -13,6 +13,7 @@
 from enum import Enum
 from typing import Annotated, Any
 
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -99,6 +100,7 @@ def _compact_schema(schema: dict) -> dict:
     },
 )
 async def get_configuration_object_schema(
+    ctx: Context,
     schema_name: Annotated[
         SchemaName,
         Field(description=("Name of the configuration object schema to retrieve.")),
@@ -125,7 +127,7 @@ async def get_configuration_object_schema(
         verbose,
     )
 
-    _, response_format = await get_apisession()
+    _, response_format = await get_apisession(ctx)
 
     entry = _SCHEMAS_DATA.get(schema_name.value)
     if entry is None:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_objects.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from mistapi.__api_response import APIResponse as _APIResponse
@@ -144,6 +145,7 @@ def _name_id_list(data: list) -> list:
     },
 )
 async def get_configuration_objects(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     object_type: Annotated[
         Object_type,
@@ -230,8 +232,8 @@ async def get_configuration_objects(
         limit,
     )
 
-    validate_org_id(str(org_id))
-    apisession, response_format = await get_apisession()
+    validate_org_id(ctx, str(org_id))
+    apisession, response_format = await get_apisession(ctx)
 
     response = None
     try:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Annotated
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -60,6 +61,7 @@ class Object_type(Enum):
     },
 )
 async def get_constants(
+    ctx: Context,
     object_type: Annotated[
         Object_type,
         Field(
@@ -79,7 +81,7 @@ async def get_constants(
     logger.debug("Tool get_constants called")
     logger.debug("Input Parameters: object_type: %s", object_type)
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         match object_type.value:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_gateway_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_gateway_details.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -32,6 +33,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_gateway_details(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     device_id: Annotated[
         UUID,
@@ -49,7 +51,7 @@ async def get_gateway_details(
         device_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.sites.devices.getSiteDevice(

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -50,6 +51,7 @@ class Object_type(Enum):
     },
 )
 async def get_insight_metrics(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     object_type: Annotated[
         Object_type,
@@ -148,7 +150,7 @@ async def get_insight_metrics(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         match object_type.value:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_next_page.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_next_page.py
@@ -12,6 +12,7 @@
 
 from typing import Annotated
 
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -38,6 +39,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_next_page(
+    ctx: Context,
     url: Annotated[
         str,
         Field(description="The '_next' URL from a previous response"),
@@ -47,7 +49,7 @@ async def get_next_page(
 
     logger.debug("Tool get_next_page called")
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = apisession.mist_get(url)

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_licenses.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_licenses.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -47,6 +48,7 @@ class Response_type(Enum):
     },
 )
 async def get_org_licenses(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     response_type: Annotated[
         Response_type,
@@ -73,7 +75,7 @@ async def get_org_licenses(
         response_type,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = response_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -46,6 +47,7 @@ class Info_type(Enum):
     },
 )
 async def get_org_or_site_info(
+    ctx: Context,
     info_type: Annotated[
         Info_type,
         Field(description=("Type of information to search for. Possible values are `org` and `site`")),
@@ -63,7 +65,7 @@ async def get_org_or_site_info(
         site_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = info_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_sites_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_sites_sle.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -47,6 +48,7 @@ class Sle(Enum):
     },
 )
 async def get_org_sites_sle(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     sle: Annotated[
         Sle,
@@ -88,7 +90,7 @@ async def get_org_sites_sle(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.orgs.insights.getOrgSitesSle(

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
@@ -14,6 +14,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -44,6 +45,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_org_sle(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     metric: Annotated[
         str,
@@ -100,7 +102,7 @@ async def get_org_sle(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.orgs.insights.getOrgSle(

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_self.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_self.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Annotated
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -64,6 +65,7 @@ class Action_type(Enum):
     },
 )
 async def get_self(
+    ctx: Context,
     action_type: Annotated[
         Action_type,
         Field(
@@ -81,7 +83,7 @@ async def get_self(
     logger.debug("Tool get_self called")
     logger.debug("Input Parameters: action_type: %s", action_type)
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = action_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -33,6 +34,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_site_health(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
 ) -> dict | list | str:
     """Get health overview across all sites in the organization."""
@@ -40,7 +42,7 @@ async def get_site_health(
     logger.debug("Tool get_site_health called")
     logger.debug("Input Parameters: org_id: %s", org_id)
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.orgs.stats.getOrgStats(apisession, org_id=str(org_id))

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -62,6 +63,7 @@ class Band(Enum):
     },
 )
 async def get_site_rrm_info(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     rrm_info_type: Annotated[
         Rrm_info_type,
@@ -153,7 +155,7 @@ async def get_site_rrm_info(
         page,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = rrm_info_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_sle.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -73,6 +74,7 @@ class Object_type(Enum):
     },
 )
 async def get_site_sle(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     scope: Annotated[
         Scope,
@@ -145,7 +147,7 @@ async def get_site_sle(
         duration,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         if object_type.value == "classifier_summary_trend" and not classifier:

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_stats.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_stats.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -71,6 +72,7 @@ class Device_type(Enum):
     },
 )
 async def get_stats(
+    ctx: Context,
     stats_type: Annotated[
         Stats_type,
         Field(
@@ -150,7 +152,7 @@ async def get_stats(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = stats_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_switch_details.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_switch_details.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -31,6 +32,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_switch_details(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     device_id: Annotated[
         UUID,
@@ -48,7 +50,7 @@ async def get_switch_details(
         device_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.sites.devices.getSiteDevice(

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_wlans.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
@@ -33,6 +34,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def get_wlans(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     site_id: Annotated[
         UUID | None,
@@ -50,8 +52,8 @@ async def get_wlans(
         site_id,
     )
 
-    validate_org_id(str(org_id))
-    apisession, response_format = await get_apisession()
+    validate_org_id(ctx, str(org_id))
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         if site_id:

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_rogue_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_rogue_devices.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -57,6 +58,7 @@ class Rogue_ap_type(Enum):
     },
 )
 async def list_rogue_devices(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     rogue_type: Annotated[
         Rogue_type,
@@ -104,7 +106,7 @@ async def list_rogue_devices(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = rogue_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_site_sle_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_site_sle_info.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -59,6 +60,7 @@ class Scope(Enum):
     },
 )
 async def list_site_sle_info(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     query_type: Annotated[
         Query_type,
@@ -112,7 +114,7 @@ async def list_site_sle_info(
         metric,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = query_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/list_upgrades.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -72,6 +73,7 @@ class Channel(Enum):
     },
 )
 async def list_upgrades(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     device_type: Annotated[
         Device_type,
@@ -161,7 +163,7 @@ async def list_upgrades(
         mac,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = device_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_alarms.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_alarms.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -66,6 +67,7 @@ class Scope(Enum):
     },
 )
 async def search_alarms(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     scope: Annotated[
         Scope,
@@ -165,7 +167,7 @@ async def search_alarms(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = scope

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_audit_logs.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -46,6 +47,7 @@ class Scope(Enum):
     },
 )
 async def search_audit_logs(
+    ctx: Context,
     scope: Annotated[
         Scope,
         Field(
@@ -103,7 +105,7 @@ async def search_audit_logs(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = scope

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_client.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -63,6 +64,7 @@ class Band(Enum):
     },
 )
 async def search_client(
+    ctx: Context,
     client_type: Annotated[
         Client_type,
         Field(description=("Type of client: WAN, wired, wireless, or NAC")),
@@ -193,7 +195,7 @@ async def search_client(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = client_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -66,6 +67,7 @@ class Status(Enum):
     },
 )
 async def search_device(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     site_id: Annotated[UUID, Field(description="Site ID", default=None)],
     serial: Annotated[
@@ -159,7 +161,7 @@ async def search_device(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         kwargs: dict = {

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_device_config_history.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_device_config_history.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -57,6 +58,7 @@ class Device_type(Enum):
     },
 )
 async def search_device_config_history(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     query_type: Annotated[
         Query_type,
@@ -113,7 +115,7 @@ async def search_device_config_history(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = query_type

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_events.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_events.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -70,6 +71,7 @@ class Event_source(Enum):
     },
 )
 async def search_events(
+    ctx: Context,
     event_source: Annotated[
         Event_source,
         Field(
@@ -164,7 +166,7 @@ async def search_events(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = event_source

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_guest_authorization.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_guest_authorization.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -46,6 +47,7 @@ class Scope(Enum):
     },
 )
 async def search_guest_authorization(
+    ctx: Context,
     scope: Annotated[
         Scope,
         Field(
@@ -129,7 +131,7 @@ async def search_guest_authorization(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         object_type = scope

--- a/src/hpe_networking_mcp/platforms/mist/tools/search_nac_user_macs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/search_nac_user_macs.py
@@ -14,6 +14,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -45,6 +46,7 @@ from hpe_networking_mcp.platforms.mist.client import (
     },
 )
 async def search_nac_user_macs(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     usermac_id: Annotated[
         str,
@@ -104,7 +106,7 @@ async def search_nac_user_macs(
         limit,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         if usermac_id:

--- a/src/hpe_networking_mcp/platforms/mist/tools/troubleshoot.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/troubleshoot.py
@@ -15,6 +15,7 @@ from typing import Annotated
 from uuid import UUID
 
 import mistapi
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
@@ -54,6 +55,7 @@ class Troubleshoot_type(Enum):
     },
 )
 async def troubleshoot(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     troubleshoot_type: Annotated[
         Troubleshoot_type,
@@ -112,7 +114,7 @@ async def troubleshoot(
         end,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     try:
         response = mistapi.api.v1.orgs.troubleshoot.troubleshootOrg(

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_org_configuration_objects.py
@@ -100,6 +100,7 @@ class Object_type(Enum):
     },
 )
 async def update_org_configuration_objects(
+    ctx: Context,
     org_id: Annotated[UUID, Field(description="Organization ID")],
     object_type: Annotated[
         Object_type,
@@ -134,7 +135,6 @@ async def update_org_configuration_objects(
             default=None,
         ),
     ],
-    ctx: Context,
     confirmed: Annotated[
         bool,
         Field(
@@ -154,7 +154,7 @@ async def update_org_configuration_objects(
         object_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     action_wording = "create a new"
     if object_id:

--- a/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/update_site_configuration_objects.py
@@ -74,6 +74,7 @@ class Object_type(Enum):
     },
 )
 async def update_site_configuration_objects(
+    ctx: Context,
     site_id: Annotated[UUID, Field(description="Site ID")],
     object_type: Annotated[
         Object_type,
@@ -108,7 +109,6 @@ async def update_site_configuration_objects(
             default=None,
         ),
     ],
-    ctx: Context,
     confirmed: Annotated[
         bool,
         Field(
@@ -128,7 +128,7 @@ async def update_site_configuration_objects(
         object_id,
     )
 
-    apisession, response_format = await get_apisession()
+    apisession, response_format = await get_apisession(ctx)
 
     action_wording = "create a new"
     if object_id:

--- a/tests/unit/test_invoke_tool_dispatch.py
+++ b/tests/unit/test_invoke_tool_dispatch.py
@@ -1,0 +1,124 @@
+"""Regression tests for ``<platform>_invoke_tool`` dispatch shape.
+
+The v2.0.0.0 release shipped with a latent bug in Mist: the dynamic-mode
+meta-tool ``mist_invoke_tool`` passes ``ctx: Context`` positionally to the
+underlying tool function, but Mist tools (ported from upstream mistmcp
+using FastMCP's ``get_context()`` helper internally) didn't accept ``ctx``
+as a parameter. Every Mist invocation in dynamic mode failed with
+``TypeError: got multiple values for argument 'action_type'`` (or the
+equivalent for whichever parameter occupied the first positional slot).
+
+This class of bug is undetectable by the existing registry-population tests
+because they never exercise the dispatch path. These tests assert the
+invariant that makes ``_invoke_tool`` dispatch work: **every tool function
+in every platform registry must accept ``ctx: Context`` as its first
+parameter**. Fixed in v2.0.0.1.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, clear_registry
+
+
+def _populate_all_registries() -> None:
+    """Import every per-platform tool module so every registry is filled.
+
+    Two module-naming conventions in use:
+    - Apstra, Central, ClearPass, GreenLake: ``TOOLS`` keys are the module
+      names (one module per category, e.g. ``tools/sites.py``).
+    - Mist: ``TOOLS`` keys are category labels like ``"devices"``; the actual
+      module files are named after the tools (e.g. ``tools/search_device.py``),
+      derived by stripping the ``mist_`` prefix.
+    """
+    for platform in ("apstra", "central", "clearpass", "greenlake", "mist"):
+        clear_registry(platform)
+
+    for pkg in ("apstra", "central", "clearpass", "greenlake", "mist"):
+        try:
+            pkg_mod = importlib.import_module(f"hpe_networking_mcp.platforms.{pkg}")
+        except ImportError:
+            continue
+        tools_dict = getattr(pkg_mod, "TOOLS", None)
+        if not tools_dict:
+            continue
+
+        if pkg == "mist":
+            # Mist: derive module names from tool names (strip ``mist_``).
+            module_names = {
+                name.removeprefix("mist_") for tool_names in tools_dict.values() for name in tool_names
+            }
+        else:
+            # Other platforms: category key == module name.
+            module_names = set(tools_dict.keys())
+
+        for mod_short in sorted(module_names):
+            try:
+                mod = importlib.import_module(f"hpe_networking_mcp.platforms.{pkg}.tools.{mod_short}")
+            except ImportError:
+                continue
+            importlib.reload(mod)
+
+
+@pytest.fixture
+def every_platform_registry_populated():
+    _populate_all_registries()
+    try:
+        yield {p: dict(reg) for p, reg in REGISTRIES.items()}
+    finally:
+        for platform in REGISTRIES:
+            clear_registry(platform)
+
+
+@pytest.mark.unit
+class TestInvokeToolDispatchShape:
+    """Every registered tool must be callable via ``func(ctx, **params)``.
+
+    This is the exact call shape emitted by ``_common/meta_tools.py::_invoke_tool``.
+    If a tool's first positional parameter isn't reserved for ``ctx``, the
+    meta-tool dispatch will collide — which is what caused Seth's bug.
+    """
+
+    @pytest.mark.parametrize("platform", ["apstra", "central", "clearpass", "greenlake", "mist"])
+    def test_every_tool_accepts_ctx_as_first_parameter(self, every_platform_registry_populated, platform):
+        from fastmcp import Context
+
+        registry = every_platform_registry_populated.get(platform, {})
+        if not registry:
+            pytest.skip(f"{platform} registry empty — tool modules failed to import")
+
+        failures: list[str] = []
+        for name, spec in registry.items():
+            sig = inspect.signature(spec.func)
+            params = list(sig.parameters.values())
+            if not params:
+                failures.append(f"{name}: function has no parameters")
+                continue
+
+            first = params[0]
+            if first.name not in ("ctx", "context"):
+                failures.append(
+                    f"{name}: first parameter is {first.name!r} (expected 'ctx' so "
+                    f"{platform}_invoke_tool can pass the Context positionally)"
+                )
+                continue
+
+            annotation = first.annotation
+            # Accept either the exact Context class or a string annotation
+            # named Context (files using ``from __future__ import annotations``
+            # produce string annotations).
+            if annotation is inspect.Parameter.empty:
+                failures.append(f"{name}: first param 'ctx' is untyped (expected Context)")
+                continue
+            annotation_name = getattr(annotation, "__name__", None) or str(annotation)
+            if annotation is not Context and "Context" not in annotation_name:
+                failures.append(f"{name}: first param 'ctx' is typed {annotation!r} (expected Context)")
+
+        assert not failures, (
+            f"\n{len(failures)} {platform} tool(s) have the wrong dispatch shape — "
+            f"this breaks {platform}_invoke_tool in dynamic mode:\n  " + "\n  ".join(failures)
+        )

--- a/tests/unit/test_invoke_tool_dispatch.py
+++ b/tests/unit/test_invoke_tool_dispatch.py
@@ -49,9 +49,7 @@ def _populate_all_registries() -> None:
 
         if pkg == "mist":
             # Mist: derive module names from tool names (strip ``mist_``).
-            module_names = {
-                name.removeprefix("mist_") for tool_names in tools_dict.values() for name in tool_names
-            }
+            module_names = {name.removeprefix("mist_") for tool_names in tools_dict.values() for name in tool_names}
         else:
             # Other platforms: category key == module name.
             module_names = set(tools_dict.keys())


### PR DESCRIPTION
## Summary

Critical v2.0.0.0 hotfix. Every \`mist_invoke_tool\` call failed with \`TypeError: got multiple values for argument\` because Mist tools didn't accept \`ctx: Context\` as a parameter — the dispatch wrapper's positional \`ctx\` collided with the tool's real first arg. Reported live by Seth and Zach. Fixes [#179](https://github.com/nowireless4u/hpe-networking-mcp/issues/179).

## Root cause (one sentence)

\`_invoke_tool\` dispatches as \`spec.func(ctx, **params)\`, but Mist tools were ported from upstream \`mistmcp\` using FastMCP's \`get_context()\` helper internally instead of accepting \`ctx\` as a parameter — positional collision → TypeError on every Mist invocation.

## Changes

**\`platforms/mist/client.py\`**
- \`get_apisession(ctx)\` and \`validate_org_id(ctx, org_id)\` now take ctx explicitly (they need \`lifespan_context\` access).
- \`process_response\` and \`handle_network_error\` stay ctx-less (they don't need lifespan_context). The two \`ctx.error()\` calls in \`process_response\` swapped for \`logger.error\` to avoid threading ctx through ~300 call sites just to duplicate info already in the raised \`ToolError\`. Matches Central's pattern.

**35 Mist tool files under \`platforms/mist/tools/\`**
- Every \`@tool(...)\`-decorated \`async def\` now accepts \`ctx: Context\` as its first parameter.
- \`from fastmcp import Context\` imported.
- \`get_apisession()\` → \`get_apisession(ctx)\` (35 call sites).
- \`validate_org_id(org_id)\` → \`validate_org_id(ctx, org_id)\` (2 call sites in \`get_configuration_objects.py\` and \`get_wlans.py\`).
- 4 files (\`change_org\`, \`change_site\`, \`update_org\`, \`update_site\` configuration objects) had duplicate \`ctx: Context\` params after the refactor — stray mid-signature ctx parameters left over from earlier work; removed.

**New regression test** \`tests/unit/test_invoke_tool_dispatch.py\`
- Parametrized over all 5 platforms (\`apstra\`, \`central\`, \`clearpass\`, \`greenlake\`, \`mist\`).
- Uses \`inspect.signature()\` to assert every registered tool's first parameter is \`ctx: Context\`.
- This is the exact invariant \`_invoke_tool\` relies on — **would have caught the v2.0.0.0 bug at test time.** Prevents the class of bug from recurring as new platforms are added.

**Metadata**
- \`pyproject.toml\` — \`2.0.0.0\` → \`2.0.0.1\`
- \`CHANGELOG.md\` — \`[2.0.0.1]\` entry explaining bug, root cause, fix, affected users, workaround

## Test plan

- [x] \`ruff check .\` — clean
- [x] \`ruff format --check .\` — clean
- [x] \`mypy src/\` — clean
- [x] \`pytest tests/\` — **458/458 passing** (453 → 458, +5 new dispatch tests)
- [x] Fresh container rebuild starts clean, \`Mist: 35 underlying tools + 3 meta-tools registered (dynamic mode)\`
- [ ] Live-test (operator, post-merge): \`mist_invoke_tool(name=\"mist_get_self\", params={\"action_type\": \"account_info\"})\` returns real data instead of TypeError

## Deferred to a follow-up (NOT in this PR)

Mist still uses a different **module-organization convention** than the other four platforms — one-tool-per-file vs. one-module-per-category. Deliberately not tackled here so Seth / Zach get the dispatch fix ASAP. Will be a separate v2.0.0.2 or v2.1 PR.

## Post-merge

1. Tag \`v2.0.0.1\` from \`main\`
2. Create GitHub release — use the \`[2.0.0.1]\` CHANGELOG section as notes
3. GHCR Docker publish workflow rolls \`:latest\` forward to 2.0.0.1

Closes #179.