### PR TITLE
v2.0.0.3: include params map in list_tools output (closes #185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0.3] - 2026-04-24
+
+**UX win: cut one round-trip per simple tool invocation.** `<platform>_list_tools` responses now include a compact `params` map per tool entry, so AI clients can skip `<platform>_get_tool_schema` when the parameter names + types alone are enough to compose an `invoke` call. Fixes [#185](https://github.com/nowireless4u/hpe-networking-mcp/issues/185).
+
+### What changed
+
+Every tool entry in `<platform>_list_tools` now looks like:
+
+```json
+{
+  "name": "mist_get_site_health",
+  "category": "get_site_health",
+  "summary": "Get a health overview across all sites...",
+  "params": {"org_id": "UUID"}
+}
+```
+
+- `params` is a `{name: "Type[?]"}` map.
+- `?` suffix means optional (has a default or absent from the schema's `required`).
+- Types: `UUID`, `string`, `integer`, `boolean`, `dict`, `list[...]`, or an Enum class name like `Action_type` / `Object_type` (AI still needs `get_tool_schema` to see the enum's valid values — for those, the round-trip isn't eliminated, just informed).
+
+### Expected AI behavior change
+
+- **Simple-tool path** (single common case — one required param whose type is obvious): `list_tools` → `invoke_tool` (**2 round-trips, down from 3**).
+- **Enum/complex-tool path**: AI still calls `get_tool_schema` in between. No regression vs. v2.0.0.2.
+- **Anti-pattern** (`invoke_tool` with `params={}` or guessed names): still fails with `invalid_params` — but now the remediation hint is explicit that the AI had the information it needed from `list_tools` already.
+
+### Code changes
+
+- **`platforms/_common/meta_tools.py`**:
+  - New `_resolve_type_name(pdef)` helper extracts a compact type string from a JSON schema property. Handles `$ref` (enum / nested model), `format` hints (`uuid` → `UUID`, `date-time` → `datetime`), `anyOf`/`oneOf` unions (picks first non-null branch), and `array` types (emits `list[item_type]`).
+  - New `_param_summary(fm_tool)` helper returns the `{name: "Type[?]"}` map from a FastMCP tool's parsed schema.
+  - `_list_tools` now fetches each matching tool's parsed schema (via `mcp._get_tool(name)` — same private accessor we already use for `_get_tool_schema`) and includes the summary in its response.
+  - Tool description updated to advertise the new `params` field and describe the `?` convention.
+
+- **`INSTRUCTIONS.md`**:
+  - TOOL DISCOVERY section: step 2 (`list_tools`) now explicitly mentions the new `params` field; step 3 (`get_tool_schema`) becomes conditional on whether step 2's info is sufficient; ✅/❌ example blocks updated to show the simple-tool 2-round-trip path alongside the full-schema 3-round-trip path.
+  - Rule 5 reframed: "use the information you already have from `list_tools`" (soft-mandatory rather than v2.0.0.2's hard-mandatory schema fetch).
+  - Rule 6 updated: names the specific cases where `get_tool_schema` is still needed (enum value lists, param descriptions, nested object shapes).
+
+### Tests added
+
+- `test_entries_include_params_summary` in `test_meta_tools.py::TestListTools` — verifies Enum-typed, UUID-typed, and str-typed params all surface correctly in the new `params` map.
+- Updated the `mcp_with_fake_tools` fixture to also register fake tools via `mcp.tool(...)` so FastMCP has parsed schemas for them (previously the fixture only populated `REGISTRIES`, which was enough for the coercion tests but not for the new `list_tools` path).
+- Fixed fake-tool ctx typing: `ctx` parameters in test fixtures are now typed as `FastMCPContext` so FastMCP recognizes them as the context-injection point and strips them from the advertised schema.
+
+Total suite: 463 tests passing (462 → 463).
+
+### Token-budget check
+
+- **Baseline per-turn tool-schema payload**: unchanged (~2,910 tokens — we only touched the `list_tools` response, not the meta-tools' own input schemas).
+- **Per-query `list_tools` response**: +10-20% depending on how many tools match. For a filtered call (`filter="health"` matching 3-5 tools): +60-100 tokens. For an unfiltered Mist list (35 tools): +400-600 tokens.
+- **Per-query net**: saves ~500-1000 tokens per *avoided* `get_tool_schema` round-trip (the full schema response is typically 10× larger than the inlined param map). **Net positive on both baseline and per-query token budgets.**
+
+### Users affected
+
+Every AI client using dynamic mode. No configuration change needed — new `params` field is additive and ignored by older clients.
+
+---
+
 ## [2.0.0.2] - 2026-04-24
 
 **Second hotfix for v2.0 dynamic-mode dispatch.** v2.0.0.1 fixed the positional-`ctx` collision (Mist tools now accept `ctx: Context`), but live-testing surfaced two more dispatch-path bugs the earlier fix didn't address.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.2"
+version = "2.0.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -16,32 +16,41 @@ Only 18 tools are directly visible at session start:
 - **3 cross-platform static tools**: `health`, `site_health_check`, `manage_wlan_profile`
 - **3 meta-tools per platform × 5 platforms** = 15: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
 
-Every per-platform tool listed below this section is reachable through the meta-tools. **Use this discovery pattern — all four steps, in this exact order:**
+Every per-platform tool listed below this section is reachable through the meta-tools. **Use this discovery pattern:**
 
 1. **Pick the platform.** Each category heading below names the platform (`mist_*`, `central_*`, etc.).
-2. **Find the tool.** Call `<platform>_list_tools(filter="<keyword>")` (e.g. `central_list_tools(filter="site")`). The result is candidate tool names + one-line descriptions. **It does NOT include parameter schemas** — you still need step 3.
-3. **Read its schema (MANDATORY — do not skip).** Call `<platform>_get_tool_schema(name="<tool_name>")` to retrieve the exact parameter names, types, required/optional markers, and enums. Do this the first time you touch any tool in a session. You can reuse what you learned for subsequent calls to the same tool in the same conversation — no need to re-fetch.
-4. **Invoke it.** Call `<platform>_invoke_tool(name="<tool_name>", params={...})`. `params` is a dict matching the schema from step 3.
+2. **Find the tool.** Call `<platform>_list_tools(filter="<keyword>")` (e.g. `central_list_tools(filter="site")`). The result gives you candidate tool names, one-line summaries, AND a compact `params` map showing each parameter's name + type — e.g. `{"org_id": "UUID", "site_id": "UUID?", "limit": "integer?"}`. A `?` suffix means optional (has a default); no suffix means required. Enum-typed params show the enum class name (e.g. `"Info_type"`).
+3. **Decide whether you need step 3a.** If the tool's `params` map from step 2 is enough to invoke — e.g. you recognize the parameter names, the types are obvious (`UUID`, `string`, `integer`), and none are enum-typed requiring specific values — skip ahead to step 4.
+   - **Step 3a (when needed):** call `<platform>_get_tool_schema(name="<tool_name>")` to retrieve parameter descriptions, valid enum values, nested object shapes. Required when you see an enum type (e.g. `"Action_type"`) and don't yet know its valid values, when you need field descriptions to understand semantics, or when a payload/body param needs a nested schema.
+4. **Invoke it.** Call `<platform>_invoke_tool(name="<tool_name>", params={...})`. Match the schema from step 2 (or 3a).
 
-**✅ Correct sequence:**
+**✅ Simple-tool path (2 round-trips):**
 ```
-central_list_tools(filter="wlan")
-→ [{"name":"central_get_wlans",...}, {"name":"central_manage_wlan_profile",...}, ...]
-central_get_tool_schema(name="central_get_wlans")
-→ {"name":"central_get_wlans","input_schema":{"properties":{"site_id":{"type":"string","format":"uuid"}},"required":["site_id"],...}}
-central_invoke_tool(name="central_get_wlans", params={"site_id":"..."})
+central_list_tools(filter="sites")
+→ [{"name":"central_get_site_health","params":{"site_name":"string","platform":"string?",...}}, ...]
+central_invoke_tool(name="central_get_site_health", params={"site_name":"HOME"})
 → <tool result>
 ```
 
-**❌ Anti-pattern — skipping step 3 costs TWO round-trips instead of one:**
+**✅ Full-schema path (3 round-trips, required when enum values matter):**
 ```
-central_invoke_tool(name="central_get_wlans", params={})      # ❌ guessed — missing required 'site_id'
-→ {"status":"invalid_params", ...}                            # ❌ failed
-central_get_tool_schema(name="central_get_wlans")             # now forced to read schema anyway
-central_invoke_tool(name="central_get_wlans", params={...})   # retry
+mist_list_tools(filter="self")
+→ [{"name":"mist_get_self","params":{"action_type":"Action_type"}}, ...]
+mist_get_tool_schema(name="mist_get_self")
+→ {..., "input_schema":{"$defs":{"Action_type":{"enum":["account_info","api_usage","login_failures"],...}},...}}
+mist_invoke_tool(name="mist_get_self", params={"action_type":"account_info"})
+→ <tool result>
 ```
 
-When the AI skips step 3, the server's Pydantic validator rejects the call with a clear error, but the AI still has to re-read the schema and retry. **Always run step 3 first.**
+**❌ Anti-pattern — guessing without seeing `list_tools` params costs TWO round-trips minimum:**
+```
+mist_invoke_tool(name="mist_get_self", params={})                 # ❌ guessed — missing required 'action_type'
+→ {"status":"invalid_params", ...}                                # ❌ failed
+mist_get_tool_schema(name="mist_get_self")                        # forced to read schema
+mist_invoke_tool(name="mist_get_self", params={"action_type":"account_info"})  # retry
+```
+
+The server's Pydantic validator rejects `invalid_params` responses with actionable detail, but the AI still has to re-read the schema and retry. **Always check `list_tools` params first, use `get_tool_schema` only when that isn't enough.**
 
 Use the cross-platform tools directly when they apply — they replace several per-platform calls:
 - `health(platform=...)` — platform reachability / status
@@ -55,8 +64,8 @@ If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front wi
 2. **Only send parameters that are needed.** Do not pass empty, null, or irrelevant parameters.
 3. **Only answer based on data returned by tools.** Never infer, estimate, or fabricate network state.
 4. If a tool returns no data or an error, say so explicitly. Do not guess.
-5. **MANDATORY: always call `<platform>_get_tool_schema(name=...)` before the first `<platform>_invoke_tool` call for any tool in this session.** Never invoke a tool with guessed params or with `params={}` — the `invalid_params` response forces a schema fetch + retry anyway (two wasted round-trips instead of one). You do NOT need to re-read a schema you've already fetched in the same conversation; cache it mentally. But never skip the first read.
-6. **`<platform>_list_tools` returns names + summaries, not parameter schemas.** Do not attempt to invoke based on the tool name alone — always go through `<platform>_get_tool_schema` in between.
+5. **MANDATORY: use the information you already have from `<platform>_list_tools` before invoking.** Every tool entry from `list_tools` includes a `params` map showing parameter names + types (and `?` suffix for optional) — always check it before calling `invoke_tool`. Never invoke with `params={}` or guessed names when the `list_tools` output already told you what's required.
+6. **Call `<platform>_get_tool_schema(name=...)` when the `list_tools` params map isn't sufficient.** Specifically: when a param's type is an enum class name (e.g. `"Action_type"`) and you don't yet know its valid values, when you need field descriptions to understand parameter semantics, or when a `dict`/`payload` param needs a nested schema. You do NOT need to re-read a schema you've already fetched in the same conversation; cache it mentally.
 
 ---
 

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -168,6 +168,80 @@ def _tool_summary(spec: ToolSpec, max_len: int = 200) -> str:
     return first_para
 
 
+def _resolve_type_name(pdef: dict[str, Any]) -> str:
+    """Extract a concise type name from a JSON schema property definition.
+
+    Used by ``_param_summary`` to produce a one-word type hint per
+    parameter for the ``list_tools`` output. Output is designed for
+    AI-consumption, not strict correctness — e.g. ``UUID | None`` is
+    shown as ``UUID`` since the null branch is already communicated
+    via the ``?`` suffix in the caller.
+    """
+    # Enum types and nested models are referenced via $ref.
+    if "$ref" in pdef:
+        return pdef["$ref"].rsplit("/", 1)[-1]
+    # Common format hints get short names.
+    fmt = pdef.get("format")
+    if fmt == "uuid":
+        return "UUID"
+    if fmt == "date-time":
+        return "datetime"
+    if fmt:
+        return fmt
+    # Union types: pick the first non-null branch.
+    for key in ("anyOf", "oneOf"):
+        options = pdef.get(key)
+        if isinstance(options, list):
+            for option in options:
+                if isinstance(option, dict) and option.get("type") != "null":
+                    return _resolve_type_name(option)
+            return "any"
+    # Array types: include the item type when it's obvious.
+    if pdef.get("type") == "array":
+        items = pdef.get("items") or {}
+        if isinstance(items, dict) and items:
+            return f"list[{_resolve_type_name(items)}]"
+        return "list"
+    # Fall back to the raw JSON schema type name.
+    return pdef.get("type", "any")
+
+
+def _param_summary(fm_tool: Any) -> dict[str, str]:
+    """Return a compact ``{name: "Type[?]"}`` map for a tool's params.
+
+    Extracted from FastMCP's parsed JSON schema. Included in the
+    ``<platform>_list_tools`` response so AI clients can skip a
+    ``<platform>_get_tool_schema`` round-trip for simple tools where
+    knowing the parameter names and their rough types is enough to
+    compose a valid invoke call. For anything more detailed (full
+    descriptions, enum value lists, nested object shapes), the AI
+    should still call ``get_tool_schema``.
+
+    Convention: ``"?"`` suffix means optional (has a default or is
+    excluded from the schema's ``required`` list). No suffix means
+    required.
+    """
+    if fm_tool is None:
+        return {}
+    schema = getattr(fm_tool, "parameters", None) or getattr(fm_tool, "input_schema", None)
+    if not isinstance(schema, dict):
+        return {}
+    props = schema.get("properties") or {}
+    if not isinstance(props, dict):
+        return {}
+    required_set = set(schema.get("required") or [])
+
+    result: dict[str, str] = {}
+    for pname, pdef in props.items():
+        if not isinstance(pdef, dict):
+            continue
+        type_name = _resolve_type_name(pdef)
+        if pname not in required_set:
+            type_name = f"{type_name}?"
+        result[pname] = type_name
+    return result
+
+
 def build_meta_tools(platform: str, mcp: FastMCP) -> None:
     """Register the three meta-tools for a platform on the FastMCP server.
 
@@ -191,9 +265,13 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
             f"description, and an optional `category` to restrict to one "
             f"module (use this tool with no arguments first to discover "
             f"available categories). Returns an array of "
-            f"{{name, category, summary}} records — call "
-            f"`{platform}_get_tool_schema(name=...)` next to fetch the "
-            f"full parameter schema for any tool you want to invoke."
+            f"`{{name, category, summary, params}}` records. The `params` "
+            f"field is a compact `{{name: 'Type[?]'}}` map — `?` suffix "
+            f"means optional, no suffix means required. For simple tools "
+            f"where the parameter names + types are enough to compose an "
+            f"invoke, you can skip straight to `{platform}_invoke_tool`. "
+            f"For full parameter descriptions, enum value lists, or nested "
+            f"object shapes, call `{platform}_get_tool_schema(name=...)`."
         ),
         annotations=_META_ANNOTATIONS_READONLY,
         tags={f"{platform}_meta"},
@@ -207,7 +285,7 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
         substring = (filter or "").lower().strip()
         category_filter = (category or "").strip() or None
 
-        matches: list[dict[str, str]] = []
+        matches: list[dict[str, Any]] = []
         for name, spec in registry_ref.items():
             if not is_tool_enabled(spec, config):
                 continue
@@ -217,11 +295,15 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
                 haystack = f"{name} {spec.description}".lower()
                 if substring not in haystack:
                     continue
+            # Use the private ``_get_tool`` to bypass the Visibility
+            # filter — hidden tools need their schema inspected here.
+            fm_tool = await mcp._get_tool(name)
             matches.append(
                 {
                     "name": name,
                     "category": spec.category,
                     "summary": _tool_summary(spec),
+                    "params": _param_summary(fm_tool),
                 }
             )
 

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastmcp import Context as FastMCPContext
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -143,6 +144,33 @@ class TestListTools:
         result = await tool.fn(_fake_ctx(config))
         assert sorted(result["categories"]) == ["blueprints", "manage_networks"]
 
+    async def test_entries_include_params_summary(self, mcp_with_fake_tools):
+        """Regression for #185: list_tools entries should include a compact
+        ``params`` map so AI clients can skip get_tool_schema for simple tools.
+
+        Uses the fake coercion fixture because ``stub_apstra_registry`` uses
+        ``AsyncMock`` functions whose signatures are just ``*args, **kwargs``
+        — FastMCP can't derive a parameter schema from those.
+        """
+        tool = await mcp_with_fake_tools.get_tool("apstra_list_tools")
+        config = ServerConfig()
+
+        result = await tool.fn(_fake_ctx(config))
+        by_name = {entry["name"]: entry for entry in result["tools"]}
+
+        # Enum-typed tool: "?" suffix absent on the required enum param.
+        enum_entry = by_name["apstra_fake_enum_tool"]
+        assert "params" in enum_entry
+        assert enum_entry["params"] == {"object_type": "_FakeEnumObjectType"}
+
+        # UUID-typed tool: format=uuid should surface as "UUID".
+        uuid_entry = by_name["apstra_fake_uuid_tool"]
+        assert uuid_entry["params"] == {"blueprint_id": "UUID"}
+
+        # Required-only string param: no "?" suffix.
+        required_entry = by_name["apstra_fake_required_tool"]
+        assert required_entry["params"] == {"required_field": "string"}
+
 
 @pytest.mark.unit
 class TestGetToolSchema:
@@ -254,7 +282,7 @@ _coerce_received: dict = {}
 
 
 async def _fake_enum_tool(
-    ctx,
+    ctx: FastMCPContext,
     object_type: _Annotated[_FakeEnumObjectType, _Field(description="what to fetch")],
 ) -> dict:
     # If coercion is missing, ``object_type`` is the raw string
@@ -268,7 +296,7 @@ _fake_enum_tool.__name__ = "apstra_fake_enum_tool"  # type: ignore[attr-defined]
 
 
 async def _fake_uuid_tool(
-    ctx,
+    ctx: FastMCPContext,
     blueprint_id: _Annotated[_UUID, _Field(description="bp id")],
 ) -> dict:
     _coerce_received["type"] = type(blueprint_id).__name__
@@ -280,7 +308,7 @@ _fake_uuid_tool.__name__ = "apstra_fake_uuid_tool"  # type: ignore[attr-defined]
 
 
 async def _fake_required_tool(
-    ctx,
+    ctx: FastMCPContext,
     required_field: _Annotated[str, _Field(description="required")],
 ) -> dict:
     return {"ok": True}
@@ -290,7 +318,7 @@ _fake_required_tool.__name__ = "apstra_fake_required_tool"  # type: ignore[attr-
 
 
 async def _fake_optional_tool(
-    ctx,
+    ctx: FastMCPContext,
     required: _Annotated[str, _Field(description="required")],
     optional_uuid: _Annotated[_UUID, _Field(default=None, description="optional")],
 ) -> dict:
@@ -302,36 +330,36 @@ _fake_optional_tool.__name__ = "apstra_fake_optional_tool"  # type: ignore[attr-
 
 @pytest.fixture
 def mcp_with_fake_tools():
-    """Install the fake coercion-test tools in the apstra registry."""
+    """Install the fake coercion-test tools in the apstra registry.
+
+    Also registers them with FastMCP directly so ``mcp._get_tool(name)``
+    returns a real Tool object with a parsed schema — required by the
+    list_tools param-summary extraction path.
+    """
     clear_registry("apstra")
     _coerce_received.clear()
 
-    REGISTRIES["apstra"]["apstra_fake_enum_tool"] = ToolSpec(
-        name="apstra_fake_enum_tool",
-        func=_fake_enum_tool,
-        platform="apstra",
-        category="testing",
-        description="Test tool with enum param.",
-        tags=set(),
-    )
-    REGISTRIES["apstra"]["apstra_fake_uuid_tool"] = ToolSpec(
-        name="apstra_fake_uuid_tool",
-        func=_fake_uuid_tool,
-        platform="apstra",
-        category="testing",
-        description="Test tool with UUID param.",
-        tags=set(),
-    )
-    REGISTRIES["apstra"]["apstra_fake_required_tool"] = ToolSpec(
-        name="apstra_fake_required_tool",
-        func=_fake_required_tool,
-        platform="apstra",
-        category="testing",
-        description="Test tool with required param.",
-        tags=set(),
-    )
+    fake_tools = [
+        ("apstra_fake_enum_tool", _fake_enum_tool, "Test tool with enum param."),
+        ("apstra_fake_uuid_tool", _fake_uuid_tool, "Test tool with UUID param."),
+        ("apstra_fake_required_tool", _fake_required_tool, "Test tool with required param."),
+    ]
 
     mcp = FastMCP(name="test-coercion")
+
+    for name, func, description in fake_tools:
+        REGISTRIES["apstra"][name] = ToolSpec(
+            name=name,
+            func=func,
+            platform="apstra",
+            category="testing",
+            description=description,
+            tags=set(),
+        )
+        # Register with FastMCP so the meta-tool's _get_tool lookup
+        # returns a real Tool object with parsed parameters.
+        mcp.tool(name=name, description=description)(func)
+
     build_meta_tools("apstra", mcp)
     return mcp
 


### PR DESCRIPTION
## Summary

First of the post-v2.0 UX polish patches. `<platform>_list_tools` responses now include a compact `{name: \"Type[?]\"}` params map per tool, letting AI clients skip `<platform>_get_tool_schema` for simple-tool invocations — **3 round-trips down to 2** in the common case.

Closes [#185](https://github.com/nowireless4u/hpe-networking-mcp/issues/185).

## What the new output looks like

Live example from the running container — `mist_list_tools(filter=\"site\")`:

```json
{
  \"name\": \"mist_get_site_health\",
  \"category\": \"get_site_health\",
  \"summary\": \"Get a health overview across all sites...\",
  \"params\": {\"org_id\": \"UUID\"}
}
{
  \"name\": \"mist_get_org_or_site_info\",
  \"category\": \"get_org_or_site_info\",
  \"summary\": \"Search information about the organizations or sites\",
  \"params\": {\"info_type\": \"Info_type\", \"org_id\": \"UUID\", \"site_id\": \"UUID?\"}
}
```

- `?` suffix = optional (has a default or absent from `required`).
- Enum-typed params show the class name (`\"Info_type\"`) — AI still needs \`get_tool_schema\` to see the enum's valid values, which is the right tradeoff (otherwise inlining every enum's full values would balloon the \`list_tools\` response).
- Types: \`UUID\`, \`string\`, \`integer\`, \`boolean\`, \`dict\`, \`list[...]\`, or an Enum class name.

## Behavior changes

**Simple-tool path (most common case — 2 round-trips):**
```
mist_list_tools(filter=\"...\")      # see params: {\"org_id\": \"UUID\"}
mist_invoke_tool(name=\"...\", params={\"org_id\": \"...\"})
```

**Enum-requires-schema path (3 round-trips — unchanged):**
```
mist_list_tools(filter=\"...\")                 # see params: {\"action_type\": \"Action_type\"}
mist_get_tool_schema(name=\"...\")              # discover Action_type's valid values
mist_invoke_tool(name=\"...\", params={...})
```

## Code changes

### `platforms/_common/meta_tools.py`
- New `_resolve_type_name(pdef)` helper — extracts concise type strings from JSON schema property definitions. Handles `$ref` (enum/nested model), `format` hints (`uuid` → `UUID`, `date-time` → `datetime`), `anyOf`/`oneOf` unions, and `array` types.
- New `_param_summary(fm_tool)` helper — walks FastMCP's parsed input schema to produce the `{name: \"Type[?]\"}` map.
- `_list_tools` fetches each matching tool via `mcp._get_tool(name)` and includes the param summary in each entry.
- Tool description updated to advertise the new `params` field.

### `INSTRUCTIONS.md`
- TOOL DISCOVERY block reworked: step 2 (\`list_tools\`) now mentions the new `params` field; step 3 (\`get_tool_schema\`) becomes conditional on whether step 2 was sufficient.
- Added a ✅ \"Simple-tool path (2 round-trips)\" example alongside the existing 3-round-trip \"Full-schema path\".
- Rule 5 softened from \"MANDATORY schema fetch\" (v2.0.0.2) to \"use the info you already have from list_tools\" — the stricter rule was the right response to v2.0.0.2's live-testing anti-pattern, but with this patch the AI can legitimately skip \`get_tool_schema\` for simple tools.
- Rule 6 names specific cases where \`get_tool_schema\` is still needed (enum value lists, field descriptions, nested schemas).

## Tests

- New: `test_entries_include_params_summary` in `TestListTools` — asserts Enum/UUID/str-typed params surface correctly.
- `mcp_with_fake_tools` fixture now registers fake tools with FastMCP too (coercion tests only needed REGISTRIES; this path needs FastMCP's parsed schema).
- Fake-tool `ctx` now typed as `FastMCPContext` so FastMCP's auto-injection recognizes and strips it from advertised schemas.

Total: **463 passing** (462 → 463). Ruff/format/mypy clean.

## Token-budget check

The v2.0 context-budget win is preserved:

| Footprint | Before | After |
|---|---|---|
| Baseline per-turn `tools` array | ~2,910 tokens | **unchanged** — we only touched the `list_tools` response, not the meta-tool's input schema |
| Per-query `list_tools` response (filtered, 3-5 tools) | ~400-800 tokens | **+60-100 tokens** (params inlined) |
| Per-query net when a schema fetch is avoided | — | **~500-1000 tokens saved** (full schema responses are ~10× larger than inlined param maps) |

Net effect: negligible cost on baseline, meaningful savings when schema fetches are avoided.

## Post-merge

1. Tag `v2.0.0.2` → `v2.0.0.2` is the current tag; this PR bumps to `v2.0.0.3`
2. `gh release create v2.0.0.3` with the CHANGELOG \`[2.0.0.3]\` section as notes
3. Docker Publish workflow rolls `:latest` forward
4. Users pick it up with `docker compose pull && docker compose up -d --force-recreate` + AI client restart

Next queue: #186 (Mist str→Enum tightening), #183 (tool-description cleanup), Axis Phase 1, Phase 7 items.