### PR TITLE
v2.0.0.5: add site_rf_check cross-platform tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0.5] - 2026-04-24
+
+**New cross-platform tool: `site_rf_check`.** Closes the AI-discovery gap where channel-planning / RF / spectrum questions produced Mist-only answers even when the user had Aruba APs in Central at the same site.
+
+### Why a new tool, not a docs rule
+
+Tested approach: a docs rule in `INSTRUCTIONS.md` saying "for platform-agnostic questions, query every enabled platform first." Track record on this codebase ([#184](https://github.com/nowireless4u/hpe-networking-mcp/issues/184), [#185](https://github.com/nowireless4u/hpe-networking-mcp/issues/185)) shows soft "consider X before deciding" rules in long instruction blocks tend to lose to whatever shortcut pattern the AI matched on first ("Wi-Fi channels → Mist" is sticky). What changes behavior reliably is removing the judgment call: a purpose-built tool whose name + description put cross-platform aggregation directly in the tool list.
+
+### What the tool does
+
+Mirrors the `site_health_check` pattern. Single call returns:
+
+- **Per-band aggregation (2.4 / 5 / 6 GHz):** AP count, channel distribution, avg/max channel utilization, avg noise floor, allowed channels (from the Mist RF template).
+- **Per-AP radio snapshot:** name, model, platform, connected status, and one row per band with channel, bandwidth, TX power, utilization, noise floor.
+- **Recommendations:** co-channel clusters (3+ APs on the same primary channel in 5/6 GHz), peak utilization ≥70%, noise floor >-70 dBm.
+- **Pre-rendered ASCII RF dashboard** in `rendered_report` — channel-occupancy bars, utilization meters, per-AP table, recommendations list. Always-on by default so even clients that don't draw charts get a visual report. Opt out with `include_rendered_report=False`.
+
+### Site-picker fallback
+
+When `site_name` is omitted, the tool returns a list of selectable sites in `site_options` (with per-platform AP counts and online counts) instead of erroring. The `platform` filter still applies — `site_rf_check(platform="central")` lists only Central sites. Two cheap cross-platform calls (orgs/inventory + sites/aps) cover the listing — no per-site fan-out.
+
+### Data sources
+
+| Side | Calls | What we extract |
+|---|---|---|
+| Mist | `/sites/{id}/stats/devices?type=ap` + `getSiteCurrentChannelPlanning` | Per-AP `radio_stat` (per-band channel, power, usage, noise_floor, num_clients), template allowed channels |
+| Central | `MonitoringAPs.get_all_aps(filter=siteId)` + per-AP `MonitoringAPs.get_ap_details` (parallel via asyncio.gather, capped by `max_aps_per_platform`) | Per-AP `radios` array (band, channel, bandwidth, power, channelUtilization, noiseFloor) |
+
+Channel notation differs across platforms: Central uses bonded-channel suffixes (`165S`, `49T+`); the new `_parse_primary_channel` helper extracts the primary channel integer for aggregation while preserving the raw value.
+
+### Verified live
+
+3 Aruba AP-755s at site HOME (Central) — full report rendered with 2.4G/5G/6G channel bars, noise floors, utilization meters, per-AP table. Picker mode tested across 19 sites with accurate online counts. Mist-side picker uses `connected: bool` from `/orgs/{id}/inventory` (not the `status` field — that endpoint doesn't carry it).
+
+### Test additions
+
+49 new unit tests in `tests/unit/test_site_rf_check.py` covering parsers (channel/numeric/bandwidth/band normalization), platform-filter normalization, band aggregation (channel distribution, util/noise math, disconnected-AP exclusion), synthesis (co-channel detection per band, utilization/noise thresholds), the rendered report, and the site picker (sort order, truncation, empty case).
+
+Total suite: **512 tests** passing (463 → 512).
+
+### Code
+
+- New module: `src/hpe_networking_mcp/platforms/site_rf_check.py` (~700 LoC; mirrors `site_health_check.py` shape).
+- New registration: `_register_site_rf_check` in `server.py`, gated by `config.mist or config.central`.
+
+### Docs in this PR
+
+- `INSTRUCTIONS.md` — adds `site_rf_check` to the cross-platform-tools list with explicit "use for any channel-planning / spectrum / RF-health question" guidance.
+- `README.md` — tool counts updated (18 → 19 default), new "Site RF Check" bullet under Cross-Platform Tools.
+- `docs/TOOLS.md` — updated counts, full param doc + return-shape doc for `site_rf_check`.
+
 ## [2.0.0.4] - 2026-04-24
 
 **Bug-fix triple for two Mist tools surfaced during live RF-planning use.** Fixes [#190](https://github.com/nowireless4u/hpe-networking-mcp/issues/190), [#191](https://github.com/nowireless4u/hpe-networking-mcp/issues/191), and [#192](https://github.com/nowireless4u/hpe-networking-mcp/issues/192).

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **126** | **19** |
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** |
-| **Cross-Platform** | **2 tools + 3 prompts** | **2 tools + 3 prompts** | — | **1 tool** | — |
+| **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — |
 
-> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus three cross-platform static tools (`health`, `site_health_check`, `manage_wlan_profile`). **18 tools total, ~2,900 tokens** — down from 261 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 261 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -76,6 +76,7 @@ The Central module includes 12 guided prompts — multi-step workflow templates 
 Tools that span multiple platforms and return pre-aggregated results — each one replaces several individual tool calls, so the AI gets a compact answer instead of paging through raw responses.
 
 - **Site Health Check** (`site_health_check`) — One call returns a unified health report for a site across every enabled platform: Mist site stats and alarms, Central site health and active alerts, and (when ClearPass is configured) session and auth-failure counts for the site's network access devices. Replaces ~8–12 separate tool calls with a compact report including overall status, top alerts, and concrete next-step recommendations. Registered when at least Mist or Central is enabled; ClearPass is additive.
+- **Site RF Check** (`site_rf_check`) — One call returns per-AP, per-band radio state from Mist AND Central in parallel: current channel, bandwidth, TX power, channel utilization, and noise floor for every AP at a site. Aggregates the channel distribution per band (2.4 / 5 / 6 GHz), flags co-channel clusters and high utilization, and ships a pre-rendered ASCII RF dashboard so even clients that don't draw charts get a visual report. When `site_name` is omitted the tool returns a list of selectable sites with AP counts per platform — pick one and call back. Registered when at least Mist or Central is enabled.
 - **Manage WLAN Profile** (`manage_wlan_profile`) — The primary entry point for all WLAN operations. Automatically checks both Mist and Central for the SSID and returns the correct sync workflow. Detects cross-platform scenarios without relying on the AI to follow instructions. Requires both Mist and Central.
 
 #### Cross-Platform WLAN Sync Prompts
@@ -172,7 +173,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 tools registered`, `ClearPass: 126 tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 18 tools are exposed to the AI — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
+Look for lines like `Mist: 35 tools registered`, `ClearPass: 126 tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 19 tools are exposed to the AI — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
 
 ### Docker Image
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -7,11 +7,12 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 ## Dynamic mode (default since v2.0.0.0)
 
-The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the AI sees **18 tools**:
+The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the AI sees **19 tools**:
 
-- **3 cross-platform static tools**
+- **4 cross-platform static tools**
   - `health(platform=...)`
   - `site_health_check(site_name=...)`
+  - `site_rf_check(site_name=...)`
   - `manage_wlan_profile(...)`
 - **3 meta-tools per platform** (× 5 platforms = 15)
   - `<platform>_list_tools(filter=...)` — list candidates
@@ -31,7 +32,7 @@ Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform 
 | Aruba ClearPass | 54 | 72 | -- | 126 |
 | Juniper Apstra | 12 | 7 | -- | 19 |
 | HPE GreenLake | 10 | -- | -- | 10 |
-| Cross-Platform | 2 | 1 | 3 | 6 |
+| Cross-Platform | 3 | 1 | 3 | 7 |
 
 Write tools are disabled by default per platform. Enable them with environment variables:
 `ENABLE_MIST_WRITE_TOOLS=true`, `ENABLE_CENTRAL_WRITE_TOOLS=true`,
@@ -45,6 +46,7 @@ Always registered regardless of `MCP_TOOL_MODE`:
   `platform: str | list[str] | None`. Replaces the v1.x `apstra_health`
   and `clearpass_test_connection` tools (both removed in v2.0).
 - **`site_health_check`** — cross-platform site aggregator.
+- **`site_rf_check`** — cross-platform RF / channel-planning aggregator.
 - **`manage_wlan_profile`** — cross-platform WLAN orchestrator.
 
 ---
@@ -1196,7 +1198,7 @@ LLM through a recommended sequence of tool calls for common network operations.
 
 ---
 
-## Cross-Platform (2 tools + 3 prompts)
+## Cross-Platform (3 tools + 3 prompts)
 
 Tools that span multiple platforms. Each replaces several individual tool calls with a single aggregated response.
 
@@ -1219,6 +1221,30 @@ Tools that span multiple platforms. Each replaces several individual tool calls 
 - `recommendations` — Concrete follow-up tool calls with the right site_id already filled in, targeting only the platforms and categories that showed issues.
 
 **Typical use:** "How is site X doing?", "Is site X healthy?", "Give me a status on site X." After reviewing the summary, follow the recommendations for deeper investigation — do not re-query the per-platform health tools unless needed.
+
+### `site_rf_check`
+
+> **One-call RF / channel-planning snapshot across every enabled platform.** Aggregates per-AP, per-band radio state from Mist AND Central in parallel — current channel, bandwidth, TX power, channel utilization, and noise floor — into a single report with an embedded ASCII RF dashboard. Replaces 10+ separate per-platform calls. Registered when at least Mist or Central is enabled.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| site_name | str | No | Exact site name as shown in Mist and/or Central. When omitted, the tool returns a list of selectable sites (with AP counts per platform) in `site_options` instead of a full RF report — call back with one of those names. |
+| platform | str \| list \| null | No | Optional filter (`mist`, `central`, or both as a list). Omit (null) for the default cross-platform aggregation. ClearPass / Apstra / GreenLake are not valid — they don't expose per-AP RF telemetry. |
+| max_aps_per_platform | int | No | Cap on per-AP detail fetches per platform (Central fans out serial-by-serial). Default 50; range 1–500. |
+| include_rendered_report | bool | No | When true (default), embed a pre-rendered markdown/ASCII RF dashboard in `rendered_report`. Set false for scripted callers that only want structured data. |
+
+**What it returns:**
+
+- `headline` — One-line summary (`Site 'X': N/M APs online | 2.4GHz: ch1×2... | 5GHz: ...`).
+- `bands` — Per-band (2.4 / 5 / 6) summary: AP count, channel distribution, avg/max utilization, avg noise floor, allowed channels (from the Mist RF template).
+- `aps` — Per-AP radio snapshot: name, model, platform, connected status, and a list of radios (one per band) with channel / bandwidth / power / utilization / noise.
+- `mist` — Mist-side metadata: site_id, AP count, RF template name, allowed channels per band.
+- `central` — Central-side metadata: site_id, AP count, online count.
+- `recommendations` — Co-channel cluster warnings (3+ APs on the same primary channel in 5/6 GHz), high-utilization warnings (peak ≥70%), elevated-noise-floor warnings (>-70 dBm).
+- `site_options` — Populated only when `site_name` is omitted. Each entry: name, platform, site_id, ap_count, online_ap_count.
+- `rendered_report` — Pre-formatted markdown/ASCII dashboard. Includes per-band channel-occupancy bars, utilization meters, a per-AP table, and the recommendations list. Designed to render directly even in clients that don't draw charts.
+
+**Typical use:** "Show me 5 GHz / 6 GHz channels at site X", "How is RF doing at site X?", "Channel planning report for site X", "Are any APs on the same channel?" Use this *instead of* picking one vendor's RF tools — even when only one platform's APs are at the site, the cross-platform call is cheap and surfaces both sides cleanly.
 
 ### `manage_wlan_profile`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.4"
+version = "2.0.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -55,6 +55,7 @@ The server's Pydantic validator rejects `invalid_params` responses with actionab
 Use the cross-platform tools directly when they apply — they replace several per-platform calls:
 - `health(platform=...)` — platform reachability / status
 - `site_health_check(site_name=...)` — unified site health across Mist + Central + ClearPass
+- `site_rf_check(site_name=...)` — unified per-AP, per-band RF state (channels, power, utilization, noise floor) across Mist + Central; includes a pre-rendered ASCII RF dashboard. **Use for any channel-planning / spectrum / RF-health / "how are my 5/6 GHz channels" question** — do NOT fall back to Mist-only or Central-only RF tools without a reason.
 - `manage_wlan_profile(...)` — the mandatory entry point for any WLAN create/copy/sync request
 
 If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front without needing the meta-tool round-trip. The names and behaviors are identical either way — only the discovery mechanism differs.

--- a/src/hpe_networking_mcp/platforms/site_rf_check.py
+++ b/src/hpe_networking_mcp/platforms/site_rf_check.py
@@ -1,0 +1,1054 @@
+"""Cross-platform site RF / channel-planning aggregation tool.
+
+One tool call that pulls per-AP, per-band radio state from every enabled
+platform (Mist + Central) for a given site, aggregates channel
+distribution + utilization per band, and returns a compact report.
+Replaces 10+ separate tool calls with a single pre-aggregated response.
+
+The AI-discovery gap this exists to close: questions like "show me how my
+5/6 GHz channels are operating" used to produce Mist-only answers even
+when the user had Aruba APs in Central at the same site. By exposing a
+single purpose-built tool the AI reaches for it directly instead of
+picking one platform's meta-tool and stopping.
+"""
+
+import asyncio
+import re
+from collections import Counter
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context
+from loguru import logger
+from pydantic import BaseModel, Field
+
+# Response models — compact shapes to keep Claude's context cheap.
+
+
+class Radio(BaseModel):
+    """One radio on one AP: live per-band state snapshot."""
+
+    band: Literal["2.4", "5", "6"]
+    channel: str | None = None
+    primary_channel: int | None = None
+    bandwidth_mhz: int | None = None
+    power_dbm: float | None = None
+    channel_utilization_pct: float | None = None
+    noise_floor_dbm: float | None = None
+    num_clients: int | None = None
+    status: str | None = None
+
+
+class APSummary(BaseModel):
+    """Per-AP RF state: name, identity, and the three radios (if present)."""
+
+    name: str | None = None
+    model: str | None = None
+    serial: str | None = None
+    mac: str | None = None
+    platform: Literal["mist", "central"]
+    connected: bool = True
+    radios: list[Radio] = Field(default_factory=list)
+    error: str | None = None
+
+
+class BandSummary(BaseModel):
+    """Site-level summary for one band across all reporting APs."""
+
+    band: Literal["2.4", "5", "6"]
+    ap_count: int = 0
+    radios_active: int = 0
+    channel_distribution: dict[str, int] = Field(default_factory=dict)
+    avg_utilization_pct: float | None = None
+    max_utilization_pct: float | None = None
+    avg_noise_floor_dbm: float | None = None
+    allowed_channels: list[int] | None = None
+    note: str | None = None
+
+
+class MistRF(BaseModel):
+    found: bool = False
+    site_id: str | None = None
+    ap_count: int = 0
+    aps_connected: int = 0
+    rf_template_name: str | None = None
+    rf_template_allowed: dict[str, list[int] | None] = Field(default_factory=dict)
+    error: str | None = None
+
+
+class CentralRF(BaseModel):
+    found: bool = False
+    site_id: str | None = None
+    ap_count: int = 0
+    aps_online: int = 0
+    error: str | None = None
+
+
+class SiteOption(BaseModel):
+    """A selectable site returned when the caller omits ``site_name``."""
+
+    name: str
+    platform: Literal["mist", "central"]
+    site_id: str | None = None
+    ap_count: int = 0
+    online_ap_count: int | None = None
+
+
+class SiteRFReport(BaseModel):
+    site_name: str
+    platforms_queried: list[str]
+    platforms_matched: list[str]
+    headline: str
+    bands: dict[Literal["2.4", "5", "6"], BandSummary] = Field(default_factory=dict)
+    aps: list[APSummary] = Field(default_factory=list)
+    mist: MistRF | None = None
+    central: CentralRF | None = None
+    recommendations: list[str] = Field(default_factory=list)
+    site_options: list[SiteOption] | None = None
+    rendered_report: str | None = None
+
+
+_RF_PLATFORMS: tuple[str, ...] = ("mist", "central")
+
+
+def _normalize_rf_platform_filter(
+    value: str | list[str] | None,
+    enabled: list[str],
+) -> list[str]:
+    """Resolve the ``platform`` argument to the subset of RF platforms to query."""
+    if value is None:
+        return [p for p in _RF_PLATFORMS if p in enabled]
+    candidates = [value] if isinstance(value, str) else [str(v) for v in value]
+
+    wanted: list[str] = []
+    for name in candidates:
+        name = name.strip().lower()
+        if name in _RF_PLATFORMS and name not in wanted:
+            wanted.append(name)
+        elif name not in _RF_PLATFORMS:
+            logger.warning(
+                "site_rf_check(platform={!r}) — not an RF platform, skipping (valid: mist, central)",
+                name,
+            )
+    return wanted
+
+
+# --- Parsing helpers -----------------------------------------------------
+
+# Central channel strings are free-form: "1", "36", "165S", "49T+" — a
+# primary-channel integer optionally followed by bonding suffixes like
+# "S" (secondary), "T+"/"T-" (triplet), "+"/"-" (HT40 pairing). The
+# leading integer is always the primary channel.
+_CHANNEL_PRIMARY_RE = re.compile(r"^(\d+)")
+_NUMERIC_RE = re.compile(r"^-?\d+(\.\d+)?")
+
+
+def _parse_primary_channel(raw: Any) -> int | None:
+    """Extract the primary channel number from a raw channel value."""
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    s = str(raw).strip()
+    if not s:
+        return None
+    m = _CHANNEL_PRIMARY_RE.match(s)
+    return int(m.group(1)) if m else None
+
+
+def _parse_numeric(raw: Any) -> float | None:
+    """Extract the leading number from a value that may carry a unit suffix."""
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    s = str(raw).strip()
+    if not s:
+        return None
+    m = _NUMERIC_RE.match(s)
+    return float(m.group(0)) if m else None
+
+
+def _parse_bandwidth_mhz(raw: Any) -> int | None:
+    """'160 MHz' -> 160; '20' -> 20; None -> None."""
+    n = _parse_numeric(raw)
+    return int(n) if n is not None else None
+
+
+def _band_key(raw: Any) -> Literal["2.4", "5", "6"] | None:
+    """Normalize Mist/Central band values to our canonical 3 keys."""
+    if raw is None:
+        return None
+    s = str(raw).strip().lower()
+    if s in ("24", "2.4", "2.4 ghz", "2.4ghz"):
+        return "2.4"
+    if s in ("5", "5 ghz", "5ghz"):
+        return "5"
+    if s in ("6", "6 ghz", "6ghz"):
+        return "6"
+    return None
+
+
+# --- Mist collection -----------------------------------------------------
+
+
+def _mist_band_from_stat_key(key: str) -> Literal["2.4", "5", "6"] | None:
+    """Mist radio_stat keys are band_24 / band_5 / band_6."""
+    return _band_key(key.removeprefix("band_"))
+
+
+async def _collect_mist(
+    ctx: Context,
+    site_name: str,
+) -> tuple[MistRF, list[APSummary]]:
+    try:
+        import mistapi
+    except ImportError as e:
+        return MistRF(error=f"mistapi not available: {e}"), []
+
+    session = ctx.lifespan_context.get("mist_session")
+    org_id = ctx.lifespan_context.get("mist_org_id")
+    if not session or not org_id:
+        return MistRF(error="Mist not initialized"), []
+
+    summary = MistRF()
+
+    try:
+        sites_resp = mistapi.api.v1.orgs.sites.listOrgSites(session, org_id=org_id)
+        if sites_resp.status_code != 200 or not isinstance(sites_resp.data, list):
+            summary.error = f"Mist listOrgSites HTTP {sites_resp.status_code}"
+            return summary, []
+        site_id = next(
+            (s["id"] for s in sites_resp.data if s.get("name") == site_name),
+            None,
+        )
+        if not site_id:
+            return summary, []
+        summary.found = True
+        summary.site_id = site_id
+    except Exception as e:
+        logger.warning("site_rf_check: Mist site resolve failed — {}", e)
+        summary.error = f"site resolve failed: {e}"
+        return summary, []
+
+    # Per-device stats (live radio_stat on each AP) and current channel
+    # planning template in parallel. The template gives us allowed_channels
+    # per band even when no APs are connected.
+    stats_resp: Any = None
+    template_resp: Any = None
+    try:
+        stats_resp, template_resp = await asyncio.gather(
+            asyncio.to_thread(
+                session.mist_get,
+                uri=f"/api/v1/sites/{site_id}/stats/devices",
+                query={"type": "ap", "limit": 100},
+            ),
+            asyncio.to_thread(
+                mistapi.api.v1.sites.rrm.getSiteCurrentChannelPlanning,
+                session,
+                site_id=site_id,
+            ),
+            return_exceptions=True,
+        )
+    except Exception as e:
+        summary.error = f"Mist stats/template call failed: {e}"
+        return summary, []
+
+    aps: list[APSummary] = []
+    if not isinstance(stats_resp, Exception):
+        data = getattr(stats_resp, "data", None) or {}
+        results = data.get("results", []) if isinstance(data, dict) else []
+        summary.ap_count = data.get("total", len(results)) if isinstance(data, dict) else len(results)
+        for dev in results:
+            connected = dev.get("status") == "connected"
+            if connected:
+                summary.aps_connected += 1
+            radios: list[Radio] = []
+            radio_stat = dev.get("radio_stat") or {}
+            if connected and isinstance(radio_stat, dict):
+                for stat_key, stat in radio_stat.items():
+                    band = _mist_band_from_stat_key(stat_key)
+                    if band is None or not isinstance(stat, dict):
+                        continue
+                    radios.append(
+                        Radio(
+                            band=band,
+                            channel=str(stat.get("channel")) if stat.get("channel") is not None else None,
+                            primary_channel=_parse_primary_channel(stat.get("channel")),
+                            bandwidth_mhz=_parse_bandwidth_mhz(stat.get("bandwidth")),
+                            power_dbm=_parse_numeric(stat.get("power")),
+                            channel_utilization_pct=_parse_numeric(stat.get("usage")),
+                            noise_floor_dbm=_parse_numeric(stat.get("noise_floor")),
+                            num_clients=stat.get("num_clients"),
+                            status="UP",
+                        )
+                    )
+            aps.append(
+                APSummary(
+                    name=dev.get("name"),
+                    model=dev.get("model"),
+                    serial=dev.get("serial"),
+                    mac=dev.get("mac"),
+                    platform="mist",
+                    connected=connected,
+                    radios=radios,
+                )
+            )
+
+    if not isinstance(template_resp, Exception) and getattr(template_resp, "status_code", 0) == 200:
+        tpl = (getattr(template_resp, "data", None) or {}).get("rftemplate") or {}
+        summary.rf_template_name = (getattr(template_resp, "data", None) or {}).get("rftemplate_name")
+        for raw_band, tpl_band in ("24", "band_24"), ("5", "band_5"), ("6", "band_6"):
+            cfg = tpl.get(tpl_band) or {}
+            channels = cfg.get("channels")
+            if isinstance(channels, list) and channels:
+                summary.rf_template_allowed[raw_band] = list(channels)
+            else:
+                summary.rf_template_allowed[raw_band] = None
+
+    return summary, aps
+
+
+# --- Central collection --------------------------------------------------
+
+
+async def _collect_central(
+    ctx: Context,
+    site_name: str,
+    max_aps: int,
+) -> tuple[CentralRF, list[APSummary]]:
+    conn = ctx.lifespan_context.get("central_conn")
+    if not conn:
+        return CentralRF(error="Central not initialized"), []
+
+    summary = CentralRF()
+
+    try:
+        from pycentral.new_monitoring.aps import MonitoringAPs
+        from pycentral.new_monitoring.sites import MonitoringSites
+    except ImportError as e:
+        return CentralRF(error=f"pycentral not available: {e}"), []
+
+    try:
+        sites = await asyncio.to_thread(MonitoringSites.get_all_sites, central_conn=conn)
+        match = next((s for s in sites if s.get("siteName") == site_name), None)
+        if not match:
+            return summary, []
+        summary.found = True
+        summary.site_id = str(match.get("id"))
+    except Exception as e:
+        logger.warning("site_rf_check: Central site resolve failed — {}", e)
+        summary.error = f"site resolve failed: {e}"
+        return summary, []
+
+    # List all APs at the site (site-level filter), then fan out per-AP
+    # details in parallel to get the radios array. Cap to max_aps to bound
+    # cost on large sites — users can raise the cap via the tool param.
+    try:
+        ap_list = await asyncio.to_thread(
+            MonitoringAPs.get_all_aps,
+            central_conn=conn,
+            filter_str=f"siteId eq '{summary.site_id}'",
+        )
+    except Exception as e:
+        summary.error = f"AP list fetch failed: {e}"
+        return summary, []
+
+    if not ap_list:
+        return summary, []
+
+    summary.ap_count = len(ap_list)
+    summary.aps_online = sum(1 for ap in ap_list if ap.get("status") == "ONLINE")
+
+    online_aps = [ap for ap in ap_list if ap.get("status") == "ONLINE"]
+    targets = online_aps[:max_aps]
+    truncated = len(online_aps) > max_aps
+
+    details_list = await asyncio.gather(
+        *[
+            asyncio.to_thread(
+                MonitoringAPs.get_ap_details,
+                central_conn=conn,
+                serial_number=ap.get("serialNumber"),
+            )
+            for ap in targets
+        ],
+        return_exceptions=True,
+    )
+
+    aps: list[APSummary] = []
+    for ap, details in zip(targets, details_list, strict=False):
+        if isinstance(details, Exception):
+            aps.append(
+                APSummary(
+                    name=ap.get("deviceName"),
+                    model=ap.get("model"),
+                    serial=ap.get("serialNumber"),
+                    mac=ap.get("macAddress"),
+                    platform="central",
+                    connected=ap.get("status") == "ONLINE",
+                    error=f"details fetch failed: {details}",
+                )
+            )
+            continue
+        d = details if isinstance(details, dict) else {}
+        radios: list[Radio] = []
+        for radio in d.get("radios") or []:
+            band = _band_key(radio.get("band"))
+            if band is None:
+                continue
+            stats = radio.get("radioStats") or [{}]
+            stat = stats[0] if isinstance(stats, list) and stats else {}
+            raw_ch = radio.get("channel")
+            radios.append(
+                Radio(
+                    band=band,
+                    channel=str(raw_ch) if raw_ch is not None else None,
+                    primary_channel=_parse_primary_channel(raw_ch),
+                    bandwidth_mhz=_parse_bandwidth_mhz(radio.get("bandwidth")),
+                    power_dbm=_parse_numeric(radio.get("power")),
+                    channel_utilization_pct=_parse_numeric(stat.get("channelUtilization")),
+                    noise_floor_dbm=_parse_numeric(stat.get("noiseFloor")),
+                    num_clients=None,
+                    status=radio.get("status"),
+                )
+            )
+        aps.append(
+            APSummary(
+                name=d.get("deviceName") or ap.get("deviceName"),
+                model=d.get("model") or ap.get("model"),
+                serial=d.get("serialNumber") or ap.get("serialNumber"),
+                mac=d.get("macAddress") or ap.get("macAddress"),
+                platform="central",
+                connected=(d.get("status") or ap.get("status")) == "ONLINE",
+                radios=radios,
+            )
+        )
+
+    if truncated:
+        summary.error = (
+            f"Per-AP details fetched for {max_aps} of {len(online_aps)} online APs — raise "
+            "`max_aps_per_platform` to cover more."
+        )
+
+    return summary, aps
+
+
+# --- Aggregation ---------------------------------------------------------
+
+
+def _aggregate_bands(
+    aps: list[APSummary],
+    mist_template: dict[str, list[int] | None],
+) -> dict[Literal["2.4", "5", "6"], BandSummary]:
+    """Build per-band summary from the flat AP list."""
+    bands: dict[Literal["2.4", "5", "6"], BandSummary] = {}
+    for band in ("2.4", "5", "6"):
+        radios = [r for ap in aps for r in ap.radios if r.band == band and ap.connected]
+        channels = Counter(str(r.primary_channel) for r in radios if r.primary_channel is not None)
+        utils = [r.channel_utilization_pct for r in radios if r.channel_utilization_pct is not None]
+        noises = [r.noise_floor_dbm for r in radios if r.noise_floor_dbm is not None]
+        ap_count_for_band = len({(ap.platform, ap.serial) for ap in aps if any(r.band == band for r in ap.radios)})
+
+        summary = BandSummary(
+            band=band,
+            ap_count=ap_count_for_band,
+            radios_active=len(radios),
+            channel_distribution=dict(channels),
+            avg_utilization_pct=round(sum(utils) / len(utils), 1) if utils else None,
+            max_utilization_pct=max(utils) if utils else None,
+            avg_noise_floor_dbm=round(sum(noises) / len(noises), 1) if noises else None,
+            allowed_channels=mist_template.get("24" if band == "2.4" else band),
+        )
+        if summary.allowed_channels is None and mist_template.get("24" if band == "2.4" else band) is None:
+            summary.note = "RF template allowed_channels not set — auto (regulatory default)."
+        bands[band] = summary  # type: ignore[index]
+    return bands
+
+
+def _synthesize(
+    site_name: str,
+    bands: dict[Literal["2.4", "5", "6"], BandSummary],
+    aps: list[APSummary],
+    mist: MistRF | None,
+    central: CentralRF | None,
+) -> tuple[str, list[str]]:
+    """Compute headline and recommendations from the aggregated bands."""
+    recommendations: list[str] = []
+    headline_parts: list[str] = []
+
+    connected_aps = sum(1 for ap in aps if ap.connected)
+    total_aps = (mist.ap_count if mist and mist.found else 0) + (central.ap_count if central and central.found else 0)
+    if total_aps:
+        headline_parts.append(f"{connected_aps}/{total_aps} APs online")
+
+    for band_name in ("2.4", "5", "6"):
+        bs = bands.get(band_name)  # type: ignore[arg-type]
+        if not bs or bs.radios_active == 0:
+            continue
+        chans = [f"ch{c}×{n}" for c, n in sorted(bs.channel_distribution.items(), key=lambda kv: -kv[1])[:3]]
+        headline_parts.append(f"{band_name}GHz: " + ", ".join(chans))
+
+        # Co-channel cluster: 3+ APs on the same primary channel in 5 or 6 GHz
+        if band_name in ("5", "6"):
+            for ch, count in bs.channel_distribution.items():
+                if count >= 3:
+                    recommendations.append(
+                        f"{band_name} GHz — {count} APs on channel {ch}; consider staggering via RRM "
+                        "or manually via the RF template."
+                    )
+
+        if bs.max_utilization_pct is not None and bs.max_utilization_pct >= 70:
+            recommendations.append(
+                f"{band_name} GHz — peak channel utilization {bs.max_utilization_pct:.0f}% "
+                "(>=70% indicates airtime pressure; check busiest AP)."
+            )
+
+        if bs.avg_noise_floor_dbm is not None and bs.avg_noise_floor_dbm > -70:
+            recommendations.append(
+                f"{band_name} GHz — noise floor {bs.avg_noise_floor_dbm:.0f} dBm is elevated (>-70 dBm); "
+                "investigate external interference."
+            )
+
+    if not headline_parts:
+        if (mist and mist.found) or (central and central.found):
+            headline = f"Site '{site_name}' resolved but no APs are currently online to report RF state."
+        else:
+            headline = f"Site '{site_name}' not found on any queried platform."
+        return headline, recommendations
+    headline = f"Site '{site_name}': " + " | ".join(headline_parts)
+    return headline, recommendations
+
+
+# --- Site enumeration (no site_name given) ------------------------------
+
+
+async def _list_mist_site_options(ctx: Context) -> list[SiteOption]:
+    """Every Mist site in the org, plus an AP-count per site.
+
+    One call to listOrgSites for the site list, one call to
+    searchOrgDevices(type=ap) for the AP counts — then group AP count by
+    site_id client-side. Total: 2 Mist calls regardless of site count.
+    """
+    try:
+        import mistapi
+    except ImportError:
+        return []
+
+    session = ctx.lifespan_context.get("mist_session")
+    org_id = ctx.lifespan_context.get("mist_org_id")
+    if not session or not org_id:
+        return []
+
+    sites_resp: Any = None
+    devices_resp: Any = None
+    try:
+        sites_resp, devices_resp = await asyncio.gather(
+            asyncio.to_thread(mistapi.api.v1.orgs.sites.listOrgSites, session, org_id=org_id),
+            asyncio.to_thread(
+                session.mist_get,
+                uri=f"/api/v1/orgs/{org_id}/inventory",
+                query={"type": "ap", "limit": 1000},
+            ),
+            return_exceptions=True,
+        )
+    except Exception as e:
+        logger.warning("site_rf_check: Mist site enumeration failed — {}", e)
+        return []
+
+    if isinstance(sites_resp, Exception) or getattr(sites_resp, "status_code", 0) != 200:
+        return []
+
+    sites = sites_resp.data if isinstance(sites_resp.data, list) else []
+    ap_counts: dict[str, int] = {}
+    online_counts: dict[str, int] = {}
+    if not isinstance(devices_resp, Exception):
+        data = getattr(devices_resp, "data", None)
+        items = data if isinstance(data, list) else []
+        for dev in items:
+            sid = dev.get("site_id")
+            if not sid:
+                continue
+            ap_counts[sid] = ap_counts.get(sid, 0) + 1
+            # /orgs/{id}/inventory uses `connected: bool`, not `status`.
+            online_counts[sid] = online_counts.get(sid, 0) + (1 if dev.get("connected") else 0)
+
+    options: list[SiteOption] = []
+    for s in sites:
+        sid = s.get("id")
+        if not sid:
+            continue
+        ap_count = ap_counts.get(sid, 0)
+        options.append(
+            SiteOption(
+                name=s.get("name") or f"site {sid}",
+                platform="mist",
+                site_id=sid,
+                ap_count=ap_count,
+                # Distinguish "no APs at all" (None) from "has APs, none online" (0).
+                online_ap_count=online_counts.get(sid, 0) if ap_count > 0 else None,
+            )
+        )
+    return options
+
+
+async def _list_central_site_options(ctx: Context) -> list[SiteOption]:
+    """Every Central site, plus an AP-count per site.
+
+    `get_all_sites` returns site metadata; `get_all_aps` (no filter) is
+    org-wide. Group AP count by siteId client-side.
+    """
+    conn = ctx.lifespan_context.get("central_conn")
+    if not conn:
+        return []
+
+    try:
+        from pycentral.new_monitoring.aps import MonitoringAPs
+        from pycentral.new_monitoring.sites import MonitoringSites
+    except ImportError:
+        return []
+
+    sites: Any = None
+    aps: Any = None
+    try:
+        sites, aps = await asyncio.gather(
+            asyncio.to_thread(MonitoringSites.get_all_sites, central_conn=conn),
+            asyncio.to_thread(MonitoringAPs.get_all_aps, central_conn=conn),
+            return_exceptions=True,
+        )
+    except Exception as e:
+        logger.warning("site_rf_check: Central site enumeration failed — {}", e)
+        return []
+
+    if isinstance(sites, Exception):
+        return []
+    aps_list = aps if isinstance(aps, list) else []
+
+    ap_counts: dict[str, int] = {}
+    online_counts: dict[str, int] = {}
+    for ap in aps_list:
+        sid = str(ap.get("siteId") or "")
+        if not sid:
+            continue
+        ap_counts[sid] = ap_counts.get(sid, 0) + 1
+        if ap.get("status") == "ONLINE":
+            online_counts[sid] = online_counts.get(sid, 0) + 1
+
+    options: list[SiteOption] = []
+    for s in sites:
+        sid = str(s.get("id") or "")
+        if not sid:
+            continue
+        ap_count = ap_counts.get(sid, 0)
+        options.append(
+            SiteOption(
+                name=s.get("siteName") or f"site {sid}",
+                platform="central",
+                site_id=sid,
+                ap_count=ap_count,
+                # Distinguish "no APs at all" (None) from "has APs, none online" (0).
+                online_ap_count=online_counts.get(sid, 0) if ap_count > 0 else None,
+            )
+        )
+    return options
+
+
+def _merge_site_options(options: list[SiteOption]) -> list[SiteOption]:
+    """Sort options: most online APs first, then most APs, then alphabetical."""
+    return sorted(
+        options,
+        key=lambda o: (
+            -(o.online_ap_count or 0),
+            -o.ap_count,
+            o.name.lower(),
+        ),
+    )
+
+
+def _render_site_options(options: list[SiteOption]) -> str:
+    """Compact picker UI for when the caller didn't name a site."""
+    if not options:
+        return "# RF Check — pick a site\n\nNo sites available on the queried platforms.\n"
+
+    lines = [
+        "# RF Check — pick a site",
+        "",
+        'No `site_name` was given. Re-run `site_rf_check(site_name="...")` with one of the below:',
+        "",
+    ]
+    rows: list[tuple[str, str, str, str]] = [("Site", "Platform", "APs total", "APs online")]
+    for opt in options[:50]:
+        rows.append(
+            (
+                opt.name,
+                opt.platform,
+                str(opt.ap_count),
+                "?" if opt.online_ap_count is None else str(opt.online_ap_count),
+            )
+        )
+    widths = [max(len(r[i]) for r in rows) for i in range(4)]
+    for i, row in enumerate(rows):
+        lines.append("  " + "  ".join(cell.ljust(widths[j]) for j, cell in enumerate(row)))
+        if i == 0:
+            lines.append("  " + "  ".join("─" * widths[j] for j in range(4)))
+    if len(options) > 50:
+        lines.append("")
+        lines.append(f"...and {len(options) - 50} more sites (truncated to top 50 by AP count).")
+    lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# --- Rendering -----------------------------------------------------------
+
+
+def _bar(value: float | None, full: float = 100.0, width: int = 20) -> str:
+    """Render a single horizontal bar. `value` and `full` are same-unit."""
+    if value is None:
+        return "░" * width
+    filled = max(0, min(width, round((value / full) * width)))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _render_channel_distribution(band_name: str, bs: BandSummary) -> list[str]:
+    """Per-band channel distribution chart (channel -> AP count bar)."""
+    lines: list[str] = []
+    if bs.radios_active == 0:
+        lines.append(f"### {band_name} GHz — no active radios")
+        if bs.allowed_channels:
+            lines.append(f"Template allows: {', '.join(str(c) for c in bs.allowed_channels)}")
+        return lines
+
+    lines.append(f"### {band_name} GHz — {bs.radios_active} radio(s) across {bs.ap_count} AP(s)")
+
+    util_line = ""
+    if bs.avg_utilization_pct is not None:
+        util_line = f"util avg {bs.avg_utilization_pct:.0f}%"
+        if bs.max_utilization_pct is not None:
+            util_line += f" / peak {bs.max_utilization_pct:.0f}%"
+    if bs.avg_noise_floor_dbm is not None:
+        noise_clause = f"noise {bs.avg_noise_floor_dbm:.0f} dBm"
+        util_line = f"{util_line} · {noise_clause}" if util_line else noise_clause
+    if util_line:
+        lines.append(util_line)
+
+    if bs.avg_utilization_pct is not None:
+        lines.append(f"  avg util  │ {_bar(bs.avg_utilization_pct)} {bs.avg_utilization_pct:.0f}%")
+    if bs.max_utilization_pct is not None:
+        lines.append(f"  peak util │ {_bar(bs.max_utilization_pct)} {bs.max_utilization_pct:.0f}%")
+
+    lines.append("")
+    lines.append("  Channel occupancy:")
+    max_count = max(bs.channel_distribution.values(), default=0) or 1
+    for ch, count in sorted(bs.channel_distribution.items(), key=lambda kv: int(kv[0])):
+        width = 20
+        filled = max(1, round((count / max_count) * width))
+        bar = "■" * filled + " " * (width - filled)
+        flag = " ⚠ co-channel" if count >= 3 and band_name in ("5", "6") else ""
+        lines.append(f"    ch{ch:>4}  │ {bar} ({count}){flag}")
+
+    if bs.allowed_channels:
+        active = {int(c) for c in bs.channel_distribution}
+        unused = [c for c in bs.allowed_channels if c not in active]
+        if unused:
+            lines.append(f"  Allowed but unused: {', '.join(str(c) for c in unused)}")
+    return lines
+
+
+def _render_ap_table(aps: list[APSummary]) -> list[str]:
+    """Compact per-AP radio table."""
+    if not aps:
+        return []
+    rows: list[tuple[str, str, str, str, str, str]] = [
+        ("AP", "Platform", "Model", "2.4 GHz", "5 GHz", "6 GHz"),
+    ]
+
+    def _fmt(r: Radio | None) -> str:
+        if r is None:
+            return "—"
+        parts = []
+        if r.channel:
+            parts.append(f"ch{r.channel}")
+        if r.bandwidth_mhz:
+            parts.append(f"{r.bandwidth_mhz}MHz")
+        if r.power_dbm is not None:
+            parts.append(f"{r.power_dbm:.0f}dBm")
+        if r.channel_utilization_pct is not None:
+            parts.append(f"{r.channel_utilization_pct:.0f}%util")
+        return " ".join(parts) if parts else "—"
+
+    for ap in aps:
+        by_band = {r.band: r for r in ap.radios}
+        name = ap.name or "(unnamed)"
+        if not ap.connected:
+            name = f"{name} (offline)"
+        rows.append(
+            (
+                name,
+                ap.platform,
+                ap.model or "—",
+                _fmt(by_band.get("2.4")),
+                _fmt(by_band.get("5")),
+                _fmt(by_band.get("6")),
+            )
+        )
+
+    widths = [max(len(r[i]) for r in rows) for i in range(6)]
+    lines: list[str] = []
+    for i, row in enumerate(rows):
+        lines.append("  " + "  ".join(cell.ljust(widths[j]) for j, cell in enumerate(row)))
+        if i == 0:
+            lines.append("  " + "  ".join("─" * widths[j] for j in range(6)))
+    return lines
+
+
+def _render_report(report: SiteRFReport) -> str:
+    """Produce a human-readable markdown/ASCII report from the structured data."""
+    lines: list[str] = []
+    lines.append(f"# RF Check — {report.site_name}")
+    lines.append("")
+    lines.append(report.headline)
+    lines.append("")
+    if report.platforms_matched:
+        lines.append(f"Platforms: queried={report.platforms_queried}, matched={report.platforms_matched}")
+    if report.mist and report.mist.rf_template_name:
+        lines.append(f"Mist RF template: {report.mist.rf_template_name}")
+    lines.append("")
+
+    for band_name in ("2.4", "5", "6"):
+        bs = report.bands.get(band_name)  # type: ignore[arg-type]
+        if not bs:
+            continue
+        lines.extend(_render_channel_distribution(band_name, bs))
+        lines.append("")
+
+    if report.aps:
+        lines.append("## Per-AP radio snapshot")
+        lines.append("")
+        lines.extend(_render_ap_table(report.aps))
+        lines.append("")
+
+    if report.recommendations:
+        lines.append("## Recommendations")
+        lines.append("")
+        for rec in report.recommendations:
+            lines.append(f"- {rec}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# --- Registration --------------------------------------------------------
+
+
+def register(mcp: Any, config: Any) -> None:
+    """Register the cross-platform site_rf_check tool.
+
+    Requires at least one of Mist or Central to be enabled — those are the
+    platforms that own AP/radio telemetry.
+    """
+    if not (config.mist or config.central):
+        logger.info("site_rf_check: skipped (neither Mist nor Central enabled)")
+        return
+
+    @mcp.tool(
+        annotations={
+            "title": "Cross-platform site RF check",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "openWorldHint": True,
+            "idempotentHint": True,
+        },
+    )
+    async def site_rf_check(
+        ctx: Context,
+        site_name: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Exact site name as shown in Mist and/or Central. "
+                    "When omitted, the tool returns a list of selectable sites "
+                    "(with AP counts per platform) in the `site_options` field "
+                    "instead of a full RF report — call back with one of those "
+                    "names. The `platform` filter still applies when listing."
+                ),
+                default=None,
+            ),
+        ] = None,
+        platform: Annotated[
+            str | list[str] | None,
+            Field(
+                description=(
+                    "Optional platform filter. Omit (null) to query every enabled RF "
+                    "platform (Mist + Central) — the normal cross-platform aggregation. "
+                    "Pass one name ('mist' or 'central') or a list (['mist','central']) to "
+                    "restrict the report. ClearPass, Apstra, and GreenLake are not valid — "
+                    "they don't expose per-AP RF telemetry."
+                ),
+                default=None,
+            ),
+        ] = None,
+        max_aps_per_platform: Annotated[
+            int,
+            Field(
+                description=(
+                    "Cap on per-AP detail fetches per platform (Central fans out serial-by-serial). "
+                    "Default 50. Lower for faster responses on large sites; raise to cover more APs."
+                ),
+                default=50,
+                ge=1,
+                le=500,
+            ),
+        ] = 50,
+        include_rendered_report: Annotated[
+            bool,
+            Field(
+                description=(
+                    "When true (default), include a pre-rendered markdown/ASCII RF dashboard in "
+                    "the `rendered_report` field — per-band channel occupancy bars, utilization "
+                    "meters, per-AP radio table. Displays directly in chat even if the client "
+                    "doesn't draw charts. Set false for scripted/bulk callers that only want the "
+                    "structured data."
+                ),
+                default=True,
+            ),
+        ] = True,
+    ) -> SiteRFReport:
+        """Aggregate per-AP RF state across enabled HPE networking platforms.
+
+        Pulls live per-band channel, power, utilization, and noise floor for
+        every AP at a site from Mist AND Central in parallel, aggregates the
+        channel distribution and utilization per band (2.4 / 5 / 6 GHz), and
+        returns a single compact report with recommendations.
+
+        Use when the user asks about channel planning, RF health, 5/6 GHz
+        spectrum, co-channel interference, or "how is my Wi-Fi doing" in
+        terms of radio-layer behavior. Do not limit the query to a single
+        vendor unless the user explicitly asks — this tool exists precisely
+        because mixed Mist + Central deployments need both sides queried.
+
+        The report includes:
+        - Per-band summary (ch distribution, avg/max util, noise floor, allowed channels from the Mist RF template)
+        - Per-AP radios (name, model, band, channel, power, util, noise)
+        - Recommendations (co-channel clusters, high util, elevated noise)
+        - A pre-rendered ASCII dashboard in `rendered_report`
+
+        When `site_name` is omitted, the tool returns a list of selectable
+        sites (with per-platform AP counts) in `site_options` instead of a
+        full RF report — the `platform` filter still applies to the listing.
+        Re-call with `site_name=<name>` to get the full report.
+        """
+        config = ctx.lifespan_context["config"]
+
+        enabled: list[str] = []
+        if config.mist:
+            enabled.append("mist")
+        if config.central:
+            enabled.append("central")
+
+        wanted = _normalize_rf_platform_filter(platform, enabled)
+        query_mist = config.mist is not None and "mist" in wanted
+        query_central = config.central is not None and "central" in wanted
+
+        platforms_queried: list[str] = []
+        if query_mist:
+            platforms_queried.append("mist")
+        if query_central:
+            platforms_queried.append("central")
+
+        # Site picker: site_name omitted -> return selectable sites, not a full RF report.
+        if not site_name:
+            enum_tasks: list[Any] = []
+            if query_mist:
+                enum_tasks.append(_list_mist_site_options(ctx))
+            if query_central:
+                enum_tasks.append(_list_central_site_options(ctx))
+            enum_results = await asyncio.gather(*enum_tasks, return_exceptions=True)
+            merged: list[SiteOption] = []
+            for r in enum_results:
+                if isinstance(r, list):
+                    merged.extend(r)
+            ordered = _merge_site_options(merged)
+
+            headline = (
+                f"No site_name given — {len(ordered)} site(s) available on {platforms_queried}. "
+                "Call back with `site_name=<one of the listed names>`."
+            )
+            report = SiteRFReport(
+                site_name="(not specified)",
+                platforms_queried=platforms_queried,
+                platforms_matched=[],
+                headline=headline,
+                site_options=ordered,
+            )
+            if include_rendered_report:
+                report.rendered_report = _render_site_options(ordered)
+            return report
+
+        tasks: list[Any] = []
+        if query_mist:
+            tasks.append(_collect_mist(ctx, site_name))
+        if query_central:
+            tasks.append(_collect_central(ctx, site_name, max_aps_per_platform))
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        mist_summary: MistRF | None = None
+        central_summary: CentralRF | None = None
+        all_aps: list[APSummary] = []
+        idx = 0
+        if query_mist:
+            r = results[idx]
+            if isinstance(r, tuple):
+                mist_summary, mist_aps = r
+                all_aps.extend(mist_aps)
+            else:
+                mist_summary = MistRF(error=str(r))
+            idx += 1
+        if query_central:
+            r = results[idx]
+            if isinstance(r, tuple):
+                central_summary, central_aps = r
+                all_aps.extend(central_aps)
+            else:
+                central_summary = CentralRF(error=str(r))
+            idx += 1
+
+        mist_template = mist_summary.rf_template_allowed if mist_summary else {}
+        bands = _aggregate_bands(all_aps, mist_template)
+
+        matched: list[str] = []
+        if mist_summary and mist_summary.found:
+            matched.append("mist")
+        if central_summary and central_summary.found:
+            matched.append("central")
+
+        headline, recommendations = _synthesize(
+            site_name,
+            bands,
+            all_aps,
+            mist_summary,
+            central_summary,
+        )
+
+        logger.info(
+            "site_rf_check: site='{}' matched={} aps={}",
+            site_name,
+            matched,
+            len(all_aps),
+        )
+
+        report = SiteRFReport(
+            site_name=site_name,
+            platforms_queried=platforms_queried,
+            platforms_matched=matched,
+            headline=headline,
+            bands=bands,
+            aps=all_aps,
+            mist=mist_summary,
+            central=central_summary,
+            recommendations=recommendations,
+        )
+        if include_rendered_report:
+            report.rendered_report = _render_report(report)
+        return report
+
+    logger.info("Cross-platform: registered site_rf_check tool")

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -208,6 +208,10 @@ def create_server(config: ServerConfig) -> FastMCP:
     if config.mist or config.central:
         _register_site_health_check(mcp, config)
 
+    # --- Cross-platform site RF check (requires at least Mist or Central) ---
+    if config.mist or config.central:
+        _register_site_rf_check(mcp, config)
+
     # --- Cross-platform `health` tool (always registered; unaffected by tool_mode) ---
     from hpe_networking_mcp.platforms.health import register as _register_health
 
@@ -307,3 +311,13 @@ def _register_site_health_check(mcp: FastMCP, config: ServerConfig) -> None:
         register(mcp, config)
     except Exception as e:
         logger.warning("Cross-platform: failed to load site_health_check — {}", e)
+
+
+def _register_site_rf_check(mcp: FastMCP, config: ServerConfig) -> None:
+    """Register the cross-platform site_rf_check aggregation tool."""
+    try:
+        from hpe_networking_mcp.platforms.site_rf_check import register
+
+        register(mcp, config)
+    except Exception as e:
+        logger.warning("Cross-platform: failed to load site_rf_check — {}", e)

--- a/tests/unit/test_site_rf_check.py
+++ b/tests/unit/test_site_rf_check.py
@@ -1,0 +1,447 @@
+"""Unit tests for the cross-platform ``site_rf_check`` tool."""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.site_rf_check import (
+    APSummary,
+    BandSummary,
+    CentralRF,
+    MistRF,
+    Radio,
+    SiteOption,
+    SiteRFReport,
+    _aggregate_bands,
+    _band_key,
+    _merge_site_options,
+    _mist_band_from_stat_key,
+    _normalize_rf_platform_filter,
+    _parse_bandwidth_mhz,
+    _parse_numeric,
+    _parse_primary_channel,
+    _render_report,
+    _render_site_options,
+    _synthesize,
+)
+
+# --- Parsers -------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParsePrimaryChannel:
+    def test_plain_int(self):
+        assert _parse_primary_channel(6) == 6
+
+    def test_plain_string(self):
+        assert _parse_primary_channel("36") == 36
+
+    def test_aruba_secondary_suffix(self):
+        # "165S" = primary 165 with a secondary 20MHz channel
+        assert _parse_primary_channel("165S") == 165
+
+    def test_aruba_triplet_suffix(self):
+        # "49T+" = Wi-Fi 6E 320MHz bonded channel notation
+        assert _parse_primary_channel("49T+") == 49
+
+    def test_none(self):
+        assert _parse_primary_channel(None) is None
+
+    def test_empty_string(self):
+        assert _parse_primary_channel("") is None
+
+    def test_non_numeric_garbage(self):
+        assert _parse_primary_channel("auto") is None
+
+
+@pytest.mark.unit
+class TestParseNumeric:
+    def test_plain_int(self):
+        assert _parse_numeric(42) == 42.0
+
+    def test_plain_float(self):
+        assert _parse_numeric(42.5) == 42.5
+
+    def test_unit_suffix(self):
+        assert _parse_numeric("28 dBm") == 28.0
+
+    def test_negative(self):
+        assert _parse_numeric("-93") == -93.0
+
+    def test_percent_suffix(self):
+        assert _parse_numeric("32") == 32.0
+
+    def test_none(self):
+        assert _parse_numeric(None) is None
+
+
+@pytest.mark.unit
+class TestParseBandwidth:
+    def test_with_unit(self):
+        assert _parse_bandwidth_mhz("160 MHz") == 160
+
+    def test_plain_int(self):
+        assert _parse_bandwidth_mhz(20) == 20
+
+    def test_none(self):
+        assert _parse_bandwidth_mhz(None) is None
+
+
+@pytest.mark.unit
+class TestBandKey:
+    def test_central_strings(self):
+        assert _band_key("2.4 GHz") == "2.4"
+        assert _band_key("5 GHz") == "5"
+        assert _band_key("6 GHz") == "6"
+
+    def test_mist_numeric_strings(self):
+        assert _band_key("24") == "2.4"
+        assert _band_key("5") == "5"
+        assert _band_key("6") == "6"
+
+    def test_mist_radio_stat_prefix(self):
+        assert _mist_band_from_stat_key("band_24") == "2.4"
+        assert _mist_band_from_stat_key("band_5") == "5"
+        assert _mist_band_from_stat_key("band_6") == "6"
+
+    def test_unknown(self):
+        assert _band_key("60 GHz") is None
+        assert _band_key(None) is None
+
+
+# --- Platform filter -----------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalizeRFPlatformFilter:
+    def test_none_returns_all_enabled(self):
+        assert _normalize_rf_platform_filter(None, ["mist", "central"]) == ["mist", "central"]
+
+    def test_missing_enabled_excluded(self):
+        # mist disabled → only central returned
+        assert _normalize_rf_platform_filter(None, ["central"]) == ["central"]
+
+    def test_single_string(self):
+        assert _normalize_rf_platform_filter("mist", ["mist", "central"]) == ["mist"]
+
+    def test_list(self):
+        assert _normalize_rf_platform_filter(["central", "mist"], ["mist", "central"]) == ["central", "mist"]
+
+    def test_case_insensitive(self):
+        assert _normalize_rf_platform_filter("MIST", ["mist"]) == ["mist"]
+
+    def test_non_rf_platform_dropped(self):
+        # clearpass, apstra, greenlake aren't RF platforms
+        assert _normalize_rf_platform_filter("clearpass", ["mist", "central"]) == []
+        assert _normalize_rf_platform_filter(["apstra", "mist"], ["mist", "central"]) == ["mist"]
+
+
+# --- Aggregation ---------------------------------------------------------
+
+
+def _ap(name: str, platform: str, *radios: Radio, connected: bool = True) -> APSummary:
+    return APSummary(
+        name=name,
+        platform=platform,  # type: ignore[arg-type]
+        connected=connected,
+        radios=list(radios),
+    )
+
+
+def _r(band: str, channel: int, power: float = 20.0, util: float = 15.0, noise: float = -90.0) -> Radio:
+    return Radio(
+        band=band,  # type: ignore[arg-type]
+        channel=str(channel),
+        primary_channel=channel,
+        bandwidth_mhz=20 if band == "2.4" else 80,
+        power_dbm=power,
+        channel_utilization_pct=util,
+        noise_floor_dbm=noise,
+        status="UP",
+    )
+
+
+@pytest.mark.unit
+class TestAggregateBands:
+    def test_empty(self):
+        bands = _aggregate_bands([], {})
+        assert bands["2.4"].radios_active == 0
+        assert bands["5"].radios_active == 0
+        assert bands["6"].radios_active == 0
+
+    def test_channel_distribution(self):
+        aps = [
+            _ap("A", "central", _r("2.4", 1), _r("5", 36)),
+            _ap("B", "central", _r("2.4", 1), _r("5", 149)),
+            _ap("C", "mist", _r("2.4", 6), _r("5", 36)),
+        ]
+        bands = _aggregate_bands(aps, {})
+        assert bands["2.4"].channel_distribution == {"1": 2, "6": 1}
+        assert bands["5"].channel_distribution == {"36": 2, "149": 1}
+        assert bands["6"].radios_active == 0
+
+    def test_util_avg_and_max(self):
+        aps = [
+            _ap("A", "central", _r("5", 36, util=30)),
+            _ap("B", "central", _r("5", 149, util=70)),
+        ]
+        bands = _aggregate_bands(aps, {})
+        assert bands["5"].avg_utilization_pct == 50.0
+        assert bands["5"].max_utilization_pct == 70.0
+
+    def test_noise_floor_average(self):
+        aps = [
+            _ap("A", "central", _r("5", 36, noise=-85)),
+            _ap("B", "central", _r("5", 149, noise=-95)),
+        ]
+        bands = _aggregate_bands(aps, {})
+        assert bands["5"].avg_noise_floor_dbm == -90.0
+
+    def test_mist_template_allowed_channels_piped_through(self):
+        bands = _aggregate_bands([], {"24": [1, 6, 11], "5": None, "6": None})
+        assert bands["2.4"].allowed_channels == [1, 6, 11]
+        assert bands["5"].allowed_channels is None
+
+    def test_disconnected_aps_excluded_from_radio_stats(self):
+        # disconnected AP contributes to ap_count (has `radios` list from history)
+        # but its radios are NOT included in the per-band aggregation.
+        aps = [
+            _ap("online", "central", _r("5", 36, util=50)),
+            _ap("offline", "mist", _r("5", 149, util=80), connected=False),
+        ]
+        bands = _aggregate_bands(aps, {})
+        # only the online AP's radio counts
+        assert bands["5"].radios_active == 1
+        assert bands["5"].channel_distribution == {"36": 1}
+        assert bands["5"].avg_utilization_pct == 50.0
+
+
+# --- Synthesis -----------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSynthesize:
+    def _bands(
+        self,
+        util_max: dict[str, float] | None = None,
+        noise_avg: dict[str, float] | None = None,
+        channel_dist: dict[str, dict[str, int]] | None = None,
+    ) -> dict[str, BandSummary]:
+        util_max = util_max or {}
+        noise_avg = noise_avg or {}
+        channel_dist = channel_dist or {}
+        bands: dict[str, BandSummary] = {}
+        for band in ("2.4", "5", "6"):
+            dist = channel_dist.get(band, {})
+            bands[band] = BandSummary(
+                band=band,  # type: ignore[arg-type]
+                ap_count=max(3, sum(dist.values())),
+                radios_active=sum(dist.values()),
+                channel_distribution=dist,
+                max_utilization_pct=util_max.get(band),
+                avg_noise_floor_dbm=noise_avg.get(band),
+            )
+        return bands
+
+    def test_co_channel_cluster_flagged_5ghz(self):
+        bands = self._bands(channel_dist={"5": {"36": 3}})
+        _, recs = _synthesize("X", bands, [_ap("A", "central", _r("5", 36))] * 3, None, None)
+        assert any("5 GHz" in r and "channel 36" in r for r in recs)
+
+    def test_co_channel_below_threshold_not_flagged(self):
+        bands = self._bands(channel_dist={"5": {"36": 2}})
+        _, recs = _synthesize("X", bands, [_ap("A", "central", _r("5", 36))] * 2, None, None)
+        assert not any("co-channel" in r.lower() or "channel 36" in r for r in recs)
+
+    def test_co_channel_not_flagged_24ghz(self):
+        # 2.4 GHz only has 3 non-overlapping channels, so 3 APs on the same one is normal.
+        bands = self._bands(channel_dist={"2.4": {"1": 3}})
+        _, recs = _synthesize("X", bands, [_ap("A", "central", _r("2.4", 1))] * 3, None, None)
+        assert not any("channel 1" in r for r in recs)
+
+    def test_high_utilization_flagged(self):
+        bands = self._bands(
+            util_max={"5": 85.0},
+            channel_dist={"5": {"36": 1}},
+        )
+        _, recs = _synthesize("X", bands, [_ap("A", "central", _r("5", 36, util=85))], None, None)
+        assert any("utilization" in r.lower() for r in recs)
+
+    def test_elevated_noise_floor_flagged(self):
+        bands = self._bands(
+            noise_avg={"5": -65.0},
+            channel_dist={"5": {"36": 1}},
+        )
+        _, recs = _synthesize("X", bands, [_ap("A", "central", _r("5", 36, noise=-65))], None, None)
+        assert any("noise" in r.lower() for r in recs)
+
+    def test_healthy_site_no_recommendations(self):
+        bands = self._bands(
+            util_max={"5": 20.0},
+            noise_avg={"5": -90.0},
+            channel_dist={"5": {"36": 1, "149": 1}},
+        )
+        headline, recs = _synthesize(
+            "X",
+            bands,
+            [_ap("A", "central", _r("5", 36)), _ap("B", "central", _r("5", 149))],
+            MistRF(found=True, ap_count=2, aps_connected=2),
+            None,
+        )
+        assert recs == []
+        assert "5GHz" in headline
+
+    def test_site_not_found_headline(self):
+        bands = self._bands()
+        headline, _ = _synthesize("X", bands, [], None, None)
+        assert "not found" in headline.lower()
+
+
+# --- Renderer ------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRenderReport:
+    def test_smoke(self):
+        report = SiteRFReport(
+            site_name="HOME",
+            platforms_queried=["mist", "central"],
+            platforms_matched=["mist", "central"],
+            headline="Site 'HOME': all good",
+            bands={
+                "2.4": BandSummary(band="2.4", ap_count=2, radios_active=2, channel_distribution={"1": 2}),
+                "5": BandSummary(band="5", ap_count=0, radios_active=0, channel_distribution={}),
+                "6": BandSummary(band="6", ap_count=0, radios_active=0, channel_distribution={}),
+            },
+            aps=[
+                _ap("AP1", "central", _r("2.4", 1), _r("5", 36)),
+                _ap("AP2", "mist", _r("2.4", 1), connected=True),
+            ],
+            recommendations=["Look into channel 1 density"],
+        )
+        out = _render_report(report)
+        # Headline + bands header + AP table + recommendations all present
+        assert "# RF Check — HOME" in out
+        assert "Site 'HOME'" in out
+        assert "### 2.4 GHz — 2 radio(s)" in out
+        assert "ch   1" in out  # channel occupancy line
+        assert "## Per-AP radio snapshot" in out
+        assert "AP1" in out and "AP2" in out
+        assert "## Recommendations" in out
+        assert "Look into channel 1 density" in out
+
+    def test_co_channel_warning_suffix_rendered(self):
+        report = SiteRFReport(
+            site_name="X",
+            platforms_queried=["central"],
+            platforms_matched=["central"],
+            headline="",
+            bands={
+                "2.4": BandSummary(band="2.4", ap_count=0, radios_active=0),
+                "5": BandSummary(
+                    band="5",
+                    ap_count=3,
+                    radios_active=3,
+                    channel_distribution={"36": 3},
+                ),
+                "6": BandSummary(band="6", ap_count=0, radios_active=0),
+            },
+            aps=[],
+        )
+        out = _render_report(report)
+        assert "co-channel" in out
+
+    def test_no_active_radios_per_band(self):
+        report = SiteRFReport(
+            site_name="X",
+            platforms_queried=["mist"],
+            platforms_matched=["mist"],
+            headline="no APs",
+            bands={
+                "2.4": BandSummary(band="2.4", ap_count=0, radios_active=0, allowed_channels=[1, 6, 11]),
+                "5": BandSummary(band="5", ap_count=0, radios_active=0),
+                "6": BandSummary(band="6", ap_count=0, radios_active=0),
+            },
+            aps=[],
+        )
+        out = _render_report(report)
+        # Should surface allowed-but-unused context even when no radios are active
+        assert "no active radios" in out
+        assert "Template allows" in out
+
+
+# --- Site picker ---------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMergeSiteOptions:
+    def test_sort_by_online_then_total_then_name(self):
+        opts = [
+            SiteOption(name="zeta", platform="mist", ap_count=2, online_ap_count=2),
+            SiteOption(name="alpha", platform="central", ap_count=10, online_ap_count=0),
+            SiteOption(name="beta", platform="mist", ap_count=5, online_ap_count=5),
+            SiteOption(name="gamma", platform="central", ap_count=0, online_ap_count=None),
+        ]
+        ordered = _merge_site_options(opts)
+        names = [o.name for o in ordered]
+        # most-online first (beta=5, zeta=2), then by total (alpha=10 > gamma=0)
+        assert names == ["beta", "zeta", "alpha", "gamma"]
+
+    def test_empty(self):
+        assert _merge_site_options([]) == []
+
+
+@pytest.mark.unit
+class TestRenderSiteOptions:
+    def test_empty(self):
+        out = _render_site_options([])
+        assert "No sites available" in out
+
+    def test_with_options(self):
+        opts = [
+            SiteOption(name="HOME", platform="central", ap_count=3, online_ap_count=3),
+            SiteOption(name="HOME", platform="mist", ap_count=5, online_ap_count=0),
+        ]
+        out = _render_site_options(opts)
+        assert "HOME" in out
+        assert "central" in out and "mist" in out
+        assert "site_rf_check" in out
+        # Header columns rendered
+        assert "APs total" in out and "APs online" in out
+
+    def test_truncation_at_50(self):
+        opts = [SiteOption(name=f"site-{i:02d}", platform="central", ap_count=i) for i in range(60)]
+        out = _render_site_options(opts)
+        assert "and 10 more sites" in out
+
+
+# --- Models --------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModels:
+    def test_site_rf_report_serializes_with_rendered_field(self):
+        report = SiteRFReport(
+            site_name="HOME",
+            platforms_queried=["mist"],
+            platforms_matched=["mist"],
+            headline="ok",
+            rendered_report="# test",
+        )
+        dumped = report.model_dump()
+        assert dumped["rendered_report"] == "# test"
+        assert dumped["site_name"] == "HOME"
+
+    def test_mist_central_summaries_default_missing(self):
+        # A report with no platforms found should still serialize cleanly.
+        report = SiteRFReport(
+            site_name="Nonexistent",
+            platforms_queried=["mist", "central"],
+            platforms_matched=[],
+            headline="Site not found",
+            mist=MistRF(),
+            central=CentralRF(),
+        )
+        dumped = report.model_dump()
+        assert dumped["mist"]["found"] is False
+        assert dumped["central"]["found"] is False


### PR DESCRIPTION
## Summary

New cross-platform tool `site_rf_check` that aggregates per-AP RF state from Mist + Central in parallel and ships a pre-rendered ASCII RF dashboard. Closes the AI-discovery gap raised in this session — channel-planning / RF questions used to produce Mist-only answers even when the user had Aruba APs in Central at the same site.

## Why a tool, not a docs rule

We considered (and partly tried) a docs rule in `INSTRUCTIONS.md` saying "for platform-agnostic questions, query every enabled platform." The repo's own track record (#184, #185) shows soft "consider X before deciding" rules in long instruction blocks tend to lose to whatever shortcut pattern the AI matched on first ("Wi-Fi channels → Mist" is sticky). What reliably changes AI behavior is removing the judgment call: a purpose-built tool whose name + description put the cross-platform aggregation directly in the tool list.

## What the tool returns

- **Per-band aggregation** (2.4 / 5 / 6 GHz): channel distribution, avg/max utilization, avg noise floor, allowed channels from the Mist RF template.
- **Per-AP radio snapshot**: name, model, platform, connected status, one row per band with channel / bandwidth / power / utilization / noise floor.
- **Recommendations**: co-channel clusters (3+ APs on the same primary channel in 5/6 GHz), peak utilization ≥70%, noise floor >-70 dBm.
- **Pre-rendered ASCII RF dashboard** in `rendered_report` (default-on; opt out with `include_rendered_report=False`) — channel-occupancy bars, utilization meters, per-AP table, recommendations list. Renders directly in chat without the AI having to generate any charts.
- **Site-picker fallback** — when `site_name` is omitted the tool returns selectable sites with per-platform AP counts and online counts. The `platform` filter still applies. Two cheap calls cover the listing — no per-site fan-out.

## Data sources

| Side | Calls | Extracts |
|---|---|---|
| Mist | `/sites/{id}/stats/devices?type=ap` + `getSiteCurrentChannelPlanning` | Per-AP `radio_stat` per band (channel/power/usage/noise/clients), template allowed channels |
| Central | `MonitoringAPs.get_all_aps(filter=siteId)` + per-AP `MonitoringAPs.get_ap_details` (parallel via `asyncio.gather`, capped by `max_aps_per_platform`, default 50) | `radios` array per AP with band/channel/bandwidth/power/channelUtilization/noiseFloor |

Channel notation differs across vendors (Central uses bonded-channel suffixes like `165S`, `49T+`). A new `_parse_primary_channel` helper extracts the primary channel integer for aggregation while preserving the raw value for display.

## Test plan

- [x] Live-tested against the live Mist+Central tenant: 3 Aruba AP-755s at HOME render a full RF report with per-band channel bars, noise floors, utilization meters, and a per-AP table. Both platforms show as `platforms_matched`. Recommendations correctly silent on a healthy site.
- [x] Picker mode tested across 19 sites — sorted by online count, accurate online totals for both Mist and Central. `platform=central` filter narrows the list to Central-only.
- [x] `ruff check` + `ruff format --check` + `mypy` + 512 pytest tests in Docker — all green (was 463; +49 new).
- [x] Disconnected-AP behavior: Mist APs at HOME are disconnected → tool reports them in `aps` with `connected=False`, excludes their (empty) radios from per-band aggregation. Site is still found.

## Docs updated in this PR

- `README.md` — Cross-Platform Tools bullet for `site_rf_check`; tool counts (18 → 19 default surface); table count for Cross-Platform tools.
- `docs/TOOLS.md` — overview counts; cross-platform-static-tools list; full param table + return-shape docs for `site_rf_check`.
- `INSTRUCTIONS.md` — added `site_rf_check` to the cross-platform tool list with explicit "use for any channel-planning / spectrum / RF-health question" guidance.
- `CHANGELOG.md` — full v2.0.0.5 entry.

## Sample rendered dashboard (live, HOME site)

```
# RF Check — HOME

Site 'HOME': 3/3 APs online | 2.4GHz: ch1×2, ch6×1 | 5GHz: ch165×1, ch56×1, ch153×1 | 6GHz: ch49×1, ch161×1, ch73×1

### 5 GHz — 3 radio(s) across 3 AP(s)
util avg 29% / peak 35% · noise -90 dBm
  avg util  │ ██████░░░░░░░░░░░░░░ 29%
  peak util │ ███████░░░░░░░░░░░░░ 35%

  Channel occupancy:
    ch  56  │ ■■■■■■■■■■■■■■■■■■■■ (1)
    ch 153  │ ■■■■■■■■■■■■■■■■■■■■ (1)
    ch 165  │ ■■■■■■■■■■■■■■■■■■■■ (1)
```