### PR TITLE
v2.1.0.2: fix site-health field-name + pagination bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0.2] - 2026-04-26
+
+**Fixes site-health field-name mismatches that caused `central_get_site_health`, `central_get_site_name_id_mapping`, and `site_health_check` to silently report empty/zero data.**
+
+Reported by a user whose AI client noticed `site_health_check` returning 0 clients for a site that had real client traffic. Investigation traced it to three code paths reading the wrong field name from Aruba Central's `/network-monitoring/v1/sites-health` response, plus a fourth pagination bug that would silently truncate results for tenants with >100 sites.
+
+### Bugs
+
+- **`central_get_site_health` returned an empty list.** [`process_site_health_data`](src/hpe_networking_mcp/platforms/central/utils.py) keyed the result dict on `site["name"]` but the API returns `siteName`. Every site got filtered out at the dict-comprehension step. Fixed in three places (the main key, plus the device-merge and client-merge loops).
+- **`central_get_site_name_id_mapping` returned `total_devices: 0` and `total_clients: 0` for every site.** Read `clients.total` and `devices.total` but the simplified shape (after `pycentral.simplified_site_resp`) uses `count`. Changed to `clients.count` / `devices.count`. `alerts.total` was already correct (it's the one field `simplified_site_resp` does map from `totalCount` → `total`).
+- **`site_health_check` (cross-platform) reported the same `total_clients: 0` / `total_devices: 0` symptom.** Same root cause as above, same fix.
+- **`fetch_site_data_parallel` used cursor pagination against offset-paginated endpoints.** All three site-health endpoints (`/sites-health`, `/sites-device-health`, `/sites-client-health`) accept `limit` + `offset` only — Aruba's dev portal does not document a cursor param. The default `paginated_fetch(use_cursor=True)` sent `next=1` and worked accidentally for tenants with ≤100 sites (the server tolerates the unknown param and returns page 1) but would silently stop after the first page for larger tenants. Switched these three calls to `use_cursor=False`.
+
+### Mode coverage
+
+The empty-list and zero-counts symptoms reproduced in both `dynamic` and `code` modes — the underlying tools share the same code path regardless of how they're surfaced. `site_health_check` is gated off in code mode (cross-platform aggregator), so its specific symptom doesn't surface there, but the per-platform tools that do appear (`central_get_site_health`, `central_get_site_name_id_mapping`) show the same data through both modes.
+
+### Verified live against a real tenant
+
+| Tool | Before | After |
+|---|---|---|
+| `central_get_site_health` | `[]` | 13 sites; HOME = 38 clients / 17 devices, with full per-type breakdown |
+| `central_get_site_name_id_mapping` (HOME) | `health: 0, total_devices: 0, total_clients: 0, total_alerts: 0` | `health: 81, total_devices: 17, total_clients: 38, total_alerts: 3` |
+
+### Tests
+
+6 new tests in `tests/unit/test_central_utils.py` pinning `process_site_health_data` and `transform_to_site_data` against captured-from-live response shapes. If Aruba ever renames `siteName` → `name` (or back), these tests fail loudly instead of letting another silent regression ship.
+
+Total: 562 → 568 tests passing.
+
 ## [2.1.0.1] - 2026-04-25
 
 **ClearPass coverage follow-up — adds 14 read/write tools to close the dev-portal gap surfaced during the v2.1.0.0 audit.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.1.0.1"
+version = "2.1.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -118,8 +118,8 @@ async def central_get_site_name_id_mapping(ctx: Context) -> dict:
         mapping[site["siteName"]] = {
             "site_id": site.get("id"),
             "health": summary,
-            "total_devices": site.get("devices", {}).get("total", 0),
-            "total_clients": site.get("clients", {}).get("total", 0),
+            "total_devices": site.get("devices", {}).get("count", 0),
+            "total_clients": site.get("clients", {}).get("count", 0),
             "total_alerts": site.get("alerts", {}).get("total", 0),
         }
     mapping = dict(

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -109,8 +109,14 @@ def fetch_site_data_parallel(
         "network-monitoring/v1/sites-client-health",
     ]
 
+    # These endpoints are offset-paginated per the Aruba dev portal — they
+    # accept ``limit`` + ``offset`` only. Default cursor pagination here
+    # silently breaks for tenants with > SITE_LIMIT sites.
     with ThreadPoolExecutor(max_workers=3) as executor:
-        futures = [executor.submit(paginated_fetch, central_conn, endpoint, SITE_LIMIT) for endpoint in endpoints]
+        futures = [
+            executor.submit(paginated_fetch, central_conn, endpoint, SITE_LIMIT, use_cursor=False)
+            for endpoint in endpoints
+        ]
         results = [future.result() for future in futures]
 
     return process_site_health_data(*results)
@@ -134,16 +140,16 @@ def process_site_health_data(
         dict: Dictionary of site names to SiteData objects
     """
     processed_sites: dict[str, SiteData] = {
-        site["name"]: transform_to_site_data(site) for site in site_health if "name" in site
+        site["siteName"]: transform_to_site_data(site) for site in site_health if "siteName" in site
     }
 
     for site in device_health:
-        site_name = site.get("name", "")
+        site_name = site.get("siteName", "")
         if site_name in processed_sites:
             processed_sites[site_name].metrics.devices["Details"] = groups_to_map(site["deviceTypes"])
 
     for site in client_health:
-        site_name = site.get("name", "")
+        site_name = site.get("siteName", "")
         if site_name in processed_sites:
             processed_sites[site_name].metrics.clients["Details"] = groups_to_map(site["clientTypes"])
 
@@ -319,7 +325,7 @@ def transform_to_site_data(site_raw: dict) -> SiteData:
 
     return SiteData(
         site_id=str(site_raw.get("id", "")),
-        name=str(site_raw.get("name", "")),
+        name=str(site_raw.get("siteName", "")),
         address=site_raw.get("address", {}),
         location={"lat": lat, "lng": lng},
         metrics=metrics,

--- a/src/hpe_networking_mcp/platforms/site_health_check.py
+++ b/src/hpe_networking_mcp/platforms/site_health_check.py
@@ -220,8 +220,8 @@ async def _collect_central(ctx: Context, site_name: str, _window_hours: int) -> 
         health_obj = groups_to_map(match.get("health", {}))
         if all(k in health_obj for k in ["Poor", "Fair", "Good"]):
             summary.health_score = round(health_obj["Fair"] * 0.5 + health_obj["Good"] * 1)
-        summary.total_devices = match.get("devices", {}).get("total", 0)
-        summary.total_clients = match.get("clients", {}).get("total", 0)
+        summary.total_devices = match.get("devices", {}).get("count", 0)
+        summary.total_clients = match.get("clients", {}).get("count", 0)
     except Exception as e:
         logger.warning("site_health_check: Central site resolve failed — {}", e)
         summary.error = f"site resolve failed: {e}"

--- a/tests/unit/test_central_utils.py
+++ b/tests/unit/test_central_utils.py
@@ -9,6 +9,8 @@ from hpe_networking_mcp.platforms.central.utils import (
     _safe_float,
     build_odata_filter,
     compute_time_window,
+    process_site_health_data,
+    transform_to_site_data,
 )
 
 # ---------------------------------------------------------------------------
@@ -143,3 +145,175 @@ class TestSafeFloat:
 
     def test_returns_none_for_empty_string(self):
         assert _safe_float("") is None
+
+
+# ---------------------------------------------------------------------------
+# process_site_health_data + transform_to_site_data — pinned to the actual
+# Aruba Central /sites-health response shape (siteName, clients.count,
+# devices.count, alerts.totalCount, *.health.groups[]). Captured live from
+# a real tenant 2026-04-26. If the API ever renames these fields again,
+# these tests fail loudly instead of silently returning empty/zero data
+# (root cause of Zach's "0 clients" bug — fix landed in this PR).
+# ---------------------------------------------------------------------------
+
+
+def _sample_sites_health_response() -> list[dict]:
+    """Single-site fragment matching the live ``/sites-health`` response shape."""
+    return [
+        {
+            "siteName": "HOME",
+            "id": "18413656377",
+            "address": {"city": "Anytown", "country": "US"},
+            "location": {"latitude": "39.0", "longitude": "-77.0"},
+            "health": {
+                "groups": [
+                    {"name": "Poor", "value": 0},
+                    {"name": "Fair", "value": 0},
+                    {"name": "Good", "value": 1},
+                ]
+            },
+            "devices": {
+                "count": 17,
+                "health": {
+                    "groups": [
+                        {"name": "Poor", "value": 6},
+                        {"name": "Fair", "value": 1},
+                        {"name": "Good", "value": 10},
+                    ]
+                },
+            },
+            "clients": {
+                "count": 38,
+                "health": {
+                    "groups": [
+                        {"name": "Poor", "value": 0},
+                        {"name": "Fair", "value": 0},
+                        {"name": "Good", "value": 38},
+                    ]
+                },
+            },
+            "alerts": {
+                "totalCount": 3,
+                "groups": [{"name": "Critical", "count": 2}],
+            },
+        }
+    ]
+
+
+def _sample_sites_device_health_response() -> list[dict]:
+    """Single-site fragment matching the live ``/sites-device-health`` response shape."""
+    return [
+        {
+            "siteName": "HOME",
+            "id": "18413656377",
+            "type": "v1",
+            "deviceTypes": [
+                {
+                    "name": "Access Points",
+                    "health": {
+                        "groups": [
+                            {"name": "Poor", "value": 1},
+                            {"name": "Fair", "value": 0},
+                            {"name": "Good", "value": 3},
+                        ]
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def _sample_sites_client_health_response() -> list[dict]:
+    """Single-site fragment matching the live ``/sites-client-health`` response shape."""
+    return [
+        {
+            "siteName": "HOME",
+            "id": "18413656377",
+            "type": "v1",
+            "clientTypes": [
+                {
+                    "name": "Wired",
+                    "health": {
+                        "groups": [
+                            {"name": "Poor", "value": 0},
+                            {"name": "Fair", "value": 0},
+                            {"name": "Good", "value": 4},
+                        ]
+                    },
+                },
+                {
+                    "name": "Wireless",
+                    "health": {
+                        "groups": [
+                            {"name": "Poor", "value": 0},
+                            {"name": "Fair", "value": 0},
+                            {"name": "Good", "value": 34},
+                        ]
+                    },
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.unit
+class TestProcessSiteHealthData:
+    """Regression coverage for the ``name`` -> ``siteName`` field-rename bug."""
+
+    def test_processes_sites_keyed_by_site_name(self):
+        """Filtering on ``"name"`` (the old code) drops every site silently.
+        With ``"siteName"`` we keep them all.
+        """
+        result = process_site_health_data(
+            _sample_sites_health_response(),
+            _sample_sites_device_health_response(),
+            _sample_sites_client_health_response(),
+        )
+        assert "HOME" in result, (
+            "process_site_health_data must key on the 'siteName' field — "
+            "if this fails, the API response shape changed or the field-rename regressed"
+        )
+        assert len(result) == 1
+
+    def test_device_details_merge_on_site_name(self):
+        """Device-health enrichment must merge on ``siteName``, not ``name``."""
+        result = process_site_health_data(
+            _sample_sites_health_response(),
+            _sample_sites_device_health_response(),
+            _sample_sites_client_health_response(),
+        )
+        details = result["HOME"].metrics.devices.get("Details")
+        assert details is not None, "deviceTypes details missing — siteName merge regression"
+        assert "Access Points" in details
+
+    def test_client_details_merge_on_site_name(self):
+        """Client-health enrichment must merge on ``siteName``, not ``name``."""
+        result = process_site_health_data(
+            _sample_sites_health_response(),
+            _sample_sites_device_health_response(),
+            _sample_sites_client_health_response(),
+        )
+        details = result["HOME"].metrics.clients.get("Details")
+        assert details is not None, "clientTypes details missing — siteName merge regression"
+        assert "Wired" in details and "Wireless" in details
+
+
+@pytest.mark.unit
+class TestTransformToSiteData:
+    """Regression coverage for the SiteData.name field — must read from siteName."""
+
+    def test_name_is_read_from_site_name_field(self):
+        """The previous implementation read ``site_raw["name"]`` which doesn't
+        exist in the real response — yielding empty-string names everywhere.
+        """
+        site = transform_to_site_data(_sample_sites_health_response()[0])
+        assert site.name == "HOME", f"Expected 'HOME', got '{site.name}' — siteName mapping regressed"
+
+    def test_summary_total_derived_from_groups_when_count_present(self):
+        """Per-site totals come from summing the health.groups[] values via
+        the existing ``groups_to_map`` helper. Asserts the derivation works
+        end-to-end against the real shape.
+        """
+        site = transform_to_site_data(_sample_sites_health_response()[0])
+        assert site.metrics.devices["Summary"].get("Total") == 17
+        assert site.metrics.clients["Summary"].get("Total") == 38


### PR DESCRIPTION
## Summary

Reported by a user whose AI client noticed `site_health_check` returning 0 clients for a site that had real client traffic. Investigation traced it to four related bugs in the Aruba Central site-health code path — three field-name mismatches against the current API response shape, plus a pagination bug that silently truncates results for tenants with >100 sites.

| Bug | Tool | Symptom | Fix |
|---|---|---|---|
| 1 | `central_get_site_health` | Returned `[]` regardless of tenant data | `process_site_health_data` filtered on `"name"` — API returns `siteName` |
| 2 | `central_get_site_name_id_mapping` | `total_devices: 0` / `total_clients: 0` for every site | Read `clients.total` / `devices.total` — simplified shape uses `count` |
| 3 | `site_health_check` (cross-platform) | Same as Bug 2 | Same fix |
| 4 | `fetch_site_data_parallel` | Worked for ≤100 sites; silently truncated for larger tenants | Cursor pagination against offset-paginated endpoints; switched to `use_cursor=False` |

Reproduced in both `dynamic` and `code` modes — the underlying tools share the same code path regardless of how they're exposed.

## Verified live against a real tenant

| Tool | Before | After |
|---|---|---|
| `central_get_site_health` | `[]` | 13 sites returned, HOME = 38 clients / 17 devices with per-type breakdown |
| `central_get_site_name_id_mapping` (HOME) | `health: 0, total_devices: 0, total_clients: 0, total_alerts: 0` | `health: 81, total_devices: 17, total_clients: 38, total_alerts: 3` |

## Test plan

- [x] Live re-verified the two read tools above against a real Aruba Central tenant
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 568 passed (was 562; +6 new regression tests pinning the field-name parsing against captured response shapes)
- [x] CHANGELOG entry + version bump (`2.1.0.1` → `2.1.0.2`)