### PR TITLE
v2.1.0.1: ClearPass coverage follow-up (+14 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0.1] - 2026-04-25
+
+**ClearPass coverage follow-up — adds 14 read/write tools to close the dev-portal gap surfaced during the v2.1.0.0 audit.**
+
+### New read tools (12)
+
+- **Endpoint visibility** (new module category) — `clearpass_get_onguard_activity`, `clearpass_get_fingerprint_dictionary`, `clearpass_get_network_scan`, `clearpass_get_onguard_settings` (with `global_settings: bool` flag).
+- **Certificate authority** (new module category) — `clearpass_get_certificates` (with `chain: bool` for chain retrieval), `clearpass_get_onboard_devices`. Path note: `/api/onboard/device` is CA-scope, distinct from `/api/device` (identity device records, already wrapped by `clearpass_get_devices`).
+- **Identities** — `clearpass_get_external_accounts` for external-account records (lookup by ID or name + paginated list).
+- **Certificates** — `clearpass_get_revocation_list` for the platform-cert CRL store.
+- **Integrations** — `clearpass_get_extension_log` (path: `/extension-instance/{id}/log`, optional `tail`).
+- **Policy elements** — `clearpass_get_radius_dynamic_authorization_template` for DUR template lookups.
+- **Local config** — `clearpass_get_cluster_servers` (no params; lists every cluster node so the AI can find `server_uuid`s).
+
+### New write tools (3, all `WRITE_DELETE`-tagged)
+
+- **`clearpass_manage_certificate_authority`** — full internal-CA cert lifecycle dispatch (`import`, `new`, `request`, `sign`, `revoke`, `reject`, `export`, `delete`).
+- **`clearpass_manage_onboard_device`** — `update` (PATCH) or `delete` for `/api/onboard/device/{id}` records.
+- **`clearpass_manage_service_params`** — PATCH `/api/server/{uuid}/service/{id}` to align per-node service parameter values. Documented use case: cluster-consistency audits — list cluster servers → fetch services per node → diff → align drifted nodes.
+
+### Path corrections caught in live testing
+
+The first round of new tools shipped with several wrong paths (the dev-portal docs and SDK names diverge in places). Fixed before commit:
+
+- `/fingerprint-dictionary` → `/fingerprint`
+- `/network-scan` → `/config/network-scan`
+- `/server` → `/cluster/server` (now uses the SDK's `get_cluster_server()` directly)
+- `/cert/revocation-list` → `/revocation-list`
+
+Dropped one tool that turned out to be a false positive: `clearpass_get_onboard_users` — `/api/onboard/user` returned 404 in our tenant and the `pyclearpass` SDK has no equivalent method, so the endpoint likely doesn't exist on this CPPM version. The matching `user` target_type was also dropped from `clearpass_manage_onboard*` (renamed to `clearpass_manage_onboard_device`).
+
+### Audit false positives caught before shipping
+
+Three tools the agent's coverage audit flagged as missing turned out to already be wrapped:
+
+- `random/mpsk` → already covered by `clearpass_generate_random_password(type="mpsk")`.
+- `run_insight_report` → already covered by `clearpass_manage_insight_report(action_type="run")`.
+- `trigger_endpoint_context_server_poll` → already covered by `clearpass_manage_endpoint_context_server(action_type="trigger_poll")`.
+
+ClearPass tool count: 126 → 140 (+14).
+
 ## [2.1.0.0] - 2026-04-25
 
 **Adds `MCP_TOOL_MODE=code` as an experimental opt-in third tool mode.** Default stays on `dynamic` — no behavior change for existing users. Code mode wires FastMCP's `CodeMode` transform so the LLM writes sandboxed Python to compose multi-step workflows in a single round-trip, rather than walking the per-platform meta-trio N times. Cloudflare's ["Code Mode"](https://blog.cloudflare.com/code-mode/) argument: LLMs are better at writing code than at choosing from tool menus.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **BGP / Protocol Session Monitoring** | — | — | — | — | ✅ |
 | **Guided Prompts** | ✅ | ✅ | — | — | — |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **126** | **19** |
+| **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **140** | **19** |
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — |
 
-> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 261 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 275 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -173,7 +173,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 tools registered`, `ClearPass: 126 tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 19 tools are exposed to the AI — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
+Look for lines like `Mist: 35 tools registered`, `ClearPass: 140 tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 19 tools are exposed to the AI — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
 
 ### Docker Image
 
@@ -376,7 +376,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 │ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐        │
 │ │    Mist    │ │  Central   │ │ GreenLake  │ │ ClearPass  │ │   Apstra   │        │
 │ │   mist_*   │ │ central_*  │ │greenlake_* │ │clearpass_* │ │  apstra_*  │        │
-│ │ 35 tools   │ │ 73 tools   │ │ 10 tools   │ │ 126 tools  │ │  19 tools  │        │
+│ │ 35 tools   │ │ 73 tools   │ │ 10 tools   │ │ 140 tools  │ │  19 tools  │        │
 │ │ + 2 prmt   │ │ + 12 prmt  │ │            │ │            │ │            │        │
 │ │            │ │            │ │            │ │            │ │            │        │
 │ │  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.       │
@@ -392,7 +392,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Dynamic tool mode by default** — each platform exposes 3 meta-tools; the AI discovers the 266 underlying tools on demand. Keeps the tool-schema payload small enough to fit in a 32K-context local LLM.
+- **Dynamic tool mode by default** — each platform exposes 3 meta-tools; the AI discovers the 280 underlying tools on demand. Keeps the tool-schema payload small enough to fit in a 32K-context local LLM.
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -429,7 +429,7 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 | `ENABLE_CLEARPASS_WRITE_TOOLS` | `false` | Enable ClearPass write/mutation tools |
 | `ENABLE_APSTRA_WRITE_TOOLS` | `false` | Enable Apstra write/mutation tools |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (18 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 266+ visible) |
+| `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (18 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 280+ visible) |
 
 ---
 
@@ -492,7 +492,7 @@ hpe-networking-mcp/
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
 │       ├── central/             # 73 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
-│       ├── clearpass/           # 126 ClearPass tools + pyclearpass SDK client
+│       ├── clearpass/           # 140 ClearPass tools + pyclearpass SDK client
 │       ├── apstra/              # 21 Apstra tools + async httpx client
 │       ├── manage_wlan.py       # Cross-platform WLAN management tool
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -75,7 +75,7 @@ If you're not sure, stay on `dynamic`. Code mode is meant for measurement + eval
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
 | Aruba Central | 60 | 13 | 12 | 85 |
-| Aruba ClearPass | 54 | 72 | -- | 126 |
+| Aruba ClearPass | 65 | 75 | -- | 140 |
 | Juniper Apstra | 12 | 7 | -- | 19 |
 | HPE GreenLake | 10 | -- | -- | 10 |
 | Cross-Platform | 3 | 1 | 3 | 7 |
@@ -1427,7 +1427,7 @@ All 10 GreenLake tools are read-only today. Write tools would follow the same ga
 
 ---
 
-## Aruba ClearPass (126 tools)
+## Aruba ClearPass (140 tools)
 
 ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write tools require
 `ENABLE_CLEARPASS_WRITE_TOOLS=true`. Update/delete operations require user confirmation.
@@ -1474,6 +1474,24 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_endpoint_profiler` | Get device profiler fingerprint data |
 | `clearpass_manage_endpoint` | Create, update, delete endpoints |
 
+### Endpoint Visibility (4 read)
+
+| Tool | Description |
+|------|-------------|
+| `clearpass_get_onguard_activity` | List active OnGuard posture sessions; lookup by `activity_id` or `mac` |
+| `clearpass_get_fingerprint_dictionary` | List or get profiler fingerprint dictionary entries (DHCP/HTTP/etc.) |
+| `clearpass_get_network_scan` | List or get network discovery scan jobs |
+| `clearpass_get_onguard_settings` | Get OnGuard posture engine settings (`global_settings: bool` for cluster-wide) |
+
+### Certificate Authority (2 read + 2 write)
+
+| Tool | Description |
+|------|-------------|
+| `clearpass_get_certificates` | List or get internal-CA certificates; `chain=true` returns the issuer chain |
+| `clearpass_get_onboard_devices` | List or get onboarded-device CA records (distinct from `/api/device` identity records) |
+| `clearpass_manage_certificate_authority` | CA cert lifecycle: import, new, request, sign, revoke, reject, export, delete |
+| `clearpass_manage_onboard_device` | Update or delete onboard device records |
+
 ### Session Control (3 read + 2 write)
 
 | Tool | Description |
@@ -1514,7 +1532,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_manage_auth_source` | Create, update, delete, configure_backup, configure_filters, configure_radius_attrs |
 | `clearpass_manage_auth_method` | Create, update, delete authentication methods |
 
-### Certificates (4 read + 2 write)
+### Certificates (5 read + 2 write)
 
 | Tool | Description |
 |------|-------------|
@@ -1522,6 +1540,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_client_certificates` | List or get client certificates |
 | `clearpass_get_server_certificates` | List or get server certificates |
 | `clearpass_get_service_certificates` | List service certificates |
+| `clearpass_get_revocation_list` | List or get certificate revocation lists (CRLs) |
 | `clearpass_manage_certificate` | Import/delete trust list, delete client cert, enable/disable server cert |
 | `clearpass_create_csr` | Generate Certificate Signing Request |
 
@@ -1538,7 +1557,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_manage_insight_report` | Create, delete, enable, disable, run reports |
 | `clearpass_create_system_event` | Create a custom system event |
 
-### Identities (5 read + 5 write)
+### Identities (6 read + 5 write)
 
 | Tool | Description |
 |------|-------------|
@@ -1547,13 +1566,14 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_static_host_lists` | List or get static host lists |
 | `clearpass_get_devices` | List or get devices by ID or MAC |
 | `clearpass_get_deny_listed_users` | List or get deny-listed users |
+| `clearpass_get_external_accounts` | List or get external account records by ID or name |
 | `clearpass_manage_api_client` | Create, update, delete API clients |
 | `clearpass_manage_local_user` | Create, update, delete local users |
 | `clearpass_manage_static_host_list` | Create, update, delete static host lists |
 | `clearpass_manage_device` | Create, update, delete devices |
 | `clearpass_manage_deny_listed_user` | Create, delete deny-listed users |
 
-### Policy Elements (7 read + 7 write)
+### Policy Elements (8 read + 7 write)
 
 | Tool | Description |
 |------|-------------|
@@ -1564,6 +1584,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_radius_dictionaries` | List or get RADIUS dictionaries |
 | `clearpass_get_tacacs_dictionaries` | List or get TACACS+ service dictionaries |
 | `clearpass_get_application_dictionaries` | List or get application dictionaries |
+| `clearpass_get_radius_dynamic_authorization_template` | List or get RADIUS Dynamic Authorization (DUR) templates |
 | `clearpass_manage_service` | Create, update, delete, enable, disable config services |
 | `clearpass_manage_device_group` | Create, update, delete device groups |
 | `clearpass_manage_posture_policy` | Create, update, delete posture policies |
@@ -1602,7 +1623,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_manage_snmp_trap_receiver` | Create, update, delete SNMP trap receivers |
 | `clearpass_manage_policy_manager_zone` | Create, update, delete policy manager zones |
 
-### Local Configuration (6 read + 4 write)
+### Local Configuration (7 read + 5 write)
 
 | Tool | Description |
 |------|-------------|
@@ -1612,12 +1633,14 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_fips_status` | Get server FIPS status |
 | `clearpass_get_server_services` | List or get server services |
 | `clearpass_get_server_snmp` | Get server SNMP configuration |
+| `clearpass_get_cluster_servers` | List all cluster nodes (UUID, name, IP, role) — discovery for `server_uuid` |
 | `clearpass_manage_access_control` | Update, delete server access controls |
 | `clearpass_manage_ad_domain` | Join, leave, configure_password_servers for AD domains |
 | `clearpass_manage_cluster_server` | Update cluster server configuration |
 | `clearpass_manage_server_service` | Start, stop server services |
+| `clearpass_manage_service_params` | PATCH per-server service parameters — used for cluster-consistency audits |
 
-### Integrations (6 read + 4 write)
+### Integrations (7 read + 4 write)
 
 | Tool | Description |
 |------|-------------|
@@ -1627,6 +1650,7 @@ ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write 
 | `clearpass_get_event_sources` | List or get event sources |
 | `clearpass_get_context_servers` | List or get context server actions |
 | `clearpass_get_endpoint_context_servers` | List or get endpoint context servers |
+| `clearpass_get_extension_log` | Fetch logs for a specific extension instance (`tail` for last N lines) |
 | `clearpass_manage_extension` | Start, stop, restart, delete extensions |
 | `clearpass_manage_syslog_target` | Create, update, delete syslog targets |
 | `clearpass_manage_syslog_export_filter` | Create, update, delete syslog export filters |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.1.0.0"
+version = "2.1.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -305,17 +305,19 @@ No special ID resolution needed. ClearPass tools connect directly to the configu
 - **Guest Management**: clearpass_get_guest_users, clearpass_manage_guest_user, clearpass_send_guest_credentials, clearpass_generate_guest_pass, clearpass_process_sponsor_action — Guest user lifecycle, credential delivery, sponsor workflows
 - **Guest Configuration**: clearpass_get_pass_templates, clearpass_get_print_templates, clearpass_get_weblogin_pages, clearpass_manage_* — Digital pass templates, print templates, captive portal pages
 - **Endpoints**: clearpass_get_endpoints, clearpass_get_endpoint_profiler, clearpass_manage_endpoint — Endpoint visibility, device fingerprinting
+- **Endpoint Visibility**: clearpass_get_onguard_activity, clearpass_get_fingerprint_dictionary, clearpass_get_network_scan, clearpass_get_onguard_settings — OnGuard posture sessions, profiler fingerprint dictionary, network discovery scans
+- **Certificate Authority (CA)**: clearpass_get_certificates (with `chain` for cert chain), clearpass_get_onboard_devices, clearpass_manage_certificate_authority (lifecycle: import/new/request/sign/revoke/reject/export/delete), clearpass_manage_onboard_device — internal CA cert lifecycle and onboarded-device records (distinct from `/api/device` identity records)
 - **Session Control**: clearpass_get_sessions, clearpass_disconnect_session, clearpass_perform_coa — Active session monitoring, disconnect, Change of Authorization (CoA)
 - **Roles & Role Mappings**: clearpass_get_roles, clearpass_get_role_mappings, clearpass_manage_role, clearpass_manage_role_mapping
 - **Enforcement**: clearpass_get_enforcement_policies, clearpass_get_enforcement_profiles, clearpass_manage_enforcement_policy, clearpass_manage_enforcement_profile
 - **Authentication**: clearpass_get_auth_sources, clearpass_get_auth_methods, clearpass_manage_auth_source, clearpass_manage_auth_method — LDAP/AD/RADIUS authentication sources and methods
-- **Certificates**: clearpass_get_trust_list, clearpass_get_client_certificates, clearpass_get_server_certificates, clearpass_manage_certificate, clearpass_create_csr
+- **Certificates**: clearpass_get_trust_list, clearpass_get_client_certificates, clearpass_get_server_certificates, clearpass_get_service_certificates, clearpass_get_revocation_list, clearpass_manage_certificate, clearpass_create_csr
 - **Audit & Insight**: clearpass_get_audit_logs, clearpass_get_system_events, clearpass_get_insight_alerts, clearpass_get_insight_reports, clearpass_get_endpoint_insights
-- **Identities**: clearpass_get_api_clients, clearpass_get_local_users, clearpass_get_static_host_lists, clearpass_get_devices, clearpass_get_deny_listed_users
-- **Policy Elements**: clearpass_get_services, clearpass_get_posture_policies, clearpass_get_device_groups, clearpass_get_proxy_targets, clearpass_get_radius_dictionaries, clearpass_get_tacacs_dictionaries, clearpass_get_application_dictionaries
+- **Identities**: clearpass_get_api_clients, clearpass_get_local_users, clearpass_get_static_host_lists, clearpass_get_devices, clearpass_get_deny_listed_users, clearpass_get_external_accounts
+- **Policy Elements**: clearpass_get_services, clearpass_get_posture_policies, clearpass_get_device_groups, clearpass_get_proxy_targets, clearpass_get_radius_dictionaries, clearpass_get_tacacs_dictionaries, clearpass_get_application_dictionaries, clearpass_get_radius_dynamic_authorization_template
 - **Server Configuration**: clearpass_get_admin_users, clearpass_get_admin_privileges, clearpass_get_licenses, clearpass_get_cluster_params + 9 more read tools + 12 manage tools
-- **Local Configuration**: clearpass_get_access_controls, clearpass_get_ad_domains, clearpass_get_server_version, clearpass_manage_ad_domain, clearpass_manage_server_service
-- **Integrations**: clearpass_get_extensions, clearpass_get_syslog_targets, clearpass_manage_extension — Extensions, syslog, event sources
+- **Local Configuration**: clearpass_get_access_controls, clearpass_get_ad_domains, clearpass_get_server_version, clearpass_get_cluster_servers, clearpass_manage_ad_domain, clearpass_manage_server_service, clearpass_manage_service_params — local server config + cluster-consistency audits (compare service params across nodes via clearpass_get_cluster_servers + clearpass_get_server_services per UUID)
+- **Integrations**: clearpass_get_extensions, clearpass_get_syslog_targets, clearpass_get_extension_log, clearpass_manage_extension — Extensions, syslog, event sources, extension logs
 - **Utilities**: clearpass_generate_random_password. For ClearPass reachability, call `health(platform="clearpass")` — the per-platform `clearpass_test_connection` was removed in v2.0.
 
 ## Session Control Operations

--- a/src/hpe_networking_mcp/platforms/clearpass/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/__init__.py
@@ -29,6 +29,16 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_endpoints",
         "clearpass_get_endpoint_profiler",
     ],
+    "endpoint_visibility": [
+        "clearpass_get_onguard_activity",
+        "clearpass_get_fingerprint_dictionary",
+        "clearpass_get_network_scan",
+        "clearpass_get_onguard_settings",
+    ],
+    "certificate_authority": [
+        "clearpass_get_certificates",
+        "clearpass_get_onboard_devices",
+    ],
     "sessions": [
         "clearpass_get_sessions",
         "clearpass_get_session_action_status",
@@ -54,6 +64,7 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_client_certificates",
         "clearpass_get_server_certificates",
         "clearpass_get_service_certificates",
+        "clearpass_get_revocation_list",
     ],
     "audit": [
         "clearpass_get_audit_logs",
@@ -84,6 +95,7 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_fips_status",
         "clearpass_get_server_services",
         "clearpass_get_server_snmp",
+        "clearpass_get_cluster_servers",
     ],
     "identities": [
         "clearpass_get_api_clients",
@@ -91,6 +103,7 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_static_host_lists",
         "clearpass_get_devices",
         "clearpass_get_deny_listed_users",
+        "clearpass_get_external_accounts",
     ],
     "policy_elements": [
         "clearpass_get_services",
@@ -100,6 +113,7 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_radius_dictionaries",
         "clearpass_get_tacacs_dictionaries",
         "clearpass_get_application_dictionaries",
+        "clearpass_get_radius_dynamic_authorization_template",
     ],
     "integrations": [
         "clearpass_get_extensions",
@@ -108,6 +122,7 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_get_event_sources",
         "clearpass_get_context_servers",
         "clearpass_get_endpoint_context_servers",
+        "clearpass_get_extension_log",
     ],
     "utilities": [
         "clearpass_generate_random_password",
@@ -171,6 +186,11 @@ TOOLS: dict[str, list[str]] = {
         "clearpass_manage_ad_domain",
         "clearpass_manage_cluster_server",
         "clearpass_manage_server_service",
+        "clearpass_manage_service_params",
+    ],
+    "manage_certificate_authority": [
+        "clearpass_manage_certificate_authority",
+        "clearpass_manage_onboard_device",
     ],
     "manage_identities": [
         "clearpass_manage_api_client",

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -1,0 +1,128 @@
+"""ClearPass internal Certificate Authority (CA) read tools.
+
+Covers ClearPass's internal CA — the certificate store
+(``/api/certificate``) and onboard device records
+(``/api/onboard/device``) that hold CA-issued identities for managed
+devices.
+
+Note: ``/api/onboard/device`` is distinct from ``/api/device``
+(identity device records, wrapped by ``clearpass_get_devices``).
+The onboard endpoint is CA-scope only.
+
+See: https://developer.arubanetworks.com/cppm/reference (Certificate Authority)
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.clearpass._registry import tool
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
+from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+
+
+def _build_query_string(
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> str:
+    """Build ClearPass REST API query string for list endpoints."""
+    params = [
+        f"filter={filter}" if filter else "",
+        f"sort={sort}" if sort else "",
+        f"offset={offset}",
+        f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
+    ]
+    return "?" + "&".join(p for p in params if p)
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_certificates(
+    ctx: Context,
+    certificate_id: str | None = None,
+    chain: bool = False,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get certificates issued by ClearPass's internal CA.
+
+    If ``certificate_id`` is provided, returns a single cert record.
+    With ``chain=True``, returns the full certificate chain for that ID
+    (issuer chain back to the root). Otherwise returns a paginated list
+    of all CA-issued certificates.
+
+    Args:
+        certificate_id: Numeric ID for single-item lookup.
+        chain: When true alongside ``certificate_id``, returns the cert chain.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference
+    (Certificate Authority → /certificate, /certificate/{id}, /certificate/{id}/chain)
+    """
+    try:
+        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
+
+        client = await get_clearpass_session(ApiCertificateAuthority)
+        if certificate_id and chain:
+            return client._send_request(f"/certificate/{certificate_id}/chain", "get")
+        if certificate_id:
+            return client._send_request(f"/certificate/{certificate_id}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/certificate" + query, "get")
+    except Exception as e:
+        return f"Error fetching CA certificates: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_onboard_devices(
+    ctx: Context,
+    onboard_device_id: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass onboard device records (CA-issued device certificates).
+
+    Onboard records track devices that received a CA-issued cert through
+    the onboarding workflow. Each record holds the cert metadata, owner
+    (user), serial number, MAC, and onboarding timestamp.
+
+    Note: this is distinct from ``clearpass_get_devices`` — that tool
+    returns RADIUS device-database records (``/api/device``), while
+    this tool covers onboarded-device cert records (``/api/onboard/device``).
+
+    If ``onboard_device_id`` is provided, returns a single record.
+    Otherwise returns a paginated list of all onboard devices.
+
+    Args:
+        onboard_device_id: Numeric ID for single-item lookup.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Certificate Authority → /onboard/device)
+    """
+    try:
+        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
+
+        client = await get_clearpass_session(ApiCertificateAuthority)
+        if onboard_device_id:
+            return client._send_request(f"/onboard/device/{onboard_device_id}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/onboard/device" + query, "get")
+    except Exception as e:
+        return f"Error fetching onboard devices: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -181,3 +181,43 @@ async def clearpass_get_service_certificates(
         return client._send_request("/service-cert" + query, "get")
     except Exception as e:
         return f"Error fetching service certificates: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_revocation_list(
+    ctx: Context,
+    revocation_list_id: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass certificate revocation lists (CRLs).
+
+    CRLs enumerate revoked client/server certificates ClearPass should
+    reject when validating peer certs (e.g. EAP-TLS sessions).
+
+    If revocation_list_id is provided, returns a single CRL.
+    Otherwise returns a paginated list of all CRLs.
+
+    Args:
+        revocation_list_id: Numeric ID for single-item lookup.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Platform Certificates → /revocation-list)
+    """
+    try:
+        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
+
+        client = await get_clearpass_session(ApiPlatformCertificates)
+        if revocation_list_id:
+            return client._send_request(f"/revocation-list/{revocation_list_id}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/revocation-list" + query, "get")
+    except Exception as e:
+        return f"Error fetching revocation lists: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -1,0 +1,185 @@
+"""ClearPass endpoint-visibility read tools.
+
+Covers OnGuard posture activity + settings, network discovery scans, and
+the profiler fingerprint dictionary. All standard Apigility list-style
+endpoints (filter / sort / offset / limit / calculate_count).
+
+See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility)
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.clearpass._registry import tool
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
+from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+
+
+def _build_query_string(
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> str:
+    """Build ClearPass REST API query string for list endpoints."""
+    params = [
+        f"filter={filter}" if filter else "",
+        f"sort={sort}" if sort else "",
+        f"offset={offset}",
+        f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
+    ]
+    return "?" + "&".join(p for p in params if p)
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_onguard_activity(
+    ctx: Context,
+    activity_id: str | None = None,
+    mac: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass OnGuard activity records (active posture sessions).
+
+    If activity_id or mac is provided, returns a single record.
+    Otherwise returns a paginated list of all OnGuard activity entries.
+
+    Args:
+        activity_id: Numeric ID for single-item lookup.
+        mac: MAC address to look up activity for a specific endpoint.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order (e.g. "+id" or "-id"). Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /onguard-activity)
+    """
+    try:
+        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
+
+        client = await get_clearpass_session(ApiEndpointVisibility)
+        if activity_id:
+            return client._send_request(f"/onguard-activity/{activity_id}", "get")
+        if mac:
+            return client._send_request(f"/onguard-activity/mac/{mac}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/onguard-activity" + query, "get")
+    except Exception as e:
+        return f"Error fetching OnGuard activity: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_fingerprint_dictionary(
+    ctx: Context,
+    fingerprint_id: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass profiler fingerprint dictionary entries.
+
+    Fingerprints are device-classification patterns (DHCP options, HTTP
+    user-agent, etc.) that ClearPass uses to profile endpoints into
+    categories like ``Computer/Windows``, ``SmartDevice/iOS``, etc.
+
+    If fingerprint_id is provided, returns a single fingerprint.
+    Otherwise returns a paginated list of all fingerprint dictionary entries.
+
+    Args:
+        fingerprint_id: Numeric ID for single-item lookup.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /fingerprint-dictionary)
+    """
+    try:
+        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
+
+        client = await get_clearpass_session(ApiEndpointVisibility)
+        if fingerprint_id:
+            return client._send_request(f"/fingerprint/{fingerprint_id}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/fingerprint" + query, "get")
+    except Exception as e:
+        return f"Error fetching fingerprint dictionary: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_network_scan(
+    ctx: Context,
+    scan_id: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass network discovery scan jobs.
+
+    Network scans are configured discovery operations that probe a subnet
+    or IP range for devices and feed the results into the endpoint
+    profiler.
+
+    If scan_id is provided, returns a single scan job.
+    Otherwise returns a paginated list of all network scans.
+
+    Args:
+        scan_id: Numeric ID for single-item lookup.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /network-scan)
+    """
+    try:
+        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
+
+        client = await get_clearpass_session(ApiEndpointVisibility)
+        if scan_id:
+            return client._send_request(f"/config/network-scan/{scan_id}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/config/network-scan" + query, "get")
+    except Exception as e:
+        return f"Error fetching network scans: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_onguard_settings(
+    ctx: Context,
+    global_settings: bool = False,
+) -> dict | str:
+    """Get ClearPass OnGuard posture engine settings.
+
+    Returns the posture-engine configuration: agent version requirements,
+    quarantine actions, audit settings.
+
+    Args:
+        global_settings: When true, fetches /onguard/global-settings instead
+            of the standard /onguard/settings record. Global settings cover
+            cluster-wide posture defaults.
+
+    See: https://developer.arubanetworks.com/cppm/reference
+    (Endpoint Visibility → /onguard/settings, /onguard/global-settings)
+    """
+    try:
+        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
+
+        client = await get_clearpass_session(ApiEndpointVisibility)
+        path = "/onguard/global-settings" if global_settings else "/onguard/settings"
+        return client._send_request(path, "get")
+    except Exception as e:
+        return f"Error fetching OnGuard settings: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -222,3 +222,49 @@ async def clearpass_get_deny_listed_users(
         return client._send_request("/deny-listed-users" + query, "get")
     except Exception as e:
         return f"Error fetching deny-listed users: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_external_accounts(
+    ctx: Context,
+    external_account_id: str | None = None,
+    name: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass external account configurations.
+
+    External accounts are credentials ClearPass uses to talk to outside
+    services — e.g. Azure AD or Okta for federated authentication, MDM
+    APIs for device-context lookups. Returns the configuration record,
+    NOT the live session state.
+
+    If external_account_id or name is provided, returns a single record.
+    Otherwise returns a paginated list of all external accounts.
+
+    Args:
+        external_account_id: Numeric ID for single-item lookup.
+        name: External account name for lookup by name.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Identities → /external-account)
+    """
+    try:
+        from pyclearpass.api_identities import ApiIdentities
+
+        client = await get_clearpass_session(ApiIdentities)
+        if external_account_id:
+            return client._send_request(f"/external-account/{external_account_id}", "get")
+        if name:
+            return client._send_request(f"/external-account/name/{name}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/external-account" + query, "get")
+    except Exception as e:
+        return f"Error fetching external accounts: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -250,3 +250,32 @@ async def clearpass_get_endpoint_context_servers(
         return client._send_request("/endpoint-context-server" + query, "get")
     except Exception as e:
         return f"Error fetching endpoint context servers: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_extension_log(
+    ctx: Context,
+    extension_id: str,
+    tail: int | None = None,
+) -> dict | str:
+    """Get the runtime log from a ClearPass extension instance.
+
+    Useful for debugging extension behavior without shelling into the
+    ClearPass server. Returns recent log lines for the named extension.
+
+    Args:
+        extension_id: Extension instance ID (UUID-like).
+        tail: Optional max number of recent log lines to return.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Integrations → /extension-instance/{id}/log)
+    """
+    try:
+        from pyclearpass.api_integrations import ApiIntegrations
+
+        client = await get_clearpass_session(ApiIntegrations)
+        path = f"/extension-instance/{extension_id}/log"
+        if tail is not None:
+            path += f"?tail={tail}"
+        return client._send_request(path, "get")
+    except Exception as e:
+        return f"Error fetching extension log: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
@@ -160,3 +160,32 @@ async def clearpass_get_server_snmp(
         return client.get_server_snmp_by_server_uuid(server_uuid=server_uuid)
     except Exception as e:
         return f"Error fetching server SNMP config: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_cluster_servers(
+    ctx: Context,
+) -> dict | str:
+    """List all ClearPass servers in the cluster.
+
+    Returns one record per cluster node with its UUID, name, IP address,
+    role (publisher/subscriber), and cluster-membership state. Use this
+    to find the ``server_uuid`` other server-scoped tools require
+    (``clearpass_get_server_services``, ``clearpass_manage_service_params``,
+    etc.).
+
+    Common use case — answer "are all servers in the cluster configured
+    consistently?":
+    1. Call this tool to get the list of server UUIDs.
+    2. Call ``clearpass_get_server_services`` for each.
+    3. Compare param values across servers in code mode.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Local Server Configuration → /server)
+    """
+    try:
+        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
+
+        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        return client.get_cluster_server()
+    except Exception as e:
+        return f"Error fetching cluster servers: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
@@ -1,0 +1,173 @@
+"""ClearPass internal Certificate Authority (CA) write tools.
+
+Covers the CA cert lifecycle (``/api/certificate/...``: import, new,
+request, sign, revoke, reject, export, delete) and onboarded
+device/user record management (``/api/onboard/device/{id}`` and
+``/api/onboard/user/{id}``).
+
+These operate against ClearPass's internal CA. Many deployments use an
+external CA, in which case this surface is inert. Use the read tools
+in ``certificate_authority.py`` to discover what's there before
+mutating.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context
+from pydantic import Field
+
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.clearpass._registry import tool
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
+from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+
+_CA_ACTIONS = (
+    "import",
+    "new",
+    "request",
+    "sign",
+    "revoke",
+    "reject",
+    "export",
+    "delete",
+)
+
+
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+async def clearpass_manage_certificate_authority(
+    ctx: Context,
+    action_type: Annotated[
+        str,
+        Field(
+            description=(
+                "CA action: 'import' (POST /api/certificate/import), "
+                "'new' (POST /api/certificate/new — create a new cert), "
+                "'request' (POST /api/certificate/request — sign a CSR), "
+                "'sign' (POST /api/certificate/{id}/sign), "
+                "'revoke' (POST /api/certificate/{id}/revoke), "
+                "'reject' (POST /api/certificate/{id}/reject), "
+                "'export' (POST /api/certificate/{id}/export), "
+                "'delete' (DELETE /api/certificate/{id})."
+            ),
+        ),
+    ],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Body for the action. For import: cert PEM and metadata. "
+                "For new/request: subject + key options. For sign/revoke/reject/export/delete: typically empty {}."
+            ),
+        ),
+    ],
+    certificate_id: Annotated[
+        str | None,
+        Field(description="Cert ID. Required for sign, revoke, reject, export, delete."),
+    ] = None,
+    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+) -> dict | str:
+    """Manage ClearPass internal-CA certificates.
+
+    The CA endpoints handle the full cert lifecycle: import existing
+    certs, generate new ones, sign CSRs, revoke/reject pending requests,
+    export, delete. Most operations target a specific cert by
+    ``certificate_id``; ``import``, ``new``, and ``request`` create new
+    records and don't take a ``certificate_id``.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Certificate Authority)
+
+    Args:
+        action_type: One of ``import``, ``new``, ``request``, ``sign``,
+            ``revoke``, ``reject``, ``export``, ``delete``.
+        payload: Request body. Varies by action — empty dict ``{}`` is
+            fine for delete/sign/revoke/reject/export.
+        certificate_id: Cert ID. Required for sign/revoke/reject/export/delete.
+        confirmed: Set true after user confirms. Skips re-prompting.
+    """
+    if action_type not in _CA_ACTIONS:
+        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CA_ACTIONS)}."
+    if action_type in ("sign", "revoke", "reject", "export", "delete") and not certificate_id:
+        return f"certificate_id is required for action '{action_type}'."
+
+    decline = await confirm_write(ctx, f"ClearPass CA: {action_type} certificate {certificate_id or '(new)'}. Confirm?")
+    if decline:
+        return decline
+
+    try:
+        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
+
+        client = await get_clearpass_session(ApiCertificateAuthority)
+
+        if action_type == "import":
+            return client._send_request("/certificate/import", "post", query=payload)
+        if action_type == "new":
+            return client._send_request("/certificate/new", "post", query=payload)
+        if action_type == "request":
+            return client._send_request("/certificate/request", "post", query=payload)
+        if action_type == "delete":
+            return client._send_request(f"/certificate/{certificate_id}", "delete")
+        # sign / revoke / reject / export
+        return client._send_request(f"/certificate/{certificate_id}/{action_type}", "post", query=payload)
+    except Exception as e:
+        return f"Error managing CA certificate ({action_type}): {e}"
+
+
+_ONBOARD_ACTIONS = ("update", "delete")
+
+
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+async def clearpass_manage_onboard_device(
+    ctx: Context,
+    action_type: Annotated[
+        str,
+        Field(description="Action: 'update' (PATCH) or 'delete'."),
+    ],
+    record_id: Annotated[str, Field(description="Numeric ID of the onboard device record.")],
+    payload: Annotated[
+        dict | None,
+        Field(description="PATCH body for update. Empty dict or omit for delete."),
+    ] = None,
+    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+) -> dict | str:
+    """Update or delete a ClearPass onboard device record.
+
+    Onboard records track devices that received a CA-issued cert via the
+    onboarding workflow. Updating typically touches metadata or
+    revocation state; deletion removes the record (the underlying cert
+    is handled separately via ``clearpass_manage_certificate_authority``
+    if it needs revoking).
+
+    See: https://developer.arubanetworks.com/cppm/reference
+    (Certificate Authority → /onboard/device)
+
+    Args:
+        action_type: 'update' (PATCH) or 'delete'.
+        record_id: Numeric ID of the onboard device record.
+        payload: PATCH body. Required for update, ignored for delete.
+        confirmed: Set true after user confirms. Skips re-prompting.
+    """
+    if action_type not in _ONBOARD_ACTIONS:
+        return f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."
+    if action_type == "update" and not payload:
+        return "payload is required for action 'update'."
+
+    decline = await confirm_write(
+        ctx,
+        f"ClearPass: {action_type} onboard device record {record_id}. Confirm?",
+    )
+    if decline:
+        return decline
+
+    try:
+        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
+
+        client = await get_clearpass_session(ApiCertificateAuthority)
+        path = f"/onboard/device/{record_id}"
+        if action_type == "delete":
+            return client._send_request(path, "delete")
+        body: Any = payload if payload is not None else {}
+        return client._send_request(path, "patch", query=body)
+    except Exception as e:
+        return f"Error managing onboard device ({action_type}): {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -165,3 +165,62 @@ async def clearpass_manage_server_service(
         )
     except Exception as e:
         return f"Error managing server service: {e}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+async def clearpass_manage_service_params(
+    ctx: Context,
+    server_uuid: Annotated[str, Field(description="UUID of the ClearPass server node.")],
+    service_id: Annotated[
+        str,
+        Field(description="Numeric service ID (NOT service name). Get via clearpass_get_server_services."),
+    ],
+    param_values: Annotated[
+        dict,
+        Field(
+            description=(
+                "PATCH body containing the service parameters to update. "
+                "Shape mirrors the structure returned by clearpass_get_server_services."
+            ),
+        ),
+    ],
+    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+) -> dict | str:
+    """Edit per-server service parameters (PATCH /api/server/{uuid}/service/{id}).
+
+    Use this to change a service's runtime parameter values on a single
+    cluster node. Common audit pattern — answer "are all servers in the
+    cluster configured the same?" by:
+
+    1. ``clearpass_get_cluster_servers`` for the list of UUIDs.
+    2. ``clearpass_get_server_services(server_uuid=...)`` per node.
+    3. Compare param values across nodes (in code mode this is one
+       ``execute`` call).
+    4. If a node drifts, call this tool to align it.
+
+    See: https://developer.arubanetworks.com/cppm/reference
+    (Local Server Configuration → /server/{server_uuid}/service/{service_id})
+
+    Args:
+        server_uuid: UUID of the ClearPass server node.
+        service_id: Numeric service ID (the integer one, not the name).
+        param_values: PATCH body with the param structure to apply.
+        confirmed: Set true after user confirms. Skips re-prompting.
+    """
+    decline = await _confirm_write(
+        ctx,
+        "edit_params",
+        "server service",
+        f"service_id={service_id}@{server_uuid}",
+        confirmed,
+    )
+    if decline:
+        return decline
+    try:
+        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
+
+        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        path = f"/server/{server_uuid}/service/{service_id}"
+        return client._send_request(path, "patch", query=param_values)
+    except Exception as e:
+        return f"Error editing service params: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -309,3 +309,48 @@ async def clearpass_get_application_dictionaries(
         return client._send_request("/application-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching application dictionaries: {e}"
+
+
+@tool(annotations=READ_ONLY)
+async def clearpass_get_radius_dynamic_authorization_template(
+    ctx: Context,
+    template_id: str | None = None,
+    name: str | None = None,
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> dict | str:
+    """Get ClearPass RADIUS dynamic-authorization (CoA) templates.
+
+    These are pre-defined CoA payload templates that enforcement profiles
+    reference to issue ``Disconnect-Request`` and ``CoA-Request`` packets
+    to network devices — e.g. role-change, VLAN-change, bandwidth limits.
+
+    If template_id or name is provided, returns a single template.
+    Otherwise returns a paginated list of all CoA templates.
+
+    Args:
+        template_id: Numeric ID for single-item lookup.
+        name: Template name for lookup by name.
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order. Default server-side: "+id".
+        offset: Pagination offset (default 0).
+        limit: Max results per page (default 25, max 1000).
+        calculate_count: When true, include total count in response.
+
+    See: https://developer.arubanetworks.com/cppm/reference (Policy Elements → /radius-dynamic-authorization-template)
+    """
+    try:
+        from pyclearpass.api_policyelements import ApiPolicyElements
+
+        client = await get_clearpass_session(ApiPolicyElements)
+        if template_id:
+            return client._send_request(f"/radius-dynamic-authorization-template/{template_id}", "get")
+        if name:
+            return client._send_request(f"/radius-dynamic-authorization-template/name/{name}", "get")
+        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        return client._send_request("/radius-dynamic-authorization-template" + query, "get")
+    except Exception as e:
+        return f"Error fetching RADIUS dynamic authorization templates: {e}"


### PR DESCRIPTION
## Summary

- Adds **14 ClearPass tools** (11 read + 3 write) closing the dev-portal coverage gap surfaced during the v2.1.0.0 audit. ClearPass count: 126 → 140.
- New module categories: `endpoint_visibility` (OnGuard, fingerprint dict, network scans) and `certificate_authority` (internal CA cert store + onboard device records).
- New write capability: full internal-CA cert lifecycle dispatch + per-server service-param edits for cluster-consistency audits.

## What changed

### New read tools (11)
- **endpoint_visibility** (new module): `clearpass_get_onguard_activity`, `clearpass_get_fingerprint_dictionary`, `clearpass_get_network_scan`, `clearpass_get_onguard_settings` (with `global_settings` flag)
- **certificate_authority** (new module): `clearpass_get_certificates` (with `chain=true` for issuer chain), `clearpass_get_onboard_devices`
- **Extensions to existing modules**: `clearpass_get_external_accounts` (identities), `clearpass_get_revocation_list` (certificates), `clearpass_get_extension_log` (integrations), `clearpass_get_radius_dynamic_authorization_template` (policy_elements), `clearpass_get_cluster_servers` (local_config)

### New write tools (3, all `WRITE_DELETE`-tagged + elicitation-gated)
- `clearpass_manage_certificate_authority` — CA cert lifecycle: `import`, `new`, `request`, `sign`, `revoke`, `reject`, `export`, `delete`
- `clearpass_manage_onboard_device` — `update` (PATCH) or `delete` for `/api/onboard/device/{id}` records
- `clearpass_manage_service_params` — PATCH `/api/server/{uuid}/service/{id}` to align per-node service params; intended for cluster-consistency audits

### Path corrections caught in live testing

Several first-cut paths were wrong (dev-portal docs and SDK names diverge in places). Fixed before commit:
- `/fingerprint-dictionary` → `/fingerprint`
- `/network-scan` → `/config/network-scan`
- `/server` → `/cluster/server` (now uses SDK `get_cluster_server()`)
- `/cert/revocation-list` → `/revocation-list`

### False positives caught before shipping

Dropped one tool that turned out to be a 404 in our tenant: `clearpass_get_onboard_users` (`/api/onboard/user`). The `pyclearpass` SDK also has no `onboard_user` methods, so the endpoint likely doesn't exist on this CPPM version. The matching `user` target was also dropped from the manage tool, which was renamed `clearpass_manage_onboard` → `clearpass_manage_onboard_device`.

Three other agent-flagged "missing" tools turned out to already be wrapped under existing multi-action `manage_*` tools (no duplicates added):
- `random/mpsk` → `clearpass_generate_random_password(type="mpsk")`
- `run_insight_report` → `clearpass_manage_insight_report(action_type="run")`
- `trigger_endpoint_context_server_poll` → `clearpass_manage_endpoint_context_server(action_type="trigger_poll")`

## Test plan

- [x] Container live-test against real ClearPass tenant — all 11 new read tools dispatch and return expected shapes (CA cert count 250, RADIUS DUR templates 37, fingerprints 815, onboard devices 14, etc.)
- [x] All 4 originally-404'd paths now return well-formed responses after corrections
- [x] Write tools register with `WRITE_DELETE` annotations + `clearpass_write_delete` tag (verified in startup logs and search index)
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 552 passed
- [x] Docs updated in same PR: README tool counts, CHANGELOG entry, INSTRUCTIONS tool categories, TOOLS.md per-section tables and overview, pyproject version bump