### PR TITLE
v2.0.0.4: fix Mist rrm_info default trap + insight_metrics SDK mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0.4] - 2026-04-24
+
+**Bug-fix triple for two Mist tools surfaced during live RF-planning use.** Fixes [#190](https://github.com/nowireless4u/hpe-networking-mcp/issues/190), [#191](https://github.com/nowireless4u/hpe-networking-mcp/issues/191), and [#192](https://github.com/nowireless4u/hpe-networking-mcp/issues/192).
+
+### Bugs fixed
+
+#### A. `mist_get_site_rrm_info` rejects its own defaults for non-events modes (#190)
+
+`limit=200, page=1` were set as Pydantic field defaults, then validated against `if limit and rrm_info_type != "events": raise`. Result: `current_channel_planning`, `current_rrm_considerations`, and `current_rrm_neighbors` always returned `400 limit parameter can only be used when rrm_info_type is "events"` — three of four modes unreachable.
+
+**Fix:** `limit`/`page` now default to `None` at the signature level; the 200/1 defaults are applied only inside the `events` case. Validation gate unchanged (still rejects explicit values for non-events modes).
+
+#### B. `mist_get_insight_metrics` leaks literal `"None"` into Mist API (#191)
+
+Every case branch unconditionally wrapped optional time-range params with `str(start)`, `str(end)`, `str(duration)`, `str(interval)`. When the client omitted any of these, Pydantic filled in `None`, `str(None)` became the 4-char string `"None"`, and that landed in Mist query params → 400/404s.
+
+**Fix:** Pre-compute `start_str = str(start) if start else None` (etc.) once, reuse across all 6 case branches. Matches the guard pattern already used in `get_site_rrm_info`'s events branch.
+
+#### C. `mist_get_insight_metrics` dispatch broken across 5 of 6 branches (#192)
+
+Every branch had at least one issue against the real `mistapi` SDK signatures:
+
+| object_type | Was | Problem |
+|---|---|---|
+| `site` | `getSiteInsightMetrics(metric=...)` | Wrong kwarg (SDK wants `metrics=`); SDK function itself builds wrong URL (`/insights?metrics=X` vs real `/insights/{metric}`) |
+| `client` | `metric=` | Wrong kwarg (SDK wants `metrics=`) — TypeError |
+| `ap` | `getSiteInsightMetricsForDevice(device_mac=mac, metric=...)` → `/insights/device/{mac}/ap-rf-metrics` | Wrong SDK function; `ap-rf-metrics` only works via `getSiteInsightMetricsForAP` → `/insights/ap/{device_id}/stats` — 404 |
+| `gateway` | `metric=` | Wrong kwarg — TypeError |
+| `mxedge` | OK | (only `str(None)` leak) |
+| `switch` | OK | (only `str(None)` leak) |
+
+**Fix:**
+
+- `site` branch: bypass the broken `getSiteInsightMetrics` and call `apisession.mist_get` directly with the correct `/api/v1/sites/{id}/insights/{metric}` URL. (Filed upstream — the SDK function's URL construction is wrong.)
+- `client`, `ap`, `gateway`: rename `metric=` → `metrics=` kwarg; switch `ap` from `ForDevice` to `ForAP`; use `device_id` UUID (not MAC) for `ap` and `gateway` endpoints.
+- New helper `_mac_to_device_id(mac)` derives the Mist device UUID from a MAC using the documented `00000000-0000-0000-1000-<mac>` convention — so callers can pass either `mac` or `device_id` for `ap`/`gateway`.
+- All 6 branches now enforce the required device-identifier explicitly (`mac` for client/mxedge/switch; `mac` or `device_id` for ap/gateway).
+
+### Verified against live Mist tenant
+
+- `rrm_info(current_channel_planning)` → RF template data ✅
+- `rrm_info(current_rrm_neighbors, band=5)` → neighbor list ✅
+- `rrm_info(events, band=6, duration=1d)` → event list ✅
+- `insight_metrics(object_type=site, metric=num_clients, duration=1d)` → 24h timeseries ✅
+- `insight_metrics(object_type=site, metric=bytes, duration=1h)` → 1h timeseries ✅
+- `insight_metrics(object_type=ap, metric=ap-rf-metrics, mac=04:cd:c0:d1:e5:5a, duration=1d)` → AP RF metrics (MAC-with-colons handling verified) ✅
+
+### Scope: Mist-wide audit
+
+Audit of all 30 Mist tool files for these two bug classes:
+
+- **Default-trips-own-validation-gate (A):** 1/30 files affected (`get_site_rrm_info.py` only).
+- **`str(None)` leak (B):** 1/30 files affected (`get_insight_metrics.py` only).
+
+No other Mist tools exhibited either pattern. All other tools already use the correct `default=None` + guarded `str()` idioms.
+
 ## [2.0.0.3] - 2026-04-24
 
 **UX win: cut one round-trip per simple tool invocation.** `<platform>_list_tools` responses now include a compact `params` map per tool entry, so AI clients can skip `<platform>_get_tool_schema` when the parameter names + types alone are enough to compose an `invoke` call. Fixes [#185](https://github.com/nowireless4u/hpe-networking-mcp/issues/185).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Fix:** `limit`/`page` now default to `None` at the signature level; the 200/1 defaults are applied only inside the `events` case. Validation gate unchanged (still rejects explicit values for non-events modes).
 
+**Bonus (same tool):** `band` is actually required for the `events` mode too (Mist returns `400 "valid band is required"` when omitted), but the tool description only listed it as required for `considerations` and `neighbors`. Added the missing client-side validation and updated the field description.
+
 #### B. `mist_get_insight_metrics` leaks literal `"None"` into Mist API (#191)
 
 Every case branch unconditionally wrapped optional time-range params with `str(start)`, `str(end)`, `str(duration)`, `str(interval)`. When the client omitted any of these, Pydantic filled in `None`, `str(None)` became the 4-char string `"None"`, and that landed in Mist query params → 400/404s.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -374,7 +374,7 @@ Always registered regardless of `MCP_TOOL_MODE`:
 | site_id | UUID | Yes | Site ID. |
 | rrm_info_type | str | Yes | `current_channel_planning`, `current_rrm_considerations`, `current_rrm_neighbors`, or `events`. |
 | device_id | UUID | No | AP device ID. Required for `current_rrm_considerations`. |
-| band | str | No | `24`, `5`, or `6`. Required for considerations and neighbors. |
+| band | str | No | `24`, `5`, or `6`. Required for considerations, neighbors, and events. |
 | start | int | No | Start of time range (epoch seconds). Events only. |
 | end | int | No | End of time range (epoch seconds). Events only. |
 | duration | str | No | Duration shorthand. Events only. |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -339,8 +339,8 @@ Always registered regardless of `MCP_TOOL_MODE`:
 | site_id | UUID | Yes | Site ID. |
 | object_type | str | Yes | `site`, `client`, `ap`, `gateway`, `mxedge`, or `switch`. |
 | metric | str | Yes | Metric name. Use `mist_get_constants` with `insight_metrics` to discover. |
-| mac | str | No | MAC address. Required for client, ap, mxedge, switch. |
-| device_id | UUID | No | Device ID. Required for gateway. |
+| mac | str | No | MAC address (with or without colons). Required for client, mxedge, switch. Optional for ap, gateway — converted to device_id UUID automatically. |
+| device_id | UUID | No | Device UUID. Optional alternative to `mac` for ap and gateway (either is accepted). |
 | start | int | No | Start of time range (epoch seconds). |
 | end | int | No | End of time range (epoch seconds). |
 | duration | str | No | Duration shorthand (e.g. `1d`, `1h`, `10m`). |
@@ -378,8 +378,8 @@ Always registered regardless of `MCP_TOOL_MODE`:
 | start | int | No | Start of time range (epoch seconds). Events only. |
 | end | int | No | End of time range (epoch seconds). Events only. |
 | duration | str | No | Duration shorthand. Events only. |
-| limit | int | No | Default: 200. Events only. |
-| page | int | No | Default: 1. Events only. |
+| limit | int | No | Events only; defaults to 200 when `rrm_info_type=events`. Rejected for other modes. |
+| page | int | No | Events only; defaults to 1 when `rrm_info_type=events`. Rejected for other modes. |
 
 ### Service Level Expectations (SLE)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.3"
+version = "2.0.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
@@ -38,6 +38,18 @@ class Object_type(Enum):
     SWITCH = "switch"
 
 
+def _mac_to_device_id(mac: str) -> str:
+    """Construct a Mist device_id UUID from a MAC address.
+
+    Mist device UUIDs follow the deterministic pattern
+    ``00000000-0000-0000-1000-<mac_lowercase_no_separators>``.
+    """
+    clean = mac.lower().replace(":", "").replace("-", "")
+    if len(clean) != 12 or not all(c in "0123456789abcdef" for c in clean):
+        raise ValueError(f"Invalid MAC address format: {mac!r}")
+    return f"00000000-0000-0000-1000-{clean}"
+
+
 @tool(
     name="mist_get_insight_metrics",
     description="Get insight metrics for a given object",
@@ -72,9 +84,12 @@ async def get_insight_metrics(
         str,
         Field(
             description=(
-                "MAC address of the client or device to "
-                "retrieve metrics for. Required if object_type "
-                "is 'client', 'ap', 'mxedge' or 'switch'"
+                "MAC address of the client or device to retrieve metrics for. "
+                "Required if object_type is 'client', 'ap', 'mxedge' or 'switch'. "
+                "Accepts 12 hex chars with or without colons. "
+                "For object_type='ap' or 'gateway', this is converted to the "
+                "Mist device_id UUID automatically — pass device_id directly "
+                "instead if you already have it."
             ),
             default=None,
         ),
@@ -82,7 +97,12 @@ async def get_insight_metrics(
     device_id: Annotated[
         UUID,
         Field(
-            description=("ID of the gateway device to retrieve metrics for. Required if object_type is 'gateway'"),
+            description=(
+                "UUID of the AP or gateway device to retrieve metrics for. "
+                "Optional alternative to `mac` for object_type='ap' or 'gateway' — "
+                "if not provided, it is derived from `mac` via the Mist "
+                "convention 00000000-0000-0000-1000-<mac>."
+            ),
             default=None,
         ),
     ],
@@ -153,86 +173,135 @@ async def get_insight_metrics(
     apisession, response_format = await get_apisession(ctx)
 
     try:
+        start_str = str(start) if start else None
+        end_str = str(end) if end else None
+        duration_str = duration if duration else None
+        interval_str = interval if interval else None
+
         match object_type.value:
             case "site":
-                response = mistapi.api.v1.sites.insights.getSiteInsightMetrics(
-                    apisession,
-                    site_id=str(site_id),
-                    metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
-                    limit=limit,
-                    page=page,
-                )
+                # Bypass mistapi.api.v1.sites.insights.getSiteInsightMetrics — that
+                # SDK function builds `/insights?metrics=X`, but the real Mist
+                # endpoint is `/insights/{metric}` (matching every `For*` variant).
+                uri = f"/api/v1/sites/{site_id}/insights/{metric}"
+                query_params: dict[str, str] = {}
+                if start_str:
+                    query_params["start"] = start_str
+                if end_str:
+                    query_params["end"] = end_str
+                if duration_str:
+                    query_params["duration"] = duration_str
+                if interval_str:
+                    query_params["interval"] = interval_str
+                if limit:
+                    query_params["limit"] = str(limit)
+                if page:
+                    query_params["page"] = str(page)
+                response = apisession.mist_get(uri=uri, query=query_params)
                 await process_response(response)
             case "client":
+                if not mac:
+                    raise ToolError(
+                        {
+                            "status_code": 400,
+                            "message": "`mac` is required when object_type='client'.",
+                        }
+                    )
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForClient(
                     apisession,
                     site_id=str(site_id),
                     client_mac=str(mac),
-                    metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
+                    metrics=str(metric),
+                    start=start_str,
+                    end=end_str,
+                    duration=duration_str,
+                    interval=interval_str,
                     limit=limit,
                     page=page,
                 )
                 await process_response(response)
             case "ap":
-                response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForDevice(
+                if not device_id and not mac:
+                    raise ToolError(
+                        {
+                            "status_code": 400,
+                            "message": "`mac` or `device_id` is required when object_type='ap'.",
+                        }
+                    )
+                ap_device_id = str(device_id) if device_id else _mac_to_device_id(str(mac))
+                response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForAP(
                     apisession,
                     site_id=str(site_id),
-                    device_mac=str(mac),
-                    metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
+                    device_id=ap_device_id,
+                    metrics=str(metric),
+                    start=start_str,
+                    end=end_str,
+                    duration=duration_str,
+                    interval=interval_str,
                     limit=limit,
                     page=page,
                 )
                 await process_response(response)
             case "gateway":
+                if not device_id and not mac:
+                    raise ToolError(
+                        {
+                            "status_code": 400,
+                            "message": "`mac` or `device_id` is required when object_type='gateway'.",
+                        }
+                    )
+                gw_device_id = str(device_id) if device_id else _mac_to_device_id(str(mac))
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForGateway(
                     apisession,
                     site_id=str(site_id),
-                    device_id=str(device_id),
-                    metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
+                    device_id=gw_device_id,
+                    metrics=str(metric),
+                    start=start_str,
+                    end=end_str,
+                    duration=duration_str,
+                    interval=interval_str,
                     limit=limit,
                     page=page,
                 )
                 await process_response(response)
             case "mxedge":
+                if not mac:
+                    raise ToolError(
+                        {
+                            "status_code": 400,
+                            "message": "`mac` is required when object_type='mxedge'.",
+                        }
+                    )
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForMxEdge(
                     apisession,
                     site_id=str(site_id),
                     device_mac=str(mac),
                     metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
+                    start=start_str,
+                    end=end_str,
+                    duration=duration_str,
+                    interval=interval_str,
                     limit=limit,
                     page=page,
                 )
                 await process_response(response)
             case "switch":
+                if not mac:
+                    raise ToolError(
+                        {
+                            "status_code": 400,
+                            "message": "`mac` is required when object_type='switch'.",
+                        }
+                    )
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForSwitch(
                     apisession,
                     site_id=str(site_id),
                     device_mac=str(mac),
                     metric=str(metric),
-                    start=str(start),
-                    end=str(end),
-                    duration=str(duration),
-                    interval=str(interval),
+                    start=start_str,
+                    end=end_str,
+                    duration=duration_str,
+                    interval=interval_str,
                     limit=limit,
                     page=page,
                 )

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
@@ -95,9 +95,7 @@ async def get_site_rrm_info(
     band: Annotated[
         Band,
         Field(
-            description=(
-                "802.11 band. Required when rrm_info_type is current_rrm_considerations or current_rrm_neighbors"
-            ),
+            description=("802.11 band. Required for current_rrm_considerations, current_rrm_neighbors, and events"),
             default=None,
         ),
     ],
@@ -183,6 +181,14 @@ async def get_site_rrm_info(
                 {
                     "status_code": 400,
                     "message": ('`band` parameter is required when `rrm_info_type` is "current_rrm_neighbors".'),
+                }
+            )
+
+        if object_type.value == "events" and not band:
+            raise ToolError(
+                {
+                    "status_code": 400,
+                    "message": ('`band` parameter is required when `rrm_info_type` is "events".'),
                 }
             )
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_rrm_info.py
@@ -125,17 +125,17 @@ async def get_site_rrm_info(
     limit: Annotated[
         int,
         Field(
-            description="Max number of results per page",
-            default=200,
+            description="Max number of results per page (events only; defaults to 200 when rrm_info_type=events)",
+            default=None,
         ),
-    ] = 200,
+    ],
     page: Annotated[
         int,
         Field(
-            description="Page number for pagination",
-            default=1,
+            description="Page number for pagination (events only; defaults to 1 when rrm_info_type=events)",
+            default=None,
         ),
-    ] = 1,
+    ],
 ) -> dict | list | str:
     """Retrieve Radio Resource Management (RRM) information."""
 
@@ -237,8 +237,8 @@ async def get_site_rrm_info(
                     start=str(start) if start else None,
                     end=str(end) if end else None,
                     duration=duration if duration else None,
-                    limit=limit,
-                    page=page,
+                    limit=limit if limit is not None else 200,
+                    page=page if page is not None else 1,
                 )
                 await process_response(response)
 


### PR DESCRIPTION
## Summary

Patch release fixing three live-surfaced Mist tool bugs plus one pre-existing rrm_info description/validation gap found along the way.

Closes #190, #191, #192.

## Bugs fixed

### #190 — `mist_get_site_rrm_info` rejects its own Pydantic defaults

`limit=200` and `page=1` were baked in as Pydantic field defaults, then validated away by `if limit and rrm_info_type != "events": raise`. Three of four modes (`current_channel_planning`, `current_rrm_considerations`, `current_rrm_neighbors`) were unreachable. Now defaults to `None`; 200/1 applied internally in the events branch only.

### #191 — `mist_get_insight_metrics` leaks literal `"None"` into Mist API

Every case branch unconditionally wrapped optional time-range params in `str()`, so `str(None)` sent the 4-char string `"None"` as a query param. Pre-compute `start_str = str(start) if start else None` once, reuse across all 6 branches.

### #192 — `mist_get_insight_metrics` dispatch broken on 5 of 6 branches

Against the real `mistapi` SDK:

- `site`/`client`/`ap`/`gateway` were passing `metric=` but the SDK wants `metrics=` (plural) → TypeError.
- `ap` was routed to `getSiteInsightMetricsForDevice` → wrong path (`/insights/device/{mac}/ap-rf-metrics`); `ap-rf-metrics` only works via `getSiteInsightMetricsForAP` → `/insights/ap/{device_id}/stats`.
- `site` branch calls `getSiteInsightMetrics` which itself builds a wrong URL (`/insights?metrics=X` vs real `/insights/{metric}`). Bypassed via `apisession.mist_get` with the correct URL.
- New `_mac_to_device_id` helper uses Mist's deterministic `00000000-0000-0000-1000-<mac>` UUID pattern so AP/gateway branches accept either MAC or UUID.

### Bonus: rrm_info events mode required `band` but didn't say so

Mist returned opaque `'{"detail": "valid band is required"}'` when omitted. Added the same client-side validation the other band-requiring modes already had, and fixed the misleading param description.

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy` + 463 pytest tests — all pass in Docker
- [x] Live-tested against a real Mist tenant:
  - `rrm_info(current_channel_planning)` → RF template data
  - `rrm_info(current_rrm_neighbors, band=5)` → neighbor list
  - `rrm_info(events, band=6, duration=1d)` → event list
  - `rrm_info(events)` without band → clean client-side 400
  - `insight_metrics(site, num_clients, 1d)` → 24h timeseries
  - `insight_metrics(site, bytes, 1h)` → 1h timeseries
  - `insight_metrics(ap, ap-rf-metrics, mac=04:cd:c0:d1:e5:5a)` → AP RF metrics (MAC-with-colons verified)

## Scope: audit across every Mist tool

Pattern A (Pydantic default trips own validation gate) — **1/30 files affected** (just the one).
Pattern B (unconditional `str()` on optional params leaks `"None"`) — **1/30 files affected** (just the one).

Both were isolated; no follow-up cleanup needed elsewhere.

## Docs

- `CHANGELOG.md` — v2.0.0.4 entry
- `docs/TOOLS.md` — updated param descriptions for `mist_get_insight_metrics` (`mac`/`device_id` semantics) and `mist_get_site_rrm_info` (`band` required for events too; `limit`/`page` events-only wording)
- `pyproject.toml` — version bump to 2.0.0.4

No README changes needed — tool counts are unchanged (fixes only, no add/remove). No INSTRUCTIONS.md changes — it only indexes tool names by category.