### PR TITLE
v2.2.0.3: ValidationCatchMiddleware (closes #206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,37 +5,87 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased — docs only (no version bump)
+## [2.2.0.3] - 2026-04-27
 
-### Tool description cleanup (closes #183)
+**Adds `ValidationCatchMiddleware` to convert Pydantic `ValidationError` into a structured tool-result string instead of letting it propagate as `MontyRuntimeError` and crash `execute()` in code mode.** Closes #206 (the FastMCP-layer follow-up to #202).
 
-Targeted fixes to tool descriptions that the AI was demonstrably misreading. Pure metadata change — no functional code changes — so no version bump per the issue's guidance and the existing convention (`feedback_versioning.md` memory).
+### Background
 
-**HIGH-severity fixes (the AI actively picked these wrong in live tests):**
+#202 (closed by PR #203) addressed tool-internal raises by converting them to error string returns. That fix didn't help **Pydantic validation errors**, which fire BEFORE the tool function runs — during FastMCP's parameter coercion step. Same crash symptom, but the fix lives at the FastMCP middleware layer rather than in tool code.
 
-- **`mist_get_site_health`** — name reads as "per-site list" but the tool actually returns an org-wide AGGREGATE (`num_sites`, `num_devices`, SLE summaries rolled up across the whole org). Description now leads with "Organization-wide health AGGREGATE — NOT a per-site breakdown" and explicitly redirects to `mist_get_org_or_site_info(info_type='site')` for the per-site-list case. Verified live: the tool returns a dict with `num_sites: N`, not a list.
-- **`clearpass_get_guest_users`** — dual-mode (single record by `guest_id`/`username` vs. paginated list) but the conditional was buried as the second sentence. Docstring's first line now leads with "Get a single ClearPass guest account by ID or username, OR list all guest accounts" so summary views (search / list_tools) surface both modes immediately.
+In code mode, the originally-crashing case looked like:
 
-**MEDIUM-severity fixes (vague descriptions that didn't say what came back):**
+```
+call_tool("mist_search_alarms", {"severity": "major"})
+→ MontyRuntimeError: ValueError: 1 validation error for severity
+→ Crashes execute(); try/except inside the sandbox CANNOT recover
+```
 
-- **`mist_get_org_or_site_info`** — was just "Search information about the organizations or sites." Description now lists the actual fields returned (id, name, address, lat/lng, timezone, country_code) and explicitly says it returns a list of every site for `info_type='site'`. Cross-references the right tools for site health and per-site stats.
-- **`mist_get_org_sle`** — confusing "all/worst sites, Mx Edges, ..." phrasing replaced with explicit org-wide-vs-per-site scope language. Cross-references `mist_get_org_sites_sle` for the per-site case.
-- **`mist_get_constants`** — reframed as a discovery tool, not just a generic "platform constants" lookup. Lists the specific use cases (insight_metrics → `mist_get_insight_metrics` discovery; alarm_definitions → `mist_search_alarms.alarm_type`; per-source events). Includes the SLE metrics warning ("`insight_metrics` is NOT the same set as SLE metrics — use `mist_list_site_sle_info(query_type='metrics', ...)` for those").
+After this fix:
 
-### Why no rename of `mist_get_site_health`?
+```
+"Error: validation failed for tool 'mist_search_alarms':
+  - severity: Input should be 'critical', 'info' or 'warn' (got: 'major')"
+→ AI receives a string, branches on it, retries with a valid value
+```
 
-The issue offered two options for the named offender — rename (breaking, tag for major version) or fix description. We took the description path because it's docs-only and ships immediately; renames can come in a future major bump if appetite warrants.
+### Implementation
 
-### Tests (582 → 587)
+New `ValidationCatchMiddleware` at [`src/hpe_networking_mcp/middleware/validation_catch.py`](src/hpe_networking_mcp/middleware/validation_catch.py) — ~50 LOC. Subclasses FastMCP's `Middleware` base class, hooks `on_call_tool`, wraps `await call_next(context)` in `try/except pydantic.ValidationError`, returns a `ToolResult(content=<readable string>)` on catch.
 
-Five new tests in `tests/unit/test_mist_dynamic_mode.py`:
+Registered between `NullStripMiddleware` and `ElicitationMiddleware` in the chain. Placement matches the FastMCP `ErrorHandlingMiddleware` precedent.
 
-- `TestMistDescriptionDisambiguation` — pins the exact disambiguation phrases (`AGGREGATE`, `NOT a per-site`, `mist_get_org_or_site_info` cross-reference) so a future rewrite can't silently revert them
-- `TestClearPassGuestUsersDualMode` — pins the dual-mode language in the docstring's first line
+The error string lists each failing field with Pydantic's own "Input should be X, Y, or Z" formatting — actionable, lets the AI immediately retry with a valid value.
 
-### Audit findings worth noting (deferred, not in this PR)
+### What this protects against
 
-The Explore agent flagged ~13 additional MEDIUM cases in Mist where the return type is `dict | list | str` without docs on which-when. These are minor improvements compared to the HIGH offenders above; addressing them is a follow-up if the description-cleanup PR pattern proves valuable.
+- Apstra's 19 Pydantic field validators in `apstra/models.py` — the originally-flagged out-of-scope concern from #202
+- Mist's enum-typed params (`AlarmSeverity`, `AlarmGroup`, `Action_type`, etc.) when given an invalid value
+- Any tool with a `Field(...)` validator that rejects input
+- Any UUID-typed param with malformed input
+- **Any future Pydantic validator added by any platform** — protected for free
+
+### Behavior change scope
+
+| Mode | Today | After |
+|---|---|---|
+| **Code** | `MontyRuntimeError` crashes `execute()` (the bug) | Clean string return — bug fixed |
+| **Static** | AI sees `McpError(-32602, "Invalid params: ...")` | AI sees string `"Error: validation failed..."` — message is more readable |
+| **Dynamic** | `<platform>_invoke_tool` wraps and returns a string | Unchanged — middleware sees only the meta-tool's flexible-typed params (no ValidationError fires there); the underlying tool's validation is caught inside `_invoke_tool`'s body |
+
+Verified by running the full dynamic-mode unit test suite (`test_*_dynamic_mode.py` × 6 platforms + `test_code_mode.py` + `test_middleware.py`) — all 100 tests pass with the middleware enabled.
+
+### Live-tested
+
+Three scenarios verified against the running container in code mode:
+
+| Test | Result |
+|---|---|
+| Invalid enum: `severity="major"` | Returns string with "Input should be 'critical', 'info' or 'warn'" |
+| Valid call: `mist_get_self(action_type="account_info")` | Returns dict with privileges (no regression) |
+| Multi-field error: missing `site_id` + bogus `object_id` | Both errors listed in one readable string |
+
+### Tests (587 → 592)
+
+Five new tests in `tests/unit/test_middleware.py::TestValidationCatchMiddleware`:
+
+- Catches ValidationError → returns ToolResult with a readable string
+- Passes through valid calls unchanged
+- Does NOT catch other exceptions (RuntimeError, etc.) — those propagate to existing handlers
+- Multi-field validation errors list every failing field
+- Tool name appears in the error string (so the AI knows which call failed)
+
+Plus the existing `TestNullStripMiddleware` suite continues to pass — middleware ordering is unchanged for that one.
+
+### Bundled in this release
+
+This release also rolls forward the docs-only tool description cleanup from PR #205 (closes #183), which was on main as "Unreleased — docs only" pending the next versioned release. That content:
+
+- **`mist_get_site_health`** description now leads with "Organization-wide health AGGREGATE — NOT a per-site breakdown" and redirects to `mist_get_org_or_site_info(info_type='site')` for the per-site-list case
+- **`clearpass_get_guest_users`** docstring's first line now leads with the dual-mode behavior so summary views surface both modes immediately
+- **`mist_get_org_or_site_info`** description lists the actual returned fields and cross-references the right tools for site health and per-site stats
+- **`mist_get_org_sle`** description replaced confusing "all/worst sites" phrasing with explicit org-wide-vs-per-site scope language
+- **`mist_get_constants`** reframed as a discovery tool with specific use cases; includes the "`insight_metrics` is NOT the same set as SLE metrics" warning
 
 ## [2.2.0.2] - 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.2.0.2"
+version = "2.2.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/validation_catch.py
+++ b/src/hpe_networking_mcp/middleware/validation_catch.py
@@ -1,0 +1,58 @@
+"""SPIKE — Pydantic ValidationError catch middleware.
+
+Goal: in MCP_TOOL_MODE=code, a tool whose parameters fail Pydantic validation
+currently propagates as MontyRuntimeError and crashes the AI's whole
+execute() block. The AI's try/except inside the sandbox cannot catch it.
+
+This middleware catches ValidationError at the on_call_tool layer (BEFORE it
+reaches FastMCP's exception transform) and returns a structured ToolResult
+with a string error the AI can branch on — same shape as tools that
+explicitly return error strings (Axis, ClearPass).
+
+If the spike works, this becomes the permanent fix for #202's out-of-scope
+follow-up (Apstra Pydantic field validators + any future similar pattern
+across all platforms).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from loguru import logger
+from pydantic import ValidationError
+
+
+class ValidationCatchMiddleware(Middleware):
+    """Convert Pydantic ValidationError into a structured tool-result string.
+
+    Without this, the error fires inside FastMCP's tool dispatcher, becomes
+    MontyRuntimeError in code mode, and crashes execute(). With this, the
+    AI sees a normal-looking string return and can recover.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: Any,
+    ) -> ToolResult:
+        try:
+            return await call_next(context)  # type: ignore[no-any-return]
+        except ValidationError as e:
+            tool_name = getattr(context.message, "name", "unknown")
+            # Format the ValidationError details into a readable string —
+            # mirrors what Pydantic's str(e) gives us but trimmed.
+            error_lines = [f"Error: validation failed for tool '{tool_name}':"]
+            for err in e.errors():
+                loc = ".".join(str(x) for x in err.get("loc", []))
+                msg = err.get("msg", "invalid")
+                err_input = err.get("input")
+                if err_input is not None:
+                    error_lines.append(f"  - {loc}: {msg} (got: {err_input!r})")
+                else:
+                    error_lines.append(f"  - {loc}: {msg}")
+            error_text = "\n".join(error_lines)
+            logger.debug("ValidationCatchMiddleware: caught {} → {}", tool_name, error_text)
+            return ToolResult(content=error_text)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -192,6 +192,7 @@ def create_server(config: ServerConfig) -> FastMCP:
         ElicitationMiddleware,
     )
     from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+    from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
 
     mcp = FastMCP(
         name="HPE Networking MCP",
@@ -199,7 +200,7 @@ def create_server(config: ServerConfig) -> FastMCP:
         lifespan=lifespan,
         on_duplicate="replace",
         mask_error_details=True,
-        middleware=[NullStripMiddleware(), ElicitationMiddleware()],
+        middleware=[NullStripMiddleware(), ValidationCatchMiddleware(), ElicitationMiddleware()],
     )
 
     # Attach config for lifespan to access

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,10 +1,12 @@
-"""Unit tests for NullStripMiddleware and ElicitationMiddleware."""
+"""Unit tests for NullStripMiddleware, ElicitationMiddleware, and ValidationCatchMiddleware."""
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import BaseModel, Field, ValidationError
 
 from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
 
 # ---------------------------------------------------------------------------
 # Helper to build a fake MiddlewareContext
@@ -115,3 +117,132 @@ class TestNullStripMiddleware:
 
         called_ctx = call_next.call_args[0][0]
         assert called_ctx.message.arguments == {}
+
+
+# ---------------------------------------------------------------------------
+# ValidationCatchMiddleware
+# ---------------------------------------------------------------------------
+
+
+def _make_validation_error(field: str, msg: str, value=None) -> ValidationError:
+    """Build a real Pydantic ValidationError for testing.
+
+    Triggers it through a Pydantic model so the structure matches what
+    FastMCP's tool dispatcher actually raises during param coercion.
+    """
+
+    class _M(BaseModel):
+        x: int = Field()
+
+    try:
+        _M(x=value if value is not None else "not-an-int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")  # pragma: no cover
+
+
+def _make_call_tool_context(name: str = "some_tool"):
+    """Mock MiddlewareContext for on_call_tool — message.name set to *name*."""
+    message = MagicMock()
+    message.name = name
+
+    context = MagicMock()
+    context.message = message
+    return context
+
+
+@pytest.mark.unit
+class TestValidationCatchMiddleware:
+    """The middleware must intercept Pydantic ValidationError and return a
+    structured ToolResult so the AI in code mode receives a readable string
+    instead of a MontyRuntimeError that crashes execute(). Closes #206.
+    """
+
+    @pytest.mark.asyncio
+    async def test_catches_validation_error_returns_string(self):
+        """The originally-bug-inducing case: Pydantic raises during param
+        coercion → middleware catches → ToolResult content is a string the
+        AI can read.
+        """
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_call_tool_context("mist_search_alarms")
+
+        async def _raise(_ctx):
+            raise _make_validation_error("severity", "Input should be 'critical', 'info' or 'warn'")
+
+        result = await middleware.on_call_tool(ctx, _raise)
+
+        # ToolResult — content is a list of TextContent blocks; first block has the readable text.
+        assert hasattr(result, "content"), "must return a ToolResult-like object"
+        text = result.content[0].text if result.content else ""
+        assert "validation failed" in text.lower()
+        assert "mist_search_alarms" in text
+
+    @pytest.mark.asyncio
+    async def test_passes_through_valid_calls(self):
+        """No ValidationError → middleware returns whatever call_next returned."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_call_tool_context("any_tool")
+        sentinel = object()
+        call_next = AsyncMock(return_value=sentinel)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result is sentinel
+        call_next.assert_called_once_with(ctx)
+
+    @pytest.mark.asyncio
+    async def test_does_not_catch_other_exceptions(self):
+        """Only Pydantic ValidationError is intercepted. Other exceptions
+        (ToolError, RuntimeError, KeyError, ...) propagate unchanged so
+        they hit the existing handlers further up the stack.
+        """
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_call_tool_context("any_tool")
+
+        async def _raise(_ctx):
+            raise RuntimeError("boom — not a ValidationError")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await middleware.on_call_tool(ctx, _raise)
+
+    @pytest.mark.asyncio
+    async def test_error_string_lists_each_failing_field(self):
+        """Multi-field validation errors should produce one readable line per field."""
+
+        class _M(BaseModel):
+            severity: str = Field()
+            limit: int = Field()
+
+        try:
+            _M(severity=None, limit="not-a-number")  # type: ignore[arg-type]
+            raise AssertionError("expected ValidationError")  # pragma: no cover
+        except ValidationError as e:
+            multi_err = e
+
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_call_tool_context("mist_search_alarms")
+
+        async def _raise(_ctx):
+            raise multi_err
+
+        result = await middleware.on_call_tool(ctx, _raise)
+        text = result.content[0].text
+
+        # Both failing fields should appear in the formatted error.
+        assert "severity" in text
+        assert "limit" in text
+
+    @pytest.mark.asyncio
+    async def test_tool_name_appears_in_error_string(self):
+        """The AI uses the tool name in error messages to know which call failed."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_call_tool_context("apstra_apply_ct_policies")
+
+        async def _raise(_ctx):
+            raise _make_validation_error("application_points", "must be a list")
+
+        result = await middleware.on_call_tool(ctx, _raise)
+        text = result.content[0].text
+
+        assert "apstra_apply_ct_policies" in text


### PR DESCRIPTION
## Summary

Closes #206. Adds a `ValidationCatchMiddleware` that converts Pydantic `ValidationError` into a structured tool-result string instead of letting it propagate as `MontyRuntimeError` and crash `execute()` in code mode.

This is the FastMCP-layer follow-up to #202 — the carved-out concern that #202's tool-level fix couldn't address because Pydantic validation fires BEFORE the tool function runs.

## Live verification

| Before | After |
|---|---|
| `call_tool("mist_search_alarms", {"severity": "major"})` → `MontyRuntimeError`, `execute()` crashes, AI's try/except cannot recover | Returns: `"Error: validation failed for tool 'mist_search_alarms':\n  - severity: Input should be 'critical', 'info' or 'warn' (got: 'major')"` — AI receives a string, branches on it, retries |

## Implementation

`src/hpe_networking_mcp/middleware/validation_catch.py` — ~50 LOC. FastMCP `Middleware` subclass with `on_call_tool` hook. Wraps `await call_next(context)` in `try/except pydantic.ValidationError`, returns `ToolResult(content=<string>)` on catch. Placement: between `NullStripMiddleware` and `ElicitationMiddleware` in the FastMCP middleware chain.

The error string uses Pydantic's own "Input should be X, Y, or Z" formatting — actionable, the AI can immediately retry with a valid value.

## What this protects against

- **Apstra's 19 Pydantic field validators** in `apstra/models.py` — the originally-flagged out-of-scope concern from #202
- **Mist's enum-typed params** (`AlarmSeverity`, `AlarmGroup`, etc.) when given an invalid value
- **Any tool with a `Field(...)` validator** that rejects input
- **Any UUID-typed param** with malformed input
- **Any future Pydantic validator** added by any platform — protected for free

## Behavior change scope

| Mode | Today | After |
|---|---|---|
| **Code** | `MontyRuntimeError` crashes `execute()` (the bug) | Clean string return — bug fixed |
| **Static** | AI sees `McpError(-32602, "Invalid params: ...")` | AI sees readable string — message is more useful |
| **Dynamic** | `<platform>_invoke_tool` wraps and returns a string | Unchanged — middleware sees only the meta-tool's flexible-typed params; the underlying tool's validation is caught inside `_invoke_tool`'s body |

Verified by running the full dynamic-mode test suite (`test_*_dynamic_mode.py` × 6 platforms + `test_code_mode.py` + `test_middleware.py`) — all 100 tests pass with the middleware enabled.

## Bundled in this release

The docs-only tool description cleanup from PR #205 (closes #183) was on main as "Unreleased — docs only" pending the next versioned release. Rolled forward into v2.2.0.3 since the GHCR image will ship that content regardless.

## Test plan

- [x] Live-verified each scenario in code mode (invalid enum, valid call, multi-field error)
- [x] Live-verified dynamic mode is unchanged (full dynamic-mode test suite passes with middleware enabled)
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run mypy src/ --ignore-missing-imports` — passes
- [x] `uv run pytest tests/ -q` — 592 passed (was 587; +5 new tests in `TestValidationCatchMiddleware`)
- [x] CHANGELOG entry + version bump 2.2.0.2 → 2.2.0.3