### PR TITLE
v2.2.0.0: reveal Axis Atmos Cloud as the 6th platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0.0] - 2026-04-26
+
+**Adds Axis Atmos Cloud as the 6th supported platform** — SASE / cloud-edge management via the Axis Atmos Admin API. Adds 25 underlying tools (12 read + 13 write) plus full documentation. The platform shipped behind the scenes in v2.1.0.x untagged commits and is publicly revealed here.
+
+### What Axis adds
+
+Axis Atmos Cloud is structurally different from the other five platforms — it manages a SASE/cloud-edge fabric rather than wired/wireless campus or datacenter infrastructure. The full tool surface:
+
+- **Connectors** (1 read + 1 write + 1 action) — tunnel-endpoint devices linking customer networks into Atmos. `axis_regenerate_connector` issues a fresh install command (immediate, not staged) and invalidates the prior one.
+- **Tunnels** (1 read + 1 write) — IPsec tunnels between customer sites and the Atmos cloud.
+- **Connector zones** (1 read + 1 write) — logical groupings of connectors.
+- **Locations + Sub-locations** (2 read + 2 write) — physical sites and nested subdivisions.
+- **Status helper** (1 cross-entity read) — `axis_get_status(entity_type, entity_id)` returns rich runtime telemetry for connectors (CPU/memory/disk/network/hostname/OS) and tunnels (connection state).
+- **Identity** (2 read + 2 write) — Atmos IdP users and groups.
+- **Applications + Application Groups** (2 read + 2 write) — published apps and tag-style groupings.
+- **Web Categories** (1 read + 1 write) — URL-classification categories for policy.
+- **SSL Exclusions** (1 read + 1 write) — hosts excluded from SSL inspection.
+- **Commit** (1 tool) — `axis_commit_changes` applies ALL pending staged writes for the tenant.
+
+### Staged-write workflow (Axis-specific)
+
+Every `axis_manage_*` write **stages** in Axis and only takes effect after `axis_commit_changes` runs — same pattern Axis enforces for changes made through the admin UI. Each write tool's response includes a `next_step` hint naming the commit tool. Commit is tenant-wide (no per-change selection) and uses a 60-second timeout. `axis_regenerate_connector` is the only mutation that does NOT stage.
+
+### JWT bearer auth + expiry surfacing
+
+Axis tokens are static JWTs generated in the admin portal at *Settings → Admin API → New API Token*. There is no refresh endpoint. The server decodes the `exp` claim at startup and:
+
+- Logs `Axis: token expires in N day(s)` at startup
+- Logs a warning when fewer than 30 days remain
+- The cross-platform `health(platform="axis")` tool returns `degraded` with a `token_expires_in_days` countdown when inside the warning window
+- A 401 surfaces a clear "regenerate at Settings → Admin API → New API Token" error
+
+### Disabled-but-on-disk
+
+Two endpoints documented in the Axis swagger return 403 even with read+write-scoped tokens — apparently hidden / unreleased upstream. Their tool implementations live on disk but are excluded from the registry via a `_DISABLED_TOOLS` dict in `platforms/axis/__init__.py`. Re-enabling either pair (`custom_ip_categories`, `ip_feed_categories`) is a one-line move when Axis flips them on.
+
+### Tool surface impact
+
+| Mode | Before | After |
+|---|---|---|
+| Dynamic (default, exposed to AI) | 19 tools (5 platforms × 3 meta + 4 cross-platform) | 22 tools (6 platforms × 3 meta + 4 cross-platform) |
+| Static (every tool registers individually) | 280+ visible | 305+ visible |
+
+Token cost in dynamic mode goes from ~3,100 to ~3,700 — the 600-token bump is the cost of three additional meta-tool entries. The four cross-platform aggregators (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) are unchanged.
+
+### Configuration
+
+| | |
+|---|---|
+| Secret | `secrets/axis_api_token` |
+| Write toggle | `ENABLE_AXIS_WRITE_TOOLS=true` (default `false`) |
+| Health probe | `health(platform="axis")` |
+| Auto-disables when | the secret file is missing or empty |
+
+### Tests
+
+571 tests passing (no new tests in this docs/reveal PR — Axis registry, write-tag, JWT-exp, and health-probe coverage all landed with the prior phases). Axis test coverage already includes:
+
+- Registry population (12 active reads + 13 active writes; the 4 disabled tools must NOT appear)
+- Every write carries `axis_write_delete` so the visibility transform + elicitation gate fires
+- Every `axis_manage_*` description references `axis_commit_changes` (regression on the staged-write contract)
+- ElicitationMiddleware reads `enable_axis_write_tools` and enables the `axis_write_delete` tag
+- JWT exp decoder: well-formed JWT, opaque token, missing `exp`
+- Health probe: outside warning, inside 30-day window, expired, undecodable
+
+### Bundles in this release
+
+- PR #198 — Phase 1 read-only surface (12 tools + JWT-exp surfacing + health-probe enrichment)
+- PR #199 — Phase 2 write surface (13 manage tools + commit + regenerate + ElicitationMiddleware fix)
+- This release — public reveal: docs (README capability matrix, INSTRUCTIONS.md tool categories, TOOLS.md overview + per-entity tables), uncomments compose entries, version bump 2.1.0.2 → 2.2.0.0
+
+### Not in this release
+
+- The Axis tools are not in scope for the cross-platform aggregators (`site_health_check`, `site_rf_check`, `manage_wlan_profile`) — Axis has no Wi-Fi / RF surface, and its "locations" concept doesn't map to the site-health aggregator's site model. Axis remains discoverable via the per-platform meta-trio in dynamic mode and via `tags(query=["axis"])` in code mode.
+
 ## [2.1.0.2] - 2026-04-26
 
 **Fixes site-health field-name mismatches that caused `central_get_site_health`, `central_get_site_name_id_mapping`, and `site_health_check` to silently report empty/zero data.**

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **Unofficial / community project.** This repository is an independent, community-driven project. It is not affiliated with, endorsed by, sponsored by, or supported by Hewlett Packard Enterprise, Aruba Networks, or Juniper Networks. "HPE", "Aruba", "Aruba Central", "Aruba ClearPass", "HPE GreenLake", "Juniper", and "Juniper Mist" are trademarks of their respective owners and are used here only to describe what this software interoperates with. Please direct support and licensing questions about those products to the respective vendors.
 
-A unified [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that brings **Juniper Mist**, **Aruba Central**, **HPE GreenLake**, **Aruba ClearPass**, and **Juniper Apstra** together into a single, deployable service. One container. One endpoint. All your HPE networking tools.
+A unified [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that brings **Juniper Mist**, **Aruba Central**, **HPE GreenLake**, **Aruba ClearPass**, **Juniper Apstra**, and **Axis Atmos Cloud** together into a single, deployable service. One container. One endpoint. All your HPE networking tools.
 
 ---
 
@@ -13,46 +13,50 @@ A unified [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server
 
 Managing HPE networking infrastructure with AI assistants today means juggling multiple separate MCP servers — each with its own setup, credentials, and quirks. This project consolidates them into one:
 
-| Category | Mist | Central | GreenLake | ClearPass | Apstra |
-|----------|:----:|:-------:|:---------:|:---------:|:------:|
-| **Sites / Health Overview** | ✅ | ✅ | — | — | — |
-| **WLANs / SSIDs** | ✅ | ✅ | — | — | — |
-| **Device Inventory** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Device Details (AP/Switch/GW)** | ✅ | ✅ | — | — | — |
-| **Device Stats & Utilization** | ✅ | ✅ | — | — | — |
-| **Client Connectivity** | ✅ | ✅ | — | — | — |
-| **Events** | ✅ | ✅ | — | ✅ | — |
-| **Alerts / Alarms** | ✅ | ✅ | — | ✅ | ✅ |
-| **Audit Logs** | ✅ | ✅ | ✅ | ✅ | — |
-| **Application Visibility** | — | ✅ | — | — | — |
-| **SLE / Performance Metrics** | ✅ | — | — | — | — |
-| **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — | — | — |
-| **Session Control / Client Disconnect** | — | ✅ | — | ✅ | — |
-| **Configuration Management** | ✅ | — | — | ✅ | ✅ |
-| **Configuration Write (CRUD)** | ✅ | — | — | ✅ | ✅ |
-| **Radio Resource Management** | ✅ | — | — | — | — |
-| **Rogue AP Detection** | ✅ | — | — | — | — |
-| **Firmware Management** | ✅ | — | — | — | — |
-| **Subscriptions / Licensing** | — | — | ✅ | ✅ | — |
-| **User Management** | — | — | ✅ | ✅ | — |
-| **Workspaces** | — | — | ✅ | — | — |
-| **Scope & Configuration Hierarchy** | — | ✅ | — | — | — |
-| **Guest Management** | — | — | — | ✅ | — |
-| **NAC / Policy Management** | — | — | — | ✅ | — |
-| **Endpoint Profiling** | — | — | — | ✅ | — |
-| **Certificates** | — | — | — | ✅ | — |
-| **Datacenter Blueprints / Templates** | — | — | — | — | ✅ |
-| **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ |
-| **Connectivity Templates / Policy Apply** | — | — | — | — | ✅ |
-| **Fabric Deploy / Diff Status** | — | — | — | — | ✅ |
-| **BGP / Protocol Session Monitoring** | — | — | — | — | ✅ |
-| **Guided Prompts** | ✅ | ✅ | — | — | — |
-| **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **140** | **19** |
-| **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** |
-| **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — |
+| Category | Mist | Central | GreenLake | ClearPass | Apstra | Axis |
+|----------|:----:|:-------:|:---------:|:---------:|:------:|:----:|
+| **Sites / Health Overview** | ✅ | ✅ | — | — | — | — |
+| **WLANs / SSIDs** | ✅ | ✅ | — | — | — | — |
+| **Device Inventory** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Device Details (AP/Switch/GW)** | ✅ | ✅ | — | — | — | — |
+| **Device Stats & Utilization** | ✅ | ✅ | — | — | — | ✅ |
+| **Client Connectivity** | ✅ | ✅ | — | — | — | — |
+| **Events** | ✅ | ✅ | — | ✅ | — | — |
+| **Alerts / Alarms** | ✅ | ✅ | — | ✅ | ✅ | — |
+| **Audit Logs** | ✅ | ✅ | ✅ | ✅ | — | — |
+| **Application Visibility** | — | ✅ | — | — | — | ✅ |
+| **SLE / Performance Metrics** | ✅ | — | — | — | — | — |
+| **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — | — | — | — |
+| **Session Control / Client Disconnect** | — | ✅ | — | ✅ | — | — |
+| **Configuration Management** | ✅ | — | — | ✅ | ✅ | ✅ |
+| **Configuration Write (CRUD)** | ✅ | — | — | ✅ | ✅ | ✅ |
+| **Radio Resource Management** | ✅ | — | — | — | — | — |
+| **Rogue AP Detection** | ✅ | — | — | — | — | — |
+| **Firmware Management** | ✅ | — | — | — | — | — |
+| **Subscriptions / Licensing** | — | — | ✅ | ✅ | — | — |
+| **User Management** | — | — | ✅ | ✅ | — | ✅ |
+| **Workspaces** | — | — | ✅ | — | — | — |
+| **Scope & Configuration Hierarchy** | — | ✅ | — | — | — | ✅ |
+| **Guest Management** | — | — | — | ✅ | — | — |
+| **NAC / Policy Management** | — | — | — | ✅ | — | — |
+| **Endpoint Profiling** | — | — | — | ✅ | — | — |
+| **Certificates** | — | — | — | ✅ | — | — |
+| **Datacenter Blueprints / Templates** | — | — | — | — | ✅ | — |
+| **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ | — |
+| **Connectivity Templates / Policy Apply** | — | — | — | — | ✅ | — |
+| **Fabric Deploy / Diff Status** | — | — | — | — | ✅ | — |
+| **BGP / Protocol Session Monitoring** | — | — | — | — | ✅ | — |
+| **SASE Cloud Connectors / Tunnels** | — | — | — | — | — | ✅ |
+| **URL / Web Category Filtering** | — | — | — | — | — | ✅ |
+| **SSL Inspection Exclusions** | — | — | — | — | — | ✅ |
+| **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ |
+| **Guided Prompts** | ✅ | ✅ | — | — | — | — |
+| **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **140** | **19** | **25** |
+| **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** | **3** |
+| **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — |
 
-> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **19 tools total, ~3,100 tokens** — down from 275 tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`). **22 tools total, ~3,700 tokens** for the six-platform configuration — down from 275+ tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -142,7 +146,12 @@ cp secrets/apstra_port.example secrets/apstra_port
 cp secrets/apstra_username.example secrets/apstra_username
 cp secrets/apstra_password.example secrets/apstra_password
 cp secrets/apstra_verify_ssl.example secrets/apstra_verify_ssl
+
+# Axis Atmos Cloud
+cp secrets/axis_api_token.example secrets/axis_api_token
 ```
+
+> **Axis token note**: Generate the token in the Axis admin portal at *Settings → Admin API → New API Token*. Pick read or read+write scope and an expiration. The MCP server decodes the JWT's `exp` claim at startup and logs a warning when the token has fewer than 30 days remaining; the `health` tool also surfaces a `token_expires_in_days` countdown when inside that window. There is no refresh — regenerate the token in the portal before it lapses.
 
 Each file contains a single value (e.g., your API token). **Do not leave placeholder contents** (like `apstra.example.com` or `replace-with-real-password`) in a file for a platform you're not using — the server will try to authenticate with those fake values at startup and fill your logs with failed-login errors. If you're not using a platform, use Path B below (override file) or leave the secret file empty — the app treats an empty file as "not configured" and disables the platform.
 
@@ -173,7 +182,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 tools registered`, `ClearPass: 140 tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 19 tools are exposed to the AI — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
+Look for lines like `Mist: 35 tools registered`, `ClearPass: 140 tools registered`, `Axis: 25 underlying tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 22 tools are exposed to the AI when all six platforms are enabled — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
 
 ### Docker Image
 
@@ -194,9 +203,9 @@ docker pull ghcr.io/nowireless4u/hpe-networking-mcp:latest
 
 ## Platform Auto-Disable
 
-You don't need credentials for all five platforms. The server detects which platforms have valid secret content at startup and only enables those. A platform is disabled if any of its required secret files is **empty or absent** from `SECRETS_DIR` (inside the container) — which, under Docker Compose, means the file on disk was empty or you used a `docker-compose.override.yml` to drop that platform's secrets entirely (see [Disable platforms you don't use](#3-disable-platforms-you-dont-use-recommended)).
+You don't need credentials for all six platforms. The server detects which platforms have valid secret content at startup and only enables those. A platform is disabled if any of its required secret files is **empty or absent** from `SECRETS_DIR` (inside the container) — which, under Docker Compose, means the file on disk was empty or you used a `docker-compose.override.yml` to drop that platform's secrets entirely (see [Disable platforms you don't use](#3-disable-platforms-you-dont-use-recommended)).
 
-- **All five platforms configured** → All tools available (Mist + Central + GreenLake + ClearPass + Apstra)
+- **All six platforms configured** → All tools available (Mist + Central + GreenLake + ClearPass + Apstra + Axis)
 - **Only Mist configured** → Only `mist_*` tools available; other platforms disabled
 - **Only ClearPass configured** → Only `clearpass_*` tools available; other platforms disabled
 - **No valid credentials** → Server refuses to start with a clear error message
@@ -367,33 +376,33 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 ┌───────────────────────────────────────────────────────────────────────────────────┐
 │                HPE Networking MCP Server (:8000)  —  MCP_TOOL_MODE=dynamic        │
 │                                                                                   │
-│   Exposed to the AI  (18 tools total):                                            │
-│     • 3 cross-platform static tools: health, site_health_check,                   │
-│       manage_wlan_profile                                                         │
-│     • 5 × 3 per-platform meta-tools: <platform>_list_tools,                       │
+│   Exposed to the AI  (22 tools total when all 6 platforms enabled):               │
+│     • 4 cross-platform static tools: health, site_health_check,                   │
+│       site_rf_check, manage_wlan_profile                                          │
+│     • 6 × 3 per-platform meta-tools: <platform>_list_tools,                       │
 │       <platform>_get_tool_schema, <platform>_invoke_tool                          │
 │                                                                                   │
-│ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐        │
-│ │    Mist    │ │  Central   │ │ GreenLake  │ │ ClearPass  │ │   Apstra   │        │
-│ │   mist_*   │ │ central_*  │ │greenlake_* │ │clearpass_* │ │  apstra_*  │        │
-│ │ 35 tools   │ │ 73 tools   │ │ 10 tools   │ │ 140 tools  │ │  19 tools  │        │
-│ │ + 2 prmt   │ │ + 12 prmt  │ │            │ │            │ │            │        │
-│ │            │ │            │ │            │ │            │ │            │        │
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│ │   Mist   │ │ Central  │ │GreenLake │ │ClearPass │ │  Apstra  │ │   Axis   │    │
+│ │  mist_*  │ │central_* │ │greenlake │ │clearpass │ │ apstra_* │ │ axis_*   │    │
+│ │ 35 tools │ │ 73 tools │ │ 10 tools │ │140 tools │ │ 19 tools │ │ 25 tools │    │
+│ │ + 2 prmt │ │+ 12 prmt │ │          │ │          │ │          │ │          │    │
+│ │          │ │          │ │          │ │          │ │          │ │          │    │
 │ │  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.       │
-│ └──────┬─────┘ └──────┬─────┘ └──────┬─────┘ └──────┬─────┘ └──────┬─────┘        │
-│        │              │              │              │              │              │
-└────────┼──────────────┼──────────────┼──────────────┼──────────────┼──────────────┘
-         ▼              ▼              ▼              ▼              ▼
-    Mist Cloud     Aruba Central   GreenLake API  ClearPass CPPM    Apstra
-       API             API                             API        Fabric API
+│ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘    │
+│      │            │            │            │            │            │           │
+└──────┼────────────┼────────────┼────────────┼────────────┼────────────┼───────────┘
+       ▼            ▼            ▼            ▼            ▼            ▼
+   Mist Cloud  Aruba Central GreenLake API ClearPass CPPM   Apstra   Axis Atmos
+      API           API                          API     Fabric API   Cloud API
 ```
 
 **Key design decisions:**
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Dynamic tool mode by default** — each platform exposes 3 meta-tools; the AI discovers the 280 underlying tools on demand. Keeps the tool-schema payload small enough to fit in a 32K-context local LLM.
-- **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*` prefixes prevent collisions
+- **Dynamic tool mode by default** — each platform exposes 3 meta-tools; the AI discovers the 300+ underlying tools on demand. Keeps the tool-schema payload small enough to fit in a 32K-context local LLM.
+- **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
 
@@ -403,7 +412,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 
 Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) are supported with safety controls:
 
-- **Disabled by default** — enable per-platform with `ENABLE_MIST_WRITE_TOOLS=true`, `ENABLE_CENTRAL_WRITE_TOOLS=true`, `ENABLE_CLEARPASS_WRITE_TOOLS=true`, or `ENABLE_APSTRA_WRITE_TOOLS=true`
+- **Disabled by default** — enable per-platform with `ENABLE_MIST_WRITE_TOOLS=true`, `ENABLE_CENTRAL_WRITE_TOOLS=true`, `ENABLE_CLEARPASS_WRITE_TOOLS=true`, `ENABLE_APSTRA_WRITE_TOOLS=true`, or `ENABLE_AXIS_WRITE_TOOLS=true`
 - **Elicitation required** — write tools prompt for user confirmation before executing
 - **Annotation-based** — all tools carry MCP annotations (`readOnlyHint`, `destructiveHint`, etc.)
 
@@ -413,6 +422,7 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 | `ENABLE_CENTRAL_WRITE_TOOLS` | `false` | Enable Central write/mutation tools |
 | `ENABLE_CLEARPASS_WRITE_TOOLS` | `false` | Enable ClearPass write/mutation tools |
 | `ENABLE_APSTRA_WRITE_TOOLS` | `false` | Enable Apstra write/mutation tools |
+| `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis Atmos Cloud write/mutation tools (every write stages — call `axis_commit_changes` to apply) |
 | `DISABLE_ELICITATION` | `false` | Skip user confirmation for write tools (**use with caution**) |
 
 ---
@@ -428,8 +438,9 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 | `ENABLE_CENTRAL_WRITE_TOOLS` | `false` | Enable Central write/mutation tools |
 | `ENABLE_CLEARPASS_WRITE_TOOLS` | `false` | Enable ClearPass write/mutation tools |
 | `ENABLE_APSTRA_WRITE_TOOLS` | `false` | Enable Apstra write/mutation tools |
+| `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (18 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 280+ visible) |
+| `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (22 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 300+ visible) |
 
 ---
 
@@ -493,11 +504,13 @@ hpe-networking-mcp/
 │       ├── central/             # 73 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
 │       ├── clearpass/           # 140 ClearPass tools + pyclearpass SDK client
-│       ├── apstra/              # 21 Apstra tools + async httpx client
+│       ├── apstra/              # 19 Apstra tools + async httpx client
+│       ├── axis/                # 25 Axis Atmos Cloud tools + httpx client (JWT bearer)
 │       ├── manage_wlan.py       # Cross-platform WLAN management tool
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
-│       └── site_health_check.py # Cross-platform site health aggregator
-├── tests/                       # Unit and integration tests (421+ unit tests)
+│       ├── site_health_check.py # Cross-platform site health aggregator
+│       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
+├── tests/                       # Unit and integration tests (568+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish
@@ -613,9 +626,9 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (18 tools vs. 260+)
+### Tool Surface Looks Wrong (22 tools vs. 300+)
 
-Since v2.0.0.0, every platform runs in dynamic mode by default: each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) and the underlying tools are discoverable through them. A correctly configured server with all 5 platforms enabled will advertise **18 tools** to the AI client — 15 meta-tools + 3 cross-platform static tools (`health`, `site_health_check`, `manage_wlan_profile`).
+Since v2.0.0.0, every platform runs in dynamic mode by default: each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) and the underlying tools are discoverable through them. A correctly configured server with all 6 platforms enabled will advertise **22 tools** to the AI client — 18 meta-tools + 4 cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`).
 
 Check the mode in the logs:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ENABLE_CENTRAL_WRITE_TOOLS=${ENABLE_CENTRAL_WRITE_TOOLS:-false}
       - ENABLE_CLEARPASS_WRITE_TOOLS=${ENABLE_CLEARPASS_WRITE_TOOLS:-false}
       - ENABLE_APSTRA_WRITE_TOOLS=${ENABLE_APSTRA_WRITE_TOOLS:-false}
-      # - ENABLE_AXIS_WRITE_TOOLS=${ENABLE_AXIS_WRITE_TOOLS:-false}
+      - ENABLE_AXIS_WRITE_TOOLS=${ENABLE_AXIS_WRITE_TOOLS:-false}
       - DISABLE_ELICITATION=${DISABLE_ELICITATION:-false}
       - MCP_TOOL_MODE=${MCP_TOOL_MODE:-dynamic}
     secrets:
@@ -42,7 +42,7 @@ services:
       - apstra_password
       - apstra_verify_ssl
       # Axis Atmos Cloud (remove lines for platforms you don't use)
-      # - axis_api_token
+      - axis_api_token
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "uv", "run", "--no-sync", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5)"]
@@ -96,5 +96,5 @@ secrets:
   apstra_verify_ssl:
     file: ./secrets/apstra_verify_ssl
   # Axis Atmos Cloud
-  # axis_api_token:
-  #   file: ./secrets/axis_api_token
+  axis_api_token:
+    file: ./secrets/axis_api_token

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -31,7 +31,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (0)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |
@@ -78,11 +78,12 @@ If you're not sure, stay on `dynamic`. Code mode is meant for measurement + eval
 | Aruba ClearPass | 65 | 75 | -- | 140 |
 | Juniper Apstra | 12 | 7 | -- | 19 |
 | HPE GreenLake | 10 | -- | -- | 10 |
+| Axis Atmos Cloud | 12 | 13 | -- | 25 |
 | Cross-Platform | 3 | 1 | 3 | 7 |
 
 Write tools are disabled by default per platform. Enable them with environment variables:
 `ENABLE_MIST_WRITE_TOOLS=true`, `ENABLE_CENTRAL_WRITE_TOOLS=true`,
-`ENABLE_CLEARPASS_WRITE_TOOLS=true`, or `ENABLE_APSTRA_WRITE_TOOLS=true`. Elicitation applies in both tool modes — the AI still gets a confirmation prompt before a destructive call, whether it invoked the tool directly (static mode) or through `<platform>_invoke_tool` (dynamic mode).
+`ENABLE_CLEARPASS_WRITE_TOOLS=true`, `ENABLE_APSTRA_WRITE_TOOLS=true`, or `ENABLE_AXIS_WRITE_TOOLS=true`. Elicitation applies in both tool modes — the AI still gets a confirmation prompt before a destructive call, whether it invoked the tool directly (static mode) or through `<platform>_invoke_tool` (dynamic mode).
 
 ## Cross-platform static tools
 
@@ -1734,3 +1735,114 @@ elicitation confirmation flow.
 | `apstra_create_virtual_network` | Create a VXLAN or VLAN virtual network via `virtual-networks-batch` |
 | `apstra_create_remote_gateway` | Create a remote EVPN gateway |
 | `apstra_apply_ct_policies` | Apply or remove connectivity-template policies on interfaces |
+
+---
+
+## Axis Atmos Cloud (25 tools)
+
+Axis tools wrap the Axis Atmos Cloud Admin API
+(`https://admin-api.axissecurity.com/api/v1.0`). Auth is a static JWT
+bearer token generated in the Axis admin portal at *Settings → Admin API
+→ New API Token* — there is no refresh endpoint, so the server decodes
+the token's `exp` claim at startup and surfaces a `token_expires_in_days`
+countdown when inside the 30-day warning window. Write tools require
+`ENABLE_AXIS_WRITE_TOOLS=true`; every write **stages** in Axis and the
+caller must invoke `axis_commit_changes` to apply pending edits — the
+same workflow Axis enforces for changes made through the admin UI.
+
+All read tools accept optional `page_number` (1-indexed) and
+`page_size` (max 100) parameters. The Axis API uses offset-based
+pagination with a `PagedApiResponse<IEnumerable<T>>` envelope; the
+response is passed through unchanged so callers see `totalRecords`,
+`totalPages`, and `nextPage`/`firstPage`/`lastPage` cursors.
+
+### Connectors (1 read + 1 write + 1 action)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_connectors` | List or get connectors (tunnel-endpoint devices) by GUID |
+| `axis_manage_connector` | Create, update, or delete a connector. Stages — call `axis_commit_changes` |
+| `axis_regenerate_connector` | Issue a fresh installation command for an existing connector. **Invalidates the prior install command.** Immediate (not staged) |
+
+### Tunnels (1 read + 1 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_tunnels` | List or get tunnels by GUID |
+| `axis_manage_tunnel` | Create, update, or delete a tunnel. Stages — call `axis_commit_changes` |
+
+### Connector Zones (1 read + 1 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_connector_zones` | List or get connector zones (groupings of connectors) |
+| `axis_manage_connector_zone` | Create, update, or delete a connector zone. Stages — call `axis_commit_changes` |
+
+### Locations and Sub-Locations (2 read + 2 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_locations` | List or get locations (physical sites) |
+| `axis_get_sub_locations` | List or get sub-locations under a parent location (location-scoped) |
+| `axis_manage_location` | Create, update, or delete a location. Stages — call `axis_commit_changes` |
+| `axis_manage_sub_location` | Create, update, or delete a sub-location under a parent location. Stages |
+
+### Status (cross-entity helper)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_status` | Runtime status for a connector or tunnel (`entity_type='connector' \| 'tunnel'`, `entity_id=GUID`). Connector status returns rich telemetry — CPU/memory/disk/network, hostname, OS version. Tunnel status returns connection state |
+
+### Identity — Users and Groups (2 read + 2 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_users` | List or get Axis IdP users |
+| `axis_get_groups` | List or get IdP user groups |
+| `axis_manage_user` | Create, update, or delete a user. Stages — call `axis_commit_changes` |
+| `axis_manage_group` | Create, update, or delete a group. Stages — call `axis_commit_changes` |
+
+### Applications and Application Groups (2 read + 2 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_applications` | List or get published applications |
+| `axis_get_application_groups` | List or get application groups (referred to as "tags" in the API) |
+| `axis_manage_application` | Create, update, or delete an application. Stages — call `axis_commit_changes` |
+| `axis_manage_application_group` | Create, update, or delete an application group / tag. Stages |
+
+### Web Categories (1 read + 1 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_web_categories` | List or get URL-classification categories used in policy |
+| `axis_manage_web_category` | Create, update, or delete a web category. Stages — call `axis_commit_changes` |
+
+### SSL Exclusions (1 read + 1 write)
+
+| Tool | Description |
+|------|-------------|
+| `axis_get_ssl_exclusions` | List or get hosts excluded from SSL inspection |
+| `axis_manage_ssl_exclusion` | Create, update, or delete an SSL exclusion. Stages — call `axis_commit_changes` |
+
+### Commit (1 tool)
+
+| Tool | Description |
+|------|-------------|
+| `axis_commit_changes` | `POST /Commit` — apply ALL pending staged writes for the tenant. Tenant-wide; no per-change selection. Uses a 60s timeout because commit can take a while when there's a lot staged |
+
+### Currently disabled (kept on disk, off the registry)
+
+These endpoints exist in the Axis swagger but return 403 even with
+fully-scoped tokens — Axis appears to gate them server-side without a
+corresponding scope toggle in the admin portal (likely
+unreleased / hidden APIs). The implementations stay on disk so
+re-enabling is a one-line move from `_DISABLED_TOOLS` back into `TOOLS`
+in `platforms/axis/__init__.py` if Axis ever flips them on.
+
+| Tool | Endpoint |
+|------|----------|
+| `axis_get_custom_ip_categories` | `GET /api/v1.0/IpCategories` |
+| `axis_manage_custom_ip_category` | `POST/PUT/DELETE /api/v1.0/IpCategories` |
+| `axis_get_ip_feed_categories` | `GET /api/v1.0/IpCategoriesFeed` |
+| `axis_manage_ip_feed_category` | `POST/PUT/DELETE /api/v1.0/IpCategoriesFeed` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.1.0.2"
+version = "2.2.0.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -481,6 +481,52 @@ If pending changes exist after a create/update, ask the user whether to deploy b
 
 ---
 
+# AXIS ATMOS CLOUD (axis_* tools)
+
+Axis Atmos Cloud is a SASE / cloud-edge platform — secure access to corporate apps via cloud-managed connectors and tunnels. Tools wrap the Atmos Admin API at `admin-api.axissecurity.com/api/v1.0` with JWT bearer auth.
+
+## Starting an Axis Session
+No special ID resolution needed. Tools connect directly using the configured `axis_api_token`. The token is decoded at startup and the server logs `Axis: token expires in N day(s)` so operators see how long they have before regenerating.
+
+## Tool Categories
+- **Connectors**: axis_get_connectors, axis_manage_connector, axis_regenerate_connector — Tunnel-endpoint devices linking customer networks into Atmos. `axis_regenerate_connector` issues a fresh installation command and **invalidates the prior install command** (use carefully).
+- **Tunnels**: axis_get_tunnels, axis_manage_tunnel — IPsec tunnels between customer locations and the Atmos cloud.
+- **Connector Zones**: axis_get_connector_zones, axis_manage_connector_zone — Logical groupings of connectors.
+- **Locations**: axis_get_locations, axis_get_sub_locations, axis_manage_location, axis_manage_sub_location — Physical sites and their subdivisions. Sub-locations are nested under a parent location.
+- **Status**: axis_get_status (entity_type='connector'|'tunnel') — Runtime status. Connector status returns rich telemetry (CPU/memory/disk/network, hostname, OS version); tunnel status returns connection state.
+- **Identity**: axis_get_users, axis_get_groups, axis_manage_user, axis_manage_group — Atmos IdP user and group records.
+- **Applications**: axis_get_applications, axis_get_application_groups, axis_manage_application, axis_manage_application_group — Published apps and tag-style groupings (the API path is `/Tags`).
+- **Web Categories**: axis_get_web_categories, axis_manage_web_category — URL-classification categories used in policy.
+- **SSL Exclusions**: axis_get_ssl_exclusions, axis_manage_ssl_exclusion — Hosts excluded from SSL inspection.
+- **Commit**: axis_commit_changes — Apply ALL pending staged writes for the tenant.
+
+For Axis reachability call `health(platform="axis")` — when the JWT has fewer than 30 days remaining, the probe returns `degraded` with a `token_expires_in_days` countdown so the AI can warn the operator before the token lapses.
+
+## Staged Writes — the Commit Workflow
+
+This is the single most important Axis-specific behavior. Every `axis_manage_*` write **stages**: it returns success but the change does not affect production until `axis_commit_changes` runs. This mirrors how the Axis admin UI works — edits live in a draft state until the operator commits.
+
+- After every successful `axis_manage_*` call, the response carries `next_step: "Call axis_commit_changes to apply these staged changes."`
+- Multiple writes can stage before a single commit — preferred for related changes (e.g., creating a location and then a sub-location under it).
+- `axis_commit_changes` is **tenant-wide**: it applies every queued change for this tenant. There is no per-change selection.
+- `axis_regenerate_connector` is the only mutation that does NOT stage — it is immediate.
+- The commit endpoint can take a while when there's a lot staged; the tool uses a 60-second timeout for that single call.
+
+When the user asks for a sequence of changes, prefer staging them all first and committing once at the end. After commit, verify with the relevant `axis_get_*` to confirm the change landed.
+
+## Pagination
+List endpoints use offset-based pagination: `page_number` (1-indexed) and `page_size` (max 100). Response envelope includes `totalRecords`, `totalPages`, and `nextPage` cursor URI for chaining.
+
+## Token Expiry
+The Axis token has no refresh mechanism. When `health(platform="axis")` returns `token_expires_in_days <= 30`, surface that to the user immediately and link them to *Settings → Admin API → New API Token* in the Axis admin portal. Once expired, every Axis tool returns a 401 with a clear regenerate-the-token error message.
+
+## Safety Notes
+- Write tools require `ENABLE_AXIS_WRITE_TOOLS=true` and prompt for elicitation confirmation.
+- `axis_regenerate_connector` invalidates the prior install command — anyone holding the old command can no longer use it. Always confirm with the user before calling it.
+- Write tools reply `{"status": "confirmation_required", ...}` when the MCP client cannot present an elicitation prompt. When you see that, ask the user in chat and re-invoke with `confirmed=True`.
+
+---
+
 # STYLING
 
 ## Tables

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -1,16 +1,17 @@
 """Axis Atmos Cloud platform module.
 
-Axis is shipped as a hidden platform: it auto-disables when its single
-``axis_api_token`` secret is missing and stays unreferenced in any
-public-facing documentation until the user chooses to announce it. See
-the scratch directory's ``AXIS_ATMOS_INTEGRATION_PLAN.md`` for the full
-plan.
+Wraps the Axis Atmos Admin API at
+``https://admin-api.axissecurity.com/api/v1.0`` for SASE / cloud-edge
+management — connectors, tunnels, locations, identity, applications,
+web-category and SSL-exclusion policy. Auto-disables when the
+``axis_api_token`` secret is missing or empty.
 
-Phase 1: scaffold + secret loader + health probe + 12 read tools.
-Phase 2: 13 ``axis_manage_*`` write tools, ``axis_commit_changes``, and
-``axis_regenerate_connector``. Reads carry no write tag; writes carry
-``axis_write_delete`` so the visibility transform gates them on
-``ENABLE_AXIS_WRITE_TOOLS=true``.
+Reads carry no write tag; writes carry ``axis_write_delete`` so the
+visibility transform + elicitation middleware gate them on
+``ENABLE_AXIS_WRITE_TOOLS=true``. Every ``axis_manage_*`` write stages —
+the caller invokes ``axis_commit_changes`` to apply pending edits,
+matching the workflow Axis enforces for changes made through the admin
+UI.
 """
 
 import importlib


### PR DESCRIPTION
## Summary

- Adds **Axis Atmos Cloud (SASE / cloud-edge)** as the 6th supported platform. The 25-tool implementation already landed via PR #198 (reads) and PR #199 (writes), both untagged. This release publicly reveals it.
- All public docs updated in this same PR per the documentation-checklist rule: README capability matrix gains an Axis column + 4 new SASE rows, INSTRUCTIONS.md gets a full AXIS section, docs/TOOLS.md gets an overview-table row + a per-entity Axis section.
- Compose entries uncommented (`ENABLE_AXIS_WRITE_TOOLS`, `axis_api_token` secret reference + block).
- Version bump `2.1.0.2 → 2.2.0.0`.

## Why a minor bump?

Adding a whole new platform is a meaningful capability change. Patch versions in this project are reserved for fixes/small features within an existing platform's surface; introducing a sixth platform with its own auth, staged-write workflow, JWT-expiry tracking, and 25 tools warrants `2.x → 2.y`.

## Tool surface impact

| Mode | Before | After |
|---|---|---|
| Dynamic (default) | 19 tools | 22 tools (+3 meta) |
| Static | 280+ visible | 305+ visible |

Token cost in dynamic mode goes from ~3,100 to ~3,700 — the 600-token bump is the cost of three additional meta-tool entries.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 571 passed
- [x] Documentation checklist (per CLAUDE.md):
  - [x] README.md — capability matrix, architecture diagram, project structure, configuration env vars
  - [x] CHANGELOG.md — v2.2.0.0 entry
  - [x] INSTRUCTIONS.md — AXIS tool-categories + commit-workflow section
  - [x] docs/TOOLS.md — overview table + per-entity tables
  - [x] pyproject.toml — version bump

## Post-merge

Tag `v2.2.0.0` → GHCR Docker Publish workflow auto-builds → `:latest` rolls forward to v2.2.0.0.