### PR TITLE
v2.2.0.4: unmask code-mode sandbox errors (closes #208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0.4] - 2026-04-27
+
+**Unmasks code-mode sandbox errors and tells the LLM upfront which tools `call_tool` can dispatch to.** Closes #208.
+
+### Background
+
+When the LLM in code mode wrote `await call_tool("search", ...)` (or `get_schema` / `tags`) inside `execute()`, the sandbox raised `MontyRuntimeError: Unknown tool: search` because those discovery tools live at the outer MCP surface — they're not in the backend catalog `call_tool` resolves against. FastMCP's masking layer (`mask_error_details=True`, set for security) caught the runtime error and re-raised it as a generic `ToolError("Error calling tool 'execute'")`, leaving the LLM with nothing to self-correct from. Both gemma-4eb (LM Studio) and Claude were observed making this exact mistake in the wild.
+
+### What's fixed
+
+Two complementary changes:
+
+1. **Custom `execute_description`** in [`server.py:_register_code_mode`](src/hpe_networking_mcp/server.py) — the default fastmcp string only said "`call_tool` is in scope" without telling the LLM what's *callable*. The new description names the platform-tool prefixes (`mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, plus `health`) and explicitly notes that `tags` / `search` / `get_schema` are NOT callable from inside `execute()` — they're for planning, before the code block.
+
+2. **`SandboxErrorCatchMiddleware`** at [`src/hpe_networking_mcp/middleware/sandbox_error_catch.py`](src/hpe_networking_mcp/middleware/sandbox_error_catch.py) — sits next to `ValidationCatchMiddleware` in the chain. Catches the masked `ToolError` for the `execute` tool, inspects `__cause__`, and if it's a `MontyError` (any subclass: runtime / syntax / typing) returns a string `ToolResult` like:
+
+```
+Sandbox error: Exception: Unknown tool: search
+```
+
+The LLM can branch on this the same way it does on tool-level error strings from Axis / ClearPass.
+
+### Why catch `ToolError` instead of `MontyError` directly
+
+FastMCP's `server.call_tool` (line 1240) already special-cases `ValidationError` to re-raise unchanged — that's why `ValidationCatchMiddleware` (#206) catches the original type. Other exceptions fall through to `mask_error_details` and become `ToolError(...) from cause`. The `MontyError` is preserved as `__cause__`, so we unwrap there.
+
+### Live-tested
+
+Three scenarios verified against the running container in code mode:
+
+| Test | Before | After |
+|---|---|---|
+| `await call_tool("search", ...)` from inside `execute()` | `Error calling tool 'execute'` | `Sandbox error: Exception: Unknown tool: search` |
+| `return "hello"` from `execute()` | (no regression) | (no regression) |
+| `await call_tool("health", {})` from inside `execute()` | (no regression) | (no regression) |
+
+### Tests (592 → 598)
+
+Six new tests in `tests/unit/test_middleware.py::TestSandboxErrorCatchMiddleware`:
+
+- Catches the wrapped sandbox runtime error → returns ToolResult with the readable string
+- Does NOT intercept `ToolError` on tools other than `execute`
+- Does NOT intercept `ToolError` whose `__cause__` is something other than `MontyError`
+- Does NOT intercept bare exceptions on `execute` (only the FastMCP-wrapped shape)
+- Successful execute calls pass through unchanged
+- The wrapped error's `str()` form is preserved verbatim in the returned text
+
+Helper `_make_monty_error` runs real failing pydantic-monty code to capture a genuine `MontyError` instance, since the three concrete subclasses (`MontyRuntimeError` / `MontySyntaxError` / `MontyTypingError`) are Rust-backed and `@final` and cannot be constructed from Python.
+
 ## [2.2.0.3] - 2026-04-27
 
 **Adds `ValidationCatchMiddleware` to convert Pydantic `ValidationError` into a structured tool-result string instead of letting it propagate as `MontyRuntimeError` and crash `execute()` in code mode.** Closes #206 (the FastMCP-layer follow-up to #202).

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ hpe-networking-mcp/
 │   ├── server.py                # FastMCP server setup and lifespan
 │   ├── config.py                # Docker secrets loading and validation
 │   ├── INSTRUCTIONS.md          # LLM instructions for all platforms
-│   ├── middleware/              # Elicitation and null-strip middleware
+│   ├── middleware/              # Elicitation, null-strip, validation-catch, sandbox-error-catch
 │   └── platforms/
 │       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
 │       ├── health.py            # Cross-platform health probe tool
@@ -510,7 +510,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (568+ unit tests)
+├── tests/                       # Unit and integration tests (598+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -61,6 +61,12 @@ Three tool calls inside one `execute`. In dynamic mode this same workflow would 
 
 The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recursion depth (50). Some Python builtins (`hasattr`, `type`, most introspection) aren't available — the LLM learns these via error messages.
 
+### What `call_tool` can dispatch to
+
+Inside `execute()`, `call_tool(name, params)` only resolves names from the backend platform catalog — every tool whose name starts with `mist_` / `central_` / `greenlake_` / `clearpass_` / `apstra_` / `axis_`, plus the cross-platform `health`. The discovery tools (`tags` / `search` / `get_schema`) are NOT callable from inside `execute()` — they live at the outer MCP surface for planning. Use them BEFORE writing your code block, then chain platform tools inside.
+
+If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMiddleware` returns a string like `Sandbox error: Exception: Unknown tool: search` so you can fix the call on the next turn (rather than seeing a generic masked error). See v2.2.0.4 release notes / #208.
+
 ### When to use which mode
 
 - **`dynamic` (default)** — stable, production-tested, best for lookup-style questions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.2.0.3"
+version = "2.2.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -1,0 +1,81 @@
+"""SandboxErrorCatchMiddleware — catch code-mode sandbox errors.
+
+In ``MCP_TOOL_MODE=code``, the ``execute`` tool runs LLM-written Python in a
+``pydantic_monty`` sandbox. Any sandbox-level error (``MontyRuntimeError``,
+``MontySyntaxError``, ``MontyTypingError``) bubbles out and, combined with
+``mask_error_details=True`` (which we deliberately set for security), is
+caught by FastMCP's tool dispatcher in ``server.py:call_tool`` and re-raised
+as a generic ``ToolError("Error calling tool 'execute'")`` — leaving the
+LLM with nothing to self-correct from.
+
+The original ``MontyError`` is preserved on ``ToolError.__cause__``, so this
+middleware catches ``ToolError`` for the ``execute`` tool, inspects the
+cause, and if it's a ``MontyError`` returns the actual error text as a
+string ``ToolResult`` so the LLM can read the real cause.
+
+(Aside on why this differs from ``ValidationCatchMiddleware``: FastMCP
+special-cases ``ValidationError`` to re-raise unchanged — so that catch can
+match the original type. ``MontyError`` falls through to the generic
+``Exception`` branch which applies the masking wrapper.)
+
+Closes #208. The "Unknown tool: search" masking case is the most common
+trigger — LLMs frequently try to call discovery tools from inside
+``execute()`` even though those only exist at the outer MCP surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from loguru import logger
+
+# pydantic_monty ships in the fastmcp[code-mode] extra. If it's missing,
+# code mode itself can't run, so we don't need this middleware to act —
+# but importing it must not crash the server.
+try:
+    from pydantic_monty import MontyError  # type: ignore[import-not-found]
+
+    _HAS_MONTY = True
+except ImportError:
+    MontyError = Exception  # type: ignore[misc,assignment]
+    _HAS_MONTY = False
+
+
+class SandboxErrorCatchMiddleware(Middleware):
+    """Convert sandbox ``MontyError`` (wrapped in ``ToolError`` by FastMCP's
+    masking layer) into a readable string ``ToolResult``.
+
+    Only acts on the code-mode ``execute`` tool. All other tools pass through
+    untouched — sandbox errors are a code-mode-specific failure mode.
+    """
+
+    EXECUTE_TOOL_NAME = "execute"
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: Any,
+    ) -> ToolResult:
+        if not _HAS_MONTY:
+            return await call_next(context)  # type: ignore[no-any-return]
+
+        tool_name = getattr(context.message, "name", "")
+        if tool_name != self.EXECUTE_TOOL_NAME:
+            return await call_next(context)  # type: ignore[no-any-return]
+
+        try:
+            return await call_next(context)  # type: ignore[no-any-return]
+        except ToolError as e:
+            # FastMCP wraps the original sandbox exception in ToolError when
+            # mask_error_details=True is set. The original is on __cause__.
+            cause = e.__cause__
+            if not isinstance(cause, MontyError):
+                # Not a sandbox failure — let the masked ToolError propagate.
+                raise
+            error_text = f"Sandbox error: {cause}"
+            logger.debug("SandboxErrorCatch: caught on {} → {}", tool_name, error_text)
+            return ToolResult(content=error_text)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -192,15 +192,28 @@ def create_server(config: ServerConfig) -> FastMCP:
         ElicitationMiddleware,
     )
     from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+    from hpe_networking_mcp.middleware.sandbox_error_catch import (
+        SandboxErrorCatchMiddleware,
+    )
     from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
 
+    # Middleware order (outermost → innermost):
+    #   NullStrip          — drop nulls before validation
+    #   ValidationCatch    — Pydantic ValidationError → readable string return
+    #   SandboxErrorCatch  — code-mode MontyRuntimeError on execute → string return
+    #   Elicitation        — write-tool confirmation gate
     mcp = FastMCP(
         name="HPE Networking MCP",
         instructions=_INSTRUCTIONS,
         lifespan=lifespan,
         on_duplicate="replace",
         mask_error_details=True,
-        middleware=[NullStripMiddleware(), ValidationCatchMiddleware(), ElicitationMiddleware()],
+        middleware=[
+            NullStripMiddleware(),
+            ValidationCatchMiddleware(),
+            SandboxErrorCatchMiddleware(),
+            ElicitationMiddleware(),
+        ],
     )
 
     # Attach config for lifespan to access
@@ -311,6 +324,25 @@ def _register_code_mode(mcp: FastMCP) -> None:
         max_memory=128 * 1024 * 1024,
         max_recursion_depth=50,
     )
+    # Override the default `execute` description with one that lists the
+    # callable platform-tool prefixes AND explicitly notes that the
+    # discovery tools (tags/search/get_schema) are NOT callable from
+    # inside the sandbox. The default fastmcp string only says
+    # "call_tool(name, params) is in scope" without telling the LLM what
+    # `call_tool` can dispatch to — both gemma-4eb and Claude have hit
+    # the same `Unknown tool: search` failure as a result. See #208.
+    execute_description = (
+        "Run Python in a sandbox to compose multiple platform tool calls. "
+        "Use `return` to produce output.\n\n"
+        "In scope: `await call_tool(name: str, params: dict) -> Any`.\n\n"
+        "`call_tool` ONLY dispatches to platform tools — names start with one "
+        "of: `mist_`, `central_`, `greenlake_`, `clearpass_`, `apstra_`, "
+        "`axis_` — plus the cross-platform `health` tool.\n\n"
+        "The discovery tools `tags`, `search`, and `get_schema` are NOT "
+        "callable from inside execute(). They live at the outer MCP surface "
+        "for planning. Call them BEFORE writing your code block to find "
+        "tool names + schemas, then chain those tools inside execute()."
+    )
     mcp.add_transform(
         CodeMode(
             sandbox_provider=MontySandboxProvider(limits=limits),
@@ -319,6 +351,7 @@ def _register_code_mode(mcp: FastMCP) -> None:
                 Search(default_detail="brief"),
                 GetSchemas(default_detail="detailed"),
             ],
+            execute_description=execute_description,
         )
     )
     logger.info("Code mode enabled — exposed surface: get_tags + search + get_schema + execute")

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,11 +1,13 @@
-"""Unit tests for NullStripMiddleware, ElicitationMiddleware, and ValidationCatchMiddleware."""
+"""Unit tests for NullStripMiddleware, ValidationCatchMiddleware, SandboxErrorCatchMiddleware."""
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field, ValidationError
 
 from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+from hpe_networking_mcp.middleware.sandbox_error_catch import SandboxErrorCatchMiddleware
 from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
 
 # ---------------------------------------------------------------------------
@@ -246,3 +248,157 @@ class TestValidationCatchMiddleware:
         text = result.content[0].text
 
         assert "apstra_apply_ct_policies" in text
+
+
+# ---------------------------------------------------------------------------
+# SandboxErrorCatchMiddleware
+# ---------------------------------------------------------------------------
+
+
+async def _make_monty_error(message: str):
+    """Build a real ``MontyError`` instance by running code that raises in
+    the sandbox.
+
+    All three concrete Monty error classes (``MontyRuntimeError`` /
+    ``MontySyntaxError`` / ``MontyTypingError``) plus their base
+    ``MontyError`` are Rust-backed and cannot be constructed from Python.
+    The only way to get one is to run failing Monty code and capture
+    what the sandbox raises.
+    """
+    import pydantic_monty
+
+    monty = pydantic_monty.Monty(f'raise Exception("{message}")')
+    try:
+        await monty.run_async()
+    except pydantic_monty.MontyError as e:
+        return e
+    raise AssertionError("expected MontyError")  # pragma: no cover
+
+
+def _wrap_in_tool_error(cause: BaseException) -> ToolError:
+    """Mirror what FastMCP's ``server.call_tool`` does with
+    ``mask_error_details=True``: wrap the original exception in a generic
+    ``ToolError`` with the original on ``__cause__``.
+    """
+    err = ToolError("Error calling tool 'execute'")
+    err.__cause__ = cause
+    return err
+
+
+@pytest.mark.unit
+class TestSandboxErrorCatchMiddleware:
+    """The middleware must intercept the ``ToolError`` that FastMCP wraps
+    around a sandbox ``MontyError`` (caused by the masking layer) and
+    return the underlying error's text as a structured ToolResult, so the
+    AI can read the actual cause and self-correct instead of seeing a
+    generic "Error calling tool 'execute'". Closes #208.
+
+    We synthesize the wrap-in-ToolError shape in tests because that's
+    exactly what FastMCP's ``server.call_tool`` produces when
+    ``mask_error_details=True`` (set in our ``create_server`` for security).
+    """
+
+    @pytest.mark.asyncio
+    async def test_catches_monty_runtime_error_on_execute(self):
+        """The originally-bug-inducing case: LLM calls `search` from inside
+        execute() → sandbox raises MontyError("Unknown tool: search")
+        → FastMCP wraps as ToolError → middleware unwraps → ToolResult
+        content carries the readable text.
+        """
+        cause = await _make_monty_error("Unknown tool: search")
+        wrapped = _wrap_in_tool_error(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise wrapped
+
+        result = await middleware.on_call_tool(ctx, _raise)
+
+        assert hasattr(result, "content"), "must return a ToolResult-like object"
+        text = result.content[0].text if result.content else ""
+        assert "sandbox error" in text.lower()
+        assert "Unknown tool: search" in text
+
+    @pytest.mark.asyncio
+    async def test_does_not_catch_on_non_execute_tools(self):
+        """Sandbox errors only happen on `execute`. The middleware must NOT
+        intercept anything on other tools — those have their own contract.
+        """
+        cause = await _make_monty_error("simulated runtime error on the wrong tool")
+        wrapped = _wrap_in_tool_error(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("mist_get_sites")
+
+        async def _raise(_ctx):
+            raise wrapped
+
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(ctx, _raise)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_successful_execute_calls(self):
+        """No exception → middleware returns whatever call_next returned."""
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+        sentinel = object()
+        call_next = AsyncMock(return_value=sentinel)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result is sentinel
+        call_next.assert_called_once_with(ctx)
+
+    @pytest.mark.asyncio
+    async def test_does_not_catch_tool_error_with_non_monty_cause(self):
+        """ToolError is also raised for non-sandbox failures (e.g. unrelated
+        bugs that get masked). When the underlying cause is NOT a MontyError,
+        the middleware must let the ToolError propagate so the existing
+        masked-error contract still applies.
+        """
+        wrapped = _wrap_in_tool_error(RuntimeError("not sandbox-related"))
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise wrapped
+
+        with pytest.raises(ToolError):
+            await middleware.on_call_tool(ctx, _raise)
+
+    @pytest.mark.asyncio
+    async def test_does_not_catch_unrelated_exceptions_on_execute(self):
+        """Bare exceptions (not a ToolError wrap) must propagate. Only the
+        wrapped-by-FastMCP-with-MontyError-cause shape is intercepted.
+        """
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise RuntimeError("boom — bare exception, not a ToolError")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await middleware.on_call_tool(ctx, _raise)
+
+    @pytest.mark.asyncio
+    async def test_error_text_carries_actionable_detail(self):
+        """The wrapped error's str() form must be preserved in the returned
+        text — that's what the LLM reads to fix its code.
+        """
+        cause = await _make_monty_error("division by zero at line 4")
+        wrapped = _wrap_in_tool_error(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise wrapped
+
+        result = await middleware.on_call_tool(ctx, _raise)
+        text = result.content[0].text
+
+        assert "division by zero" in text
+        assert "line 4" in text


### PR DESCRIPTION
## Summary

- Custom `execute` description tells the LLM upfront which tools `call_tool` can dispatch to, and notes that the discovery tools (`tags` / `search` / `get_schema`) are NOT callable from inside `execute()` — they live at the outer MCP surface for planning.
- New `SandboxErrorCatchMiddleware` catches the `ToolError` that FastMCP wraps around a `MontyError` (the masking behavior of `mask_error_details=True`), inspects `__cause__`, and returns the actual error text as a string `ToolResult` so the LLM can self-correct.

Closes #208.

## Why both layers

- **Preventive (description)** — Sonnet 4.6/4.7 figure the rules out from the default fastmcp description, but smaller/older models (gemma-4eb in LM Studio, earlier Claude releases) call `search` from inside `execute()` and get stuck. Naming the rules eliminates the guesswork.
- **Recovery (middleware)** — when a model still makes the mistake, the masked `Error calling tool 'execute'` becomes `Sandbox error: Exception: Unknown tool: search` so it can fix the call on the next turn.

## Live-tested

| Test | Before | After |
|---|---|---|
| `await call_tool("search", ...)` from inside `execute()` | `Error calling tool 'execute'` | `Sandbox error: Exception: Unknown tool: search` |
| `return "hello"` from `execute()` | (no regression) | (no regression) |
| `await call_tool("health", {})` from inside `execute()` | (no regression) | (no regression) |

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — 598 passed (592 → 598; 6 new SandboxErrorCatch tests)
- [x] Live verify against running container in code mode: failing case now returns string, normal cases unchanged.
