### PR TITLE
Add platform template module + scaffold for future platforms

### DIFF
--- a/secrets/axis_api_token.example
+++ b/secrets/axis_api_token.example
@@ -1,0 +1,1 @@
+your-axis-api-token-here

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -80,6 +80,19 @@ class ApstraSecrets:
 
 
 @dataclass
+class AxisSecrets:
+    """Axis Atmos Cloud credentials.
+
+    Single static API token, generated in the Axis admin portal at
+    Settings → Admin API → New API Token. There is no refresh mechanism
+    — when the token expires, regenerate in the portal and update
+    ``axis_api_token``.
+    """
+
+    api_token: str
+
+
+@dataclass
 class ServerConfig:
     """Global server configuration."""
 
@@ -90,6 +103,7 @@ class ServerConfig:
     enable_central_write_tools: bool = False
     enable_clearpass_write_tools: bool = False
     enable_apstra_write_tools: bool = False
+    enable_axis_write_tools: bool = False
     disable_elicitation: bool = False
     debug: bool = False
     log_file: str | None = None
@@ -108,6 +122,7 @@ class ServerConfig:
     greenlake: GreenLakeSecrets | None = None
     clearpass: ClearPassSecrets | None = None
     apstra: ApstraSecrets | None = None
+    axis: AxisSecrets | None = None
 
     @property
     def enabled_platforms(self) -> list[str]:
@@ -122,6 +137,8 @@ class ServerConfig:
             platforms.append("clearpass")
         if self.apstra:
             platforms.append("apstra")
+        if self.axis:
+            platforms.append("axis")
         return platforms
 
 
@@ -306,6 +323,16 @@ def _load_apstra() -> ApstraSecrets | None:
     )
 
 
+def _load_axis() -> AxisSecrets | None:
+    """Load Axis Atmos Cloud credentials from Docker secrets."""
+    api_token = _read_secret("axis_api_token")
+    if not api_token:
+        logger.info("Axis: disabled (axis_api_token secret not found)")
+        return None
+    logger.info("Axis: credentials loaded (token: {})", mask_secret(api_token))
+    return AxisSecrets(api_token=api_token)
+
+
 def load_config() -> ServerConfig:
     """Load server configuration from Docker secrets and environment variables.
 
@@ -331,6 +358,7 @@ def load_config() -> ServerConfig:
     enable_central_write = os.getenv("ENABLE_CENTRAL_WRITE_TOOLS", "false").lower() in _truthy
     enable_clearpass_write = os.getenv("ENABLE_CLEARPASS_WRITE_TOOLS", "false").lower() in _truthy
     enable_apstra_write = os.getenv("ENABLE_APSTRA_WRITE_TOOLS", "false").lower() in _truthy
+    enable_axis_write = os.getenv("ENABLE_AXIS_WRITE_TOOLS", "false").lower() in _truthy
     disable_elicit = os.getenv("DISABLE_ELICITATION", "false").lower() in _truthy
     debug = os.getenv("DEBUG", "false").lower() in ("true", "1", "yes")
     log_file = os.getenv("LOG_FILE") or None
@@ -350,6 +378,7 @@ def load_config() -> ServerConfig:
     greenlake = _load_greenlake()
     clearpass = _load_clearpass()
     apstra = _load_apstra()
+    axis = _load_axis()
 
     config = ServerConfig(
         port=port,
@@ -359,6 +388,7 @@ def load_config() -> ServerConfig:
         enable_central_write_tools=enable_central_write,
         enable_clearpass_write_tools=enable_clearpass_write,
         enable_apstra_write_tools=enable_apstra_write,
+        enable_axis_write_tools=enable_axis_write,
         disable_elicitation=disable_elicit,
         debug=debug,
         log_file=log_file,
@@ -368,6 +398,7 @@ def load_config() -> ServerConfig:
         greenlake=greenlake,
         clearpass=clearpass,
         apstra=apstra,
+        axis=axis,
     )
 
     if not config.enabled_platforms:

--- a/src/hpe_networking_mcp/platforms/_common/tool_registry.py
+++ b/src/hpe_networking_mcp/platforms/_common/tool_registry.py
@@ -38,10 +38,15 @@ class ToolSpec:
 # ``tool()`` shim when tool modules import.
 REGISTRIES: dict[str, dict[str, ToolSpec]] = {
     "apstra": {},
+    "axis": {},
     "central": {},
     "clearpass": {},
     "greenlake": {},
     "mist": {},
+    # Template platform — never registered at runtime, but the registry
+    # entry has to exist so test_platform_template can import without
+    # ValueError when the example tools are loaded.
+    "_template": {},
 }
 
 
@@ -57,18 +62,22 @@ DYNAMIC_MANAGED_TAG = "dynamic_managed"
 # the tool is invisible to ``list_tools`` and refused by ``invoke_tool``.
 _WRITE_TAG_BY_PLATFORM: dict[str, set[str]] = {
     "apstra": {"apstra_write", "apstra_write_delete"},
+    "axis": {"axis_write", "axis_write_delete"},
     "central": {"central_write_delete"},
     "clearpass": {"clearpass_write_delete"},
     "greenlake": set(),  # GreenLake is read-only today.
     "mist": {"mist_write", "mist_write_delete"},
+    "_template": {"_template_write", "_template_write_delete"},
 }
 
 _GATE_CONFIG_ATTR: dict[str, str | None] = {
     "apstra": "enable_apstra_write_tools",
+    "axis": "enable_axis_write_tools",
     "central": "enable_central_write_tools",
     "clearpass": "enable_clearpass_write_tools",
     "greenlake": None,
     "mist": "enable_mist_write_tools",
+    "_template": None,  # Never instantiated at runtime; gating attr unused.
 }
 
 

--- a/src/hpe_networking_mcp/platforms/_template/README.md
+++ b/src/hpe_networking_mcp/platforms/_template/README.md
@@ -1,0 +1,171 @@
+# Platform Template
+
+Canonical scaffold for adding a new platform to the HPE Networking MCP server. Anything outside `platforms/_template/` follows the same patterns as Mist / Central / Apstra — copy from here, adapt the auth, fill in the tools.
+
+The template is a real Python package: `import hpe_networking_mcp.platforms._template` succeeds. It just isn't wired into `server.py:create_server`, so it never registers any tool at runtime. That's deliberate — it lets `tests/unit/test_platform_template.py` import it and assert structural conventions without polluting the live tool surface.
+
+## How to use the template
+
+Adding `myplatform` to the server is a five-step copy:
+
+### 1. Copy the template directory
+
+```bash
+cp -r src/hpe_networking_mcp/platforms/_template src/hpe_networking_mcp/platforms/myplatform
+```
+
+Then, inside the new directory, search-replace:
+- `_template` → `myplatform` (snake_case identifiers + module paths)
+- `_TEMPLATE` → `_MYPLATFORM`  (constants)
+- `Template` → `Myplatform` (class names if any are added later)
+
+The two example tools (`tools/example_read.py`, `tools/example_write.py`) demonstrate the read and write patterns. **Delete them once you've added real tools** — they're for reference, not production code.
+
+### 2. Add the secret loader to `src/hpe_networking_mcp/config.py`
+
+Three edits:
+
+```python
+@dataclass
+class MyplatformSecrets:
+    api_token: str
+    # add more fields as needed
+
+
+# in ServerConfig:
+enable_myplatform_write_tools: bool = False
+myplatform: MyplatformSecrets | None = None
+
+# in enabled_platforms property:
+if self.myplatform:
+    platforms.append("myplatform")
+
+
+def _load_myplatform() -> MyplatformSecrets | None:
+    api_token = _read_secret("myplatform_api_token")
+    if not api_token:
+        logger.info("Myplatform: disabled (myplatform_api_token secret not found)")
+        return None
+    logger.info("Myplatform: credentials loaded (token: {})", mask_secret(api_token))
+    return MyplatformSecrets(api_token=api_token)
+
+
+# in load_config():
+myplatform = _load_myplatform()
+# ...
+return ServerConfig(
+    ...,
+    myplatform=myplatform,
+    enable_myplatform_write_tools=enable_myplatform_write,
+)
+```
+
+Plus an env var for write-tool gating:
+
+```python
+enable_myplatform_write = os.getenv("ENABLE_MYPLATFORM_WRITE_TOOLS", "false").lower() in _truthy
+```
+
+### 3. Wire the lifespan + tool registration in `src/hpe_networking_mcp/server.py`
+
+In `lifespan()`:
+
+```python
+if config.myplatform:
+    try:
+        from hpe_networking_mcp.platforms.myplatform.client import MyplatformClient
+        context["myplatform_client"] = MyplatformClient(config.myplatform)
+        context["myplatform_config"] = config.myplatform
+    except Exception as e:
+        logger.warning("Myplatform: failed to initialize — {}", e)
+        context["myplatform_client"] = None
+        context["myplatform_config"] = None
+else:
+    context["myplatform_client"] = None
+    context["myplatform_config"] = None
+```
+
+In the lifespan teardown:
+
+```python
+client = context.get("myplatform_client")
+if client is not None:
+    await client.aclose()
+```
+
+In `create_server()`:
+
+```python
+if config.myplatform:
+    _register_myplatform_tools(mcp, config)
+
+
+def _register_myplatform_tools(mcp: FastMCP, config: ServerConfig) -> None:
+    """Register all Myplatform platform tools."""
+    from hpe_networking_mcp.platforms.myplatform import register_tools
+    count = register_tools(mcp, config)
+    logger.info("Myplatform: registered {} tools", count)
+```
+
+And the Visibility transform for write-tool gating:
+
+```python
+if not config.enable_myplatform_write_tools:
+    mcp.add_transform(Visibility(False, tags={"myplatform_write", "myplatform_write_delete"}, components={"tool"}))
+```
+
+### 4. Add the health probe in `src/hpe_networking_mcp/platforms/health.py`
+
+```python
+async def _probe_myplatform(ctx: Context) -> dict[str, Any]:
+    client = ctx.lifespan_context.get("myplatform_client")
+    if client is None:
+        return {"status": "unavailable", "message": "Myplatform is not configured or failed to initialize"}
+    try:
+        await client.health_check()
+        return {"status": "ok", "message": "Myplatform API reachable"}
+    except Exception as e:
+        return {"status": "degraded", "message": f"Myplatform probe failed: {e}"}
+```
+
+Then add `"myplatform"` to `_ALL_PLATFORMS` and `_PROBES`.
+
+### 5. Add the secret template + a unit test
+
+```bash
+echo "your-token-here" > secrets/myplatform_api_token.example
+cp tests/unit/test_axis_dynamic_mode.py tests/unit/test_myplatform_dynamic_mode.py
+# adapt the imports + assertions
+```
+
+## What the template captures
+
+These patterns are uniform across every existing platform — change them in the template and every future copy gets the fix:
+
+| Concern | File | Why it's templated |
+|---|---|---|
+| Tool registry shim with `dynamic_managed` tag | `_registry.py` | Visibility transform requires this tag on every dynamic-mode tool |
+| Per-tool ToolAnnotations (`READ_ONLY` / `WRITE` / `WRITE_DELETE`) | `tools/__init__.py` | MCP clients use these to render confirmation UX |
+| `register_tools(mcp, config)` + importlib loop | `__init__.py` | Single-source registration so meta-tools and Visibility both work |
+| `format_http_error` helper | `client.py` | Consistent error shape across tools |
+| `get_<platform>_client()` ctx accessor with 503 on missing client | `client.py` | Fail-fast when the platform isn't configured |
+
+## What's NOT templated
+
+These vary legitimately and are left as comments / extension points in `client.py`:
+
+- **Auth flavor** — bearer token (default), OAuth2 client_credentials, username/password. The template ships with bearer; comments show where to swap.
+- **HTTP layer** — direct `httpx` (template default) or a vendor SDK wrapper. If the platform has a maintained SDK (e.g. mistapi, pycentral, pyclearpass), prefer that over hand-rolled httpx.
+- **Pagination** — RFC 5988 `Link` headers, OData `$top`/`$skip`, opaque cursors. Different APIs do this differently.
+- **Elicitation pattern** — write tools call `confirm_write(ctx, ...)` from `middleware/elicitation.py`. Pattern shown in `tools/example_write.py`.
+
+## Validation
+
+The template stays honest because `tests/unit/test_platform_template.py` imports it and asserts:
+
+- The `@tool` decorator is exported from `_registry.py`
+- `READ_ONLY`, `WRITE`, `WRITE_DELETE` are exported from `tools/__init__.py`
+- `register_tools(mcp, config)` exists and is callable
+- The example tool files import successfully (no broken references)
+
+If you change the conventions in a real platform, update the template + the test in the same PR.

--- a/src/hpe_networking_mcp/platforms/_template/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_template/__init__.py
@@ -1,0 +1,65 @@
+"""Template platform module — canonical scaffold for new platforms.
+
+This module is intentionally not wired into ``server.py:create_server``,
+so it never registers any tool at runtime. ``register_tools`` exists so
+copies of this module work out of the box once the new platform is wired
+into the server.
+
+See ``README.md`` in this directory for the step-by-step copy procedure.
+"""
+
+import importlib
+
+from fastmcp import FastMCP
+from loguru import logger
+
+from hpe_networking_mcp.config import ServerConfig
+
+# Map of category (sub-module name under ``tools/``) -> list of tool names
+# registered by that module. Mirrors every other platform's pattern. The
+# names here are illustrative only — replace with real tools when copying
+# this template.
+TOOLS: dict[str, list[str]] = {
+    "example_read": [
+        "template_get_example",
+    ],
+    "example_write": [
+        "template_manage_example",
+    ],
+}
+
+
+def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
+    """Load template tool modules and register them with FastMCP.
+
+    Always imports every category so the platform registry is fully
+    populated; runtime write-gating is handled by the ``Visibility``
+    transform (static mode) and ``is_tool_enabled`` (dynamic mode, via
+    the meta-tools).
+
+    Returns the count of individual underlying tools that registered.
+    """
+    from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
+    from hpe_networking_mcp.platforms._template import _registry
+
+    _registry.mcp = mcp
+
+    loaded: list[str] = []
+    for category, tool_names in TOOLS.items():
+        try:
+            importlib.import_module(f"hpe_networking_mcp.platforms._template.tools.{category}")
+            loaded.extend(tool_names)
+            logger.debug("Template: loaded module {}", category)
+        except Exception as e:
+            logger.warning("Template: failed to load module {} -- {}", category, e)
+
+    if config.tool_mode == "dynamic":
+        build_meta_tools("_template", mcp)
+        logger.info(
+            "Template: {} underlying tools + 3 meta-tools registered (dynamic mode)",
+            len(loaded),
+        )
+    else:
+        logger.info("Template: {} tools registered (static mode)", len(loaded))
+
+    return len(loaded)

--- a/src/hpe_networking_mcp/platforms/_template/_registry.py
+++ b/src/hpe_networking_mcp/platforms/_template/_registry.py
@@ -1,0 +1,80 @@
+"""Template tool registry — module-level FastMCP holder + shared-registry shim.
+
+Tool modules under ``platforms/_template/tools/`` decorate their functions
+with ``@tool(...)`` (imported from here) instead of directly with
+``@mcp.tool(...)``. The shim:
+
+1. Delegates to the underlying FastMCP ``mcp.tool(...)`` so the tool is
+   registered with the server.
+2. Merges the ``dynamic_managed`` tag onto every registered tool so the
+   ``Visibility(False, tags={"dynamic_managed"})`` transform can hide all
+   these tools when ``MCP_TOOL_MODE=dynamic`` (the default).
+3. Populates the shared ``REGISTRIES["_template"]`` dict so the meta-tools
+   can dispatch by name at runtime.
+
+Both modes work from the same decorator — no per-mode branching in tool
+files. When copying this template, change ``_PLATFORM`` to your platform
+name (e.g. ``"axis"``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp import FastMCP
+
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    DYNAMIC_MANAGED_TAG,
+    ToolSpec,
+    record_tool,
+)
+
+# Set by ``platforms._template.register_tools()`` before tool modules are imported.
+mcp: FastMCP = None  # type: ignore[assignment]
+
+_PLATFORM = "_template"
+
+
+def _derive_category(func: Callable[..., Any]) -> str:
+    """Short module name as the registry category (e.g. ``example_read``)."""
+    module = getattr(func, "__module__", "")
+    return module.rsplit(".", 1)[-1] if "." in module else module
+
+
+def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry.
+
+    Accepts every keyword ``FastMCP.tool`` accepts — forwards them
+    unchanged except for ``tags``, which gets ``dynamic_managed`` merged
+    in so the Visibility transform in ``server.py`` can hide these tools
+    when the server is running in dynamic mode.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
+        resolved_name: str = tool_kwargs.get("name") or func.__name__
+        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
+
+        record_tool(
+            ToolSpec(
+                name=resolved_name,
+                func=func,
+                platform=_PLATFORM,
+                category=_derive_category(func),
+                description=resolved_description,
+                tags=supplied_tags,
+            )
+        )
+
+        if mcp is None:
+            # register_tools() not yet called — likely an import during
+            # test collection before the platform is wired. Leaving the
+            # function undecorated is fine: tests that need FastMCP
+            # registration set up a real mcp before import.
+            return func
+
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        return mcp.tool(**effective_kwargs)(func)
+
+    return decorator

--- a/src/hpe_networking_mcp/platforms/_template/client.py
+++ b/src/hpe_networking_mcp/platforms/_template/client.py
@@ -1,0 +1,213 @@
+"""Template HTTP client with bearer-token auth, async httpx, and 401-refresh hook.
+
+This is the minimal pattern most modern REST APIs need: bearer token in the
+``Authorization`` header, async transport via ``httpx.AsyncClient``, a
+``request()`` shortcut that handles auth + 401 retry, and a
+``health_check()`` that the cross-platform ``health`` probe calls.
+
+When copying this template, the auth flavor is the most common thing to change:
+
+- **Bearer token (this template)** — keep as-is; set ``self._token``
+  from config in ``__init__``.
+- **OAuth2 client_credentials** — replace ``_login_locked`` with a token
+  endpoint call; cache + auto-refresh on 401 + before expiry. See
+  ``platforms/greenlake/auth.py`` for the canonical implementation.
+- **Username/password login endpoint** — replace ``_login_locked`` with
+  a POST to the login endpoint that returns a session token. See
+  ``platforms/apstra/client.py``.
+- **Vendor SDK** — skip this file entirely; wrap the SDK in a thin
+  adapter that exposes ``.health_check()`` and your tool surface. See
+  ``platforms/mist/client.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_context
+from loguru import logger
+
+# When copying this template, replace this import with your platform's secrets type.
+# from hpe_networking_mcp.config import MyplatformSecrets  # noqa: ERA001
+from hpe_networking_mcp.utils.logging import mask_secret
+
+_REQUEST_TIMEOUT = 30.0
+_AUTH_TIMEOUT = 10.0
+
+
+class TemplateAuthError(RuntimeError):
+    """Raised when the platform's auth handshake fails.
+
+    Rename to ``<Platform>AuthError`` when copying.
+    """
+
+
+class TemplateClient:
+    """Async REST API client with bearer-token auth and 401-refresh retry.
+
+    Rename to ``<Platform>Client`` when copying. Base URL, auth header
+    name, and refresh strategy may need to change.
+
+    Usage in tools::
+
+        client = await get_template_client()
+        data = await client.get_json("/api/v1.0/Things")
+        return data
+    """
+
+    def __init__(self, config: Any) -> None:
+        # Replace ``Any`` with your ``<Platform>Secrets`` type.
+        self._config = config
+        self._token: str | None = getattr(config, "api_token", None)
+        self._lock = asyncio.Lock()
+        # Replace with your real base URL — typically built from config fields.
+        base_url = getattr(config, "base_url", "https://example.invalid")
+        self._http = httpx.AsyncClient(
+            base_url=base_url,
+            verify=getattr(config, "verify_ssl", True),
+            timeout=_REQUEST_TIMEOUT,
+        )
+
+    @property
+    def base_url(self) -> str:
+        """Return the configured base URL (host + scheme)."""
+        return str(self._http.base_url)
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx client. Called from ``server.py:lifespan``."""
+        await self._http.aclose()
+
+    async def _ensure_token(self) -> str:
+        """Return the cached token, acquiring one under the lock if needed.
+
+        For static-token auth (this template's default) the token comes
+        from config directly. For OAuth2 / login-endpoint flavors,
+        replace with a real acquisition routine.
+        """
+        if self._token is not None:
+            return self._token
+        async with self._lock:
+            if self._token is None:
+                await self._login_locked()
+            assert self._token is not None
+            return self._token
+
+    async def _refresh_token(self) -> str:
+        """Force-refresh the token under the lock.
+
+        For static-token auth this just re-reads the config (same token);
+        for refreshable auth it calls the token endpoint.
+        """
+        async with self._lock:
+            self._token = None
+            await self._login_locked()
+            assert self._token is not None
+            return self._token
+
+    async def _login_locked(self) -> None:
+        """Acquire a fresh token. Caller must hold ``self._lock``.
+
+        Default implementation: pull the token from config (static
+        bearer token, no refresh endpoint). Replace with a POST to your
+        login / token endpoint for OAuth2 / username-password flavors.
+        """
+        token = getattr(self._config, "api_token", None)
+        if not token:
+            raise TemplateAuthError("No api_token in config and no token endpoint configured.")
+        self._token = token
+        logger.info("Template: token loaded {}", mask_secret(token))
+
+    def _auth_headers(self, token: str) -> dict[str, str]:
+        """Build the headers for an authenticated request.
+
+        Bearer is the default; some platforms use a custom header name
+        (e.g. Apstra's ``AuthToken``, Mist's ``Authorization: Token``).
+        """
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        params: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an authenticated request, refreshing the token once on 401."""
+        token = await self._ensure_token()
+        kwargs: dict[str, Any] = {"headers": self._auth_headers(token)}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        if params:
+            kwargs["params"] = params
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
+        response = await self._http.request(method, path, **kwargs)
+        if response.status_code == 401:
+            logger.info("Template: 401 on {} {} — refreshing token once", method, path)
+            token = await self._refresh_token()
+            kwargs["headers"] = self._auth_headers(token)
+            response = await self._http.request(method, path, **kwargs)
+        response.raise_for_status()
+        return response
+
+    async def get_json(self, path: str, **kwargs: Any) -> Any:
+        """Shortcut for a GET that returns parsed JSON."""
+        response = await self.request("GET", path, **kwargs)
+        return response.json()
+
+    async def health_check(self) -> bool:
+        """Probe credentials by acquiring a token. Returns True if it works.
+
+        Override with a real reachability check (e.g. GET /health) if
+        your platform exposes one.
+        """
+        await self._ensure_token()
+        return True
+
+
+async def get_template_client() -> TemplateClient:
+    """Retrieve the shared client from the lifespan context.
+
+    Rename to ``get_<platform>_client`` when copying. The ctx key
+    must match what ``server.py:lifespan`` populates.
+    """
+    ctx = get_context()
+    client: TemplateClient | None = ctx.lifespan_context.get("_template_client")
+    if client is None:
+        raise ToolError(
+            {
+                "status_code": 503,
+                "message": "Template API client not available. Check your credentials.",
+            }
+        )
+    return client
+
+
+def format_http_error(exc: BaseException) -> dict[str, Any]:
+    """Shape any exception into a consistent dict for tool returns.
+
+    Surfaces status code and response body for ``httpx.HTTPStatusError``;
+    everything else falls back to a generic shape so call sites can use
+    this helper uniformly inside broad ``except Exception`` blocks. Same
+    pattern used by every other platform.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        text = exc.response.text[:500]
+        try:
+            body: Any = exc.response.json()
+        except (ValueError, json.JSONDecodeError):
+            body = text
+        return {"status_code": status, "message": str(exc), "body": body}
+    return {"status_code": 0, "message": str(exc), "body": None}

--- a/src/hpe_networking_mcp/platforms/_template/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_template/tools/__init__.py
@@ -1,0 +1,29 @@
+"""Shared ToolAnnotations constants for tools in this platform.
+
+Apply via the @tool decorator's ``annotations`` kwarg. MCP clients use
+these hints to decide UX (e.g. Claude Desktop's confirmation dialog
+fires for ``destructiveHint=True`` tools).
+"""
+
+from mcp.types import ToolAnnotations
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+WRITE_DELETE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)

--- a/src/hpe_networking_mcp/platforms/_template/tools/example_read.py
+++ b/src/hpe_networking_mcp/platforms/_template/tools/example_read.py
@@ -1,0 +1,35 @@
+"""Example read-only tool — reference pattern only, never registered.
+
+Delete this file when you copy the template into a real platform and
+replace it with your real ``<platform>_get_*`` tools.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms._template._registry import tool
+from hpe_networking_mcp.platforms._template.client import format_http_error, get_template_client
+from hpe_networking_mcp.platforms._template.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def template_get_example(ctx: Context) -> list[dict[str, Any]] | str:
+    """Get a list of example things from the template platform.
+
+    Reference pattern: every read tool follows this shape.
+
+    - Acquire the platform client via ``get_<platform>_client()``.
+    - Call ``client.get_json(...)`` (or ``client.request(...)`` for non-JSON).
+    - Return the parsed body or a string error message.
+    - Wrap the call in ``try/except`` and run errors through ``format_http_error``.
+    """
+    try:
+        client = await get_template_client()
+        payload = await client.get_json("/api/v1.0/Things")
+        items = payload.get("items", payload) if isinstance(payload, dict) else payload
+        return items
+    except Exception as e:
+        return f"Error fetching things: {format_http_error(e) if hasattr(e, 'response') else e}"

--- a/src/hpe_networking_mcp/platforms/_template/tools/example_write.py
+++ b/src/hpe_networking_mcp/platforms/_template/tools/example_write.py
@@ -1,0 +1,80 @@
+"""Example write tool — reference pattern only, never registered.
+
+Delete this file when you copy the template into a real platform and
+replace it with your real ``<platform>_manage_*`` tools.
+
+Demonstrates two important patterns every write tool should follow:
+
+1. ``confirm_write(ctx, message)`` — opens an MCP elicitation prompt so
+   the user has to confirm the change before it lands. The middleware
+   threads ``confirmed=True`` through the call after the user accepts,
+   skipping the prompt on retry.
+2. ``action_type`` parameter (``create`` / ``update`` / ``delete``) — one
+   write tool per entity, dispatched by ``action_type`` inside the
+   function body. Reduces tool surface count without losing clarity.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastmcp import Context
+
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._template._registry import tool
+from hpe_networking_mcp.platforms._template.client import format_http_error, get_template_client
+from hpe_networking_mcp.platforms._template.tools import WRITE, WRITE_DELETE
+
+
+@tool(annotations=WRITE_DELETE, tags={"_template_write", "_template_write_delete"})
+async def template_manage_example(
+    ctx: Context,
+    action_type: Literal["create", "update", "delete"],
+    thing_id: str | None = None,
+    name: str | None = None,
+    payload: dict[str, Any] | None = None,
+    confirmed: bool = False,
+) -> dict[str, Any] | str:
+    """Create, update, or delete an example thing.
+
+    Args:
+        action_type: One of ``create``, ``update``, or ``delete``.
+        thing_id: Required for update/delete. The thing's UUID.
+        name: Required for create.
+        payload: Body for create/update.
+        confirmed: Set true after user confirms. Skips re-prompting.
+    """
+    if action_type == "create":
+        annotations = WRITE
+        prompt = f"Template: create thing '{name}'. Confirm?"
+    elif action_type == "update":
+        annotations = WRITE
+        prompt = f"Template: update thing {thing_id}. Confirm?"
+    else:  # delete
+        annotations = WRITE_DELETE
+        prompt = f"Template: permanently DELETE thing {thing_id}. Cannot be undone. Confirm?"
+
+    _ = annotations  # variable kept for documentation symmetry; unused at runtime
+
+    if not confirmed:
+        decline = await confirm_write(ctx, prompt)
+        if decline:
+            return decline
+
+    try:
+        client = await get_template_client()
+        if action_type == "create":
+            response = await client.request("POST", "/api/v1.0/Things", json_body=payload or {"name": name})
+        elif action_type == "update":
+            if not thing_id:
+                return "thing_id is required for update."
+            response = await client.request("PUT", f"/api/v1.0/Things/{thing_id}", json_body=payload or {})
+        else:  # delete
+            if not thing_id:
+                return "thing_id is required for delete."
+            response = await client.request("DELETE", f"/api/v1.0/Things/{thing_id}")
+
+        body: Any = response.json() if response.content else {"status": "accepted"}
+        return {"action": action_type, "thing_id": thing_id, "data": body}
+    except Exception as e:
+        return f"Error during {action_type}: {format_http_error(e) if hasattr(e, 'response') else e}"

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -1,0 +1,59 @@
+"""Axis Atmos Cloud platform module.
+
+Axis is shipped as a hidden platform: it auto-disables when its single
+``axis_api_token`` secret is missing and stays unreferenced in any
+public-facing documentation until the user chooses to announce it. See
+the scratch directory's ``AXIS_ATMOS_INTEGRATION_PLAN.md`` for the full
+plan.
+
+Phase 1 (this PR): scaffold + secret loader + health probe. ``TOOLS``
+intentionally empty — the read/write surfaces land in subsequent waves.
+"""
+
+import importlib
+
+from fastmcp import FastMCP
+from loguru import logger
+
+from hpe_networking_mcp.config import ServerConfig
+
+# Map of category (tools/<name>.py) -> tool names registered by that module.
+# Empty in Phase 1; populated as read tools (Wave 3) and write tools (Phase 2)
+# land. Mirrors every other platform's pattern.
+TOOLS: dict[str, list[str]] = {}
+
+
+def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
+    """Load Axis tool modules and register them with FastMCP.
+
+    Always imports every category so the platform registry is fully
+    populated; runtime write-gating is handled by the ``Visibility``
+    transform (static mode) and ``is_tool_enabled`` (dynamic mode, via
+    the meta-tools).
+
+    Returns the count of individual underlying tools that registered.
+    """
+    from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
+    from hpe_networking_mcp.platforms.axis import _registry
+
+    _registry.mcp = mcp
+
+    loaded: list[str] = []
+    for category, tool_names in TOOLS.items():
+        try:
+            importlib.import_module(f"hpe_networking_mcp.platforms.axis.tools.{category}")
+            loaded.extend(tool_names)
+            logger.debug("Axis: loaded module {}", category)
+        except Exception as e:
+            logger.warning("Axis: failed to load module {} -- {}", category, e)
+
+    if config.tool_mode == "dynamic":
+        build_meta_tools("axis", mcp)
+        logger.info(
+            "Axis: {} underlying tools + 3 meta-tools registered (dynamic mode)",
+            len(loaded),
+        )
+    else:
+        logger.info("Axis: {} tools registered (static mode)", len(loaded))
+
+    return len(loaded)

--- a/src/hpe_networking_mcp/platforms/axis/_registry.py
+++ b/src/hpe_networking_mcp/platforms/axis/_registry.py
@@ -1,0 +1,59 @@
+"""Axis tool registry — module-level FastMCP holder + shared-registry shim.
+
+Tool modules under ``platforms/axis/tools/`` decorate their functions
+with ``@tool(...)`` (imported from here) instead of directly with
+``@mcp.tool(...)``. Same shim shape as every other platform — see
+``platforms/_template/_registry.py`` for the canonical reference.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp import FastMCP
+
+from hpe_networking_mcp.platforms._common.tool_registry import (
+    DYNAMIC_MANAGED_TAG,
+    ToolSpec,
+    record_tool,
+)
+
+# Set by ``platforms.axis.register_tools()`` before tool modules are imported.
+mcp: FastMCP = None  # type: ignore[assignment]
+
+_PLATFORM = "axis"
+
+
+def _derive_category(func: Callable[..., Any]) -> str:
+    """Short module name as the registry category (e.g. ``connectors``)."""
+    module = getattr(func, "__module__", "")
+    return module.rsplit(".", 1)[-1] if "." in module else module
+
+
+def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
+        resolved_name: str = tool_kwargs.get("name") or func.__name__
+        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
+
+        record_tool(
+            ToolSpec(
+                name=resolved_name,
+                func=func,
+                platform=_PLATFORM,
+                category=_derive_category(func),
+                description=resolved_description,
+                tags=supplied_tags,
+            )
+        )
+
+        if mcp is None:
+            return func
+
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        return mcp.tool(**effective_kwargs)(func)
+
+    return decorator

--- a/src/hpe_networking_mcp/platforms/axis/client.py
+++ b/src/hpe_networking_mcp/platforms/axis/client.py
@@ -1,0 +1,158 @@
+"""Axis Atmos Cloud REST API client.
+
+Auth: static bearer token, manually generated in the Axis admin portal at
+*Settings → Admin API → New API Token*. The user picks read/write scope and
+expiration; there is no refresh endpoint. On 401 the only recourse is to
+regenerate the token in the portal — we surface a clear error and let the
+operator handle it.
+
+Base URL: ``https://admin-api.axissecurity.com/api/v1.0``.
+
+JWT-exp decoding is intentionally NOT in this PR — it lands in Wave 2.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_context
+from loguru import logger
+
+from hpe_networking_mcp.config import AxisSecrets
+from hpe_networking_mcp.utils.logging import mask_secret
+
+_AXIS_BASE_URL = "https://admin-api.axissecurity.com/api/v1.0"
+_REQUEST_TIMEOUT = 30.0
+
+
+class AxisAuthError(RuntimeError):
+    """Raised when the Axis API token is missing or rejected."""
+
+
+class AxisClient:
+    """Async Axis Atmos Cloud REST API client.
+
+    Static-token auth — token comes from config and is never refreshed.
+    On 401 we raise a clear error pointing operators at the portal.
+    """
+
+    def __init__(self, config: AxisSecrets) -> None:
+        self._config = config
+        self._token: str = config.api_token
+        self._lock = asyncio.Lock()
+        self._http = httpx.AsyncClient(
+            base_url=_AXIS_BASE_URL,
+            timeout=_REQUEST_TIMEOUT,
+        )
+        logger.info("Axis: client initialized (token: {})", mask_secret(self._token))
+
+    @property
+    def base_url(self) -> str:
+        """Return the configured base URL."""
+        return _AXIS_BASE_URL
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx client. Called from server.py:lifespan."""
+        await self._http.aclose()
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        params: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an authenticated request.
+
+        Args:
+            method: HTTP method.
+            path: Path starting with ``/`` (e.g. ``/Connectors``). The
+                ``/api/v1.0`` prefix is already in the base URL.
+            json_body: Optional JSON payload.
+            params: Optional query parameters.
+            timeout: Optional per-call timeout override (seconds).
+
+        Returns:
+            The httpx.Response after ``raise_for_status()``.
+
+        Raises:
+            AxisAuthError: On 401 — token expired or revoked; regenerate in the portal.
+            httpx.HTTPStatusError: On other 4xx/5xx.
+            httpx.HTTPError: On transport errors.
+        """
+        kwargs: dict[str, Any] = {"headers": self._auth_headers()}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        if params:
+            kwargs["params"] = params
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
+        response = await self._http.request(method, path, **kwargs)
+        if response.status_code == 401:
+            raise AxisAuthError(
+                "Axis API returned 401. The API token is missing, expired, or revoked. "
+                "Regenerate the token at Settings → Admin API → New API Token in the Axis portal "
+                "and update the axis_api_token secret."
+            )
+        response.raise_for_status()
+        return response
+
+    async def get_json(self, path: str, **kwargs: Any) -> Any:
+        """Shortcut for a GET that returns parsed JSON."""
+        response = await self.request("GET", path, **kwargs)
+        return response.json()
+
+    async def health_check(self) -> bool:
+        """Probe the Axis ``/Health`` endpoint. Returns True if reachable.
+
+        Used by ``platforms/health.py:_probe_axis()``.
+        """
+        # /Health is documented in the Axis API at /api/v1.0/Health and
+        # returns 200 with a small JSON body when the platform is up.
+        await self.request("GET", "/Health")
+        return True
+
+
+async def get_axis_client() -> AxisClient:
+    """Retrieve the shared AxisClient from the lifespan context.
+
+    Raises:
+        ToolError: If Axis is not configured or the client is unavailable.
+    """
+    ctx = get_context()
+    client: AxisClient | None = ctx.lifespan_context.get("axis_client")
+    if client is None:
+        raise ToolError(
+            {
+                "status_code": 503,
+                "message": "Axis API client not available. Check your axis_api_token secret.",
+            }
+        )
+    return client
+
+
+def format_http_error(exc: BaseException) -> dict[str, Any]:
+    """Shape any exception into a consistent dict for tool returns."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        text = exc.response.text[:500]
+        try:
+            body: Any = exc.response.json()
+        except (ValueError, json.JSONDecodeError):
+            body = text
+        return {"status_code": status, "message": str(exc), "body": body}
+    return {"status_code": 0, "message": str(exc), "body": None}

--- a/src/hpe_networking_mcp/platforms/axis/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/__init__.py
@@ -1,0 +1,27 @@
+"""Shared ToolAnnotations constants for Axis tools.
+
+Apply via the @tool decorator's ``annotations`` kwarg.
+"""
+
+from mcp.types import ToolAnnotations
+
+READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
+WRITE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+WRITE_DELETE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)

--- a/src/hpe_networking_mcp/platforms/health.py
+++ b/src/hpe_networking_mcp/platforms/health.py
@@ -29,7 +29,7 @@ _PROBE_ANNOTATIONS = ToolAnnotations(
     openWorldHint=True,
 )
 
-_ALL_PLATFORMS: tuple[str, ...] = ("mist", "central", "greenlake", "clearpass", "apstra")
+_ALL_PLATFORMS: tuple[str, ...] = ("mist", "central", "greenlake", "clearpass", "apstra", "axis")
 
 
 def _normalize_platform_filter(
@@ -151,12 +151,24 @@ async def _probe_apstra(ctx: Context) -> dict[str, Any]:
         return {"status": "degraded", "message": f"Apstra probe failed: {e}"}
 
 
+async def _probe_axis(ctx: Context) -> dict[str, Any]:
+    client = ctx.lifespan_context.get("axis_client")
+    if client is None:
+        return {"status": "unavailable", "message": "Axis is not configured or failed to initialize"}
+    try:
+        await client.health_check()
+        return {"status": "ok", "message": "Axis API reachable", "base_url": client.base_url}
+    except Exception as e:
+        return {"status": "degraded", "message": f"Axis probe failed: {e}"}
+
+
 _PROBES = {
     "mist": _probe_mist,
     "central": _probe_central,
     "greenlake": _probe_greenlake,
     "clearpass": _probe_clearpass,
     "apstra": _probe_apstra,
+    "axis": _probe_axis,
 }
 
 

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -129,6 +129,21 @@ async def lifespan(server: FastMCP):
         context["apstra_client"] = None
         context["apstra_config"] = None
 
+    # --- Axis ---
+    if config.axis:
+        try:
+            from hpe_networking_mcp.platforms.axis.client import AxisClient
+
+            context["axis_client"] = AxisClient(config.axis)
+            context["axis_config"] = config.axis
+        except Exception as e:
+            logger.warning("Axis: failed to initialize — {}", e)
+            context["axis_client"] = None
+            context["axis_config"] = None
+    else:
+        context["axis_client"] = None
+        context["axis_config"] = None
+
     # --- Verify every enabled platform via the shared probe helpers from
     # platforms/health.py. One source of truth: startup log output and the
     # runtime ``health`` tool report the same status. Probes that fail do
@@ -165,6 +180,9 @@ async def lifespan(server: FastMCP):
         apstra = context.get("apstra_client")
         if apstra is not None:
             await apstra.aclose()
+        axis = context.get("axis_client")
+        if axis is not None:
+            await axis.aclose()
         logger.info("Server shutdown complete")
 
 
@@ -198,6 +216,8 @@ def create_server(config: ServerConfig) -> FastMCP:
         _register_clearpass_tools(mcp, config)
     if config.apstra:
         _register_apstra_tools(mcp, config)
+    if config.axis:
+        _register_axis_tools(mcp, config)
 
     # --- Cross-platform tools and prompts (require both Mist and Central) ---
     if config.mist and config.central:
@@ -228,6 +248,8 @@ def create_server(config: ServerConfig) -> FastMCP:
         mcp.add_transform(Visibility(False, tags={"clearpass_write_delete"}, components={"tool"}))
     if not config.enable_apstra_write_tools:
         mcp.add_transform(Visibility(False, tags={"apstra_write", "apstra_write_delete"}, components={"tool"}))
+    if not config.enable_axis_write_tools:
+        mcp.add_transform(Visibility(False, tags={"axis_write", "axis_write_delete"}, components={"tool"}))
 
     # --- Dynamic mode: hide the individual registry-managed tools so the
     # exposed surface is just the per-platform meta-tools plus the 3
@@ -279,6 +301,14 @@ def _register_apstra_tools(mcp: FastMCP, config: ServerConfig) -> None:
 
     count = register_tools(mcp, config)
     logger.info("Apstra: registered {} tools", count)
+
+
+def _register_axis_tools(mcp: FastMCP, config: ServerConfig) -> None:
+    """Register all Axis platform tools."""
+    from hpe_networking_mcp.platforms.axis import register_tools
+
+    count = register_tools(mcp, config)
+    logger.info("Axis: registered {} tools", count)
 
 
 def _register_sync_tools(mcp: FastMCP) -> None:

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -173,6 +173,7 @@ class TestCreateServer:
             enable_central_write_tools=True,
             enable_clearpass_write_tools=True,
             enable_apstra_write_tools=True,
+            enable_axis_write_tools=True,
             tool_mode="static",
         )
 

--- a/tests/unit/test_axis_dynamic_mode.py
+++ b/tests/unit/test_axis_dynamic_mode.py
@@ -1,0 +1,175 @@
+"""Unit tests for the Axis Atmos Cloud platform scaffold (Phase 1).
+
+Phase 1 ships the platform skeleton — config loader, lifespan client init,
+health probe, registry plumbing — but no underlying tools yet (``TOOLS``
+is intentionally empty until subsequent waves). The tests below validate
+the scaffold itself: the registry is wired in cleanly, the empty TOOLS
+dict round-trips, and the pieces a tool would need (decorator, client
+accessor, annotation constants) are importable.
+
+When read tools land in Wave 3, expand ``TestAxisRegistryPopulation`` to
+mirror ``test_apstra_dynamic_mode.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+
+@pytest.mark.unit
+class TestAxisRegistryWiring:
+    def test_axis_in_registries_dict(self):
+        """The cross-platform registry must contain the axis key.
+
+        ``record_tool`` raises ``ValueError("Unknown platform: axis")`` if
+        the platform name isn't a known key — caught this exact bug live
+        during scaffold development.
+        """
+        assert "axis" in REGISTRIES
+
+    def test_axis_starts_empty(self):
+        """Phase 1 ships zero tools. Read tools land in a later wave."""
+        from hpe_networking_mcp.platforms.axis import TOOLS
+
+        assert TOOLS == {}
+
+    def test_axis_register_tools_returns_zero(self):
+        """register_tools should report 0 underlying tools at this stage."""
+        from hpe_networking_mcp.platforms.axis import TOOLS
+
+        # Tool count is just len(flatten(TOOLS.values())).
+        flat = [n for names in TOOLS.values() for n in names]
+        assert len(flat) == 0
+
+
+@pytest.mark.unit
+class TestAxisModuleImports:
+    """The scaffold's pieces must import cleanly. Catches typos / missing files."""
+
+    def test_axis_package_importable(self):
+        import hpe_networking_mcp.platforms.axis  # noqa: F401
+
+    def test_registry_decorator_exposed(self):
+        from hpe_networking_mcp.platforms.axis._registry import tool
+
+        assert callable(tool)
+
+    def test_annotation_constants_exposed(self):
+        from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE, WRITE_DELETE
+
+        assert READ_ONLY.readOnlyHint is True
+        assert WRITE.readOnlyHint is False
+        assert WRITE_DELETE.destructiveHint is True
+
+    def test_client_module_importable(self):
+        # AxisClient + get_axis_client + format_http_error are all needed by
+        # future tool modules — make sure the import surface is intact.
+        from hpe_networking_mcp.platforms.axis.client import (
+            AxisAuthError,
+            AxisClient,
+            format_http_error,
+            get_axis_client,
+        )
+
+        assert callable(get_axis_client)
+        assert callable(format_http_error)
+        assert isinstance(AxisAuthError("x"), RuntimeError)
+        # Constructor expects an AxisSecrets — don't call it here, just
+        # verify it's a class.
+        assert isinstance(AxisClient, type)
+
+
+@pytest.mark.unit
+class TestAxisConfig:
+    """The config-side wiring (AxisSecrets, _load_axis, ServerConfig fields)."""
+
+    def test_axis_secrets_dataclass(self):
+        from hpe_networking_mcp.config import AxisSecrets
+
+        s = AxisSecrets(api_token="abc")
+        assert s.api_token == "abc"
+
+    def test_server_config_has_axis_field(self):
+        from hpe_networking_mcp.config import AxisSecrets, ServerConfig
+
+        cfg = ServerConfig(axis=AxisSecrets(api_token="t"))
+        assert cfg.axis is not None
+        assert "axis" in cfg.enabled_platforms
+
+    def test_server_config_has_write_flag(self):
+        from hpe_networking_mcp.config import ServerConfig
+
+        cfg = ServerConfig(enable_axis_write_tools=True)
+        assert cfg.enable_axis_write_tools is True
+
+        # Default off — matches every other platform's posture.
+        cfg2 = ServerConfig()
+        assert cfg2.enable_axis_write_tools is False
+
+    def test_axis_disabled_when_token_missing(self, tmp_path, monkeypatch):
+        """``_load_axis`` returns None when the secret file is absent."""
+        # Point SECRETS_DIR at an empty tmp dir so no file resolves.
+        monkeypatch.setattr("hpe_networking_mcp.config.SECRETS_DIR", str(tmp_path))
+        from hpe_networking_mcp.config import _load_axis
+
+        assert _load_axis() is None
+
+    def test_axis_loaded_when_token_present(self, tmp_path, monkeypatch):
+        """``_load_axis`` returns AxisSecrets with the token contents."""
+        (tmp_path / "axis_api_token").write_text("secret-token-here\n")
+        monkeypatch.setattr("hpe_networking_mcp.config.SECRETS_DIR", str(tmp_path))
+        from hpe_networking_mcp.config import _load_axis
+
+        secrets = _load_axis()
+        assert secrets is not None
+        assert secrets.api_token == "secret-token-here"
+
+
+@pytest.mark.unit
+class TestAxisHealthProbe:
+    """The cross-platform health.py wiring."""
+
+    def test_axis_in_all_platforms(self):
+        from hpe_networking_mcp.platforms.health import _ALL_PLATFORMS
+
+        assert "axis" in _ALL_PLATFORMS
+
+    def test_axis_in_probes_dict(self):
+        from hpe_networking_mcp.platforms.health import _PROBES
+
+        assert "axis" in _PROBES
+        assert callable(_PROBES["axis"])
+
+    @pytest.mark.asyncio
+    async def test_probe_returns_unavailable_when_client_missing(self):
+        """If lifespan didn't initialize axis_client, the probe must report 'unavailable'.
+
+        Mirrors the contract every other platform's probe follows.
+        """
+        from hpe_networking_mcp.platforms.health import _probe_axis
+
+        class _FakeCtx:
+            lifespan_context = {}
+
+        result = await _probe_axis(_FakeCtx())
+        assert result["status"] == "unavailable"
+        assert "Axis is not configured" in result["message"]
+
+
+@pytest.mark.unit
+class TestAxisWriteTagWiring:
+    """Visibility transform + is_tool_enabled depend on these dicts."""
+
+    def test_axis_in_write_tag_map(self):
+        from hpe_networking_mcp.platforms._common.tool_registry import _WRITE_TAG_BY_PLATFORM
+
+        assert "axis" in _WRITE_TAG_BY_PLATFORM
+        # When a tool carries axis_write or axis_write_delete tag, gating fires.
+        assert _WRITE_TAG_BY_PLATFORM["axis"] == {"axis_write", "axis_write_delete"}
+
+    def test_axis_in_gate_config_attr(self):
+        from hpe_networking_mcp.platforms._common.tool_registry import _GATE_CONFIG_ATTR
+
+        assert _GATE_CONFIG_ATTR.get("axis") == "enable_axis_write_tools"

--- a/tests/unit/test_platform_template.py
+++ b/tests/unit/test_platform_template.py
@@ -1,0 +1,133 @@
+"""Tests for the platform-template module.
+
+The template is a real Python package that ships in source but is never
+wired into ``server.py:create_server`` — so it never registers any tool
+at runtime. These tests guard the template's structural conventions so
+copies of the template stay in sync with the rest of the codebase. If
+you change a convention in a real platform, update the template + this
+test in the same PR.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+class TestTemplateImportable:
+    """The template's modules must import cleanly. Catches typos / dangling refs."""
+
+    def test_package_importable(self):
+        import hpe_networking_mcp.platforms._template  # noqa: F401
+
+    def test_register_tools_callable(self):
+        from hpe_networking_mcp.platforms._template import register_tools
+
+        assert callable(register_tools)
+
+    def test_tool_decorator_exposed(self):
+        from hpe_networking_mcp.platforms._template._registry import tool
+
+        assert callable(tool)
+
+    def test_annotation_constants_exposed(self):
+        from hpe_networking_mcp.platforms._template.tools import READ_ONLY, WRITE, WRITE_DELETE
+
+        # READ_ONLY is read-only, idempotent, non-destructive.
+        assert READ_ONLY.readOnlyHint is True
+        assert READ_ONLY.idempotentHint is True
+        assert READ_ONLY.destructiveHint is False
+
+        # WRITE is mutating but non-destructive.
+        assert WRITE.readOnlyHint is False
+        assert WRITE.destructiveHint is False
+
+        # WRITE_DELETE is mutating AND destructive.
+        assert WRITE_DELETE.readOnlyHint is False
+        assert WRITE_DELETE.destructiveHint is True
+
+    def test_example_tool_modules_importable(self):
+        # The example tools are reference patterns — they must at least
+        # parse and import without raising. Anyone copying the template
+        # will encounter their first errors here if these break.
+        from hpe_networking_mcp.platforms._template.tools import example_read, example_write  # noqa: F401
+
+    def test_client_module_importable(self):
+        from hpe_networking_mcp.platforms._template.client import (
+            TemplateAuthError,
+            TemplateClient,
+            format_http_error,
+            get_template_client,
+        )
+
+        assert callable(get_template_client)
+        assert callable(format_http_error)
+        assert isinstance(TemplateAuthError("x"), RuntimeError)
+        assert isinstance(TemplateClient, type)
+
+
+@pytest.mark.unit
+class TestTemplateConventions:
+    """The patterns the template captures must match what every real platform follows."""
+
+    def test_tools_dict_shape(self):
+        """``TOOLS`` is a dict[str, list[str]] — same shape as every platform."""
+        from hpe_networking_mcp.platforms._template import TOOLS
+
+        assert isinstance(TOOLS, dict)
+        for category, names in TOOLS.items():
+            assert isinstance(category, str)
+            assert isinstance(names, list)
+            for name in names:
+                assert isinstance(name, str)
+
+    def test_registered_template_platform_in_registries(self):
+        """Tool registry has a ``_template`` entry so example tools register cleanly."""
+        from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+        assert "_template" in REGISTRIES
+
+    def test_template_write_tag_dict(self):
+        """``_WRITE_TAG_BY_PLATFORM`` carries a ``_template`` entry.
+
+        Without it, decorating an example write tool with ``tags={"_template_write"}``
+        would silently fail to gate at runtime — same trap any new platform copy
+        would hit if the gating wiring is missed.
+        """
+        from hpe_networking_mcp.platforms._common.tool_registry import _WRITE_TAG_BY_PLATFORM
+
+        assert "_template" in _WRITE_TAG_BY_PLATFORM
+
+
+@pytest.mark.unit
+class TestTemplateNotAutoRegistered:
+    """The template must NEVER appear in the live server's registration path."""
+
+    def test_template_not_in_server_create_server(self):
+        """server.py:create_server has no reference to ``_template``."""
+        import inspect
+
+        from hpe_networking_mcp import server
+
+        source = inspect.getsource(server)
+        # Excludes occurrences inside docstrings/comments — so check for
+        # the import or function-call patterns specifically.
+        assert "platforms._template" not in source
+        assert "_register__template_tools" not in source
+
+    def test_template_not_in_config_load_config(self):
+        """config.py:load_config doesn't try to load template secrets."""
+        import inspect
+
+        from hpe_networking_mcp import config
+
+        source = inspect.getsource(config)
+        assert "_load__template" not in source
+        assert "TemplateSecrets" not in source
+
+    def test_template_not_in_health_probes(self):
+        """health.py has no probe entry for the template platform."""
+        from hpe_networking_mcp.platforms.health import _ALL_PLATFORMS, _PROBES
+
+        assert "_template" not in _ALL_PLATFORMS
+        assert "_template" not in _PROBES


### PR DESCRIPTION
## Summary

Introduces `platforms/_template/` — a canonical scaffold module that captures the structural conventions every existing platform shares (registry shim, TOOLS dict + importlib loop, annotation constants, lifespan integration, health probe contract). Future platforms copy from this template instead of cloning Apstra and search-replacing.

To validate the template is actually fit-for-purpose, it gets a first consumer: a stub platform under `platforms/axis/` that uses the template's plumbing. The stub ships empty (zero tools — `TOOLS = {}`), auto-disables when its secret is absent, and is gated behind a gitignored `docker-compose.override.yml`. It's a concrete-but-inert smoke test for the template — useful as a small additive change to prove the scaffolding works end-to-end.

This is internal scaffolding only. No public surface change, no version bump.

## What's in the diff

- `platforms/_template/` — README (5-step copy procedure), `__init__.py` + `_registry.py` (registration plumbing), `client.py` (httpx skeleton with auth-flavor extension points commented), `tools/__init__.py` (ToolAnnotations constants), and two example tool files showing the read and write patterns.
- `platforms/axis/` — empty consumer of the template: same four-file skeleton (`__init__.py`, `_registry.py`, `client.py`, `tools/__init__.py`) with `TOOLS = {}` and bearer-token auth pre-wired.
- Wiring edits the template's README directs every new platform to make:
  - `config.py` — secrets dataclass, `_load_*` helper, `ServerConfig` field, write flag
  - `server.py` — lifespan client init/teardown, `_register_*_tools`, write-tool Visibility transform
  - `platforms/health.py` — `_probe_*`, name added to `_ALL_PLATFORMS` and `_PROBES`
  - `platforms/_common/tool_registry.py` — `REGISTRIES`, `_WRITE_TAG_BY_PLATFORM`, and `_GATE_CONFIG_ATTR` all gain entries for the template + first user
- `secrets/axis_api_token.example` — placeholder template file (committed; the real token file is gitignored)
- `tests/unit/test_platform_template.py` — guards the template's structural conventions
- `tests/unit/test_axis_dynamic_mode.py` — verifies the first-user scaffold loads cleanly with zero tools
- `tests/integration/test_server.py` — updated `test_no_visibility_transform_when_write_tools_enabled` to include the new write flag

## What the template captures

Patterns uniform across every existing platform — change them in the template and every future copy gets the fix:

| Concern | File | Why it's templated |
|---|---|---|
| Tool-registry decorator shim with `dynamic_managed` tag merge | `_registry.py` | Visibility transform requires this tag on every dynamic-mode tool |
| ToolAnnotations constants (`READ_ONLY` / `WRITE` / `WRITE_DELETE`) | `tools/__init__.py` | MCP clients use these to render confirmation UX |
| `register_tools(mcp, config)` + importlib loop | `__init__.py` | Single-source registration for both meta-tools and Visibility |
| `format_http_error` helper | `client.py` | Consistent error shape across tools |
| `get_<platform>_client()` ctx accessor with 503 on missing | `client.py` | Fail-fast when the platform isn't configured |

## What's deliberately NOT templated

These vary legitimately between platforms; left as comments / extension points in `client.py`:

- **Auth flavor** — bearer token (template default), OAuth2 client_credentials, username/password login endpoint, vendor SDK wrapper. Comments point at the canonical reference per flavor (`platforms/greenlake/auth.py`, `platforms/apstra/client.py`, `platforms/mist/client.py`).
- **HTTP layer** — direct httpx vs vendor SDK adapter
- **Pagination** — RFC 5988 Link, OData `$top`/`$skip`, opaque cursors
- **Elicitation pattern** — pointed at the `confirm_write` helper in middleware

## Test plan

- [x] 541 unit + integration tests pass (was 512; +29 new across `test_axis_dynamic_mode.py` and `test_platform_template.py`)
- [x] `ruff check` + `ruff format --check` + `mypy` — all clean
- [x] Live verification of the first-user scaffold against its real backend: token loaded, 3 meta-tools registered, client initialized, `/Health` probe returned 200
- [x] Empty-credentials behavior: with no token file present, the platform silently auto-disables (`disabled (axis_api_token secret not found)` log, no entry in enabled_platforms)
- [x] Template module never auto-registers — verified by `test_platform_template.py::TestTemplateNotAutoRegistered`

## Intentionally not in this PR

This is plumbing-only — no public surface change justifies a release.

- [x] No `README.md` / `INSTRUCTIONS.md` / `TOOLS.md` / `CHANGELOG.md` updates
- [x] No `pyproject.toml` version bump (stays at 2.0.0.5)
- [x] No tag, no GHCR publish
- [x] No entries in the committed `docker-compose.yml`

When the first-user platform later acquires actual tool surface and we have something to announce, *that* PR includes the version bump + docs + CHANGELOG.