### PR TITLE
v2.2.0.1: code-mode error handling — return strings instead of raising (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0.1] - 2026-04-27
+
+**Fixes tool-level `raise` patterns that crashed the entire `execute()` block in `MCP_TOOL_MODE=code`.** When a tool raised `ValueError` / `TypeError` / `RuntimeError`, the exception propagated through FastMCP's `call_tool` machinery as `MontyRuntimeError` and the AI's `try/except` inside the sandbox could not catch it. Closes #202.
+
+### Background
+
+Code mode replaces the exposed catalog with a 4-tool surface (`tags` / `search` / `get_schema` / `execute`); the LLM writes Python in `execute(code)` and dispatches via `call_tool(name, params)`. When a tool raises, the exception bubbles up at the runtime layer above the AI's Python — the `execute()` call returns "Error calling tool 'execute'" and the AI never sees the validation message. Same code path is fine in dynamic and static modes because the meta-tool wrapper (`<platform>_invoke_tool`) catches the exception and surfaces it as a structured tool result.
+
+### Affected tools (now return error strings)
+
+| Platform | Tool | What used to raise |
+|---|---|---|
+| GreenLake | `greenlake_get_users` | `_coerce_int` invalid `limit` / `offset` |
+| GreenLake | `greenlake_get_user_details` | empty `id` |
+| GreenLake | `greenlake_get_devices` | `_coerce_int` invalid `limit` / `offset` |
+| GreenLake | `greenlake_get_device_by_id` | empty `id` |
+| GreenLake | `greenlake_get_subscriptions` | `_coerce_int` invalid `limit` / `offset` |
+| GreenLake | `greenlake_get_subscription_details` | empty `id` |
+| GreenLake | `greenlake_get_audit_logs` | `_coerce_int` invalid `limit` / `offset` |
+| GreenLake | `greenlake_get_audit_log_details` | empty `id` |
+| GreenLake | `greenlake_get_workspace` | empty `workspaceId` |
+| GreenLake | `greenlake_get_workspace_details` | empty `workspaceId` |
+| Mist | `mist_get_insight_metrics` | `_mac_to_device_id` invalid MAC |
+| Mist | `mist_get_configuration_object_schema` | schema-not-found |
+| Central | `central_get_alerts` | `build_odata_filter` invalid value |
+| Central | `central_get_clients` | `build_odata_filter` invalid value |
+| Central | `central_get_devices` | `build_odata_filter` invalid value |
+| Central | `central_find_device` | `build_odata_filter` invalid value |
+| Central | `central_get_aps` (monitoring) | `build_odata_filter` invalid value |
+| Central | `central_get_events` | `compute_time_window` invalid `time_range` |
+| Central | `central_get_events_count` | `compute_time_window` invalid `time_range` |
+
+Pattern: each tool now wraps the validation/helper call in a top-level `try/except ValueError` and `return f"Error: {e}"` (or returns an error string directly). Helpers (`_coerce_int`, `compute_time_window`, `build_odata_filter`) keep their existing raising contract — only public tool entries that face the LLM had to be made code-mode-safe.
+
+`_mac_to_device_id` was changed from raising to returning `None` because its existing call sites flow through `handle_network_error` → `ToolError`, which also crashed the sandbox. Now the calling tool checks for `None` and returns an error string explicitly.
+
+### Verified live against the running container
+
+```
+greenlake_get_user_details(id="")        → "Error: id is required and cannot be empty"
+greenlake_get_users(limit="abc")         → "Error: Parameter 'limit' must be an integer, got 'abc'"
+mist_get_insight_metrics(mac="not-a-mac", object_type="ap")
+                                          → "Error: invalid MAC address format: 'not-a-mac'"
+```
+
+All previously crashed `execute()` with `MontyRuntimeError`. All now return strings the AI can branch on.
+
+### Tests
+
+6 new tests in `tests/unit/test_code_mode.py::TestCodeModeErrorReturns`:
+- 3 dynamic tests calling the fixed tools directly with bad input
+- 1 contract test pinning `_mac_to_device_id` returns `None` instead of raising
+- 1 contract test pinning `_coerce_int` still raises (helpers stay raising; only entry points are wrapped)
+- 1 static AST guard scanning every public function in `greenlake/tools/*.py` and failing if a `raise` re-appears (catches future regressions for free)
+
+Total suite: 571 → 577 passing.
+
+### Out of scope
+
+The 19 raises in `apstra/models.py` are Pydantic field validators. Their `ValueError` becomes a `ValidationError` that fires during FastMCP parameter coercion *before* the tool function runs. Same crash symptom, but the fix lives at the FastMCP middleware layer, not in tool code. Tracking that separately if it becomes a real-world friction point.
+
 ## [2.2.0.0] - 2026-04-26
 
 **Adds Axis Atmos Cloud as the 6th supported platform** — SASE / cloud-edge management via the Axis Atmos Admin API. Adds 25 underlying tools (12 read + 13 write) plus full documentation. The platform shipped behind the scenes in v2.1.0.x untagged commits and is publicly revealed here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.2.0.0"
+version = "2.2.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -75,7 +75,10 @@ async def central_get_alerts(
     pairs = [(ALERT_FILTER_FIELDS[k], v) for k, v in raw_pairs if v is not None]
 
     query_params: dict = {"sort": sort}
-    odata = build_odata_filter(pairs)
+    try:
+        odata = build_odata_filter(pairs)
+    except ValueError as e:
+        return f"Error: {e}"
     if odata:
         query_params["filter"] = odata
 

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -70,7 +70,10 @@ async def central_get_clients(
         ("tunnel_type", tunnel_type),
     ]
     pairs = [(CLIENT_FILTER_FIELDS[k], v) for k, v in raw_pairs if v is not None]
-    filter_str = build_odata_filter(pairs)
+    try:
+        filter_str = build_odata_filter(pairs)
+    except ValueError as e:
+        return f"Error: {e}"
 
     try:
         clients = Clients.get_all_clients(

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -79,7 +79,10 @@ async def central_get_devices(
             )
         )
 
-    filter_str = build_odata_filter(pairs)
+    try:
+        filter_str = build_odata_filter(pairs)
+    except ValueError as e:
+        return f"Error: {e}"
 
     # normalize site_assigned: True -> "ASSIGNED", False -> "UNASSIGNED"
     site_assigned_str: str | None = None if site_assigned is None else ("ASSIGNED" if site_assigned else "UNASSIGNED")
@@ -128,7 +131,10 @@ async def central_find_device(
         ]
         if v is not None
     ]
-    filter_str = build_odata_filter(pairs)
+    try:
+        filter_str = build_odata_filter(pairs)
+    except ValueError as e:
+        return f"Error: {e}"
     try:
         device_resp = MonitoringDevices.get_device_inventory(
             central_conn=ctx.lifespan_context["central_conn"],

--- a/src/hpe_networking_mcp/platforms/central/tools/events.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/events.py
@@ -94,7 +94,10 @@ async def central_get_events(
     WARNING: last_30d can match thousands of events. Use central_get_events_count first to
     assess volume, then page incrementally using cursor.
     """
-    start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
+    try:
+        start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
+    except ValueError as e:
+        return f"Error: {e}"
 
     query_params: dict = {
         "context-type": context_type,
@@ -138,7 +141,7 @@ async def central_get_events_count(
     time_range: TIME_RANGE = "last_1h",
     start_time: str | None = None,
     end_time: str | None = None,
-) -> EventFilters:
+) -> EventFilters | str:
     """
     Return a breakdown of event counts for a context without fetching full event details.
 
@@ -162,7 +165,10 @@ async def central_get_events_count(
     Returns an EventFilters object: total event count plus breakdowns by event name, source
     type, and category.
     """
-    start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
+    try:
+        start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
+    except ValueError as e:
+        return f"Error: {e}"
 
     response = retry_central_command(
         ctx.lifespan_context["central_conn"],

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -74,7 +74,10 @@ async def central_get_aps(
         ("deployment", deployment),
     ]
     pairs = [(_AP_FILTER_FIELDS[k], v) for k, v in raw_pairs if v is not None]
-    filter_str = build_odata_filter(pairs)
+    try:
+        filter_str = build_odata_filter(pairs)
+    except ValueError as e:
+        return f"Error: {e}"
 
     try:
         kwargs: dict = {"central_conn": conn}

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
@@ -104,15 +104,11 @@ async def greenlake_get_audit_logs(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve audit logs from HPE GreenLake."""
     logger.debug("greenlake_get_audit_logs called")
 
-    token_manager = ctx.lifespan_context["greenlake_token_manager"]
-    config = ctx.lifespan_context["config"]
-    base_url = config.greenlake.api_base_url
-
-    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
+    try:
         params: dict[str, Any] = {}
         if filter is not None:
             params["filter"] = filter
@@ -124,7 +120,14 @@ async def greenlake_get_audit_logs(
             params["limit"] = _coerce_int(limit, "limit")
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
+    except ValueError as e:
+        return f"Error: {e}"
 
+    token_manager = ctx.lifespan_context["greenlake_token_manager"]
+    config = ctx.lifespan_context["config"]
+    base_url = config.greenlake.api_base_url
+
+    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
         return await client.get("/audit-log/v1/logs", params=params)
 
 
@@ -153,12 +156,12 @@ async def greenlake_get_audit_log_details(
             description=("ID of the audit log record whose ``hasDetails`` value is ``true``."),
         ),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve detailed information for a single audit log entry."""
     logger.debug("greenlake_get_audit_log_details called, id={}", id)
 
     if not id or not id.strip():
-        raise ValueError("id is required and cannot be empty")
+        return "Error: id is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
@@ -112,15 +112,11 @@ async def greenlake_get_devices(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """List devices in the GreenLake workspace."""
     logger.debug("greenlake_get_devices called")
 
-    token_manager = ctx.lifespan_context["greenlake_token_manager"]
-    config = ctx.lifespan_context["config"]
-    base_url = config.greenlake.api_base_url
-
-    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
+    try:
         params: dict[str, Any] = {}
         if filter is not None:
             params["filter"] = filter
@@ -134,7 +130,14 @@ async def greenlake_get_devices(
             params["limit"] = _coerce_int(limit, "limit")
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
+    except ValueError as e:
+        return f"Error: {e}"
 
+    token_manager = ctx.lifespan_context["greenlake_token_manager"]
+    config = ctx.lifespan_context["config"]
+    base_url = config.greenlake.api_base_url
+
+    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
         return await client.get("/devices/v1/devices", params=params)
 
 
@@ -165,12 +168,12 @@ async def greenlake_get_device_by_id(
         str,
         Field(description="The resource ID of the device."),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve details for a single device."""
     logger.debug("greenlake_get_device_by_id called, id={}", id)
 
     if not id or not id.strip():
-        raise ValueError("id is required and cannot be empty")
+        return "Error: id is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
@@ -113,15 +113,11 @@ async def greenlake_get_subscriptions(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """List subscriptions in the GreenLake workspace."""
     logger.debug("greenlake_get_subscriptions called")
 
-    token_manager = ctx.lifespan_context["greenlake_token_manager"]
-    config = ctx.lifespan_context["config"]
-    base_url = config.greenlake.api_base_url
-
-    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
+    try:
         params: dict[str, Any] = {}
         if filter is not None:
             params["filter"] = filter
@@ -135,7 +131,14 @@ async def greenlake_get_subscriptions(
             params["limit"] = _coerce_int(limit, "limit")
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
+    except ValueError as e:
+        return f"Error: {e}"
 
+    token_manager = ctx.lifespan_context["greenlake_token_manager"]
+    config = ctx.lifespan_context["config"]
+    base_url = config.greenlake.api_base_url
+
+    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
         return await client.get("/subscriptions/v1/subscriptions", params=params)
 
 
@@ -166,12 +169,12 @@ async def greenlake_get_subscription_details(
         str,
         Field(description="The unique identifier of the subscription."),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve detailed information for a single subscription."""
     logger.debug("greenlake_get_subscription_details called, id={}", id)
 
     if not id or not id.strip():
-        raise ValueError("id is required and cannot be empty")
+        return "Error: id is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
@@ -89,15 +89,11 @@ async def greenlake_get_users(
             description=("Pagination offset (number of pages to skip)."),
         ),
     ] = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """List users in the GreenLake workspace."""
     logger.debug("greenlake_get_users called")
 
-    token_manager = ctx.lifespan_context["greenlake_token_manager"]
-    config = ctx.lifespan_context["config"]
-    base_url = config.greenlake.api_base_url
-
-    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
+    try:
         params: dict[str, Any] = {}
         if filter is not None:
             params["filter"] = filter
@@ -105,7 +101,14 @@ async def greenlake_get_users(
             params["limit"] = _coerce_int(limit, "limit")
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
+    except ValueError as e:
+        return f"Error: {e}"
 
+    token_manager = ctx.lifespan_context["greenlake_token_manager"]
+    config = ctx.lifespan_context["config"]
+    base_url = config.greenlake.api_base_url
+
+    async with GreenLakeHttpClient(token_manager=token_manager, base_url=base_url) as client:
         return await client.get("/identity/v1/users", params=params)
 
 
@@ -134,12 +137,12 @@ async def greenlake_get_user_details(
             description=("The unique identifier of the user. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve detailed information for a single user."""
     logger.debug("greenlake_get_user_details called, id={}", id)
 
     if not id or not id.strip():
-        raise ValueError("id is required and cannot be empty")
+        return "Error: id is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
@@ -44,7 +44,7 @@ async def greenlake_get_workspace(
             description=("The unique identifier of the workspace. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve basic information for a single workspace."""
     logger.debug(
         "greenlake_get_workspace called, workspaceId={}",
@@ -52,7 +52,7 @@ async def greenlake_get_workspace(
     )
 
     if not workspaceId or not workspaceId.strip():
-        raise ValueError("workspaceId is required and cannot be empty")
+        return "Error: workspaceId is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -87,7 +87,7 @@ async def greenlake_get_workspace_details(
             description=("The unique identifier of the workspace. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any]:
+) -> dict[str, Any] | str:
     """Retrieve detailed workspace information (contact info)."""
     logger.debug(
         "greenlake_get_workspace_details called, workspaceId={}",
@@ -95,7 +95,7 @@ async def greenlake_get_workspace_details(
     )
 
     if not workspaceId or not workspaceId.strip():
-        raise ValueError("workspaceId is required and cannot be empty")
+        return "Error: workspaceId is required and cannot be empty"
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_configuration_object_schema.py
@@ -131,12 +131,12 @@ async def get_configuration_object_schema(
 
     entry = _SCHEMAS_DATA.get(schema_name.value)
     if entry is None:
-        raise ValueError(f"Schema '{schema_name.value}' not found. Re-run the generator to rebuild schemas_data.py.")
+        return f"Error: Schema '{schema_name.value}' not found. Re-run the generator to rebuild schemas_data.py."
 
     resolved: dict = dict(entry["schema"])  # shallow copy
 
     if not resolved:
-        raise ValueError(f"No schema found for '{schema_name.value}'. Re-run the generator to rebuild schemas_data.py.")
+        return f"Error: No schema found for '{schema_name.value}'. Re-run the generator to rebuild schemas_data.py."
 
     resolved["x-schema-name"] = entry["_schema_name"]
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_insight_metrics.py
@@ -38,15 +38,19 @@ class Object_type(Enum):
     SWITCH = "switch"
 
 
-def _mac_to_device_id(mac: str) -> str:
+def _mac_to_device_id(mac: str) -> str | None:
     """Construct a Mist device_id UUID from a MAC address.
 
     Mist device UUIDs follow the deterministic pattern
     ``00000000-0000-0000-1000-<mac_lowercase_no_separators>``.
+
+    Returns ``None`` if the MAC isn't 12 hex chars (with or without
+    separators) — caller surfaces a tool-level error instead of letting
+    a raise propagate, which would crash the code-mode sandbox.
     """
     clean = mac.lower().replace(":", "").replace("-", "")
     if len(clean) != 12 or not all(c in "0123456789abcdef" for c in clean):
-        raise ValueError(f"Invalid MAC address format: {mac!r}")
+        return None
     return f"00000000-0000-0000-1000-{clean}"
 
 
@@ -229,6 +233,8 @@ async def get_insight_metrics(
                         }
                     )
                 ap_device_id = str(device_id) if device_id else _mac_to_device_id(str(mac))
+                if ap_device_id is None:
+                    return f"Error: invalid MAC address format: {mac!r}"
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForAP(
                     apisession,
                     site_id=str(site_id),
@@ -251,6 +257,8 @@ async def get_insight_metrics(
                         }
                     )
                 gw_device_id = str(device_id) if device_id else _mac_to_device_id(str(mac))
+                if gw_device_id is None:
+                    return f"Error: invalid MAC address format: {mac!r}"
                 response = mistapi.api.v1.sites.insights.getSiteInsightMetricsForGateway(
                     apisession,
                     site_id=str(site_id),

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -243,3 +243,136 @@ class TestCodeModeRegistrationHook:
 # attribute, leaking state across tests in ways that are disproportionate to
 # what the check is worth. The ``TestCodeModeCrossPlatformGating`` class above
 # already proves the code-mode branch is reached in create_server.
+
+
+@pytest.mark.unit
+class TestCodeModeErrorReturns:
+    """Regression coverage for the issue #202 fix.
+
+    In code mode, a tool function that raises propagates as ``MontyRuntimeError``
+    and crashes the AI's whole ``execute()`` call — even a ``try/except`` inside
+    the sandbox can't catch it. Tools must therefore RETURN errors as a string
+    or dict, not raise. These tests assert the contract for the affected
+    surface so a future edit can't silently regress.
+
+    See ``CHANGELOG.md`` and issue #202 for the full root-cause writeup.
+    """
+
+    @pytest.mark.asyncio
+    async def test_greenlake_get_user_details_empty_id_returns_string(self):
+        """Empty-string id returns an error string instead of raising.
+        The registry shim (with ``_registry.mcp = None`` at import time in
+        tests) returns the raw function, so ``ctx`` can be ``None`` for the
+        early-return path that never touches it.
+        """
+        from hpe_networking_mcp.platforms.greenlake.tools.users import (
+            greenlake_get_user_details,
+        )
+
+        result = await greenlake_get_user_details(None, id="")  # type: ignore[arg-type]
+        assert isinstance(result, str)
+        assert result.startswith("Error:")
+
+    @pytest.mark.asyncio
+    async def test_greenlake_get_workspace_empty_returns_string(self):
+        from hpe_networking_mcp.platforms.greenlake.tools.workspaces import (
+            greenlake_get_workspace,
+        )
+
+        result = await greenlake_get_workspace(None, workspaceId="")  # type: ignore[arg-type]
+        assert isinstance(result, str)
+        assert result.startswith("Error:")
+
+    def test_greenlake_users_coerce_int_still_raises_for_helper_callers(self):
+        """``_coerce_int`` itself remains a raising helper — only the public
+        tool entry that calls it is required to be code-mode-safe (via try/
+        except wrapping the param-build block). Pinning this so we don't
+        accidentally rewrite the helper to return error sentinels and
+        silently break unrelated callers.
+        """
+        from hpe_networking_mcp.platforms.greenlake.tools.users import _coerce_int
+
+        with pytest.raises(ValueError):
+            _coerce_int("abc", "limit")
+
+    def test_mist_mac_to_device_id_returns_none_on_invalid(self):
+        """``_mac_to_device_id`` was changed from raising to returning ``None``
+        so the calling tool can surface a string error instead of letting a
+        ValueError propagate through ``handle_network_error`` → ``ToolError``
+        → ``MontyRuntimeError``.
+        """
+        from hpe_networking_mcp.platforms.mist.tools.get_insight_metrics import (
+            _mac_to_device_id,
+        )
+
+        assert _mac_to_device_id("not-a-mac") is None
+        assert _mac_to_device_id("") is None
+        assert _mac_to_device_id("zz:zz:zz:zz:zz:zz") is None
+        # Sanity: a real MAC still works and returns the Mist UUID convention.
+        assert _mac_to_device_id("aa:bb:cc:dd:ee:ff") == "00000000-0000-0000-1000-aabbccddeeff"
+
+    def test_mist_get_configuration_object_schema_uses_return_not_raise(self):
+        """Static check: the schema-not-found and empty-resolved paths
+        ``return f"Error: ..."`` instead of ``raise ValueError(...)``.
+
+        Going for an AST-based check rather than triggering the path live
+        because ``SchemaName`` is built dynamically from ``_SCHEMAS_DATA``
+        contents at import time, making it awkward to monkey-patch in a
+        unit test.
+        """
+        import ast
+        from pathlib import Path
+
+        src = (
+            Path(__file__).parent.parent.parent
+            / "src"
+            / "hpe_networking_mcp"
+            / "platforms"
+            / "mist"
+            / "tools"
+            / "get_configuration_object_schema.py"
+        ).read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "get_configuration_object_schema"
+            ):
+                raises = [n for n in ast.walk(node) if isinstance(n, ast.Raise)]
+                assert not raises, (
+                    f"get_configuration_object_schema must not raise — "
+                    f"found raise at lines {[r.lineno for r in raises]}"
+                )
+                return
+        raise AssertionError("get_configuration_object_schema function not found in source")
+
+    def test_no_raise_in_greenlake_tool_files(self):
+        """Static guard: every public tool function in ``greenlake/tools/*.py``
+        must return errors as strings (or dicts), not raise. This catches a
+        future edit that re-introduces the bug.
+
+        Helper functions (names starting with ``_``) are exempt — they may
+        raise as long as their callers wrap the call.
+        """
+        import ast
+        from pathlib import Path
+
+        tools_dir = (
+            Path(__file__).parent.parent.parent / "src" / "hpe_networking_mcp" / "platforms" / "greenlake" / "tools"
+        )
+        offenders: list[str] = []
+        for py_file in tools_dir.glob("*.py"):
+            if py_file.name == "__init__.py":
+                continue
+            tree = ast.parse(py_file.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    # Skip helpers — names starting with ``_``.
+                    if node.name.startswith("_"):
+                        continue
+                    for inner in ast.walk(node):
+                        if isinstance(inner, ast.Raise):
+                            offenders.append(f"{py_file.name}::{node.name}:{inner.lineno}")
+        assert not offenders, (
+            f"Public GreenLake tool functions must not raise — code mode crashes the sandbox. Offenders: {offenders}"
+        )


### PR DESCRIPTION
## Summary

Closes #202. In `MCP_TOOL_MODE=code`, a tool that raises `ValueError` / `TypeError` / `RuntimeError` propagates as `MontyRuntimeError` and crashes the entire `execute()` block. The AI's `try/except` inside the sandbox cannot catch it — the error bubbles up at the runtime layer above the user's Python.

## Surgical scope

The fix wraps the validation/helper call in each affected tool entry with a top-level `try/except ValueError` and returns `f"Error: {e}"`. Helpers (`_coerce_int`, `build_odata_filter`, `compute_time_window`) keep their existing raising contract — only public tool entries that face the LLM had to be made code-mode-safe.

`_mac_to_device_id` was changed from raising to returning `None` because its existing call sites flow through `handle_network_error` → `ToolError`, which also crashed the sandbox.

## Files touched

| Platform | Files | Sites |
|---|---|---|
| GreenLake | `users.py`, `devices.py`, `subscriptions.py`, `audit_logs.py`, `workspaces.py` | 14 raise sites → returns |
| Mist | `get_insight_metrics.py`, `get_configuration_object_schema.py` | 3 raises → 2 returns + 1 helper-returns-None |
| Central | `alerts.py`, `clients.py`, `devices.py`, `monitoring.py`, `events.py` | 6 helper-call sites wrapped in `try/except` |

## Live verification

Tested each fixed path against the running container in code mode:

```
greenlake_get_user_details(id="")        → "Error: id is required and cannot be empty"
greenlake_get_users(limit="abc")         → "Error: Parameter 'limit' must be an integer, got 'abc'"
greenlake_get_workspace(workspaceId="")  → "Error: workspaceId is required and cannot be empty"
mist_get_insight_metrics(mac="not-a-mac", object_type="ap", site_id="...", metric="rx_bytes")
                                          → "Error: invalid MAC address format: 'not-a-mac'"
```

All previously crashed `execute()` with `MontyRuntimeError`.

## Tests (571 → 577)

New `TestCodeModeErrorReturns` class in `tests/unit/test_code_mode.py`:
- 2 dynamic tests calling fixed tools with bad input
- 2 contract pins (`_mac_to_device_id` returns None, `_coerce_int` still raises)
- 1 AST guard pinning `get_configuration_object_schema` doesn't raise
- 1 AST guard scanning every public function in `greenlake/tools/*.py` and failing if any `raise` re-appears (catches future regressions for free)

## Out of scope

The 19 raises in `apstra/models.py` are Pydantic field validators — their `ValueError` becomes a `ValidationError` during FastMCP parameter coercion *before* the tool function runs. Same crash symptom but the fix lives at the FastMCP middleware layer, not in tool code. Tracking separately if it becomes a real-world friction point.

## Test plan

- [x] Live re-verified each fixed tool against the running container
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 577 passed (was 571; +6 new tests)
- [x] CHANGELOG entry + version bump 2.2.0.0 → 2.2.0.1