### PR TITLE
v2.0.0.2 hotfix: Pydantic coercion + hidden-tool schema in meta-tool (closes #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0.2] - 2026-04-24
+
+**Second hotfix for v2.0 dynamic-mode dispatch.** v2.0.0.1 fixed the positional-`ctx` collision (Mist tools now accept `ctx: Context`), but live-testing surfaced two more dispatch-path bugs the earlier fix didn't address.
+
+### Bugs fixed
+
+**1. `AttributeError: 'str' object has no attribute 'value'` on Enum params.** The meta-tool was calling `spec.func(ctx, **safe_params)` directly — bypassing FastMCP's normal Pydantic validation/coercion layer. So tools doing `object_type.value` got back the raw string `"org_sites"` (from the incoming JSON) instead of the `Object_type.ORG_SITES` enum instance. Affected every tool with `Annotated[SomeEnum, ...]` params, including `mist_get_configuration_objects`, `mist_get_org_or_site_info`, `mist_get_stats`, `mist_get_site_sle`, and the `manage_*` tools.
+
+**2. `input_schema: null` in `<platform>_get_tool_schema` responses.** The handler called `mcp.get_tool(name)` which respects the Visibility transform and returns `None` for hidden tools — i.e., every registered platform tool in dynamic mode. Since the AI couldn't see parameter schemas, it had to guess at param names, producing errors like `unexpected keyword argument 'stat_type'` (tool expected `stats_type`) or `missing 8 required positional arguments`.
+
+### Fixes
+
+**`platforms/_common/meta_tools.py`:**
+
+- **New `_coerce_params(spec, raw_params)` helper.** Builds a Pydantic model from the tool's function signature via `inspect.signature` + `get_type_hints(include_extras=True)` (so `from __future__ import annotations`-style string annotations resolve against the tool module's globals), then validates `raw_params` against it. Returns the coerced Python objects (`Enum` instances, `UUID` objects, etc.) via attribute access rather than `model_dump()` so typed values survive to the tool body.
+- **Strips explicit `None` from incoming params.** AI clients commonly pass `{"site_id": null}` for optional params, but Mist signatures use `Annotated[UUID, Field(default=None)]` (not `UUID | None`), which Pydantic rejects as "UUID required." The coercion helper now drops None-valued keys before validation so the Field-level default applies.
+- **Handles Annotated-embedded defaults.** When `inspect.Parameter.default` is empty but the annotation is `Annotated[T, Field(default=X)]`, the helper now extracts `X` from the `FieldInfo` metadata and uses it — matching how FastMCP's own dispatch handles this pattern.
+- **`_invoke_tool` now calls `_coerce_params` before `spec.func`.** `ValidationError` surfaces cleanly as `{"status": "invalid_params", "message": ...}` with actionable detail (missing fields, coercion failures).
+- **`_get_tool_schema` uses `mcp._get_tool(name)` (underscore prefix) instead of `mcp.get_tool(name)`.** The underscore version bypasses the Visibility filter, so hidden underlying tools now return their JSON schema as expected. The AI can actually see parameter names + types + requiredness instead of guessing.
+
+### Tests added
+
+Four new coercion regression tests in `tests/unit/test_meta_tools.py::TestInvokeToolCoercion`:
+- Enum string → Enum instance coercion
+- UUID string → UUID object coercion
+- Missing-required-param produces `invalid_params` (not the opaque API 404 v2.0.0.1 allowed through)
+- Explicit `null` for optional params falls through to the Annotated default
+
+Total suite: 462 tests passing (458 → 462).
+
+### Affected users
+
+Anyone on v2.0.0.1 who hit `AttributeError: 'str' object has no attribute 'value'` or `input_schema: null` when calling Mist tools via `mist_invoke_tool`. Same workaround as v2.0.0.1 while the image propagates: `MCP_TOOL_MODE=static` restores v1.x-style direct-tool surface.
+
+### Note on v2.0.0.1 + v2.0.0.2
+
+v2.0.0.1 and v2.0.0.2 together complete what should have been a single "dynamic dispatch actually works" fix — the bug class was simply bigger than the first pass caught. Both ship in the same 24-hour window post-v2.0.0.0.
+
+---
+
 ## [2.0.0.1] - 2026-04-24
 
 **Hotfix for a critical v2.0.0.0 regression.** Every Mist tool invocation through `mist_invoke_tool` failed in dynamic mode with `TypeError: got multiple values for argument 'action_type'` (or the equivalent for whichever parameter was the tool's actual first positional argument). Reported separately by Seth and Zach during v2.0 live testing. Fixes [#179](https://github.com/nowireless4u/hpe-networking-mcp/issues/179).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.1"
+version = "2.0.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -14,17 +14,130 @@ exactly; only the invocation surface changes.
 
 from __future__ import annotations
 
-from typing import Any
+import inspect
+from typing import Any, get_args, get_origin, get_type_hints
 
 from fastmcp import Context, FastMCP
 from loguru import logger
 from mcp.types import ToolAnnotations
+from pydantic import ConfigDict, ValidationError, create_model
+from pydantic.fields import FieldInfo
 
 from hpe_networking_mcp.platforms._common.tool_registry import (
     REGISTRIES,
     ToolSpec,
     is_tool_enabled,
 )
+
+# Parameter names we strip from the Pydantic validation model because
+# ``_invoke_tool`` injects them itself.
+_CTX_PARAM_NAMES = frozenset({"ctx", "context"})
+
+
+def _extract_annotated_default(annotation: Any) -> Any:
+    """Return a Pydantic-usable default from ``Annotated[T, Field(default=X)]``.
+
+    Many Mist tool signatures use ``Annotated[UUID, Field(default=None)]``
+    where the function signature itself has no default — the default lives
+    inside the ``Field(...)`` metadata. When ``inspect.Parameter.default``
+    is empty, we look into the ``Annotated`` metadata for a ``FieldInfo``
+    that carries a default and surface it. Returns ``Ellipsis`` (Pydantic's
+    "required" marker) if no default is found.
+    """
+    if get_origin(annotation) is not None and hasattr(annotation, "__metadata__"):
+        for meta in getattr(annotation, "__metadata__", ()):
+            if isinstance(meta, FieldInfo):
+                default = meta.default
+                # ``FieldInfo.default`` uses ``PydanticUndefined`` for
+                # required fields; only surface concrete defaults.
+                if default is not None and str(type(default).__name__) == "PydanticUndefinedType":
+                    continue
+                return default
+    # Also handle the raw generic form ``Annotated[T, ...]`` where
+    # ``__metadata__`` isn't attached directly.
+    args = get_args(annotation)
+    for meta in args[1:] if len(args) > 1 else ():
+        if isinstance(meta, FieldInfo):
+            default = meta.default
+            if default is not None and str(type(default).__name__) == "PydanticUndefinedType":
+                continue
+            return default
+    return ...
+
+
+def _coerce_params(spec: ToolSpec, raw_params: dict[str, Any]) -> dict[str, Any]:
+    """Build a Pydantic model from the tool signature and validate/coerce.
+
+    FastMCP's normal dispatch path (``tools/call`` → ``@mcp.tool`` wrapper)
+    applies Pydantic validation to incoming arguments, converting strings
+    into ``Enum`` instances, ``UUID`` objects, etc. The meta-tool
+    dispatch in ``_invoke_tool`` calls ``spec.func`` directly, bypassing
+    that wrapper — so we have to replicate the coercion step here. Without
+    it, tools doing ``my_enum_param.value`` hit
+    ``AttributeError: 'str' object has no attribute 'value'``.
+
+    Returns a new dict of coerced parameter values. Raises
+    ``ValidationError`` if the params don't match the signature (missing
+    required params, unknown keys, or type-coercion failures).
+    """
+    sig = inspect.signature(spec.func)
+    # ``from __future__ import annotations`` in tool modules leaves
+    # ``inspect.signature()`` annotations as strings. Pydantic can't
+    # evaluate those strings without a matching namespace. Resolve
+    # eagerly with ``get_type_hints`` using the function's own globals
+    # + localns so ``Annotated``, ``UUID``, enums defined beside the
+    # tool, etc. all resolve correctly.
+    try:
+        resolved_hints = get_type_hints(spec.func, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+
+    fields: dict[str, Any] = {}
+    for pname, param in sig.parameters.items():
+        if pname in _CTX_PARAM_NAMES:
+            continue
+        # Skip variadic parameters (``*args`` / ``**kwargs``). Pydantic
+        # can't build a field from them; real tools almost never use this
+        # shape, but ``AsyncMock()`` stubs in tests do — and a runtime
+        # crash there is worse than no coercion.
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        annotation = resolved_hints.get(pname, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            annotation = Any
+        if param.default is not inspect.Parameter.empty:
+            fields[pname] = (annotation, param.default)
+        else:
+            # Signature has no default; fall back to any default baked
+            # into the ``Annotated`` FieldInfo. Returns ``...`` (required)
+            # if none is found.
+            fields[pname] = (annotation, _extract_annotated_default(annotation))
+
+    if not fields:
+        # Signature has no validatable params — nothing to coerce. Hand
+        # the raw dict back so ``spec.func(**raw_params)`` still works.
+        return dict(raw_params)
+
+    # AI clients often pass explicit ``null`` for optional params that
+    # should just fall through to the default. Mist tool signatures
+    # commonly use ``Annotated[UUID, Field(default=None)]`` (default=None
+    # without typing the field as Optional), so Pydantic rejects
+    # ``{"site_id": None}``. Strip explicit-None entries so Pydantic
+    # uses the declared default instead. Required params will still be
+    # flagged as missing by the validator below.
+    cleaned = {k: v for k, v in raw_params.items() if v is not None}
+
+    model_cls = create_model(
+        f"{spec.name}__Params",
+        __config__=ConfigDict(arbitrary_types_allowed=True, extra="forbid"),
+        **fields,
+    )
+    validated = model_cls.model_validate(cleaned)
+    # Use attribute access so we get the Pydantic-coerced Python objects
+    # (``Enum`` instances, ``UUID``, etc.) rather than the serialized form
+    # that ``model_dump()`` produces.
+    return {pname: getattr(validated, pname) for pname in fields}
+
 
 _META_ANNOTATIONS_READONLY = ToolAnnotations(
     readOnlyHint=True,
@@ -157,8 +270,13 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
                 ),
             }
 
+        # Use ``_get_tool`` (underscore prefix) instead of ``get_tool``:
+        # the public ``get_tool`` applies the Visibility filter and returns
+        # ``None`` for tools hidden by the dynamic-mode transform, which
+        # includes every tool in the registry. ``_get_tool`` bypasses the
+        # filter so we can actually fetch the schema.
         try:
-            fm_tool = await mcp.get_tool(name)
+            fm_tool = await mcp._get_tool(name)
         except Exception as exc:
             logger.warning(
                 "{}_get_tool_schema: failed to resolve tool {!r} from FastMCP — {}",
@@ -226,13 +344,28 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
             name,
             len(safe_params),
         )
+
+        # Replicate the Pydantic coercion FastMCP would do on a direct
+        # tool call: turn string enum values into ``Enum`` instances,
+        # strings into ``UUID`` objects, etc. Without this, any tool that
+        # does ``enum_param.value`` blows up with ``'str' object has no
+        # attribute 'value'`` because the meta-tool bypasses FastMCP's
+        # normal dispatch wrapper.
         try:
-            return await spec.func(ctx, **safe_params)
+            coerced = _coerce_params(spec, safe_params)
+        except ValidationError as exc:
+            return {
+                "status": "invalid_params",
+                "message": str(exc),
+                "hint": f"Call {platform}_get_tool_schema(name={name!r}) for the exact parameter shape.",
+            }
+
+        try:
+            return await spec.func(ctx, **coerced)
         except TypeError as exc:
-            # Usually "unexpected keyword argument" — the caller sent a
-            # param that the tool doesn't accept. Mirror the shape
-            # Pydantic-validation errors use so clients can handle them
-            # uniformly.
+            # Residual TypeError after validation — typically a signature
+            # issue (missing ctx param on the tool, or a mismatch between
+            # the signature and the registered call shape).
             return {
                 "status": "invalid_params",
                 "message": str(exc),

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -230,3 +230,184 @@ class TestInvokeTool:
         )
         assert result["status"] == "invalid_params"
         assert "bogus" in result["message"]
+
+
+# ---- Fixtures for coercion tests -----------------------------------------
+# Tool functions and their types are defined at module level so
+# ``get_type_hints`` can resolve annotations using this module's globals.
+# Defining them inside test methods puts the types in a nested scope that
+# Pydantic's string-annotation resolver can't see.
+
+from enum import Enum  # noqa: E402
+from typing import Annotated as _Annotated  # noqa: E402
+from uuid import UUID as _UUID  # noqa: E402
+
+from pydantic import Field as _Field  # noqa: E402
+
+
+class _FakeEnumObjectType(Enum):
+    ORG_SITES = "org_sites"
+    SITE_DEVICES = "site_devices"
+
+
+_coerce_received: dict = {}
+
+
+async def _fake_enum_tool(
+    ctx,
+    object_type: _Annotated[_FakeEnumObjectType, _Field(description="what to fetch")],
+) -> dict:
+    # If coercion is missing, ``object_type`` is the raw string
+    # ``'org_sites'`` and ``.value`` access raises AttributeError.
+    _coerce_received["value"] = object_type.value
+    _coerce_received["type"] = type(object_type).__name__
+    return {"ok": True}
+
+
+_fake_enum_tool.__name__ = "apstra_fake_enum_tool"  # type: ignore[attr-defined]
+
+
+async def _fake_uuid_tool(
+    ctx,
+    blueprint_id: _Annotated[_UUID, _Field(description="bp id")],
+) -> dict:
+    _coerce_received["type"] = type(blueprint_id).__name__
+    _coerce_received["value"] = blueprint_id
+    return {"ok": True}
+
+
+_fake_uuid_tool.__name__ = "apstra_fake_uuid_tool"  # type: ignore[attr-defined]
+
+
+async def _fake_required_tool(
+    ctx,
+    required_field: _Annotated[str, _Field(description="required")],
+) -> dict:
+    return {"ok": True}
+
+
+_fake_required_tool.__name__ = "apstra_fake_required_tool"  # type: ignore[attr-defined]
+
+
+async def _fake_optional_tool(
+    ctx,
+    required: _Annotated[str, _Field(description="required")],
+    optional_uuid: _Annotated[_UUID, _Field(default=None, description="optional")],
+) -> dict:
+    return {"optional_is_none": optional_uuid is None}
+
+
+_fake_optional_tool.__name__ = "apstra_fake_optional_tool"  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def mcp_with_fake_tools():
+    """Install the fake coercion-test tools in the apstra registry."""
+    clear_registry("apstra")
+    _coerce_received.clear()
+
+    REGISTRIES["apstra"]["apstra_fake_enum_tool"] = ToolSpec(
+        name="apstra_fake_enum_tool",
+        func=_fake_enum_tool,
+        platform="apstra",
+        category="testing",
+        description="Test tool with enum param.",
+        tags=set(),
+    )
+    REGISTRIES["apstra"]["apstra_fake_uuid_tool"] = ToolSpec(
+        name="apstra_fake_uuid_tool",
+        func=_fake_uuid_tool,
+        platform="apstra",
+        category="testing",
+        description="Test tool with UUID param.",
+        tags=set(),
+    )
+    REGISTRIES["apstra"]["apstra_fake_required_tool"] = ToolSpec(
+        name="apstra_fake_required_tool",
+        func=_fake_required_tool,
+        platform="apstra",
+        category="testing",
+        description="Test tool with required param.",
+        tags=set(),
+    )
+
+    mcp = FastMCP(name="test-coercion")
+    build_meta_tools("apstra", mcp)
+    return mcp
+
+
+@pytest.mark.unit
+class TestInvokeToolCoercion:
+    """Regression tests for Pydantic-based parameter coercion.
+
+    v2.0.0.1 shipped with the meta-tool dispatching raw string params
+    directly to tool functions — Enum-typed params failed with
+    ``AttributeError: 'str' object has no attribute 'value'`` because
+    FastMCP's normal Pydantic coercion was bypassed. v2.0.0.2 restores
+    coercion inside ``_invoke_tool``.
+    """
+
+    async def test_enum_string_coerces_to_enum_instance(self, mcp_with_fake_tools):
+        tool = await mcp_with_fake_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        result = await tool.fn(
+            _fake_ctx(config),
+            name="apstra_fake_enum_tool",
+            params={"object_type": "org_sites"},
+        )
+
+        assert result == {"ok": True}
+        assert _coerce_received["type"] == "_FakeEnumObjectType"
+        assert _coerce_received["value"] == "org_sites"
+
+    async def test_uuid_string_coerces_to_uuid_instance(self, mcp_with_fake_tools):
+        tool = await mcp_with_fake_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        result = await tool.fn(
+            _fake_ctx(config),
+            name="apstra_fake_uuid_tool",
+            params={"blueprint_id": "5f79daeb-8ae8-4b1b-a560-f8cfcbc51e76"},
+        )
+
+        assert result == {"ok": True}
+        assert _coerce_received["type"] == "UUID"
+        assert str(_coerce_received["value"]) == "5f79daeb-8ae8-4b1b-a560-f8cfcbc51e76"
+
+    async def test_missing_required_param_returns_invalid_params(self, mcp_with_fake_tools):
+        tool = await mcp_with_fake_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        result = await tool.fn(_fake_ctx(config), name="apstra_fake_required_tool", params={})
+
+        assert result["status"] == "invalid_params"
+        assert "required_field" in result["message"]
+
+    async def test_explicit_null_for_optional_param_uses_default(self):
+        """AI clients often pass ``null`` for optional params; should use the default.
+
+        Mist tool signatures commonly use ``Annotated[UUID, Field(default=None)]``
+        without the ``| None`` in the type. Passing ``{"site_id": null}`` should
+        strip the None and let Pydantic apply the default.
+        """
+        clear_registry("apstra")
+        REGISTRIES["apstra"]["apstra_fake_optional_tool"] = ToolSpec(
+            name="apstra_fake_optional_tool",
+            func=_fake_optional_tool,
+            platform="apstra",
+            category="testing",
+            description="Test tool with optional UUID param.",
+            tags=set(),
+        )
+        mcp = FastMCP(name="test-optional")
+        build_meta_tools("apstra", mcp)
+        tool = await mcp.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        result = await tool.fn(
+            _fake_ctx(config),
+            name="apstra_fake_optional_tool",
+            params={"required": "value", "optional_uuid": None},
+        )
+        assert result == {"optional_is_none": True}


### PR DESCRIPTION
## Summary

Second dispatch-path hotfix within 24h of v2.0.0.0. v2.0.0.1 fixed the positional-\`ctx\` collision; live testing against a real Mist tenant surfaced two more bugs this PR fixes. Together v2.0.0.1 + v2.0.0.2 complete what should've been a single \"dynamic dispatch actually works\" fix.

Closes [#181](https://github.com/nowireless4u/hpe-networking-mcp/issues/181).

## Bugs fixed

### A. \`AttributeError: 'str' object has no attribute 'value'\`

\`_invoke_tool\`'s \`spec.func(ctx, **params)\` bypassed FastMCP's Pydantic validation. Enum-typed params arrived as raw strings; tools doing \`object_type.value\` crashed.

**Affected tools:** every Mist tool with \`Annotated[SomeEnum, ...]\` params — \`mist_get_configuration_objects\`, \`mist_get_org_or_site_info\`, \`mist_get_stats\`, \`mist_get_site_sle\`, and every \`manage_*\` tool.

### B. \`input_schema: null\` in \`<platform>_get_tool_schema\` responses

\`mcp.get_tool(name)\` respects the Visibility transform and returns \`None\` for all hidden underlying tools. The AI couldn't see schemas and resorted to guessing param names — producing errors like \`unexpected keyword argument 'stat_type'\` (tool expected \`stats_type\`).

## Fixes in \`platforms/_common/meta_tools.py\`

### New \`_coerce_params(spec, raw_params)\` helper

- Builds a Pydantic model from the tool's signature via \`inspect.signature\` + \`get_type_hints(include_extras=True)\` — resolves string annotations from \`from __future__ import annotations\` using the tool module's own globals (needed for \`Annotated\`, UUID, module-local enums, etc.).
- Returns coerced Python objects via attribute access (\`getattr(validated, ...)\`) rather than \`model_dump()\`, so \`Enum\` instances and \`UUID\` objects survive to the tool body.
- Extracts field defaults from \`Annotated[T, Field(default=X)]\` metadata when \`inspect.Parameter.default\` is empty — matches how FastMCP's own dispatch handles this pattern.
- **Strips explicit \`None\` from raw_params.** AI clients routinely pass \`{\"site_id\": null}\` for optional params, but Mist signatures use \`Annotated[UUID, Field(default=None)]\` (not \`UUID | None\`), which Pydantic would reject. Stripping None lets the Field-level default apply.
- Raises \`ValidationError\` for missing required / type-coercion failures / unknown keys — surfaced as a clean \`{\"status\": \"invalid_params\", ...}\` by \`_invoke_tool\`.

### \`_invoke_tool\` dispatches via coerced params

\`\`\`python
# Replicate the Pydantic coercion FastMCP would do on a direct
# tool call: turn string enum values into Enum instances, strings
# into UUID objects, etc.
coerced = _coerce_params(spec, safe_params)
return await spec.func(ctx, **coerced)
\`\`\`

### \`_get_tool_schema\` uses unfiltered lookup

\`\`\`python
# Use ``_get_tool`` (underscore prefix) instead of ``get_tool``:
# the public ``get_tool`` applies the Visibility filter and returns
# ``None`` for tools hidden by the dynamic-mode transform.
fm_tool = await mcp._get_tool(name)
\`\`\`

## Tests

Four new coercion-regression tests in \`tests/unit/test_meta_tools.py::TestInvokeToolCoercion\` cover:

1. Enum string → Enum instance coercion (the Mist bug)
2. UUID string → UUID object coercion
3. Missing required param → clean \`invalid_params\` response (so the AI gets actionable \"missing X\" detail rather than an opaque 404 from the Mist API)
4. Explicit \`null\` for optional param → Field default applied

Total suite: **462 passing** (458 → 462).

## Live-verified

Before commit, ran the coercion helper against the real \`mist_get_configuration_objects\` registered tool in the running container:

- \`object_type=\"org_sites\"\` → \`Object_type.ORG_SITES\` enum (\`.value\` access works)
- \`org_id=\"5f79daeb-...\"\` → \`UUID\` object
- \`site_id=None\` → stripped, Field default applied
- Missing \`org_id\` → \`ValidationError\` with \`Required missing: ['org_id']\`

## Checklist

- [x] \`ruff check .\` clean
- [x] \`ruff format --check .\` clean
- [x] \`mypy src/\` clean
- [x] \`pytest tests/\` — 462/462 passing
- [x] Container rebuild + live-verification against a registered Mist tool
- [ ] Post-merge: tag v2.0.0.2, create release, Docker Publish workflow rolls \`:latest\` forward

## Post-merge

1. Tag \`v2.0.0.2\` from \`main\`
2. \`gh release create v2.0.0.2\` with the \`[2.0.0.2]\` CHANGELOG section as notes
3. GHCR Docker Publish workflow rolls \`:latest\` forward to 2.0.0.2