### PR TITLE
Internal: read-tool surface follow-up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,12 @@ services:
       - MCP_PORT=8000
       - MCP_HOST=0.0.0.0
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      - ENABLE_MIST_WRITE_TOOLS=${ENABLE_MIST_WRITE_TOOLS:-true}
-      - ENABLE_CENTRAL_WRITE_TOOLS=${ENABLE_CENTRAL_WRITE_TOOLS:-true}
-      - ENABLE_CLEARPASS_WRITE_TOOLS=${ENABLE_CLEARPASS_WRITE_TOOLS:-true}
-      - ENABLE_APSTRA_WRITE_TOOLS=${ENABLE_APSTRA_WRITE_TOOLS:-true}
-      - DISABLE_ELICITATION=${DISABLE_ELICITATION:-true}
+      - ENABLE_MIST_WRITE_TOOLS=${ENABLE_MIST_WRITE_TOOLS:-false}
+      - ENABLE_CENTRAL_WRITE_TOOLS=${ENABLE_CENTRAL_WRITE_TOOLS:-false}
+      - ENABLE_CLEARPASS_WRITE_TOOLS=${ENABLE_CLEARPASS_WRITE_TOOLS:-false}
+      - ENABLE_APSTRA_WRITE_TOOLS=${ENABLE_APSTRA_WRITE_TOOLS:-false}
+      # - ENABLE_AXIS_WRITE_TOOLS=${ENABLE_AXIS_WRITE_TOOLS:-false}
+      - DISABLE_ELICITATION=${DISABLE_ELICITATION:-false}
       - MCP_TOOL_MODE=${MCP_TOOL_MODE:-dynamic}
     secrets:
       # Mist (remove lines for platforms you don't use)
@@ -40,6 +41,8 @@ services:
       - apstra_username
       - apstra_password
       - apstra_verify_ssl
+      # Axis Atmos Cloud (remove lines for platforms you don't use)
+      # - axis_api_token
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "uv", "run", "--no-sync", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5)"]
@@ -92,3 +95,6 @@ secrets:
     file: ./secrets/apstra_password
   apstra_verify_ssl:
     file: ./secrets/apstra_verify_ssl
+  # Axis Atmos Cloud
+  # axis_api_token:
+  #   file: ./secrets/axis_api_token

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -6,8 +6,8 @@ public-facing documentation until the user chooses to announce it. See
 the scratch directory's ``AXIS_ATMOS_INTEGRATION_PLAN.md`` for the full
 plan.
 
-Phase 1 (this PR): scaffold + secret loader + health probe. ``TOOLS``
-intentionally empty — the read/write surfaces land in subsequent waves.
+Phase 1: scaffold + secret loader + health probe + 15 read tools.
+Phase 2 (later) will add the manage/commit/regenerate write surface.
 """
 
 import importlib
@@ -18,9 +18,31 @@ from loguru import logger
 from hpe_networking_mcp.config import ServerConfig
 
 # Map of category (tools/<name>.py) -> tool names registered by that module.
-# Empty in Phase 1; populated as read tools (Wave 3) and write tools (Phase 2)
-# land. Mirrors every other platform's pattern.
-TOOLS: dict[str, list[str]] = {}
+# Read-only tool files only in Phase 1. Phase 2 will add manage_* categories.
+TOOLS: dict[str, list[str]] = {
+    "application_groups": ["axis_get_application_groups"],
+    "applications": ["axis_get_applications"],
+    "connector_zones": ["axis_get_connector_zones"],
+    "connectors": ["axis_get_connectors"],
+    "groups": ["axis_get_groups"],
+    "locations": ["axis_get_locations", "axis_get_sub_locations"],
+    "ssl_exclusions": ["axis_get_ssl_exclusions"],
+    "status": ["axis_get_status"],
+    "tunnels": ["axis_get_tunnels"],
+    "users": ["axis_get_users"],
+    "web_categories": ["axis_get_web_categories"],
+}
+
+# Tools whose endpoints exist in the Axis swagger but currently return 403
+# even when the token has read access — Axis appears to gate these
+# server-side without a corresponding scope toggle in the admin portal
+# (likely an unreleased / hidden API). Implementations stay on disk so
+# re-enabling is a one-line move from this dict back into ``TOOLS`` when
+# Axis flips them on.
+_DISABLED_TOOLS: dict[str, list[str]] = {
+    "custom_ip_categories": ["axis_get_custom_ip_categories"],
+    "ip_feed_categories": ["axis_get_ip_feed_categories"],
+}
 
 
 def register_tools(mcp: FastMCP, config: ServerConfig) -> int:

--- a/src/hpe_networking_mcp/platforms/axis/client.py
+++ b/src/hpe_networking_mcp/platforms/axis/client.py
@@ -8,13 +8,17 @@ operator handle it.
 
 Base URL: ``https://admin-api.axissecurity.com/api/v1.0``.
 
-JWT-exp decoding is intentionally NOT in this PR — it lands in Wave 2.
+The token is a JWT (per the Axis swagger security definition). At client
+construction we decode the ``exp`` claim and surface days-until-expiry both
+at startup (log warning if <30 days) and at health-probe time.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+import time
 from typing import Any
 
 import httpx
@@ -27,6 +31,24 @@ from hpe_networking_mcp.utils.logging import mask_secret
 
 _AXIS_BASE_URL = "https://admin-api.axissecurity.com/api/v1.0"
 _REQUEST_TIMEOUT = 30.0
+_TOKEN_EXPIRY_WARNING_DAYS = 30
+
+
+def _decode_jwt_exp(token: str) -> int | None:
+    """Decode the ``exp`` claim from a JWT without verifying the signature.
+
+    Returns the Unix timestamp at which the token expires, or ``None`` if
+    the input doesn't look like a JWT we can read.
+    """
+    try:
+        _header, payload_b64, _sig = token.split(".", 2)
+        padding = "=" * (-len(payload_b64) % 4)
+        decoded = base64.urlsafe_b64decode(payload_b64 + padding)
+        claims = json.loads(decoded)
+        exp = claims.get("exp")
+        return int(exp) if isinstance(exp, (int, float)) else None
+    except (ValueError, json.JSONDecodeError):
+        return None
 
 
 class AxisAuthError(RuntimeError):
@@ -48,12 +70,37 @@ class AxisClient:
             base_url=_AXIS_BASE_URL,
             timeout=_REQUEST_TIMEOUT,
         )
+        self._token_expires_at: int | None = _decode_jwt_exp(self._token)
         logger.info("Axis: client initialized (token: {})", mask_secret(self._token))
+        days = self.token_expires_in_days
+        if days is None:
+            logger.info("Axis: token format unrecognized — expiry tracking disabled")
+        elif days <= 0:
+            logger.warning("Axis: token has already expired — regenerate at Settings → Admin API")
+        elif days <= _TOKEN_EXPIRY_WARNING_DAYS:
+            logger.warning(
+                "Axis: token expires in {} day(s) — regenerate at Settings → Admin API before it lapses",
+                days,
+            )
+        else:
+            logger.info("Axis: token expires in {} day(s)", days)
 
     @property
     def base_url(self) -> str:
         """Return the configured base URL."""
         return _AXIS_BASE_URL
+
+    @property
+    def token_expires_at(self) -> int | None:
+        """Unix timestamp at which the JWT expires, or ``None`` if undecodable."""
+        return self._token_expires_at
+
+    @property
+    def token_expires_in_days(self) -> int | None:
+        """Days until token expiry, or ``None`` if undecodable. Negative if already expired."""
+        if self._token_expires_at is None:
+            return None
+        return (self._token_expires_at - int(time.time())) // 86400
 
     async def aclose(self) -> None:
         """Close the underlying httpx client. Called from server.py:lifespan."""
@@ -115,6 +162,22 @@ class AxisClient:
         """Shortcut for a GET that returns parsed JSON."""
         response = await self.request("GET", path, **kwargs)
         return response.json()
+
+    async def get_paged(
+        self,
+        path: str,
+        *,
+        page_number: int = 1,
+        page_size: int = 50,
+    ) -> dict[str, Any]:
+        """GET a list endpoint using Axis's standard ``pageNumber``/``pageSize`` params.
+
+        All Axis ``Query`` operations return a ``PagedApiResponse<IEnumerable<X>>``
+        envelope. We pass it through unchanged so callers see ``totalRecords``
+        / ``totalPages`` without further wrapping.
+        """
+        params = {"pageNumber": page_number, "pageSize": page_size}
+        return await self.get_json(path, params=params)
 
     async def health_check(self) -> bool:
         """Probe the Axis ``/Health`` endpoint. Returns True if reachable.

--- a/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
@@ -1,0 +1,38 @@
+"""Axis application-group (tag) read tools (``/Tags``).
+
+Application groups are also called "tags" in the Axis API path. They
+group applications for policy reference.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_application_groups(
+    ctx: Context,
+    application_group_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis application groups (tags).
+
+    Args:
+        application_group_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if application_group_id:
+            return await client.get_json(f"/Tags/{application_group_id}")
+        return await client.get_paged("/Tags", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching application groups: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/applications.py
@@ -1,0 +1,34 @@
+"""Axis application read tools (``/Applications``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_applications(
+    ctx: Context,
+    application_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis published applications.
+
+    Args:
+        application_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if application_id:
+            return await client.get_json(f"/Applications/{application_id}")
+        return await client.get_paged("/Applications", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching applications: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
@@ -1,0 +1,34 @@
+"""Axis connector-zone read tools (``/ConnectorZones``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_connector_zones(
+    ctx: Context,
+    connector_zone_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis connector zones (groupings of connectors).
+
+    Args:
+        connector_zone_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if connector_zone_id:
+            return await client.get_json(f"/ConnectorZones/{connector_zone_id}")
+        return await client.get_paged("/ConnectorZones", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching connector zones: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
@@ -1,0 +1,44 @@
+"""Axis connector read tools (``/Connectors``).
+
+Connectors are tunnel-endpoint devices that link the customer network
+into Axis Atmos Cloud. Each carries rich telemetry (state, CPU/mem/disk,
+hostname, OS, version) — fetch it via ``axis_get_status``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_connectors(
+    ctx: Context,
+    connector_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis connectors (tunnel-endpoint devices).
+
+    If ``connector_id`` is provided, returns a single connector record.
+    Otherwise returns a paged list. For runtime telemetry on a specific
+    connector (state, CPU/mem/disk, version), call ``axis_get_status``
+    with ``entity_type="connector"``.
+
+    Args:
+        connector_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if connector_id:
+            return await client.get_json(f"/Connectors/{connector_id}")
+        return await client.get_paged("/Connectors", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching connectors: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
@@ -1,0 +1,37 @@
+"""Axis custom IP category read tools (``/IpCategories``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_custom_ip_categories(
+    ctx: Context,
+    custom_ip_category_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis custom IP categories.
+
+    Customer-defined IP groupings used in policy rules. For threat-intel
+    feeds maintained by Axis, see ``axis_get_ip_feed_categories``.
+
+    Args:
+        custom_ip_category_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if custom_ip_category_id:
+            return await client.get_json(f"/IpCategories/{custom_ip_category_id}")
+        return await client.get_paged("/IpCategories", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching custom IP categories: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/groups.py
@@ -1,0 +1,34 @@
+"""Axis group read tools (``/Groups``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_groups(
+    ctx: Context,
+    group_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis groups (Atmos IdP user groups).
+
+    Args:
+        group_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if group_id:
+            return await client.get_json(f"/Groups/{group_id}")
+        return await client.get_paged("/Groups", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching groups: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
@@ -1,0 +1,37 @@
+"""Axis IP-feed category read tools (``/IpCategoriesFeed``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_ip_feed_categories(
+    ctx: Context,
+    ip_feed_category_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis IP-feed categories.
+
+    Threat-intel IP feeds maintained by Axis (vs. customer-defined feeds
+    in ``axis_get_custom_ip_categories``).
+
+    Args:
+        ip_feed_category_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if ip_feed_category_id:
+            return await client.get_json(f"/IpCategoriesFeed/{ip_feed_category_id}")
+        return await client.get_paged("/IpCategoriesFeed", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching IP feed categories: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/locations.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/locations.py
@@ -1,0 +1,67 @@
+"""Axis location and sub-location read tools (``/Locations``).
+
+Locations are physical sites; sub-locations are logical subdivisions
+nested under a location. The sub-location list endpoint is location-scoped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_locations(
+    ctx: Context,
+    location_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis locations (physical sites).
+
+    Args:
+        location_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if location_id:
+            return await client.get_json(f"/Locations/{location_id}")
+        return await client.get_paged("/Locations", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching locations: {format_http_error(e)}"
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_sub_locations(
+    ctx: Context,
+    location_id: str,
+    sub_location_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get sub-locations nested under a parent location.
+
+    Args:
+        location_id: GUID of the parent location (required).
+        sub_location_id: GUID for single sub-location lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if sub_location_id:
+            return await client.get_json(f"/Locations/{location_id}/SubLocations/{sub_location_id}")
+        return await client.get_paged(
+            f"/Locations/{location_id}/SubLocations",
+            page_number=page_number,
+            page_size=page_size,
+        )
+    except Exception as e:
+        return f"Error fetching sub-locations: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
@@ -1,0 +1,34 @@
+"""Axis SSL exclusion read tools (``/SslExclusions``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_ssl_exclusions(
+    ctx: Context,
+    ssl_exclusion_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis SSL exclusions (hosts excluded from SSL inspection).
+
+    Args:
+        ssl_exclusion_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if ssl_exclusion_id:
+            return await client.get_json(f"/SslExclusions/{ssl_exclusion_id}")
+        return await client.get_paged("/SslExclusions", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching SSL exclusions: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/status.py
@@ -1,0 +1,46 @@
+"""Axis runtime-status helper for connectors and tunnels.
+
+The Axis API exposes ``/Connectors/{id}/status`` and ``/Tunnels/{id}/status``
+with similar shapes. This single tool dispatches on ``entity_type`` to keep
+the surface narrow.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastmcp import Context
+from pydantic import Field
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_status(
+    ctx: Context,
+    entity_type: Annotated[str, Field(description="Either 'connector' or 'tunnel'.")],
+    entity_id: Annotated[str, Field(description="GUID of the connector or tunnel.")],
+) -> dict[str, Any] | str:
+    """Get runtime status for a connector or tunnel.
+
+    Connector status returns rich telemetry (state, CPU/mem/disk/network,
+    hostname, OS, version). Tunnel status returns connection state and
+    last-seen metrics.
+
+    Args:
+        entity_type: ``'connector'`` or ``'tunnel'``.
+        entity_id: GUID of the connector or tunnel.
+    """
+    if entity_type == "connector":
+        path = f"/Connectors/{entity_id}/status"
+    elif entity_type == "tunnel":
+        path = f"/Tunnels/{entity_id}/status"
+    else:
+        return f"Invalid entity_type '{entity_type}'. Must be 'connector' or 'tunnel'."
+    try:
+        client = await get_axis_client()
+        return await client.get_json(path)
+    except Exception as e:
+        return f"Error fetching {entity_type} status: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
@@ -1,0 +1,42 @@
+"""Axis tunnel read tools (``/Tunnels``).
+
+Tunnels carry traffic between customer locations and Axis Atmos Cloud.
+For runtime status on a tunnel, call ``axis_get_status`` with
+``entity_type="tunnel"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_tunnels(
+    ctx: Context,
+    tunnel_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis tunnels.
+
+    If ``tunnel_id`` is provided, returns a single tunnel.
+    Otherwise returns a paged list.
+
+    Args:
+        tunnel_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if tunnel_id:
+            return await client.get_json(f"/Tunnels/{tunnel_id}")
+        return await client.get_paged("/Tunnels", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching tunnels: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/users.py
@@ -1,0 +1,34 @@
+"""Axis user read tools (``/Users``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_users(
+    ctx: Context,
+    user_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis users (Atmos IdP user records).
+
+    Args:
+        user_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if user_id:
+            return await client.get_json(f"/Users/{user_id}")
+        return await client.get_paged("/Users", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching users: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
@@ -1,0 +1,34 @@
+"""Axis web category read tools (``/WebCategories``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+
+
+@tool(annotations=READ_ONLY)
+async def axis_get_web_categories(
+    ctx: Context,
+    web_category_id: str | None = None,
+    page_number: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any] | str:
+    """Get Axis web categories (URL-classification categories used in policy).
+
+    Args:
+        web_category_id: GUID for single-item lookup.
+        page_number: 1-indexed page number for list calls.
+        page_size: Items per page for list calls.
+    """
+    try:
+        client = await get_axis_client()
+        if web_category_id:
+            return await client.get_json(f"/WebCategories/{web_category_id}")
+        return await client.get_paged("/WebCategories", page_number=page_number, page_size=page_size)
+    except Exception as e:
+        return f"Error fetching web categories: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/health.py
+++ b/src/hpe_networking_mcp/platforms/health.py
@@ -157,9 +157,29 @@ async def _probe_axis(ctx: Context) -> dict[str, Any]:
         return {"status": "unavailable", "message": "Axis is not configured or failed to initialize"}
     try:
         await client.health_check()
-        return {"status": "ok", "message": "Axis API reachable", "base_url": client.base_url}
     except Exception as e:
         return {"status": "degraded", "message": f"Axis probe failed: {e}"}
+
+    days = client.token_expires_in_days
+    result: dict[str, Any] = {"status": "ok", "message": "Axis API reachable", "base_url": client.base_url}
+    if days is None:
+        return result
+    if days <= 0:
+        return {
+            "status": "degraded",
+            "message": "Axis API token has expired — regenerate at Settings → Admin API",
+            "base_url": client.base_url,
+            "token_expires_in_days": days,
+        }
+    if days <= 30:
+        return {
+            "status": "degraded",
+            "message": f"Axis token expires in {days} day(s) — regenerate at Settings → Admin API before it lapses",
+            "base_url": client.base_url,
+            "token_expires_in_days": days,
+        }
+    result["token_expires_in_days"] = days
+    return result
 
 
 _PROBES = {

--- a/tests/unit/test_axis_dynamic_mode.py
+++ b/tests/unit/test_axis_dynamic_mode.py
@@ -1,47 +1,78 @@
-"""Unit tests for the Axis Atmos Cloud platform scaffold (Phase 1).
+"""Unit tests for the Axis Atmos Cloud platform (Phase 1: 12 read tools).
 
-Phase 1 ships the platform skeleton — config loader, lifespan client init,
-health probe, registry plumbing — but no underlying tools yet (``TOOLS``
-is intentionally empty until subsequent waves). The tests below validate
-the scaffold itself: the registry is wired in cleanly, the empty TOOLS
-dict round-trips, and the pieces a tool would need (decorator, client
-accessor, annotation constants) are importable.
-
-When read tools land in Wave 3, expand ``TestAxisRegistryPopulation`` to
-mirror ``test_apstra_dynamic_mode.py``.
+Validates the registry wiring, the read-tool surface, the JWT-exp decoder,
+the health probe enrichment, and the disabled-tools list. Phase 2 will
+add ``manage_*`` write tools and a corresponding test class.
 """
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
-from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, clear_registry
+
+
+@pytest.fixture
+def axis_registry_populated():
+    """Import every Axis tool module so ``REGISTRIES['axis']`` is full."""
+    clear_registry("axis")
+    from hpe_networking_mcp.platforms.axis import TOOLS
+
+    for category in TOOLS:
+        module = importlib.import_module(f"hpe_networking_mcp.platforms.axis.tools.{category}")
+        importlib.reload(module)
+    yield REGISTRIES["axis"]
+    clear_registry("axis")
 
 
 @pytest.mark.unit
-class TestAxisRegistryWiring:
+class TestAxisRegistryPopulation:
     def test_axis_in_registries_dict(self):
-        """The cross-platform registry must contain the axis key.
-
-        ``record_tool`` raises ``ValueError("Unknown platform: axis")`` if
-        the platform name isn't a known key — caught this exact bug live
-        during scaffold development.
-        """
         assert "axis" in REGISTRIES
 
-    def test_axis_starts_empty(self):
-        """Phase 1 ships zero tools. Read tools land in a later wave."""
+    def test_registry_contains_all_tools(self, axis_registry_populated):
+        """Every name in ``TOOLS`` registers cleanly."""
         from hpe_networking_mcp.platforms.axis import TOOLS
 
-        assert TOOLS == {}
+        expected = {name for names in TOOLS.values() for name in names}
+        actual = set(axis_registry_populated.keys())
+        assert actual == expected, f"missing: {expected - actual}, extra: {actual - expected}"
 
-    def test_axis_register_tools_returns_zero(self):
-        """register_tools should report 0 underlying tools at this stage."""
-        from hpe_networking_mcp.platforms.axis import TOOLS
+    def test_disabled_tools_not_registered(self, axis_registry_populated):
+        """``_DISABLED_TOOLS`` entries (403 in our tenant) must not appear in the registry."""
+        from hpe_networking_mcp.platforms.axis import _DISABLED_TOOLS
 
-        # Tool count is just len(flatten(TOOLS.values())).
-        flat = [n for names in TOOLS.values() for n in names]
-        assert len(flat) == 0
+        disabled_names = {n for names in _DISABLED_TOOLS.values() for n in names}
+        actual = set(axis_registry_populated.keys())
+        assert not (disabled_names & actual), f"disabled tools leaked into registry: {disabled_names & actual}"
+
+    def test_categories_match_module_names(self, axis_registry_populated):
+        """Registry category == source module's short name (powers list_tools(category=...))."""
+        for name, spec in axis_registry_populated.items():
+            module_short = spec.func.__module__.rsplit(".", 1)[-1]
+            assert spec.category == module_short, f"{name} category={spec.category} module={module_short}"
+
+    def test_read_tools_carry_no_write_tag(self, axis_registry_populated):
+        """Phase 1 has only reads — none should carry ``axis_write`` or ``axis_write_delete``."""
+        for name, spec in axis_registry_populated.items():
+            assert not (spec.tags & {"axis_write", "axis_write_delete"}), (
+                f"{name} unexpectedly carries a write tag: {spec.tags}"
+            )
+
+    def test_descriptions_are_populated(self, axis_registry_populated):
+        for name, spec in axis_registry_populated.items():
+            assert spec.description, f"{name} has empty description"
+
+    def test_every_tool_anchored_to_axis_platform(self, axis_registry_populated):
+        """Code mode's ``search(tags=["axis"])`` and ``tags()`` discovery
+        surfaces depend on each tool's ``ToolSpec.platform`` being ``axis``
+        (the ``_registry.tool`` shim adds the platform tag at the FastMCP
+        layer using this same anchor).
+        """
+        for name, spec in axis_registry_populated.items():
+            assert spec.platform == "axis", f"{name} platform={spec.platform} — code-mode discovery would mis-bucket it"
 
 
 @pytest.mark.unit
@@ -173,3 +204,117 @@ class TestAxisWriteTagWiring:
         from hpe_networking_mcp.platforms._common.tool_registry import _GATE_CONFIG_ATTR
 
         assert _GATE_CONFIG_ATTR.get("axis") == "enable_axis_write_tools"
+
+
+@pytest.mark.unit
+class TestAxisJwtExpDecoder:
+    """The JWT-exp decoder powers the startup warning + health-probe countdown."""
+
+    def test_decode_real_shaped_jwt(self):
+        """A well-formed JWT with an ``exp`` claim returns the integer timestamp."""
+        import base64
+        import json
+
+        from hpe_networking_mcp.platforms.axis.client import _decode_jwt_exp
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"exp": 1900000000}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fake-sig"
+
+        assert _decode_jwt_exp(token) == 1900000000
+
+    def test_decode_returns_none_for_opaque_string(self):
+        from hpe_networking_mcp.platforms.axis.client import _decode_jwt_exp
+
+        assert _decode_jwt_exp("not-a-jwt-just-an-opaque-string") is None
+
+    def test_decode_returns_none_when_exp_missing(self):
+        import base64
+        import json
+
+        from hpe_networking_mcp.platforms.axis.client import _decode_jwt_exp
+
+        header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(json.dumps({"sub": "x"}).encode()).rstrip(b"=").decode()
+        token = f"{header}.{payload}.fake-sig"
+
+        assert _decode_jwt_exp(token) is None
+
+
+@pytest.mark.unit
+class TestAxisHealthProbeEnrichment:
+    """Health probe must surface token-expiry countdown + downgrade to degraded near expiry."""
+
+    @pytest.mark.asyncio
+    async def test_probe_reports_days_when_outside_warning_window(self):
+        from hpe_networking_mcp.platforms.health import _probe_axis
+
+        class _FakeClient:
+            base_url = "https://x"
+            token_expires_in_days = 100
+
+            async def health_check(self):
+                return True
+
+        class _FakeCtx:
+            lifespan_context = {"axis_client": _FakeClient()}
+
+        result = await _probe_axis(_FakeCtx())
+        assert result["status"] == "ok"
+        assert result["token_expires_in_days"] == 100
+
+    @pytest.mark.asyncio
+    async def test_probe_degrades_inside_30_day_window(self):
+        from hpe_networking_mcp.platforms.health import _probe_axis
+
+        class _FakeClient:
+            base_url = "https://x"
+            token_expires_in_days = 7
+
+            async def health_check(self):
+                return True
+
+        class _FakeCtx:
+            lifespan_context = {"axis_client": _FakeClient()}
+
+        result = await _probe_axis(_FakeCtx())
+        assert result["status"] == "degraded"
+        assert result["token_expires_in_days"] == 7
+        assert "regenerate" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_probe_degrades_when_already_expired(self):
+        from hpe_networking_mcp.platforms.health import _probe_axis
+
+        class _FakeClient:
+            base_url = "https://x"
+            token_expires_in_days = -1
+
+            async def health_check(self):
+                return True
+
+        class _FakeCtx:
+            lifespan_context = {"axis_client": _FakeClient()}
+
+        result = await _probe_axis(_FakeCtx())
+        assert result["status"] == "degraded"
+        assert "expired" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_probe_omits_days_when_undecodable(self):
+        """Opaque-token case: probe still ok, just no countdown field."""
+        from hpe_networking_mcp.platforms.health import _probe_axis
+
+        class _FakeClient:
+            base_url = "https://x"
+            token_expires_in_days = None
+
+            async def health_check(self):
+                return True
+
+        class _FakeCtx:
+            lifespan_context = {"axis_client": _FakeClient()}
+
+        result = await _probe_axis(_FakeCtx())
+        assert result["status"] == "ok"
+        assert "token_expires_in_days" not in result


### PR DESCRIPTION
## Summary

- Internal follow-up to PR #195 (the platform scaffold). Adds the read-only tool surface, JWT-exp surfacing, and a paged-list helper.
- 12 read tools register cleanly; 2 endpoints documented in the upstream API spec are kept off the registry because they 403 even with a fully-scoped token (apparently hidden / unreleased).
- Compose entries land commented-out — present so anyone editing the file can see the shape, inactive by default.

## Test plan

- [x] Live-tested against a real tenant: 12 read tools return paged data, by-id lookups work, status helper returns rich runtime telemetry, sub-locations scope correctly under parent location
- [x] Token-expiry surfacing verified end-to-end (startup log shows days remaining; health probe returns countdown field)
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 562 passed (was 552; +10 new tests)
- [x] Hidden-feature audit: no new mentions in README, INSTRUCTIONS.md, TOOLS.md, MIGRATING_TO_V2.md