### PR TITLE
v2.1.0.0: code mode + ClearPass query-param audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,108 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0.0] - 2026-04-25
+
+**Adds `MCP_TOOL_MODE=code` as an experimental opt-in third tool mode.** Default stays on `dynamic` — no behavior change for existing users. Code mode wires FastMCP's `CodeMode` transform so the LLM writes sandboxed Python to compose multi-step workflows in a single round-trip, rather than walking the per-platform meta-trio N times. Cloudflare's ["Code Mode"](https://blog.cloudflare.com/code-mode/) argument: LLMs are better at writing code than at choosing from tool menus.
+
+### Four-tier progressive disclosure
+
+The exposed catalog in code mode is exactly 4 tools:
+
+| Tier | Tool | Purpose |
+|---|---|---|
+| 1 | `tags(detail)` | Browse the tag space — platform names, read/write buckets, module categories |
+| 2 | `search(query, tags, detail)` | BM25 tool search, optionally scoped by tag |
+| 3 | `get_schema(tools, detail)` | Parameter shapes for named tools |
+| 4 | `execute(code)` | Run async Python in a `pydantic-monty` sandbox with `call_tool(name, params)` in scope |
+
+Inside `execute`, `call_tool` dispatches through the real FastMCP call_tool — so `NullStripMiddleware`, `ElicitationMiddleware`, and Pydantic coercion all continue to fire. Writes still prompt for confirmation. Per-platform write-gating Visibility transforms still apply.
+
+### Cross-platform aggregators gated off in code mode
+
+`site_health_check`, `site_rf_check`, and `manage_wlan_profile` are NOT registered when `MCP_TOOL_MODE=code`. Those tools exist to work around dynamic mode's "AI reaches for one platform and stops" problem — code mode's premise is that the LLM can do the cross-platform join itself via `call_tool`. Keeping them would contradict the premise and make measurement meaningless. `health` stays registered in every mode (reachability info, not aggregation).
+
+### Platform tags on every tool
+
+Every tool registered through a platform's `_registry.py` shim now carries its platform name in `tool.tags`:
+- Mist tools: `{"mist", "dynamic_managed", ...optional write tags}`
+- Central: `{"central", "dynamic_managed", ...}`
+- etc.
+
+This lets `tags(detail=brief)` surface useful platform buckets and `search(query=..., tags=["mist"])` scope filtering to one vendor. Side benefit: static and dynamic modes also gain platform tagging for free — no behavior change, but the data's now there if we want to use it.
+
+### Config + server wiring
+
+- `config.py` — `MCP_TOOL_MODE=code` is now a valid value (was `{"static", "dynamic"}`, now `{"static", "dynamic", "code"}`). Default stays `"dynamic"`; unknown values fall back to `"dynamic"` with a warning.
+- `server.py` — new `_register_code_mode(mcp)` helper installs `CodeMode(sandbox_provider=MontySandboxProvider(limits=ResourceLimits(max_duration_secs=30.0, max_memory=128 MB, max_recursion_depth=50)), discovery_tools=[GetTags(brief), Search(brief), GetSchemas(detailed)])`. Falls back with a warning if `pydantic-monty` is missing.
+- Per-platform `register_tools` — `build_meta_tools()` skipped in code mode (already skipped in static); log message now distinguishes "code mode" from "static mode" for accurate startup output.
+- `docker-compose.yml` — untouched. Users opt in via `-e MCP_TOOL_MODE=code` or a compose override.
+
+### Verified live against a real tenant
+
+- `MCP_TOOL_MODE=code` — exposed catalog is exactly 4 tools (`tags`, `search`, `get_schema`, `execute`). No `site_health_check`, `site_rf_check`, or `manage_wlan_profile`.
+- `tags(brief)` returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (0)`, etc.) plus module categories.
+- `search(query="disconnected", tags=["mist"])` returns 7 of 173 tools, BM25-ranked and platform-scoped.
+- `execute` with `return await call_tool("health", {})` returns the live health report.
+- Cross-platform join (mist_get_self → mist_search_device → central_get_aps) runs in ONE execute call, returning `{"mist_aps_count": 5, "central_aps_count": 3, "sample_mist_ap": "KNAPP-BASEMENT", "sample_central_ap": "HOME-GARAGE-AP", "cross_platform_match": True}`.
+- `call_tool("site_health_check", ...)` correctly raises `Unknown tool: site_health_check` — gating verified.
+- `MCP_TOOL_MODE=dynamic` (default) — unchanged. Still 18 tools advertised (15 meta + health + site_health_check + site_rf_check).
+
+### Sandbox constraints the AI has to work around
+
+`pydantic-monty` is a restricted Python subset. Some things NOT available in the sandbox:
+- `hasattr`, `type`, and most introspection builtins
+- stdlib imports beyond what monty whitelists
+
+The AI learns these the same way it learns any API — via error messages from its first attempt. Early Phase 2 measurement will tell us how much friction this adds.
+
+Tool return values inside `execute` are wrapped as `{"result": <value>}` (FastMCP's `structured_content` for non-schema-typed returns). The AI accesses via `me["result"]["..."]`.
+
+### Tests
+
+11 new tests in `tests/unit/test_code_mode.py`:
+- Config parsing (`code` accepted, unknown falls back, `static`/`dynamic` unchanged, default is `dynamic`)
+- Cross-platform aggregator gating (dynamic + static register all; code registers none; code invokes `_register_code_mode` hook)
+- Registry platform tagging (Mist + Axis shims add platform name to effective tags)
+- `_register_code_mode` falls back gracefully if `pydantic-monty` import fails
+
+Total suite: **552 tests** passing (541 → 552).
+
+### Not in this release
+
+- No default flip. Code mode is opt-in experimental. A decision on whether to change the default will come after Phase 2 head-to-head measurement work — see `CODE_MODE_PLAN.md` (scratch).
+- No `INSTRUCTIONS.md` changes. Dynamic mode remains the documented default pattern.
+- `fastmcp.experimental.transforms.code_mode` is still in `experimental/` upstream. Using it means accepting that the API may change — `MCP_TOOL_MODE=dynamic` remains the production-stable choice.
+
+### ClearPass query-param audit
+
+Bundled into this release: a systematic audit of every `clearpass_get_*` tool against the public ClearPass API reference at https://developer.arubanetworks.com/cppm/reference. Surfaced two real gaps and fixed both.
+
+#### `calculate_count` added to all 45 list-style read tools
+
+Every `/api/<resource>` list endpoint accepts a `calculate_count: bool` query param (per Apigility convention) that adds a `count` field to the response. Useful for the AI to know whether a paginated query has more pages without doing another request — and surprisingly informative on its own (e.g. "your tenant has 85,515 active sessions" landed in measurement testing).
+
+Only `clearpass_get_endpoints` had this param before. Added it to:
+- `clearpass_get_system_events`, `clearpass_get_auth_sources`, `clearpass_get_auth_methods`, `clearpass_get_trust_list`, `clearpass_get_client_certificates`, `clearpass_get_service_certificates`
+- `clearpass_get_enforcement_policies`, `clearpass_get_enforcement_profiles`
+- `clearpass_get_pass_templates`, `clearpass_get_print_templates`, `clearpass_get_weblogin_pages`
+- `clearpass_get_guest_users`, `clearpass_get_api_clients`, `clearpass_get_local_users`, `clearpass_get_static_host_lists`, `clearpass_get_devices`, `clearpass_get_deny_listed_users`
+- `clearpass_get_extensions`, `clearpass_get_syslog_targets`, `clearpass_get_syslog_export_filters`, `clearpass_get_event_sources`, `clearpass_get_context_servers`, `clearpass_get_endpoint_context_servers`
+- `clearpass_get_network_devices`, `clearpass_get_services`, `clearpass_get_posture_policies`, `clearpass_get_device_groups`, `clearpass_get_proxy_targets`, `clearpass_get_radius_dictionaries`, `clearpass_get_tacacs_dictionaries`, `clearpass_get_application_dictionaries`
+- `clearpass_get_roles`, `clearpass_get_role_mappings`
+- `clearpass_get_admin_users`, `clearpass_get_admin_privileges`, `clearpass_get_operator_profiles`, `clearpass_get_attributes`, `clearpass_get_data_filters`, `clearpass_get_file_backup_servers`, `clearpass_get_snmp_trap_receivers`, `clearpass_get_policy_manager_zones`
+- `clearpass_get_sessions`
+
+Implementation: 5 files share a `_build_query_string` helper (audit, certificates, guest_config, identities, integrations, network_devices, policy_elements, server_config); helper signature gained `calculate_count: bool = False`. Inline-pattern files (auth, endpoints, enforcement, guests, roles, sessions) had the param block updated directly.
+
+#### `/alert` and `/report` no longer accept unsupported `filter` / `sort`
+
+Per the dev portal, ClearPass `/alert` and `/report` endpoints document **only** `offset`, `limit`, and `calculate_count` — they do not support `filter` or `sort`. Our `clearpass_get_insight_alerts` and `clearpass_get_insight_reports` tools were exposing `filter` and `sort` and forwarding them in the query string. Either Mist would 400 or silently ignore them. Removed both params from those two tool signatures and switched to a simpler inlined query string. Other tools that DO support filter+sort are unchanged.
+
+#### What this didn't touch
+
+- 11 ClearPass API endpoints documented in the dev portal still don't have wrapping tools — high-value gaps include `/api/onguard-activity`, `/api/external-account`, `/api/cert/revocation-list`, `/api/fingerprint-dictionary`, `/api/extension-instance/{id}/log`, `/api/network-scan`, `/api/onguard/settings`, `/api/radius-dynamic-authorization-template`, plus a handful of write/POST endpoints. Tracked as a follow-up; the audit's coverage report lives in `~/Documents/Coding Projects/hpe-networking-mcp-scratch/` for reference.
+
 ## [2.0.0.5] - 2026-04-24
 
 **New cross-platform tool: `site_rf_check`.** Closes the AI-discovery gap where channel-planning / RF / spectrum questions produced Mist-only answers even when the user had Aruba APs in Central at the same site.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — |
 
-> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 261 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 261 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -21,7 +21,53 @@ The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the A
 
 All the per-platform tools documented below still exist and are discoverable through the meta-tools. Their names, parameters, and return shapes are unchanged from v1.x. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the meta-tools.
 
-Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform tool registers individually (260+ visible).
+Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform tool registers individually (260+ visible). Set `MCP_TOOL_MODE=code` for an experimental four-tier discovery + sandboxed Python execution surface — see the next section.
+
+## Code mode (experimental, opt-in since v2.1.0.0)
+
+With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool surface: `tags`, `search`, `get_schema`, and `execute`. The LLM writes async Python inside `execute`; `call_tool(tool_name, params)` dispatches through the real FastMCP call_tool so every middleware (NullStrip, Elicitation, Pydantic coercion) keeps working. Multi-step workflows collapse from N MCP round-trips to one.
+
+### Four-tier progressive disclosure
+
+| Tier | Tool | What the LLM calls |
+|---|---|---|
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (0)`, etc.) plus module categories |
+| 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
+| 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
+| 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |
+
+### Example — cross-platform join in one call
+
+```python
+me = await call_tool("mist_get_self", {"action_type": "account_info"})
+org_id = me["result"]["privileges"][0]["org_id"]
+
+mist_aps = await call_tool("mist_search_device", {"org_id": org_id, "device_type": "ap", "limit": 5})
+central_aps = await call_tool("central_get_aps", {"site_name": "HOME", "status": "ONLINE"})
+
+return {
+    "mist_count": len(mist_aps["result"]["results"]),
+    "central_count": len(central_aps["result"]),
+}
+```
+
+Three tool calls inside one `execute`. In dynamic mode this same workflow would be 5+ MCP round-trips.
+
+### Cross-platform aggregators are NOT registered in code mode
+
+`site_health_check`, `site_rf_check`, and `manage_wlan_profile` exist to work around dynamic mode's "AI reaches for one platform and stops" problem. Code mode's premise is that the LLM can compose per-platform tools itself — keeping aggregators would contradict it and make head-to-head measurement with dynamic mode meaningless. `health` stays registered in every mode.
+
+### Sandbox limits
+
+The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recursion depth (50). Some Python builtins (`hasattr`, `type`, most introspection) aren't available — the LLM learns these via error messages.
+
+### When to use which mode
+
+- **`dynamic` (default)** — stable, production-tested, best for lookup-style questions
+- **`static`** — v1.x behavior, every tool visible, only useful for agents that hardcode tool names
+- **`code`** — experimental; best for multi-step aggregations, cross-platform joins, filter/map/reduce workflows
+
+If you're not sure, stay on `dynamic`. Code mode is meant for measurement + evaluation right now.
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.0.0.5"
+version = "2.1.0.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -368,7 +368,7 @@ def load_config() -> ServerConfig:
     # ``tool_mode`` because every platform honors it in v2.0. Default flipped
     # from "static" → "dynamic" in v2.0.0.0.
     tool_mode = os.getenv("MCP_TOOL_MODE", "dynamic").lower().strip()
-    if tool_mode not in ("static", "dynamic"):
+    if tool_mode not in ("static", "dynamic", "code"):
         logger.warning("Ignoring unknown MCP_TOOL_MODE={!r}, defaulting to 'dynamic'", tool_mode)
         tool_mode = "dynamic"
 

--- a/src/hpe_networking_mcp/platforms/_template/_registry.py
+++ b/src/hpe_networking_mcp/platforms/_template/_registry.py
@@ -74,7 +74,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
             # registration set up a real mcp before import.
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/apstra/__init__.py
+++ b/src/hpe_networking_mcp/platforms/apstra/__init__.py
@@ -78,6 +78,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Apstra: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("Apstra: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("Apstra: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/apstra/_registry.py
+++ b/src/hpe_networking_mcp/platforms/apstra/_registry.py
@@ -72,7 +72,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
             # up a real mcp before import (see tests/conftest.py stubs).
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -53,6 +53,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Axis: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("Axis: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("Axis: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/axis/_registry.py
+++ b/src/hpe_networking_mcp/platforms/axis/_registry.py
@@ -53,7 +53,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
         if mcp is None:
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -138,6 +138,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Central: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("Central: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("Central: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/central/_registry.py
+++ b/src/hpe_networking_mcp/platforms/central/_registry.py
@@ -55,7 +55,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
         if mcp is None:
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/clearpass/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/__init__.py
@@ -226,6 +226,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "ClearPass: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("ClearPass: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("ClearPass: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/clearpass/_registry.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/_registry.py
@@ -56,7 +56,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
         if mcp is None:
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -22,6 +23,7 @@ def _build_query_string(
         sort: Sort order (e.g. "+name" or "-id").
         offset: Pagination offset.
         limit: Max results per page.
+        calculate_count: When true, response includes total item count.
 
     Returns:
         Query string starting with '?' for appending to a path.
@@ -31,6 +33,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -63,6 +66,7 @@ async def clearpass_get_system_events(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass system events.
 
@@ -70,15 +74,18 @@ async def clearpass_get_system_events(
 
     Args:
         filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+timestamp" or "-id").
+        sort: Sort order (e.g. "+timestamp" or "-id"). Default server-side: "+source".
         offset: Pagination offset (default 0).
-        limit: Max results per page (default 25).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response (default false).
+
+    See: https://developer.arubanetworks.com/cppm/reference (Logs → /system-events)
     """
     try:
         from pyclearpass.api_logs import ApiLogs
 
         client = await get_clearpass_session(ApiLogs)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/system-event" + query, "get")
     except Exception as e:
         return f"Error fetching system events: {e}"
@@ -89,10 +96,9 @@ async def clearpass_get_insight_alerts(
     ctx: Context,
     alert_id: str | None = None,
     name: str | None = None,
-    filter: str | None = None,
-    sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass Insight alerts.
 
@@ -102,10 +108,13 @@ async def clearpass_get_insight_alerts(
     Args:
         alert_id: Numeric ID for single-item lookup.
         name: Alert name for lookup by name.
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
         offset: Pagination offset (default 0).
-        limit: Max results per page (default 25).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response (default false).
+
+    Note: /alert does not accept ``filter`` or ``sort`` (per ClearPass API
+    spec — only pagination + count). See:
+    https://developer.arubanetworks.com/cppm/reference (Insight → /alert)
     """
     try:
         from pyclearpass.api_insight import ApiInsight
@@ -115,7 +124,7 @@ async def clearpass_get_insight_alerts(
             return client.get_alert_by_id(id=alert_id)
         if name:
             return client.get_alert_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return client._send_request("/alert" + query, "get")
     except Exception as e:
         return f"Error fetching insight alerts: {e}"
@@ -126,10 +135,9 @@ async def clearpass_get_insight_reports(
     ctx: Context,
     report_id: str | None = None,
     name: str | None = None,
-    filter: str | None = None,
-    sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass Insight reports.
 
@@ -139,10 +147,13 @@ async def clearpass_get_insight_reports(
     Args:
         report_id: Numeric ID for single-item lookup.
         name: Report name for lookup by name.
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
         offset: Pagination offset (default 0).
-        limit: Max results per page (default 25).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response (default false).
+
+    Note: /report does not accept ``filter`` or ``sort`` (per ClearPass API
+    spec — only pagination + count). See:
+    https://developer.arubanetworks.com/cppm/reference (Insight → /report)
     """
     try:
         from pyclearpass.api_insight import ApiInsight
@@ -152,7 +163,7 @@ async def clearpass_get_insight_reports(
             return client.get_report_by_id(id=report_id)
         if name:
             return client.get_report_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return client._send_request("/report" + query, "get")
     except Exception as e:
         return f"Error fetching insight reports: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -18,6 +18,7 @@ async def clearpass_get_auth_sources(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass authentication sources (AD, LDAP, SQL, local DB, etc.).
 
@@ -45,6 +46,7 @@ async def clearpass_get_auth_sources(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/auth-source" + query, "get")
@@ -111,6 +113,7 @@ async def clearpass_get_auth_methods(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass authentication methods (EAP, MAC Auth, RADIUS proxy, etc.).
 
@@ -138,6 +141,7 @@ async def clearpass_get_auth_methods(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/auth-method" + query, "get")

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -22,6 +23,7 @@ def _build_query_string(
         sort: Sort order (e.g. "+name" or "-id").
         offset: Pagination offset.
         limit: Max results per page.
+        calculate_count: When true, response includes total item count.
 
     Returns:
         Query string starting with '?' for appending to a path.
@@ -31,6 +33,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -44,6 +47,7 @@ async def clearpass_get_trust_list(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass certificate trust list entries.
 
@@ -71,7 +75,7 @@ async def clearpass_get_trust_list(
             return client.get_cert_trust_list_by_cert_trust_list_id(
                 cert_trust_list_id=cert_trust_list_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/cert-trust-list" + query, "get")
     except Exception as e:
         return f"Error fetching trust list: {e}"
@@ -85,6 +89,7 @@ async def clearpass_get_client_certificates(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass client certificates.
 
@@ -104,7 +109,7 @@ async def clearpass_get_client_certificates(
         client = await get_clearpass_session(ApiPlatformCertificates)
         if client_cert_id:
             return client.get_client_cert_by_client_cert_id(client_cert_id=client_cert_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/client-cert" + query, "get")
     except Exception as e:
         return f"Error fetching client certificates: {e}"
@@ -152,6 +157,7 @@ async def clearpass_get_service_certificates(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass service certificates.
 
@@ -171,7 +177,7 @@ async def clearpass_get_service_certificates(
         client = await get_clearpass_session(ApiPlatformCertificates)
         if service_cert_id:
             return client.get_service_cert_by_service_cert_id(service_cert_id=service_cert_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/service-cert" + query, "get")
     except Exception as e:
         return f"Error fetching service certificates: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -18,6 +18,8 @@ async def clearpass_get_endpoints(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
+    profile_details: bool = False,
 ) -> dict | str:
     """Get ClearPass endpoints (known MAC addresses in the endpoint database).
 
@@ -27,10 +29,14 @@ async def clearpass_get_endpoints(
     Args:
         endpoint_id: Numeric ID for single-item lookup.
         mac_address: MAC address for lookup (e.g. "001122334455" or "00:11:22:33:44:55").
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+mac_address" or "-id").
+        filter: JSON filter expression (ClearPass REST API syntax, e.g. ``{"mac_address":"00:11:22:33:44:55"}``).
+        sort: Sort order (e.g. "+mac_address" or "-id"). Default "+id" server-side.
         offset: Pagination offset (default 0).
-        limit: Max results per page (default 25).
+        limit: Max results per page, 1–1000 (default 25).
+        calculate_count: When true, ClearPass returns the total item count alongside the page.
+            Off by default to avoid the extra count query on large datasets.
+        profile_details: When true, each endpoint includes its profiler fingerprint
+            details (DHCP, HTTP user-agent, device category). Off by default.
     """
     try:
         from pyclearpass.api_identities import ApiIdentities
@@ -45,6 +51,10 @@ async def clearpass_get_endpoints(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            # ClearPass expects lowercase JSON booleans in query strings.
+            f"calculate_count={'true' if calculate_count else 'false'}",
+            # profile_details is required by the API; always include it.
+            f"profile_details={'true' if profile_details else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/endpoint" + query, "get")

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -18,6 +18,7 @@ async def clearpass_get_enforcement_policies(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass enforcement policies.
 
@@ -48,6 +49,7 @@ async def clearpass_get_enforcement_policies(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/enforcement-policy" + query, "get")
@@ -64,6 +66,7 @@ async def clearpass_get_enforcement_profiles(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass enforcement profiles.
 
@@ -94,6 +97,7 @@ async def clearpass_get_enforcement_profiles(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/enforcement-profile" + query, "get")

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints."""
     params = [
@@ -21,6 +22,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -33,6 +35,7 @@ async def clearpass_get_pass_templates(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass guest pass templates (receipt/credential templates).
 
@@ -52,7 +55,7 @@ async def clearpass_get_pass_templates(
         client = await get_clearpass_session(ApiGuestConfiguration)
         if template_id:
             return client.get_template_pass_by_id(id=template_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/template/pass" + query, "get")
     except Exception as e:
         return f"Error fetching pass templates: {e}"
@@ -66,6 +69,7 @@ async def clearpass_get_print_templates(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass guest print templates (printable credential layouts).
 
@@ -85,7 +89,7 @@ async def clearpass_get_print_templates(
         client = await get_clearpass_session(ApiGuestConfiguration)
         if template_id:
             return client.get_template_print_by_id(id=template_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/template/print" + query, "get")
     except Exception as e:
         return f"Error fetching print templates: {e}"
@@ -100,6 +104,7 @@ async def clearpass_get_weblogin_pages(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass web login (captive portal) page configurations.
 
@@ -122,7 +127,7 @@ async def clearpass_get_weblogin_pages(
             return client.get_weblogin_by_id(id=page_id)
         if page_name:
             return client.get_weblogin_page_name_by_page_name(page_name=page_name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/weblogin" + query, "get")
     except Exception as e:
         return f"Error fetching web login pages: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -18,6 +18,7 @@ async def clearpass_get_guest_users(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass guest user accounts.
 
@@ -45,6 +46,7 @@ async def clearpass_get_guest_users(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/guest" + query, "get")

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -31,6 +32,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -43,6 +45,7 @@ async def clearpass_get_api_clients(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass API clients (OAuth2 client registrations).
 
@@ -62,7 +65,7 @@ async def clearpass_get_api_clients(
         client = await get_clearpass_session(ApiIdentities)
         if client_id:
             return client.get_api_client_by_client_id(client_id=client_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/api-client" + query, "get")
     except Exception as e:
         return f"Error fetching API clients: {e}"
@@ -77,6 +80,7 @@ async def clearpass_get_local_users(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass local user accounts.
 
@@ -100,7 +104,7 @@ async def clearpass_get_local_users(
             return client.get_local_user_by_local_user_id(local_user_id=local_user_id)
         if user_id:
             return client.get_local_user_user_id_by_user_id(user_id=user_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/local-user" + query, "get")
     except Exception as e:
         return f"Error fetching local users: {e}"
@@ -115,6 +119,7 @@ async def clearpass_get_static_host_lists(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass static host lists.
 
@@ -139,7 +144,7 @@ async def clearpass_get_static_host_lists(
             )
         if name:
             return client.get_static_host_list_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/static-host-list" + query, "get")
     except Exception as e:
         return f"Error fetching static host lists: {e}"
@@ -154,6 +159,7 @@ async def clearpass_get_devices(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass device accounts (onboarded devices).
 
@@ -176,7 +182,7 @@ async def clearpass_get_devices(
             return client.get_device_by_device_id(device_id=device_id)
         if macaddr:
             return client.get_device_mac_by_macaddr(macaddr=macaddr)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/device" + query, "get")
     except Exception as e:
         return f"Error fetching devices: {e}"
@@ -190,6 +196,7 @@ async def clearpass_get_deny_listed_users(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass deny-listed (blacklisted) users.
 
@@ -211,7 +218,7 @@ async def clearpass_get_deny_listed_users(
             return client.get_deny_listed_users_by_deny_listed_users_id(
                 deny_listed_users_id=deny_listed_users_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/deny-listed-users" + query, "get")
     except Exception as e:
         return f"Error fetching deny-listed users: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -31,6 +32,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -44,6 +46,7 @@ async def clearpass_get_extensions(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass extension instances (third-party integrations).
 
@@ -67,7 +70,7 @@ async def clearpass_get_extensions(
             return client.get_extension_instance_by_id_config(id=extension_id)
         if extension_id:
             return client.get_extension_instance_by_id(id=extension_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/extension/instance" + query, "get")
     except Exception as e:
         return f"Error fetching extensions: {e}"
@@ -81,6 +84,7 @@ async def clearpass_get_syslog_targets(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass syslog export targets.
 
@@ -100,7 +104,7 @@ async def clearpass_get_syslog_targets(
         client = await get_clearpass_session(ApiIntegrations)
         if syslog_target_id:
             return client.get_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/syslog-target" + query, "get")
     except Exception as e:
         return f"Error fetching syslog targets: {e}"
@@ -114,6 +118,7 @@ async def clearpass_get_syslog_export_filters(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass syslog export filter configurations.
 
@@ -135,7 +140,7 @@ async def clearpass_get_syslog_export_filters(
             return client.get_syslog_export_filter_by_syslog_export_filter_id(
                 syslog_export_filter_id=syslog_export_filter_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/syslog-export-filter" + query, "get")
     except Exception as e:
         return f"Error fetching syslog export filters: {e}"
@@ -149,6 +154,7 @@ async def clearpass_get_event_sources(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass event sources (external event ingestion sources).
 
@@ -168,7 +174,7 @@ async def clearpass_get_event_sources(
         client = await get_clearpass_session(ApiIntegrations)
         if event_sources_id:
             return client.get_event_sources_by_event_sources_id(event_sources_id=event_sources_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/event-sources" + query, "get")
     except Exception as e:
         return f"Error fetching event sources: {e}"
@@ -182,6 +188,7 @@ async def clearpass_get_context_servers(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass context server actions (HTTP-based integrations).
 
@@ -203,7 +210,7 @@ async def clearpass_get_context_servers(
             return client.get_context_server_action_by_context_server_action_id(
                 context_server_action_id=context_server_action_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/context-server-action" + query, "get")
     except Exception as e:
         return f"Error fetching context server actions: {e}"
@@ -217,6 +224,7 @@ async def clearpass_get_endpoint_context_servers(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass endpoint context servers (MDM/EMM integrations).
 
@@ -238,7 +246,7 @@ async def clearpass_get_endpoint_context_servers(
             return client.get_endpoint_context_server_by_endpoint_context_server_id(
                 endpoint_context_server_id=endpoint_context_server_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/endpoint-context-server" + query, "get")
     except Exception as e:
         return f"Error fetching endpoint context servers: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -22,6 +23,7 @@ def _build_query_string(
         sort: Sort order (e.g. "+name" or "-id").
         offset: Pagination offset.
         limit: Max results per page.
+        calculate_count: When true, response includes total item count.
 
     Returns:
         Query string starting with '?' for appending to a path.
@@ -31,6 +33,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -44,6 +47,7 @@ async def clearpass_get_network_devices(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass network devices (RADIUS/TACACS+ clients).
 
@@ -66,7 +70,7 @@ async def clearpass_get_network_devices(
             return client.get_network_device_by_network_device_id(network_device_id=device_id)
         if name:
             return client.get_network_device_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/network-device" + query, "get")
     except Exception as e:
         return f"Error fetching network devices: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -31,6 +32,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -44,6 +46,7 @@ async def clearpass_get_services(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass policy services (authentication/authorization service rules).
 
@@ -66,7 +69,7 @@ async def clearpass_get_services(
             return client.get_config_service_by_config_service_id(config_service_id=config_service_id)
         if name:
             return client.get_config_service_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/config/service" + query, "get")
     except Exception as e:
         return f"Error fetching services: {e}"
@@ -81,6 +84,7 @@ async def clearpass_get_posture_policies(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass posture (health check) policies.
 
@@ -103,7 +107,7 @@ async def clearpass_get_posture_policies(
             return client.get_posture_policy_by_posture_policy_id(posture_policy_id=posture_policy_id)
         if name:
             return client.get_posture_policy_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/posture-policy" + query, "get")
     except Exception as e:
         return f"Error fetching posture policies: {e}"
@@ -118,6 +122,7 @@ async def clearpass_get_device_groups(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass network device groups.
 
@@ -142,7 +147,7 @@ async def clearpass_get_device_groups(
             )
         if name:
             return client.get_network_device_group_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/network-device-group" + query, "get")
     except Exception as e:
         return f"Error fetching device groups: {e}"
@@ -157,6 +162,7 @@ async def clearpass_get_proxy_targets(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass RADIUS proxy targets.
 
@@ -179,7 +185,7 @@ async def clearpass_get_proxy_targets(
             return client.get_proxy_target_by_proxy_target_id(proxy_target_id=proxy_target_id)
         if name:
             return client.get_proxy_target_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/proxy-target" + query, "get")
     except Exception as e:
         return f"Error fetching proxy targets: {e}"
@@ -194,6 +200,7 @@ async def clearpass_get_radius_dictionaries(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass RADIUS dictionary definitions.
 
@@ -218,7 +225,7 @@ async def clearpass_get_radius_dictionaries(
             )
         if name:
             return client.get_radius_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/radius-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching RADIUS dictionaries: {e}"
@@ -233,6 +240,7 @@ async def clearpass_get_tacacs_dictionaries(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass TACACS+ service dictionary definitions.
 
@@ -257,7 +265,7 @@ async def clearpass_get_tacacs_dictionaries(
             )
         if name:
             return client.get_tacacs_service_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/tacacs-service-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching TACACS+ dictionaries: {e}"
@@ -272,6 +280,7 @@ async def clearpass_get_application_dictionaries(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass application dictionary definitions.
 
@@ -296,7 +305,7 @@ async def clearpass_get_application_dictionaries(
             )
         if name:
             return client.get_application_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/application-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching application dictionaries: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -18,6 +18,7 @@ async def clearpass_get_roles(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass roles used in enforcement and authorization policies.
 
@@ -45,6 +46,7 @@ async def clearpass_get_roles(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/role" + query, "get")
@@ -61,6 +63,7 @@ async def clearpass_get_role_mappings(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass role mapping policies.
 
@@ -91,6 +94,7 @@ async def clearpass_get_role_mappings(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/role-mapping" + query, "get")

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -14,6 +14,7 @@ def _build_query_string(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> str:
     """Build ClearPass REST API query string for list endpoints.
 
@@ -31,6 +32,7 @@ def _build_query_string(
         f"sort={sort}" if sort else "",
         f"offset={offset}",
         f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
     ]
     return "?" + "&".join(p for p in params if p)
 
@@ -43,6 +45,7 @@ async def clearpass_get_admin_users(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass admin user accounts.
 
@@ -62,7 +65,7 @@ async def clearpass_get_admin_users(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if admin_user_id:
             return client.get_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/admin-user" + query, "get")
     except Exception as e:
         return f"Error fetching admin users: {e}"
@@ -76,6 +79,7 @@ async def clearpass_get_admin_privileges(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass admin privilege definitions.
 
@@ -97,7 +101,7 @@ async def clearpass_get_admin_privileges(
             return client.get_admin_privilege_by_admin_privilege_id(
                 admin_privilege_id=admin_privilege_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/admin-privilege" + query, "get")
     except Exception as e:
         return f"Error fetching admin privileges: {e}"
@@ -110,6 +114,7 @@ async def clearpass_get_operator_profiles(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass operator profiles (guest operator login profiles).
 
@@ -125,7 +130,7 @@ async def clearpass_get_operator_profiles(
         from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/operator-profile" + query, "get")
     except Exception as e:
         return f"Error fetching operator profiles: {e}"
@@ -203,6 +208,7 @@ async def clearpass_get_attributes(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass custom attributes (dictionary attributes).
 
@@ -222,7 +228,7 @@ async def clearpass_get_attributes(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if attribute_id:
             return client.get_attribute_by_attribute_id(attribute_id=attribute_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/attribute" + query, "get")
     except Exception as e:
         return f"Error fetching attributes: {e}"
@@ -236,6 +242,7 @@ async def clearpass_get_data_filters(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass data filters (role-based data visibility filters).
 
@@ -255,7 +262,7 @@ async def clearpass_get_data_filters(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if data_filter_id:
             return client.get_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/data-filter" + query, "get")
     except Exception as e:
         return f"Error fetching data filters: {e}"
@@ -269,6 +276,7 @@ async def clearpass_get_file_backup_servers(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass file backup server configurations.
 
@@ -290,7 +298,7 @@ async def clearpass_get_file_backup_servers(
             return client.get_file_backup_server_by_file_backup_server_id(
                 file_backup_server_id=file_backup_server_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/file-backup-server" + query, "get")
     except Exception as e:
         return f"Error fetching file backup servers: {e}"
@@ -322,6 +330,7 @@ async def clearpass_get_snmp_trap_receivers(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass SNMP trap receiver configurations.
 
@@ -343,7 +352,7 @@ async def clearpass_get_snmp_trap_receivers(
             return client.get_snmp_trap_receiver_by_snmp_trap_receiver_id(
                 snmp_trap_receiver_id=snmp_trap_receiver_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/snmp-trap-receiver" + query, "get")
     except Exception as e:
         return f"Error fetching SNMP trap receivers: {e}"
@@ -357,6 +366,7 @@ async def clearpass_get_policy_manager_zones(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass Policy Manager zones.
 
@@ -378,7 +388,7 @@ async def clearpass_get_policy_manager_zones(
             return client.get_server_policy_manager_zones_by_policy_manager_zones_id(
                 policy_manager_zones_id=policy_manager_zones_id,
             )
-        query = _build_query_string(filter, sort, offset, limit)
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/server/policy-manager-zones" + query, "get")
     except Exception as e:
         return f"Error fetching Policy Manager zones: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -17,6 +17,7 @@ async def clearpass_get_sessions(
     sort: str | None = None,
     offset: int = 0,
     limit: int = 25,
+    calculate_count: bool = False,
 ) -> dict | str:
     """Get ClearPass active sessions.
 
@@ -41,6 +42,7 @@ async def clearpass_get_sessions(
             f"sort={sort}" if sort else "",
             f"offset={offset}",
             f"limit={limit}",
+            f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
         return client._send_request("/session" + query, "get")

--- a/src/hpe_networking_mcp/platforms/greenlake/__init__.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/__init__.py
@@ -47,6 +47,8 @@ def register_tools(mcp_instance: FastMCP, config: ServerConfig) -> int:
             "GreenLake: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("GreenLake: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("GreenLake: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/greenlake/_registry.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/_registry.py
@@ -55,7 +55,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
         if mcp is None:
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -104,6 +104,8 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Mist: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
+    elif config.tool_mode == "code":
+        logger.info("Mist: {} underlying tools registered (code mode)", len(loaded))
     else:
         logger.info("Mist: {} tools registered (static mode)", len(loaded))
 

--- a/src/hpe_networking_mcp/platforms/mist/_registry.py
+++ b/src/hpe_networking_mcp/platforms/mist/_registry.py
@@ -65,7 +65,7 @@ def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any
             # mcp first (see tests/conftest.py stubs).
             return func
 
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG}}
+        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
         return mcp.tool(**effective_kwargs)(func)
 
     return decorator

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -219,20 +219,24 @@ def create_server(config: ServerConfig) -> FastMCP:
     if config.axis:
         _register_axis_tools(mcp, config)
 
-    # --- Cross-platform tools and prompts (require both Mist and Central) ---
-    if config.mist and config.central:
-        _register_sync_tools(mcp)
-        _register_sync_prompts(mcp)
+    # --- Cross-platform aggregators ---
+    # These are workarounds for dynamic mode's "AI picks one platform and stops"
+    # problem. Code mode's premise is that the LLM can compose per-platform tools
+    # into cross-platform answers itself via `call_tool` in the sandbox — so we
+    # explicitly do NOT register the aggregators in code mode. If code mode
+    # can't reliably synthesize cross-platform answers, that's the "keep dynamic
+    # as default" signal, not a reason to re-register them here.
+    if config.tool_mode != "code":
+        if config.mist and config.central:
+            _register_sync_tools(mcp)
+            _register_sync_prompts(mcp)
+        if config.mist or config.central:
+            _register_site_health_check(mcp, config)
+            _register_site_rf_check(mcp, config)
 
-    # --- Cross-platform site health check (requires at least Mist or Central) ---
-    if config.mist or config.central:
-        _register_site_health_check(mcp, config)
-
-    # --- Cross-platform site RF check (requires at least Mist or Central) ---
-    if config.mist or config.central:
-        _register_site_rf_check(mcp, config)
-
-    # --- Cross-platform `health` tool (always registered; unaffected by tool_mode) ---
+    # --- Cross-platform `health` tool (always registered in every mode —
+    # reachability info is not aggregation; useful to have callable in the
+    # code-mode sandbox too) ---
     from hpe_networking_mcp.platforms.health import register as _register_health
 
     _register_health(mcp)
@@ -251,16 +255,72 @@ def create_server(config: ServerConfig) -> FastMCP:
     if not config.enable_axis_write_tools:
         mcp.add_transform(Visibility(False, tags={"axis_write", "axis_write_delete"}, components={"tool"}))
 
-    # --- Dynamic mode: hide the individual registry-managed tools so the
-    # exposed surface is just the per-platform meta-tools plus the 3
-    # cross-platform statics (health, site_health_check, manage_wlan_profile).
-    # Tools opt in by being tagged "dynamic_managed" via their platform's
-    # tool() shim; any platform that hasn't migrated yet keeps all its tools
-    # visible regardless of tool_mode. ---
+    # --- Tool-mode-specific catalog transforms ---
     if config.tool_mode == "dynamic":
+        # Dynamic mode: hide the individual registry-managed tools so the
+        # exposed surface is just the per-platform meta-tools plus the 3
+        # cross-platform statics (health, site_health_check, manage_wlan_profile).
+        # Tools opt in by being tagged "dynamic_managed" via their platform's
+        # tool() shim; any platform that hasn't migrated yet keeps all its
+        # tools visible regardless of tool_mode.
         mcp.add_transform(Visibility(False, tags={"dynamic_managed"}, components={"tool"}))
+    elif config.tool_mode == "code":
+        # Code mode: replace the catalog with `CodeMode` — a four-tier
+        # progressive-disclosure surface (get_tags → search → get_schema →
+        # execute). The LLM writes Python inside `execute`; `call_tool(name,
+        # params)` dispatches through the real FastMCP call_tool, so our
+        # NullStripMiddleware + ElicitationMiddleware + Pydantic coercion
+        # all keep working. Write gating (the per-platform Visibility
+        # transforms above) still fires.
+        #
+        # Cross-platform aggregators (site_health_check, site_rf_check,
+        # manage_wlan_profile) were not registered above in code mode, so
+        # they don't leak into Search's catalog.
+        _register_code_mode(mcp)
 
     return mcp
+
+
+def _register_code_mode(mcp: FastMCP) -> None:
+    """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
+
+    Falls back with a warning if ``pydantic-monty`` isn't installed — the
+    dependency ships in the ``fastmcp[code-mode]`` extra and is already
+    pinned in ``pyproject.toml``, but older wheels may have it missing.
+    """
+    try:
+        from fastmcp.experimental.transforms.code_mode import (
+            CodeMode,
+            GetSchemas,
+            GetTags,
+            MontySandboxProvider,
+            Search,
+        )
+        from pydantic_monty import ResourceLimits
+    except ImportError as e:
+        logger.error(
+            "MCP_TOOL_MODE=code requires fastmcp[code-mode] + pydantic-monty ({}); "
+            "falling back to untransformed catalog (every registered tool visible)",
+            e,
+        )
+        return
+
+    limits = ResourceLimits(
+        max_duration_secs=30.0,
+        max_memory=128 * 1024 * 1024,
+        max_recursion_depth=50,
+    )
+    mcp.add_transform(
+        CodeMode(
+            sandbox_provider=MontySandboxProvider(limits=limits),
+            discovery_tools=[
+                GetTags(default_detail="brief"),
+                Search(default_detail="brief"),
+                GetSchemas(default_detail="detailed"),
+            ],
+        )
+    )
+    logger.info("Code mode enabled — exposed surface: get_tags + search + get_schema + execute")
 
 
 def _register_mist_tools(mcp: FastMCP, config: ServerConfig) -> None:

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -1,0 +1,245 @@
+"""Unit tests for the ``MCP_TOOL_MODE=code`` tool mode.
+
+Code mode wires FastMCP's ``CodeMode`` transform into the server, replacing
+the exposed catalog with a four-tier surface (``tags`` + ``search`` +
+``get_schema`` + ``execute``). These tests guard the wiring — config
+parsing, per-platform meta-tool skipping, cross-platform aggregator
+gating, and registry-level tag plumbing. End-to-end sandbox behavior
+lives in ``tests/integration/test_code_mode_end_to_end.py`` so the unit
+suite stays offline-friendly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hpe_networking_mcp.config import ServerConfig
+
+
+@pytest.mark.unit
+class TestCodeModeConfig:
+    """Patch ``_load_mist`` to return a fake credential so ``load_config``
+    gets past the "no enabled platforms" SystemExit and we can observe the
+    ``tool_mode`` field on the resulting ServerConfig.
+    """
+
+    @staticmethod
+    def _load_with_mode(mode: str) -> ServerConfig:
+        from hpe_networking_mcp.config import MistSecrets, load_config
+
+        with (
+            patch("os.environ", {"MCP_TOOL_MODE": mode}),
+            patch(
+                "hpe_networking_mcp.config._load_mist",
+                return_value=MistSecrets(api_token="x", host="y"),
+            ),
+            patch("hpe_networking_mcp.config._load_central", return_value=None),
+            patch("hpe_networking_mcp.config._load_greenlake", return_value=None),
+            patch("hpe_networking_mcp.config._load_clearpass", return_value=None),
+            patch("hpe_networking_mcp.config._load_apstra", return_value=None),
+            patch("hpe_networking_mcp.config._load_axis", return_value=None),
+        ):
+            return load_config()
+
+    def test_code_value_parses(self):
+        cfg = self._load_with_mode("code")
+        assert cfg.tool_mode == "code"
+
+    def test_unknown_value_falls_back_to_dynamic(self):
+        cfg = self._load_with_mode("codee")
+        assert cfg.tool_mode == "dynamic"
+
+    def test_static_still_accepted(self):
+        cfg = self._load_with_mode("static")
+        assert cfg.tool_mode == "static"
+
+    def test_dynamic_still_accepted(self):
+        cfg = self._load_with_mode("dynamic")
+        assert cfg.tool_mode == "dynamic"
+
+    def test_default_is_dynamic(self):
+        # No MCP_TOOL_MODE env var set.
+        from hpe_networking_mcp.config import MistSecrets, load_config
+
+        with (
+            patch("os.environ", {}),
+            patch(
+                "hpe_networking_mcp.config._load_mist",
+                return_value=MistSecrets(api_token="x", host="y"),
+            ),
+            patch("hpe_networking_mcp.config._load_central", return_value=None),
+            patch("hpe_networking_mcp.config._load_greenlake", return_value=None),
+            patch("hpe_networking_mcp.config._load_clearpass", return_value=None),
+            patch("hpe_networking_mcp.config._load_apstra", return_value=None),
+            patch("hpe_networking_mcp.config._load_axis", return_value=None),
+        ):
+            cfg = load_config()
+        assert cfg.tool_mode == "dynamic"
+
+
+@pytest.mark.unit
+class TestCodeModeCrossPlatformGating:
+    """Cross-platform aggregators (``site_health_check`` / ``site_rf_check`` /
+    ``manage_wlan_profile``) are NOT registered when ``tool_mode == "code"``.
+
+    We assert the gating path in ``server.create_server`` by patching the
+    registration helpers and checking call counts.
+    """
+
+    def _run_create_server(self, tool_mode: str):
+        from hpe_networking_mcp.config import CentralSecrets, MistSecrets, ServerConfig
+
+        cfg = ServerConfig(
+            tool_mode=tool_mode,
+            # Both platforms present so the aggregators would otherwise register.
+            mist=MistSecrets(api_token="x", host="y"),
+            central=CentralSecrets(base_url="https://c", client_id="id", client_secret="s"),
+        )
+
+        targets = {
+            # Stub every per-platform register so we don't pull real tool modules.
+            "mist": "hpe_networking_mcp.server._register_mist_tools",
+            "central": "hpe_networking_mcp.server._register_central_tools",
+            # Capture the cross-platform-aggregator registration points.
+            "health": "hpe_networking_mcp.server._register_site_health_check",
+            "rf": "hpe_networking_mcp.server._register_site_rf_check",
+            "sync_tools": "hpe_networking_mcp.server._register_sync_tools",
+            "sync_prompts": "hpe_networking_mcp.server._register_sync_prompts",
+            "code_mode": "hpe_networking_mcp.server._register_code_mode",
+        }
+        patchers = {key: patch(path) for key, path in targets.items()}
+        mocks = {key: p.start() for key, p in patchers.items()}
+        try:
+            from hpe_networking_mcp.server import create_server
+
+            create_server(cfg)
+            return mocks
+        finally:
+            for p in patchers.values():
+                p.stop()
+
+    def test_dynamic_mode_registers_all_aggregators(self):
+        mocks = self._run_create_server("dynamic")
+        assert mocks["health"].call_count == 1
+        assert mocks["rf"].call_count == 1
+        assert mocks["sync_tools"].call_count == 1
+        assert mocks["sync_prompts"].call_count == 1
+        assert mocks["code_mode"].call_count == 0
+
+    def test_static_mode_registers_all_aggregators(self):
+        mocks = self._run_create_server("static")
+        assert mocks["health"].call_count == 1
+        assert mocks["rf"].call_count == 1
+        assert mocks["sync_tools"].call_count == 1
+        assert mocks["sync_prompts"].call_count == 1
+        assert mocks["code_mode"].call_count == 0
+
+    def test_code_mode_skips_every_aggregator_and_invokes_code_mode_hook(self):
+        mocks = self._run_create_server("code")
+        assert mocks["health"].call_count == 0, "site_health_check must NOT register in code mode"
+        assert mocks["rf"].call_count == 0, "site_rf_check must NOT register in code mode"
+        assert mocks["sync_tools"].call_count == 0, "manage_wlan_profile must NOT register in code mode"
+        assert mocks["sync_prompts"].call_count == 0, "sync prompts must NOT register in code mode"
+        assert mocks["code_mode"].call_count == 1, "CodeMode transform hook must be invoked"
+
+
+@pytest.mark.unit
+class TestRegistryPlatformTag:
+    """Every tool registered through a platform's ``_registry.py`` shim carries
+    the platform name in ``tool.tags`` so ``GetTags`` and ``Search(tags=[...])``
+    can scope by platform in code mode.
+
+    We don't import every real platform's tool modules here (that pulls in
+    heavy SDK deps). Instead we verify the shim itself by instantiating a
+    fake mcp and checking what the decorator passes through.
+    """
+
+    def test_mist_shim_adds_platform_tag(self):
+        from hpe_networking_mcp.platforms.mist import _registry as mist_registry
+
+        captured: list[dict] = []
+
+        class FakeMCP:
+            def tool(self, **kwargs):
+                captured.append(kwargs)
+
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+        mist_registry.mcp = FakeMCP()  # type: ignore[assignment]
+
+        @mist_registry.tool(name="t_mist", description="d", tags={"mist_write"})
+        async def _fake(ctx):  # pragma: no cover — never actually invoked
+            pass
+
+        assert captured, "mist registry shim did not forward to FastMCP"
+        tags = captured[0]["tags"]
+        assert "mist" in tags, "platform name must be in effective tags"
+        assert "mist_write" in tags, "supplied tags must pass through"
+        assert "dynamic_managed" in tags, "dynamic_managed must still be present"
+
+    def test_axis_shim_adds_platform_tag(self):
+        # Axis has zero real tools today; verify the shim in isolation.
+        from hpe_networking_mcp.platforms.axis import _registry as axis_registry
+
+        captured: list[dict] = []
+
+        class FakeMCP:
+            def tool(self, **kwargs):
+                captured.append(kwargs)
+
+                def decorator(fn):
+                    return fn
+
+                return decorator
+
+        axis_registry.mcp = FakeMCP()  # type: ignore[assignment]
+
+        @axis_registry.tool(name="t_axis", description="d")
+        async def _fake(ctx):  # pragma: no cover
+            pass
+
+        assert "axis" in captured[0]["tags"]
+
+
+@pytest.mark.unit
+class TestCodeModeRegistrationHook:
+    """``_register_code_mode(mcp)`` falls back gracefully if pydantic-monty is missing."""
+
+    def test_import_error_falls_back_with_log(self, caplog):
+        """Simulate a broken install — the hook should NOT raise."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("pydantic_monty") or "code_mode" in name:
+                raise ImportError(f"simulated missing: {name}")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            from hpe_networking_mcp.server import _register_code_mode
+
+            class FakeMCP:
+                def __init__(self):
+                    self.transforms: list = []
+
+                def add_transform(self, t):  # pragma: no cover
+                    self.transforms.append(t)
+
+            m = FakeMCP()
+            # Should not raise — just log and return.
+            _register_code_mode(m)
+            assert m.transforms == [], "no transform should be added when imports fail"
+
+
+# NOTE: per-platform register_tools behavior (skipping build_meta_tools in code
+# mode) is exercised by the live docker check in the PR, not by a unit test —
+# calling real register_tools mutates each platform's ``_registry.mcp`` module
+# attribute, leaking state across tests in ways that are disproportionate to
+# what the check is worth. The ``TestCodeModeCrossPlatformGating`` class above
+# already proves the code-mode branch is reached in create_server.


### PR DESCRIPTION
## Summary

Two distinct features bundled because both ride the v2.1.0.0 version bump:

1. **`MCP_TOOL_MODE=code`** — new experimental opt-in tool mode wiring FastMCP's `CodeMode` transform. Default stays `dynamic`. Two commits (one per feature) for reviewable diff.
2. **ClearPass query-param audit** — adds `calculate_count` to 45 list-style get tools, removes unsupported `filter`/`sort` from `/alert` and `/report`. Audit-driven against the public dev portal.

## Commit 1 — code mode

The exposed catalog in code mode is exactly 4 tools: `tags`, `search`, `get_schema`, `execute`. The LLM writes async Python in `execute`; `call_tool(name, params)` dispatches through real FastMCP call_tool so middleware (NullStrip, Elicitation, Pydantic coercion) keeps firing. Sandbox: `pydantic-monty` with 30 s wall clock, 128 MB, recursion depth 50.

**Cross-platform aggregators are NOT registered in code mode** (`site_health_check`, `site_rf_check`, `manage_wlan_profile`). They exist to work around dynamic mode's "AI picks one platform and stops" problem — code mode's premise is that the LLM does the cross-platform join itself via `call_tool`. `health` stays registered everywhere.

**Every per-platform tool now carries its platform name in `tool.tags`** (via `_registry.py` shim adding `_PLATFORM` to effective tags). Lets `tags(brief)` show useful platform buckets and `search(tags=["mist"])` scope filtering. Side benefit for static + dynamic — no behavior change, just better metadata.

### Verified live against a real tenant
- Exposed catalog is exactly 4 tools — no aggregators leak in.
- Cross-platform join (Mist `mist_search_device` + Central `central_get_aps`) collapses to **one MCP round-trip**.
- Workflow C' rematch — code mode produces the same RF-report richness as dynamic-mode's `site_rf_check` aggregator, in **1 round-trip vs dynamic mode's 6** for multi-site coverage.
- Measurement report: `~/Documents/Coding Projects/hpe-networking-mcp-scratch/CODE_MODE_MEASUREMENT_REPORT.md`.

### Recommendation
Keep `dynamic` as default for now. Re-measure with local LLMs before any default flip — that's the actual blocker, not code mode's capabilities (Opus 4.7 handled it well).

### Tests
+11 unit tests in `tests/unit/test_code_mode.py` covering config parsing, cross-platform aggregator gating, registry platform tagging, and the `pydantic-monty` import-error fallback. Total: **552 passing** (541 → 552).

## Commit 2 — ClearPass query-param audit

Walking the public API reference at https://developer.arubanetworks.com/cppm/reference and cross-checking every `clearpass_get_*` tool surfaced two real gaps:

1. **`calculate_count` missing on 45/46 list tools.** Documented as a standard Apigility list-endpoint param. Only `clearpass_get_endpoints` had it (from this morning's earlier fix). Now added universally. Engineers can request page totals alongside data — useful even on its own (your tenant has 85,515 active sessions, surfaced during testing).

2. **`/alert` and `/report` were forwarding unsupported `filter` and `sort`.** Per the dev portal, those two endpoints accept only `offset`, `limit`, `calculate_count`. Our tools were exposing extras the API would reject or silently ignore. Removed `filter` and `sort` from `clearpass_get_insight_alerts` and `clearpass_get_insight_reports`.

### Live-verified
- `clearpass_get_endpoints(limit=1, calculate_count=True)` → `count: 265`
- `clearpass_get_sessions(limit=1, calculate_count=True)` → `count: 85515`
- `clearpass_get_network_devices(limit=1, calculate_count=True)` → `count: 25`

### Implementation note
5 files share a `_build_query_string` helper (audit, certificates, guest_config, identities, integrations, network_devices, policy_elements, server_config). Updated each in place rather than refactoring to a single shared module — keeps the diff scoped. A future cleanup PR could consolidate to a single helper in `clearpass/utils.py`.

## Test plan

- [x] 552 unit + integration tests pass
- [x] `ruff check` + `ruff format --check` + `mypy` all clean
- [x] Live-tested code mode end-to-end against tenant: catalog shape, cross-platform join, aggregator gating
- [x] Live-tested `calculate_count` against 3 different file patterns (inline, helper, endpoints-with-extras)
- [x] Dynamic mode regression-checked (still 18 tools, same behavior)

## What's NOT in this PR

Tracked as follow-up:

- **8–11 missing ClearPass tools** for documented endpoints we don't yet wrap (`/api/onguard-activity`, `/api/external-account`, `/api/cert/revocation-list`, `/api/fingerprint-dictionary`, `/api/extension-instance/{id}/log`, `/api/network-scan`, `/api/onguard/settings`, `/api/radius-dynamic-authorization-template`, plus a few writes). Coverage report in scratch dir.
- **Vendor-specific enforcement profiles** (`/api/enforce/{product}/policy` family — 10+ endpoints). Big surface, vendor-specific; deserves its own PR.
- **Local-LLM measurement** for code mode (gpt-oss, Llama). Required before any default flip.

## Why two commits in one PR

Both features ride v2.1.0.0. Reviewable as separate diffs but ship together. Splitting would mean either two version bumps a few minutes apart or one feature with the version bump + the other dangling on the next number.