### PR TITLE
docs: tool description cleanup (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased — docs only (no version bump)
+
+### Tool description cleanup (closes #183)
+
+Targeted fixes to tool descriptions that the AI was demonstrably misreading. Pure metadata change — no functional code changes — so no version bump per the issue's guidance and the existing convention (`feedback_versioning.md` memory).
+
+**HIGH-severity fixes (the AI actively picked these wrong in live tests):**
+
+- **`mist_get_site_health`** — name reads as "per-site list" but the tool actually returns an org-wide AGGREGATE (`num_sites`, `num_devices`, SLE summaries rolled up across the whole org). Description now leads with "Organization-wide health AGGREGATE — NOT a per-site breakdown" and explicitly redirects to `mist_get_org_or_site_info(info_type='site')` for the per-site-list case. Verified live: the tool returns a dict with `num_sites: N`, not a list.
+- **`clearpass_get_guest_users`** — dual-mode (single record by `guest_id`/`username` vs. paginated list) but the conditional was buried as the second sentence. Docstring's first line now leads with "Get a single ClearPass guest account by ID or username, OR list all guest accounts" so summary views (search / list_tools) surface both modes immediately.
+
+**MEDIUM-severity fixes (vague descriptions that didn't say what came back):**
+
+- **`mist_get_org_or_site_info`** — was just "Search information about the organizations or sites." Description now lists the actual fields returned (id, name, address, lat/lng, timezone, country_code) and explicitly says it returns a list of every site for `info_type='site'`. Cross-references the right tools for site health and per-site stats.
+- **`mist_get_org_sle`** — confusing "all/worst sites, Mx Edges, ..." phrasing replaced with explicit org-wide-vs-per-site scope language. Cross-references `mist_get_org_sites_sle` for the per-site case.
+- **`mist_get_constants`** — reframed as a discovery tool, not just a generic "platform constants" lookup. Lists the specific use cases (insight_metrics → `mist_get_insight_metrics` discovery; alarm_definitions → `mist_search_alarms.alarm_type`; per-source events). Includes the SLE metrics warning ("`insight_metrics` is NOT the same set as SLE metrics — use `mist_list_site_sle_info(query_type='metrics', ...)` for those").
+
+### Why no rename of `mist_get_site_health`?
+
+The issue offered two options for the named offender — rename (breaking, tag for major version) or fix description. We took the description path because it's docs-only and ships immediately; renames can come in a future major bump if appetite warrants.
+
+### Tests (582 → 587)
+
+Five new tests in `tests/unit/test_mist_dynamic_mode.py`:
+
+- `TestMistDescriptionDisambiguation` — pins the exact disambiguation phrases (`AGGREGATE`, `NOT a per-site`, `mist_get_org_or_site_info` cross-reference) so a future rewrite can't silently revert them
+- `TestClearPassGuestUsersDualMode` — pins the dual-mode language in the docstring's first line
+
+### Audit findings worth noting (deferred, not in this PR)
+
+The Explore agent flagged ~13 additional MEDIUM cases in Mist where the return type is `dict | list | str` without docs on which-when. These are minor improvements compared to the HIGH offenders above; addressing them is a follow-up if the description-cleanup PR pattern proves valuable.
+
 ## [2.2.0.2] - 2026-04-27
 
 **Mist tool schema tightening — alarm severity/group enum corrections + SLE metric description fixes that point at the right discovery tools.** Closes #186.

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -20,18 +20,18 @@ async def clearpass_get_guest_users(
     limit: int = 25,
     calculate_count: bool = False,
 ) -> dict | str:
-    """Get ClearPass guest user accounts.
+    """Get a single ClearPass guest account by ID or username, OR list all guest accounts.
 
-    If guest_id or username is provided, returns a single guest account.
-    Otherwise returns a paginated list of all guest accounts.
+    Dual-mode: if `guest_id` or `username` is provided, returns ONE guest record.
+    Otherwise returns a paginated LIST of all guests (use `filter`/`sort`/`offset`/`limit`).
 
     Args:
-        guest_id: Numeric ID for single-item lookup.
-        username: Guest username for lookup by username.
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset (default 0).
-        limit: Max results per page (default 25).
+        guest_id: Numeric ID for single-record lookup.
+        username: Guest username for single-record lookup.
+        filter: JSON filter expression (ClearPass REST API syntax). List mode only.
+        sort: Sort order (e.g. "+name" or "-id"). List mode only.
+        offset: Pagination offset (default 0). List mode only.
+        limit: Max results per page (default 25). List mode only.
     """
     try:
         from pyclearpass.api_identities import ApiIdentities

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_constants.py
@@ -45,11 +45,21 @@ class Object_type(Enum):
 @tool(
     name="mist_get_constants",
     description=(
-        "Retrieve Mist platform constants including insight "
-        "metrics, webhook topics, alarm definitions, device "
-        "models, events definitions, and license types. Use this "
-        "to understand available options and configurations for "
-        "the Mist API."
+        "Discovery tool for Mist API enumerations. Returns the "
+        "valid value set for a given `object_type` — e.g. "
+        "`insight_metrics` (metric names usable with "
+        "`mist_get_insight_metrics` and `mist_get_org_sle`), "
+        "`alarm_definitions` (alarm types for "
+        "`mist_search_alarms.alarm_type`), `device_events` / "
+        "`client_events` / `mxedge_events` / `nac_events` (event "
+        "types for `mist_search_events.event_type`), "
+        "`device_models`, `webhook_topics`, `license_types`, "
+        "`fingerprint_types`. Many other tools' descriptions "
+        "point here for parameter discovery. Returns a dict "
+        "keyed by the constants for that object_type. NOTE: "
+        "`insight_metrics` is NOT the same set as SLE metrics — "
+        "for site-level SLE metrics use "
+        "`mist_list_site_sle_info(query_type='metrics', ...)`."
     ),
     tags={"constants"},
     annotations={

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_or_site_info.py
@@ -36,7 +36,17 @@ class Info_type(Enum):
 
 @tool(
     name="mist_get_org_or_site_info",
-    description=("Search information about the organizations or sites"),
+    description=(
+        "Get org or site METADATA records. With `info_type='org'`, "
+        "returns the org record (name, settings, SLE thresholds, "
+        "subscriptions). With `info_type='site'`, returns a LIST "
+        "of every site under the org — one record per site with "
+        "id, name, address, lat/lng, timezone, country_code. "
+        "This is the right tool for 'list every site I have' "
+        "queries. NOT for site health or device counts — see "
+        "`mist_get_site_health` for org-wide aggregates or "
+        "`mist_get_stats` for per-site stats."
+    ),
     tags={"info"},
     annotations={
         "title": "Get org or site info",

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_org_sle.py
@@ -31,9 +31,13 @@ from hpe_networking_mcp.platforms.mist.client import (
 @tool(
     name="mist_get_org_sle",
     description=(
-        "Get Org SLEs (all/worst sites, Mx Edges, ...). "
-        "Discover the available metric names via "
-        "`mist_get_constants` with "
+        "Get organization-wide SLE data for a single metric (e.g. "
+        "`wifi-coverage`, `wired-throughput`). Returns the SLE "
+        "value rolled up across the whole org — including the "
+        "worst-performing sites and impacted entities for that "
+        "metric. This is org-scope; for per-site SLE summaries "
+        "use `mist_get_org_sites_sle`. Discover valid metric "
+        "names via `mist_get_constants` with "
         "`object_type=insight_metrics`."
     ),
     tags={"sles"},

--- a/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/get_site_health.py
@@ -20,9 +20,13 @@ from hpe_networking_mcp.platforms.mist.client import (
 @tool(
     name="mist_get_site_health",
     description=(
-        "Get a health overview across all sites in the organization. "
-        "Returns site names, device counts, client counts, and "
-        "overall status for quick assessment."
+        "Organization-wide health AGGREGATE — total device counts, "
+        "client counts, SLE summaries, and `num_sites` rolled up "
+        "across every site in the org. NOT a per-site breakdown. "
+        "If you want a per-site list (one record per site with that "
+        "site's health), use `mist_get_org_or_site_info("
+        "info_type='site')` instead. Calls "
+        "`/api/v1/orgs/{org_id}/stats` under the hood."
     ),
     tags={"info"},
     annotations={

--- a/tests/unit/test_mist_dynamic_mode.py
+++ b/tests/unit/test_mist_dynamic_mode.py
@@ -154,3 +154,90 @@ class TestMistSleDescriptionDiscovery:
             "mist_get_constants(object_type='insight_metrics') — that's the correct discovery "
             "for org-level SLE per Mist's published API reference."
         )
+
+
+@pytest.mark.unit
+class TestMistDescriptionDisambiguation:
+    """Regression coverage for issue #183 — tool descriptions that
+    previously misled the AI now contain explicit scope/shape language.
+
+    These tests assert specific strings appear in each tool's source so
+    a future rewrite cannot silently drop the disambiguation.
+    """
+
+    def test_get_site_health_warns_about_org_wide_aggregate(self):
+        """The cited offender — name reads as per-site list, actually returns
+        org-wide aggregate. Description must call this out and point at the
+        right tool for the per-site-list case.
+        """
+        import inspect
+
+        from hpe_networking_mcp.platforms.mist.tools import get_site_health
+
+        src = inspect.getsource(get_site_health)
+        # Must explicitly say it's org-wide (not per-site) and point at the
+        # alternative tool for per-site queries.
+        assert "AGGREGATE" in src, "get_site_health description must explicitly say AGGREGATE"
+        assert "NOT a per-site" in src, "get_site_health must explicitly negate the per-site reading"
+        assert "mist_get_org_or_site_info" in src, (
+            "get_site_health must point at mist_get_org_or_site_info for the per-site-list case"
+        )
+
+    def test_get_org_or_site_info_describes_returned_fields(self):
+        import inspect
+
+        from hpe_networking_mcp.platforms.mist.tools import get_org_or_site_info
+
+        src = inspect.getsource(get_org_or_site_info)
+        # Description should name fields the AI can rely on.
+        assert "id" in src and "name" in src, (
+            "get_org_or_site_info description should list at least the id/name fields it returns"
+        )
+
+    def test_get_org_sle_clarifies_org_vs_per_site_scope(self):
+        """The previous description said 'all/worst sites' which read as confusingly
+        ambiguous. The new description should explicitly distinguish org-wide vs.
+        per-site SLE, and point at `mist_get_org_sites_sle` for the per-site case.
+        """
+        import inspect
+
+        from hpe_networking_mcp.platforms.mist.tools import get_org_sle
+
+        src = inspect.getsource(get_org_sle)
+        assert "mist_get_org_sites_sle" in src, (
+            "get_org_sle description must point at mist_get_org_sites_sle for the per-site case"
+        )
+
+    def test_get_constants_warns_insight_metrics_is_not_sle(self):
+        """The `insight_metrics` constants set is a different vocabulary from
+        SLE metrics. Description must call this out so the AI doesn't reuse
+        the wrong set when looking for SLE metric names.
+        """
+        import inspect
+
+        from hpe_networking_mcp.platforms.mist.tools import get_constants
+
+        src = inspect.getsource(get_constants)
+        assert "mist_list_site_sle_info" in src, (
+            "get_constants description should redirect to mist_list_site_sle_info for SLE metrics"
+        )
+
+
+@pytest.mark.unit
+class TestClearPassGuestUsersDualMode:
+    """Regression for issue #183 — clearpass_get_guest_users is dual-mode
+    (single record by ID/username vs. paginated list). Description must
+    lead with this, not bury it.
+    """
+
+    def test_dual_mode_in_first_line(self):
+        from hpe_networking_mcp.platforms.clearpass.tools.guests import clearpass_get_guest_users
+
+        doc = clearpass_get_guest_users.__doc__ or ""
+        first_line = doc.strip().split("\n")[0]
+        # Must include both modes in the headline so the AI sees both
+        # in summary views (search / list_tools).
+        assert "single" in first_line.lower() or "OR" in first_line, (
+            f"clearpass_get_guest_users docstring's first line must surface "
+            f"the dual-mode behavior — got: {first_line!r}"
+        )


### PR DESCRIPTION
## Summary

Closes #183. Targeted description fixes for tools the AI was demonstrably misreading in live tests. Pure docstring/description edits — **no functional code changes, no version bump** per the issue's guidance and the existing convention.

## HIGH-severity fixes (the AI actively picked these wrong)

| Tool | Problem | Fix |
|---|---|---|
| `mist_get_site_health` | Name reads as "per-site list" but returns org-wide AGGREGATE (`num_sites`, `num_devices`, SLE summaries rolled up across the whole org) | Description now leads with "Organization-wide health AGGREGATE — NOT a per-site breakdown" and redirects to `mist_get_org_or_site_info(info_type='site')` for the per-site case |
| `clearpass_get_guest_users` | Dual-mode (single record vs. paginated list) but the conditional was buried as the second docstring sentence | Docstring's first line now leads with both modes so summary views surface both immediately |

## MEDIUM-severity fixes

| Tool | Fix |
|---|---|
| `mist_get_org_or_site_info` | Now names the returned fields (id, name, address, lat/lng, timezone) and cross-references the right tools for site health and per-site stats |
| `mist_get_org_sle` | Replaced confusing "all/worst sites, Mx Edges, ..." phrasing with explicit org-vs-per-site scope language |
| `mist_get_constants` | Reframed as a discovery tool with specific use cases. Includes the "`insight_metrics` is NOT SLE metrics" warning that cost a 404 in v2.2.0.2 |

## Why no rename of `mist_get_site_health`?

The issue offered two paths — rename (breaking, tag for major version) OR description fix. We took the description path because it ships immediately as docs-only; renames can come in a future major bump if appetite warrants.

## Live-verified

- `mist_get_site_health(org_id=...)` → dict with `num_sites: 6, num_devices: N, ...` (org-wide aggregate, exactly what the new description claims — NOT a list)
- `mist_get_org_or_site_info(info_type='site', org_id=...)` → list of 6 site records with `id`, `name`, `address`, `country_code` fields (the per-site path the new description points at)

## Audit findings deferred

The Explore agent flagged ~13 additional MEDIUM cases in Mist where the return type is `dict | list | str` without docs on which-when. These are minor compared to the HIGH offenders above; addressing them is a follow-up if this PR pattern proves valuable.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 587 passed (was 582; +5 new tests)
- [x] `TestMistDescriptionDisambiguation` pins the exact disambiguation phrases — future rewrites can't silently revert
- [x] `TestClearPassGuestUsersDualMode` pins the dual-mode language in the docstring's first line
- [x] Live-verified the two HIGH-severity fixes against the running tenant
- [x] CHANGELOG entry under "Unreleased — docs only" (no version bump)

## Both modes benefit

This same description text surfaces in both modes:
- **Dynamic**: AI sees it via `mist_get_tool_schema(name=...)` / `clearpass_get_tool_schema(name=...)`
- **Code**: AI sees it via `get_schema(tools=[...])`

Same source-of-truth, same fix.