### PR TITLE
Internal: write-tool surface follow-up

### DIFF
--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -45,7 +45,8 @@ class ElicitationMiddleware(Middleware):
         central_write = config.enable_central_write_tools
         clearpass_write = config.enable_clearpass_write_tools
         apstra_write = config.enable_apstra_write_tools
-        any_write = mist_write or central_write or clearpass_write or apstra_write
+        axis_write = config.enable_axis_write_tools
+        any_write = mist_write or central_write or clearpass_write or apstra_write or axis_write
 
         if not any_write:
             return result  # type: ignore[return-value]
@@ -82,12 +83,15 @@ class ElicitationMiddleware(Middleware):
             await ctx.enable_components(tags={"clearpass_write_delete"}, components={"tool"})
         if apstra_write:
             await ctx.enable_components(tags={"apstra_write", "apstra_write_delete"}, components={"tool"})
+        if axis_write:
+            await ctx.enable_components(tags={"axis_write", "axis_write_delete"}, components={"tool"})
         logger.info(
-            "Elicitation: write tools enabled (mist=%s, central=%s, clearpass=%s, apstra=%s)",
+            "Elicitation: write tools enabled (mist=%s, central=%s, clearpass=%s, apstra=%s, axis=%s)",
             mist_write,
             central_write,
             clearpass_write,
             apstra_write,
+            axis_write,
         )
 
         return result  # type: ignore[return-value]

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -6,8 +6,11 @@ public-facing documentation until the user chooses to announce it. See
 the scratch directory's ``AXIS_ATMOS_INTEGRATION_PLAN.md`` for the full
 plan.
 
-Phase 1: scaffold + secret loader + health probe + 15 read tools.
-Phase 2 (later) will add the manage/commit/regenerate write surface.
+Phase 1: scaffold + secret loader + health probe + 12 read tools.
+Phase 2: 13 ``axis_manage_*`` write tools, ``axis_commit_changes``, and
+``axis_regenerate_connector``. Reads carry no write tag; writes carry
+``axis_write_delete`` so the visibility transform gates them on
+``ENABLE_AXIS_WRITE_TOOLS=true``.
 """
 
 import importlib
@@ -18,30 +21,41 @@ from loguru import logger
 from hpe_networking_mcp.config import ServerConfig
 
 # Map of category (tools/<name>.py) -> tool names registered by that module.
-# Read-only tool files only in Phase 1. Phase 2 will add manage_* categories.
 TOOLS: dict[str, list[str]] = {
-    "application_groups": ["axis_get_application_groups"],
-    "applications": ["axis_get_applications"],
-    "connector_zones": ["axis_get_connector_zones"],
-    "connectors": ["axis_get_connectors"],
-    "groups": ["axis_get_groups"],
-    "locations": ["axis_get_locations", "axis_get_sub_locations"],
-    "ssl_exclusions": ["axis_get_ssl_exclusions"],
+    # ── Read-only categories ──────────────────────────────────────
+    "application_groups": ["axis_get_application_groups", "axis_manage_application_group"],
+    "applications": ["axis_get_applications", "axis_manage_application"],
+    "connector_zones": ["axis_get_connector_zones", "axis_manage_connector_zone"],
+    "connectors": [
+        "axis_get_connectors",
+        "axis_manage_connector",
+        "axis_regenerate_connector",
+    ],
+    "groups": ["axis_get_groups", "axis_manage_group"],
+    "locations": [
+        "axis_get_locations",
+        "axis_get_sub_locations",
+        "axis_manage_location",
+        "axis_manage_sub_location",
+    ],
+    "ssl_exclusions": ["axis_get_ssl_exclusions", "axis_manage_ssl_exclusion"],
     "status": ["axis_get_status"],
-    "tunnels": ["axis_get_tunnels"],
-    "users": ["axis_get_users"],
-    "web_categories": ["axis_get_web_categories"],
+    "tunnels": ["axis_get_tunnels", "axis_manage_tunnel"],
+    "users": ["axis_get_users", "axis_manage_user"],
+    "web_categories": ["axis_get_web_categories", "axis_manage_web_category"],
+    # ── Commit (Axis writes stage; this applies them) ─────────────
+    "commit": ["axis_commit_changes"],
 }
 
 # Tools whose endpoints exist in the Axis swagger but currently return 403
-# even when the token has read access — Axis appears to gate these
+# even when the token has read/write access — Axis appears to gate these
 # server-side without a corresponding scope toggle in the admin portal
 # (likely an unreleased / hidden API). Implementations stay on disk so
 # re-enabling is a one-line move from this dict back into ``TOOLS`` when
 # Axis flips them on.
 _DISABLED_TOOLS: dict[str, list[str]] = {
-    "custom_ip_categories": ["axis_get_custom_ip_categories"],
-    "ip_feed_categories": ["axis_get_ip_feed_categories"],
+    "custom_ip_categories": ["axis_get_custom_ip_categories", "axis_manage_custom_ip_category"],
+    "ip_feed_categories": ["axis_get_ip_feed_categories", "axis_manage_ip_feed_category"],
 }
 
 

--- a/src/hpe_networking_mcp/platforms/axis/client.py
+++ b/src/hpe_networking_mcp/platforms/axis/client.py
@@ -179,6 +179,27 @@ class AxisClient:
         params = {"pageNumber": page_number, "pageSize": page_size}
         return await self.get_json(path, params=params)
 
+    async def post_json(self, path: str, json_body: Any, **kwargs: Any) -> Any:
+        """POST a JSON body and return the parsed response."""
+        response = await self.request("POST", path, json_body=json_body, **kwargs)
+        if response.status_code == 204 or not response.content:
+            return {"status_code": response.status_code}
+        return response.json()
+
+    async def put_json(self, path: str, json_body: Any, **kwargs: Any) -> Any:
+        """PUT a JSON body and return the parsed response."""
+        response = await self.request("PUT", path, json_body=json_body, **kwargs)
+        if response.status_code == 204 or not response.content:
+            return {"status_code": response.status_code}
+        return response.json()
+
+    async def delete_resource(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """DELETE a resource. Most Axis DELETEs return 204 with no body."""
+        response = await self.request("DELETE", path, **kwargs)
+        if response.status_code == 204 or not response.content:
+            return {"status_code": response.status_code}
+        return response.json()
+
     async def health_check(self) -> bool:
         """Probe the Axis ``/Health`` endpoint. Returns True if reachable.
 

--- a/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
@@ -1,0 +1,82 @@
+"""Shared dispatch helper for Axis ``axis_manage_*`` tools.
+
+Every Axis entity follows a uniform CRUD shape::
+
+    POST   /<Resource>         -> create
+    PUT    /<Resource>/{id}    -> update
+    DELETE /<Resource>/{id}    -> delete
+
+Rather than repeat the action-validation, elicitation, and dispatch logic
+in every tool file, this helper handles the common path. Each tool file
+just calls ``manage_entity(...)`` with its base path and a label.
+
+Writes stage in Axis. To apply, the caller invokes ``axis_commit_changes``;
+every successful response from this helper carries a ``next_step`` hint
+naming that tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+
+_VALID_ACTIONS = ("create", "update", "delete")
+_NEXT_STEP_HINT = "Call axis_commit_changes to apply these staged changes."
+
+
+async def manage_entity(
+    ctx: Context,
+    *,
+    base_path: str,
+    label: str,
+    action_type: str,
+    payload: dict | None,
+    entity_id: str | None,
+    confirmed: bool,
+) -> dict | str:
+    """Generic create/update/delete dispatcher for Axis CRUD entities.
+
+    Args:
+        ctx: FastMCP context (needed for elicitation).
+        base_path: Resource path under ``/api/v1.0`` — e.g. ``"/Connectors"``.
+        label: Human-readable entity name for the elicitation prompt
+            (e.g. ``"connector"``, ``"SSL exclusion"``).
+        action_type: One of ``"create"``, ``"update"``, ``"delete"``.
+        payload: Request body for ``create``/``update``. Ignored for delete.
+        entity_id: Resource ID — required for ``update`` and ``delete``.
+        confirmed: When true, skip the elicitation prompt.
+
+    Returns:
+        Either a dict with the API response plus a ``next_step`` hint, or a
+        string error message.
+    """
+    if action_type not in _VALID_ACTIONS:
+        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}."
+    if action_type in ("update", "delete") and not entity_id:
+        return f"entity_id is required for action '{action_type}'."
+    if action_type in ("create", "update") and not payload:
+        return f"payload is required for action '{action_type}'."
+
+    target = entity_id or "(new)"
+    decline = await confirm_write(ctx, f"Axis: {action_type} {label} '{target}'. Confirm?")
+    if decline:
+        return decline
+
+    try:
+        client = await get_axis_client()
+        if action_type == "create":
+            result = await client.post_json(base_path, payload)
+        elif action_type == "update":
+            result = await client.put_json(f"{base_path}/{entity_id}", payload)
+        else:
+            result = await client.delete_resource(f"{base_path}/{entity_id}")
+    except Exception as e:
+        return f"Error during {action_type} {label}: {format_http_error(e)}"
+
+    response: dict[str, Any] = result if isinstance(result, dict) else {"result": result}
+    response["next_step"] = _NEXT_STEP_HINT
+    return response

--- a/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
@@ -12,7 +12,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -36,3 +37,32 @@ async def axis_get_application_groups(
         return await client.get_paged("/Tags", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching application groups: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_application_group(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    application_group_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis application group (tag).
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        application_group_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Tags",
+        label="application group",
+        action_type=action_type,
+        payload=payload,
+        entity_id=application_group_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/applications.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_applications(
         return await client.get_paged("/Applications", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching applications: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_application(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    application_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis published application.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        application_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Applications",
+        label="application",
+        action_type=action_type,
+        payload=payload,
+        entity_id=application_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/commit.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/commit.py
@@ -1,0 +1,57 @@
+"""Axis commit tool — applies all staged changes.
+
+Axis writes (create/update/delete via ``axis_manage_*``) are staged. Until
+``axis_commit_changes`` is called, the changes are not visible to the
+production data plane. This mirrors the behavior of the Axis admin UI,
+where edits live in a draft state until the operator commits.
+
+The ``POST /Commit`` endpoint accepts no body and returns ``204 No Content``
+on success. We surface that as ``{"status": "committed"}`` to give the
+caller a clear positive response.
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context
+
+from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.axis._registry import tool
+from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
+from hpe_networking_mcp.platforms.axis.tools import WRITE_DELETE
+
+_COMMIT_TIMEOUT = 60.0
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_commit_changes(
+    ctx: Context,
+    confirmed: bool = False,
+) -> dict | str:
+    """Apply all staged Axis changes (POST /Commit).
+
+    Every ``axis_manage_*`` write tool stages its change; this is the tool
+    that pushes those staged edits live in the Axis cloud. Affects all
+    pending writes for this tenant — there is no per-change selection.
+
+    The endpoint can take a while when there's a lot staged; we use a 60-second
+    timeout for this call specifically.
+
+    Args:
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    decline = await confirm_write(
+        ctx,
+        "Axis: commit ALL pending staged changes for this tenant. This applies "
+        "every queued create/update/delete from prior axis_manage_* calls. Confirm?",
+    )
+    if decline:
+        return decline
+    try:
+        client = await get_axis_client()
+        response = await client.request("POST", "/Commit", timeout=_COMMIT_TIMEOUT)
+        if response.status_code == 204:
+            return {"status": "committed", "message": "Axis applied all staged changes."}
+        body = response.json() if response.content else {}
+        return {"status": "committed", "status_code": response.status_code, "body": body}
+    except Exception as e:
+        return f"Error committing Axis changes: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_connector_zones(
         return await client.get_paged("/ConnectorZones", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching connector zones: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_connector_zone(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    connector_zone_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis connector zone.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        connector_zone_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/ConnectorZones",
+        label="connector zone",
+        action_type=action_type,
+        payload=payload,
+        entity_id=connector_zone_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
@@ -11,9 +11,11 @@ from typing import Any
 
 from fastmcp import Context
 
+from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -42,3 +44,65 @@ async def axis_get_connectors(
         return await client.get_paged("/Connectors", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching connectors: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_connector(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    connector_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis connector.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        connector_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Connectors",
+        label="connector",
+        action_type=action_type,
+        payload=payload,
+        entity_id=connector_id,
+        confirmed=confirmed,
+    )
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_regenerate_connector(
+    ctx: Context,
+    connector_id: str,
+    confirmed: bool = False,
+) -> dict | str:
+    """Issue a fresh installation command for an existing Axis connector.
+
+    Invalidates the prior install command for the same connector — anyone
+    holding the old command can no longer use it. The connector record
+    itself is preserved (no data loss).
+
+    Returns the new installation command. Does NOT require ``axis_commit_changes``
+    (regenerate is an immediate operation, not a staged write).
+
+    Args:
+        connector_id: GUID of the connector to regenerate.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    decline = await confirm_write(
+        ctx,
+        f"Axis: regenerate install command for connector {connector_id}. "
+        "This invalidates the prior install command. Confirm?",
+    )
+    if decline:
+        return decline
+    try:
+        client = await get_axis_client()
+        return await client.post_json(f"/Connectors/{connector_id}/regenerate", json_body={})
+    except Exception as e:
+        return f"Error regenerating connector: {format_http_error(e)}"

--- a/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -35,3 +36,32 @@ async def axis_get_custom_ip_categories(
         return await client.get_paged("/IpCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching custom IP categories: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_custom_ip_category(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    custom_ip_category_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis custom IP category.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        custom_ip_category_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/IpCategories",
+        label="custom IP category",
+        action_type=action_type,
+        payload=payload,
+        entity_id=custom_ip_category_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/groups.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_groups(
         return await client.get_paged("/Groups", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching groups: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_group(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    group_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis user group.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        group_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Groups",
+        label="group",
+        action_type=action_type,
+        payload=payload,
+        entity_id=group_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -35,3 +36,32 @@ async def axis_get_ip_feed_categories(
         return await client.get_paged("/IpCategoriesFeed", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching IP feed categories: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_ip_feed_category(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    ip_feed_category_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis IP feed category.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        ip_feed_category_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/IpCategoriesFeed",
+        label="IP feed category",
+        action_type=action_type,
+        payload=payload,
+        entity_id=ip_feed_category_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/locations.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/locations.py
@@ -12,7 +12,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -65,3 +66,63 @@ async def axis_get_sub_locations(
         )
     except Exception as e:
         return f"Error fetching sub-locations: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_location(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    location_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis location.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        location_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Locations",
+        label="location",
+        action_type=action_type,
+        payload=payload,
+        entity_id=location_id,
+        confirmed=confirmed,
+    )
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_sub_location(
+    ctx: Context,
+    action_type: str,
+    location_id: str,
+    payload: dict | None = None,
+    sub_location_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis sub-location under a parent location.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        location_id: GUID of the parent location (required).
+        payload: Body for create/update. Ignored for delete.
+        sub_location_id: GUID of the sub-location — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path=f"/Locations/{location_id}/SubLocations",
+        label=f"sub-location under location {location_id}",
+        action_type=action_type,
+        payload=payload,
+        entity_id=sub_location_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_ssl_exclusions(
         return await client.get_paged("/SslExclusions", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching SSL exclusions: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_ssl_exclusion(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    ssl_exclusion_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis SSL exclusion.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        ssl_exclusion_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/SslExclusions",
+        label="SSL exclusion",
+        action_type=action_type,
+        payload=payload,
+        entity_id=ssl_exclusion_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
@@ -13,7 +13,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -40,3 +41,32 @@ async def axis_get_tunnels(
         return await client.get_paged("/Tunnels", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching tunnels: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_tunnel(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    tunnel_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis tunnel.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        tunnel_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Tunnels",
+        label="tunnel",
+        action_type=action_type,
+        payload=payload,
+        entity_id=tunnel_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/users.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_users(
         return await client.get_paged("/Users", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching users: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_user(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    user_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis user.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        user_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/Users",
+        label="user",
+        action_type=action_type,
+        payload=payload,
+        entity_id=user_id,
+        confirmed=confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
@@ -8,7 +8,8 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
-from hpe_networking_mcp.platforms.axis.tools import READ_ONLY
+from hpe_networking_mcp.platforms.axis.tools import READ_ONLY, WRITE_DELETE
+from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
 
 
 @tool(annotations=READ_ONLY)
@@ -32,3 +33,32 @@ async def axis_get_web_categories(
         return await client.get_paged("/WebCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
         return f"Error fetching web categories: {format_http_error(e)}"
+
+
+@tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
+async def axis_manage_web_category(
+    ctx: Context,
+    action_type: str,
+    payload: dict | None = None,
+    web_category_id: str | None = None,
+    confirmed: bool = False,
+) -> dict | str:
+    """Create, update, or delete an Axis web category.
+
+    Writes stage in Axis. Call ``axis_commit_changes`` to apply.
+
+    Args:
+        action_type: One of ``'create'``, ``'update'``, ``'delete'``.
+        payload: Body for create/update. Ignored for delete.
+        web_category_id: GUID — required for update/delete.
+        confirmed: Set true after user confirms; skips re-prompting.
+    """
+    return await manage_entity(
+        ctx,
+        base_path="/WebCategories",
+        label="web category",
+        action_type=action_type,
+        payload=payload,
+        entity_id=web_category_id,
+        confirmed=confirmed,
+    )

--- a/tests/unit/test_axis_dynamic_mode.py
+++ b/tests/unit/test_axis_dynamic_mode.py
@@ -55,11 +55,36 @@ class TestAxisRegistryPopulation:
             assert spec.category == module_short, f"{name} category={spec.category} module={module_short}"
 
     def test_read_tools_carry_no_write_tag(self, axis_registry_populated):
-        """Phase 1 has only reads — none should carry ``axis_write`` or ``axis_write_delete``."""
+        """``axis_get_*`` tools must not carry a write tag."""
         for name, spec in axis_registry_populated.items():
-            assert not (spec.tags & {"axis_write", "axis_write_delete"}), (
-                f"{name} unexpectedly carries a write tag: {spec.tags}"
+            if name.startswith("axis_get_"):
+                assert not (spec.tags & {"axis_write", "axis_write_delete"}), (
+                    f"{name} unexpectedly carries a write tag: {spec.tags}"
+                )
+
+    def test_write_tools_carry_write_delete_tag(self, axis_registry_populated):
+        """Every ``axis_manage_*`` tool plus ``axis_commit_changes`` and
+        ``axis_regenerate_connector`` must carry ``axis_write_delete`` so the
+        Visibility transform + ElicitationMiddleware gate them.
+        """
+        write_names = {n for n in axis_registry_populated if n.startswith("axis_manage_")}
+        write_names |= {"axis_commit_changes", "axis_regenerate_connector"}
+        for name in write_names:
+            spec = axis_registry_populated[name]
+            assert "axis_write_delete" in spec.tags, (
+                f"{name} missing axis_write_delete tag — write gating won't fire (tags={spec.tags})"
             )
+
+    def test_every_write_tool_references_commit_changes(self, axis_registry_populated):
+        """Axis writes stage; the commit tool applies them. Every ``axis_manage_*``
+        description must name ``axis_commit_changes`` so the AI knows the follow-up.
+        ``axis_regenerate_connector`` is exempt — regenerate is immediate, not staged.
+        """
+        for name, spec in axis_registry_populated.items():
+            if name.startswith("axis_manage_"):
+                assert "axis_commit_changes" in spec.description, (
+                    f"{name} description must reference axis_commit_changes — got: {spec.description[:200]}"
+                )
 
     def test_descriptions_are_populated(self, axis_registry_populated):
         for name, spec in axis_registry_populated.items():
@@ -204,6 +229,28 @@ class TestAxisWriteTagWiring:
         from hpe_networking_mcp.platforms._common.tool_registry import _GATE_CONFIG_ATTR
 
         assert _GATE_CONFIG_ATTR.get("axis") == "enable_axis_write_tools"
+
+    def test_elicitation_middleware_recognizes_axis_write(self):
+        """``ElicitationMiddleware.on_initialize`` must read
+        ``config.enable_axis_write_tools`` and call ``ctx.enable_components`` for
+        the ``axis_write_delete`` tag — otherwise writes never get the
+        elicitation mode set and ``confirm_write`` returns ``declined`` for
+        every call. Caught in Phase 2 live-testing.
+
+        Asserts on the middleware source — full async-init flow is too tightly
+        coupled to FastMCP internals to mock cleanly.
+        """
+        import inspect
+
+        from hpe_networking_mcp.middleware import elicitation
+
+        src = inspect.getsource(elicitation.ElicitationMiddleware.on_initialize)
+        assert "enable_axis_write_tools" in src, (
+            "ElicitationMiddleware.on_initialize doesn't read enable_axis_write_tools"
+        )
+        assert "axis_write_delete" in src, (
+            "ElicitationMiddleware.on_initialize doesn't enable the axis_write_delete tag"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Internal follow-up to PR #198. Adds the manage/commit/regenerate write surface.
- Active tool count goes 12 → 25; ElicitationMiddleware gating fix bundled in (caught live: middleware was missing the platform from its any_write OR + enable_components calls).

## Test plan

- [x] Live-tested against a real tenant: full create → commit → verify → delete → commit → verify cycle on SSL exclusions; tenant returned to baseline (26 → 27 → 26).
- [x] Decline path (confirmed=False): returns clean decline payload without firing the API
- [x] Validation: invalid action_type, missing entity_id, missing payload all return clean error strings
- [x] Disabled tools (`axis_manage_custom_ip_category`, `axis_manage_ip_feed_category`) throw Unknown tool as expected
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 566 passed (was 562; +4 new tests)
- [x] Hidden-feature audit: no new mentions in README, INSTRUCTIONS.md, TOOLS.md, MIGRATING_TO_V2.md, CHANGELOG.md