### PR TITLE
v2.2.0.5: RetryMiddleware for 5xx + 429 (closes #133, #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0.5] - 2026-04-27
+
+**Adds `RetryMiddleware` for transparent retry of transient API failures (5xx server errors and 429 rate-limit responses).** Closes #133 (5xx retry) and #134 (429 + Retry-After).
+
+### Background
+
+Network APIs occasionally return transient failures — server overload (5xx), rate limiting (429), brief network blips. Without retry handling, every transient failure surfaces to the AI as a tool-level error, forcing the user to either re-ask or watch the model decide whether to retry. Both make the experience worse than necessary.
+
+This middleware catches the two failure shapes our platforms produce:
+
+1. **Response-dict pattern** (Mist / Central / ClearPass) — older clients return a dict shaped like `{"status_code": 503, ...}` (or `"code"` / `"status"` depending on platform).
+2. **Exception pattern** (GreenLake / Apstra / Axis) — newer httpx-based clients raise `httpx.HTTPStatusError` whose `.response.status_code` indicates the failure.
+
+### Behavior
+
+| Status | Reads | Writes | Notes |
+|---|---|---|---|
+| 5xx (500/502/503/504) | retried | NOT retried | Writes may not be idempotent — better to surface and let the user decide |
+| 429 | retried | retried | Always safe — server is asking us to slow down, not telling us the request was processed |
+| 4xx (other) | not retried | not retried | Client error — retrying won't help |
+| 2xx success | returned | returned | No retry path |
+
+Read/write classification reads the FastMCP tool's `tags` at call time — any tag matching `*_write` or `*_write_delete` marks the tool as a write. Cross-platform convention; works for all six platforms.
+
+### Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `RETRY_MAX_ATTEMPTS` | `3` | Max attempts including the first; set to `1` to disable |
+| `RETRY_INITIAL_DELAY` | `1.0` | Initial backoff (seconds); doubles on each retry |
+| `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep + on Retry-After header values |
+
+### Retry-After header support
+
+For 429 responses, the middleware honors a `Retry-After` header when present — both via the response-dict shape (looks for `Retry-After` / `retry_after` / `retry-after` keys) and via `httpx.HTTPStatusError.response.headers["Retry-After"]`. Only the integer-seconds form is honored; HTTP-date form falls back to exponential backoff. The Retry-After value is capped at `RETRY_MAX_DELAY` to prevent a runaway "retry in 24 hours" lock-up.
+
+### Middleware chain (post-#208, post-#133/#134)
+
+Outermost → innermost as of v2.2.0.5:
+
+1. `NullStripMiddleware` — drop nulls before validation
+2. `ValidationCatchMiddleware` — Pydantic ValidationError → string `ToolResult`
+3. `SandboxErrorCatchMiddleware` — code-mode MontyError → string `ToolResult`
+4. `ElicitationMiddleware` — write-tool confirmation gate
+5. `RetryMiddleware` — innermost, so re-tries don't re-prompt elicitation
+
+### Tests (598 → 612)
+
+Fourteen new tests in `tests/unit/test_middleware.py::TestRetryMiddleware`:
+
+- 5xx retry on reads, no-retry on writes
+- 429 retry on both reads and writes
+- 4xx and 2xx no-retry passthrough
+- max-attempts cap respected
+- Retry-After header honored (response-dict + httpx exception forms)
+- Retry-After capped at `RETRY_MAX_DELAY`
+- `max_attempts=1` disables retry entirely
+- Central `code` field pattern + ClearPass `status` field pattern
+- httpx 429 with Retry-After header
+- Unknown exceptions (non-httpx, non-status) propagate unchanged
+
 ## [2.2.0.4] - 2026-04-27
 
 **Unmasks code-mode sandbox errors and tells the LLM upfront which tools `call_tool` can dispatch to.** Closes #208.

--- a/README.md
+++ b/README.md
@@ -427,6 +427,25 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 
 ---
 
+## Reliability
+
+The server transparently retries transient API failures so the AI doesn't have to reason about flakey upstream services.
+
+- **5xx errors on read tools** — auto-retried with exponential backoff (1s, 2s, 4s — 3 attempts total)
+- **429 rate-limit responses** — retried on both reads and writes (always safe — the server is asking us to slow down). Honors the `Retry-After` response header when present, capped at 60s
+- **Write tools (5xx)** — never auto-retried for idempotency safety. The error surfaces to the AI which can decide whether to re-issue
+- **4xx errors (other than 429)** — never retried; surface immediately
+
+The retry logic detects transient failures in two patterns: response-dict (Mist/Central/ClearPass return `{"status_code": 503, ...}`) and httpx exception (GreenLake/Apstra/Axis raise `httpx.HTTPStatusError`). Read/write classification is via the underlying tool's tags — anything tagged `*_write` or `*_write_delete` is treated as a write.
+
+| Environment Variable | Default | Effect |
+|---------------------|---------|--------|
+| `RETRY_MAX_ATTEMPTS` | `3` | Max attempts including the first call. Set to `1` to disable retry entirely |
+| `RETRY_INITIAL_DELAY` | `1.0` | Initial backoff delay in seconds (doubles per attempt up to `RETRY_MAX_DELAY`) |
+| `RETRY_MAX_DELAY` | `60.0` | Cap on a single sleep — also caps `Retry-After` header values |
+
+---
+
 ## Configuration
 
 | Environment Variable | Default | Description |
@@ -441,6 +460,9 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
 | `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (22 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 300+ visible) |
+| `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
+| `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
+| `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
 
 ---
 
@@ -496,7 +518,7 @@ hpe-networking-mcp/
 │   ├── server.py                # FastMCP server setup and lifespan
 │   ├── config.py                # Docker secrets loading and validation
 │   ├── INSTRUCTIONS.md          # LLM instructions for all platforms
-│   ├── middleware/              # Elicitation, null-strip, validation-catch, sandbox-error-catch
+│   ├── middleware/              # null-strip, validation-catch, sandbox-error-catch, elicitation, retry
 │   └── platforms/
 │       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
 │       ├── health.py            # Cross-platform health probe tool
@@ -510,7 +532,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (598+ unit tests)
+├── tests/                       # Unit and integration tests (612+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.2.0.4"
+version = "2.2.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -67,6 +67,7 @@ If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front wi
 4. If a tool returns no data or an error, say so explicitly. Do not guess.
 5. **MANDATORY: use the information you already have from `<platform>_list_tools` before invoking.** Every tool entry from `list_tools` includes a `params` map showing parameter names + types (and `?` suffix for optional) — always check it before calling `invoke_tool`. Never invoke with `params={}` or guessed names when the `list_tools` output already told you what's required.
 6. **Call `<platform>_get_tool_schema(name=...)` when the `list_tools` params map isn't sufficient.** Specifically: when a param's type is an enum class name (e.g. `"Action_type"`) and you don't yet know its valid values, when you need field descriptions to understand parameter semantics, or when a `dict`/`payload` param needs a nested schema. You do NOT need to re-read a schema you've already fetched in the same conversation; cache it mentally.
+7. **Don't manually retry transient API failures.** The server auto-retries 5xx errors on read tools (3 attempts, exponential backoff) and 429 rate-limit responses on both reads and writes (honors `Retry-After` header). If a tool returns a 5xx or 429 to you, it has *already* exhausted retries — don't loop calling the same tool. 4xx errors (other than 429) and 5xx errors on write tools are NOT auto-retried; surface those to the user with the actual error message.
 
 ---
 

--- a/src/hpe_networking_mcp/middleware/retry.py
+++ b/src/hpe_networking_mcp/middleware/retry.py
@@ -1,0 +1,278 @@
+"""Retry middleware for transient API failures.
+
+Catches two kinds of transient errors and retries reads (5xx + 429) and
+writes (429 only — 4xx/5xx writes are NOT retried for idempotency safety):
+
+1. **Response-dict pattern** — older platform clients (Mist, Central,
+   ClearPass) return a dict shaped like ``{"status_code": 503, ...}``
+   (or ``"code": 503`` / ``"status": 503`` depending on platform).
+2. **Exception pattern** — newer httpx-based clients (GreenLake, Apstra,
+   Axis) raise ``httpx.HTTPStatusError`` whose ``.response.status_code``
+   indicates the failure.
+
+Configuration via env vars:
+
+- ``RETRY_MAX_ATTEMPTS`` — max attempts including the first (default 3)
+- ``RETRY_INITIAL_DELAY`` — initial backoff seconds (default 1.0)
+- ``RETRY_MAX_DELAY`` — cap on a single retry sleep (default 60.0 — also
+  caps Retry-After header values)
+
+Read/write classification reads the FastMCP tool's tags at call time —
+any tag matching ``*_write`` or ``*_write_delete`` marks the tool as a
+write. The middleware retries 5xx only on reads; 429 retries on
+both (since 429 is always safe — the server is asking us to slow down,
+not telling us the request was processed).
+
+Closes #133 (5xx retry) and #134 (429 + Retry-After).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import httpx
+import mcp.types
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from loguru import logger
+
+# Status codes we treat as transient. 5xx = server failure; 429 = rate limit.
+_TRANSIENT_STATUS_CODES = frozenset({500, 502, 503, 504})
+_RATE_LIMIT_STATUS_CODE = 429
+
+
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Retry: invalid {} value {!r}, falling back to {}", name, raw, default)
+        return default
+
+
+def _get_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Retry: invalid {} value {!r}, falling back to {}", name, raw, default)
+        return default
+
+
+def _extract_status_code(value: Any) -> int | None:
+    """Return the HTTP status code from a tool-result dict, or None if absent.
+
+    Looks for the three response-dict shapes our platforms use:
+    Mist/GreenLake (``status_code``), Central (``code``), ClearPass (``status``).
+    """
+    if not isinstance(value, dict):
+        return None
+    for key in ("status_code", "code", "status"):
+        candidate = value.get(key)
+        if isinstance(candidate, int) and 100 <= candidate < 600:
+            return candidate
+    return None
+
+
+def _extract_retry_after_seconds(value: Any, max_delay: float) -> float | None:
+    """Pull a Retry-After value from a tool-result dict.
+
+    Handles both the integer-seconds and HTTP-date forms (we only honor
+    the integer form here; HTTP-date would require parsing and the
+    benefit is tiny). Returns the seconds value capped at ``max_delay``,
+    or ``None`` if no usable value is present.
+    """
+    if not isinstance(value, dict):
+        return None
+    # Try canonical Retry-After plus a couple of pragmatic variants
+    # (some platforms surface them differently).
+    for key in ("Retry-After", "retry_after", "retry-after"):
+        raw = value.get(key)
+        if raw is None:
+            continue
+        try:
+            seconds = float(raw)
+            return min(seconds, max_delay)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _retry_after_from_exception(exc: BaseException, max_delay: float) -> float | None:
+    """Pull Retry-After from an httpx.HTTPStatusError's response headers."""
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    try:
+        raw = exc.response.headers.get("Retry-After")
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        seconds = float(raw)
+        return min(seconds, max_delay)
+    except (TypeError, ValueError):
+        return None
+
+
+def _exception_status_code(exc: BaseException) -> int | None:
+    """Extract status code from an httpx.HTTPStatusError, or None."""
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    try:
+        return int(exc.response.status_code)
+    except Exception:
+        return None
+
+
+async def _is_write_tool(context: MiddlewareContext[mcp.types.CallToolRequestParams], name: str) -> bool:
+    """Look up the tool's tags via FastMCP and return True if any tag ends
+    in ``_write`` or ``_write_delete`` (the cross-platform convention).
+    Falls back to False if the lookup fails — better to retry once
+    erroneously than to mis-classify a real read as a write and skip
+    the retry entirely.
+    """
+    ctx = context.fastmcp_context
+    if ctx is None:
+        return False
+    try:
+        fastmcp = ctx.fastmcp
+        if fastmcp is None:
+            return False
+        tool = await fastmcp.get_tool(name)
+    except Exception:
+        return False
+    if tool is None:
+        return False
+    tags: set[str] = set(getattr(tool, "tags", None) or set())
+    return any(tag.endswith("_write") or tag.endswith("_write_delete") for tag in tags)
+
+
+class RetryMiddleware(Middleware):
+    """Retry transient failures on read tools.
+
+    See module docstring for the design rationale and configuration.
+    """
+
+    def __init__(
+        self,
+        max_attempts: int | None = None,
+        initial_delay: float | None = None,
+        max_delay: float | None = None,
+    ) -> None:
+        self.max_attempts = max_attempts if max_attempts is not None else _get_int_env("RETRY_MAX_ATTEMPTS", 3)
+        self.initial_delay = initial_delay if initial_delay is not None else _get_float_env("RETRY_INITIAL_DELAY", 1.0)
+        self.max_delay = max_delay if max_delay is not None else _get_float_env("RETRY_MAX_DELAY", 60.0)
+
+    def _backoff_delay(self, attempt: int) -> float:
+        """Exponential backoff: initial * 2^attempt, capped at max_delay."""
+        delay = self.initial_delay * (2**attempt)
+        return min(delay, self.max_delay)
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: Any,
+    ) -> ToolResult:
+        if self.max_attempts <= 1:
+            # Disabled — don't retry, just pass through
+            return await call_next(context)  # type: ignore[no-any-return]
+
+        tool_name = context.message.name
+        is_write = await _is_write_tool(context, tool_name)
+
+        last_result: ToolResult | None = None
+        last_exception: BaseException | None = None
+
+        for attempt in range(self.max_attempts):
+            sleep_seconds: float | None = None
+
+            try:
+                result = await call_next(context)
+                # Inspect the response payload for transient-error status codes
+                # in the response-dict pattern (Mist/Central/ClearPass).
+                status = None
+                if hasattr(result, "structured_content") and result.structured_content:
+                    status = _extract_status_code(result.structured_content)
+                if status is None and hasattr(result, "content") and result.content:
+                    # Some tools return the dict-shape inside the content list.
+                    for block in result.content:
+                        text_value = getattr(block, "text", None)
+                        if isinstance(text_value, str):
+                            try:
+                                import json
+
+                                parsed = json.loads(text_value)
+                                status = _extract_status_code(parsed)
+                                if status is not None:
+                                    break
+                            except (ValueError, json.JSONDecodeError):
+                                continue
+
+                if status is None:
+                    # Successful tool call — return the result as-is.
+                    return result  # type: ignore[no-any-return]
+
+                last_result = result
+
+                if status == _RATE_LIMIT_STATUS_CODE:
+                    # 429 retried on reads AND writes (always safe)
+                    if hasattr(result, "structured_content"):
+                        retry_after = _extract_retry_after_seconds(
+                            result.structured_content,
+                            self.max_delay,
+                        )
+                        if retry_after is not None:
+                            sleep_seconds = retry_after
+                elif status in _TRANSIENT_STATUS_CODES:
+                    # 5xx retried on reads only — writes may not be idempotent
+                    if is_write:
+                        return result  # type: ignore[no-any-return]
+                else:
+                    # Non-transient (4xx other than 429, etc.) — return immediately
+                    return result  # type: ignore[no-any-return]
+
+            except httpx.HTTPStatusError as exc:
+                status = _exception_status_code(exc)
+                if status is None:
+                    raise
+                last_exception = exc
+
+                if status == _RATE_LIMIT_STATUS_CODE:
+                    sleep_seconds = _retry_after_from_exception(exc, self.max_delay)
+                elif status in _TRANSIENT_STATUS_CODES:
+                    if is_write:
+                        raise
+                else:
+                    raise
+
+            # If we get here, we're going to retry. Decide the sleep duration.
+            if attempt >= self.max_attempts - 1:
+                # Out of attempts — fall through to return the last result/exception
+                break
+
+            if sleep_seconds is None:
+                sleep_seconds = self._backoff_delay(attempt)
+
+            logger.info(
+                "Retry: {} returned transient error (attempt {}/{}) — sleeping {:.1f}s",
+                tool_name,
+                attempt + 1,
+                self.max_attempts,
+                sleep_seconds,
+            )
+            await asyncio.sleep(sleep_seconds)
+
+        # Out of attempts — return the last result if we have one, or re-raise
+        if last_exception is not None:
+            raise last_exception
+        if last_result is not None:
+            return last_result
+        # Defensive — shouldn't reach here unless max_attempts was 0
+        return await call_next(context)  # type: ignore[no-any-return]

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -192,6 +192,7 @@ def create_server(config: ServerConfig) -> FastMCP:
         ElicitationMiddleware,
     )
     from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+    from hpe_networking_mcp.middleware.retry import RetryMiddleware
     from hpe_networking_mcp.middleware.sandbox_error_catch import (
         SandboxErrorCatchMiddleware,
     )
@@ -202,6 +203,8 @@ def create_server(config: ServerConfig) -> FastMCP:
     #   ValidationCatch    — Pydantic ValidationError → readable string return
     #   SandboxErrorCatch  — code-mode MontyRuntimeError on execute → string return
     #   Elicitation        — write-tool confirmation gate
+    #   Retry              — transient failures retry transparently after elicitation
+    #                        has approved (re-tries don't re-prompt)
     mcp = FastMCP(
         name="HPE Networking MCP",
         instructions=_INSTRUCTIONS,
@@ -213,6 +216,7 @@ def create_server(config: ServerConfig) -> FastMCP:
             ValidationCatchMiddleware(),
             SandboxErrorCatchMiddleware(),
             ElicitationMiddleware(),
+            RetryMiddleware(),
         ],
     )
 

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -1,9 +1,11 @@
-"""Unit tests for NullStripMiddleware, ValidationCatchMiddleware, SandboxErrorCatchMiddleware."""
+"""Unit tests for NullStripMiddleware, ValidationCatchMiddleware,
+SandboxErrorCatchMiddleware, and RetryMiddleware."""
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
+from fastmcp.tools.tool import ToolResult
 from pydantic import BaseModel, Field, ValidationError
 
 from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
@@ -402,3 +404,335 @@ class TestSandboxErrorCatchMiddleware:
 
         assert "division by zero" in text
         assert "line 4" in text
+
+
+# ---------------------------------------------------------------------------
+# RetryMiddleware
+# ---------------------------------------------------------------------------
+
+
+def _toolresult_with_status(status_code: int, **extra) -> ToolResult:
+    """Build a ToolResult whose structured_content carries a status code,
+    matching the shape Mist/GreenLake return on error.
+    """
+    body = {"status_code": status_code, "message": "test", **extra}
+    return ToolResult(structured_content=body)
+
+
+def _toolresult_ok() -> ToolResult:
+    """Build a successful ToolResult with no status_code field."""
+    return ToolResult(structured_content={"results": [], "ok": True})
+
+
+def _make_retry_context(tool_name: str, fastmcp_tool=None):
+    """Mock MiddlewareContext for RetryMiddleware tests.
+
+    fastmcp_tool: optional Tool-like object whose .tags drive read/write
+    classification. None means the tool isn't found → treated as read.
+    """
+    message = MagicMock()
+    message.name = tool_name
+
+    class _FakeFastMCP:
+        async def get_tool(self, _name):
+            return fastmcp_tool
+
+    class _FakeFastMCPContext:
+        @property
+        def fastmcp(self):
+            return _FakeFastMCP()
+
+    context = MagicMock()
+    context.message = message
+    context.fastmcp_context = _FakeFastMCPContext()
+    return context
+
+
+def _fake_tool(*tags: str):
+    """Build a fake Tool-like object with the given tags set."""
+    t = MagicMock()
+    t.tags = set(tags)
+    return t
+
+
+@pytest.mark.unit
+class TestRetryMiddleware:
+    """Closes #133 + #134. RetryMiddleware retries 5xx on reads, 429 on
+    reads+writes, honors Retry-After, respects max-attempts cap, leaves
+    valid responses + non-transient errors untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retries_5xx_on_read_and_succeeds(self):
+        """A read tool that 503s once then 200s should be retried and succeed."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        responses = [_toolresult_with_status(503), _toolresult_ok()]
+        call_next = AsyncMock(side_effect=responses)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2  # one retry
+        # The second response (the OK one) is what we should see
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_5xx_on_write_tool(self):
+        """5xx on a write tool returns immediately (idempotency unsafe)."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context(
+            "mist_change_site_configuration_objects",
+            fastmcp_tool=_fake_tool("mist", "mist_write_delete"),
+        )
+
+        result_503 = _toolresult_with_status(503)
+        call_next = AsyncMock(return_value=result_503)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 1  # no retry on write
+        assert result.structured_content["status_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_retries_429_on_write_tool(self):
+        """429 retries even on write tools — server is asking us to slow down."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("axis_manage_user", fastmcp_tool=_fake_tool("axis", "axis_write_delete"))
+
+        responses = [_toolresult_with_status(429), _toolresult_ok()]
+        call_next = AsyncMock(side_effect=responses)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_2xx_or_4xx(self):
+        """Non-transient responses pass through unchanged on the first call."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        # 200-shaped (no status_code in dict) — middleware sees it as a clean success
+        call_next = AsyncMock(return_value=_toolresult_ok())
+        await middleware.on_call_tool(ctx, call_next)
+        assert call_next.call_count == 1
+
+        # 400-shaped — non-transient, pass through
+        call_next = AsyncMock(return_value=_toolresult_with_status(400))
+        await middleware.on_call_tool(ctx, call_next)
+        assert call_next.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_cap_enforced(self):
+        """If every attempt fails, return after max_attempts and don't retry forever."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        result_503 = _toolresult_with_status(503)
+        call_next = AsyncMock(return_value=result_503)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 3  # exactly max_attempts
+        # Last result is what surfaces back
+        assert result.structured_content["status_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_retry_after_header_respected(self):
+        """When 429 carries Retry-After, sleep that many seconds (capped at max_delay)."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=2, initial_delay=10.0, max_delay=60.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        # Server says wait 5 seconds — middleware should honor that, not the 10s default
+        responses = [
+            _toolresult_with_status(429, **{"Retry-After": "5"}),
+            _toolresult_ok(),
+        ]
+        call_next = AsyncMock(side_effect=responses)
+
+        # Patch asyncio.sleep so the test doesn't actually wait
+        async def _spy_sleep(seconds):
+            _spy_sleep.last_seconds = seconds  # type: ignore[attr-defined]
+
+        from unittest.mock import patch
+
+        with patch("hpe_networking_mcp.middleware.retry.asyncio.sleep", side_effect=_spy_sleep):
+            await middleware.on_call_tool(ctx, call_next)
+
+        assert _spy_sleep.last_seconds == 5.0  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_retry_after_capped_at_max_delay(self):
+        """Server-supplied Retry-After is capped — don't sleep forever even if asked."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=2, initial_delay=1.0, max_delay=60.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        # Server says wait 999 seconds — we cap at max_delay (60)
+        responses = [
+            _toolresult_with_status(429, **{"Retry-After": "999"}),
+            _toolresult_ok(),
+        ]
+        call_next = AsyncMock(side_effect=responses)
+
+        async def _spy_sleep(seconds):
+            _spy_sleep.last_seconds = seconds  # type: ignore[attr-defined]
+
+        from unittest.mock import patch
+
+        with patch("hpe_networking_mcp.middleware.retry.asyncio.sleep", side_effect=_spy_sleep):
+            await middleware.on_call_tool(ctx, call_next)
+
+        assert _spy_sleep.last_seconds == 60.0  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_one_disables_retry(self):
+        """RETRY_MAX_ATTEMPTS=1 should pass through with no retry behavior."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=1, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        result_503 = _toolresult_with_status(503)
+        call_next = AsyncMock(return_value=result_503)
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 1  # no retry
+
+    @pytest.mark.asyncio
+    async def test_status_in_response_central_pattern(self):
+        """Central uses ``code`` instead of ``status_code`` — middleware should still detect."""
+        from fastmcp.tools.tool import ToolResult
+
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=2, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("central_get_devices", fastmcp_tool=_fake_tool("central"))
+
+        # pycentral's error shape uses ``code``, not ``status_code``
+        first = ToolResult(structured_content={"code": 503, "msg": "transient"})
+        second = _toolresult_ok()
+        call_next = AsyncMock(side_effect=[first, second])
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_status_in_response_clearpass_pattern(self):
+        """ClearPass uses ``status`` instead of ``status_code``."""
+        from fastmcp.tools.tool import ToolResult
+
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=2, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("clearpass_get_network_devices", fastmcp_tool=_fake_tool("clearpass"))
+
+        first = ToolResult(structured_content={"status": 503, "title": "transient"})
+        second = _toolresult_ok()
+        call_next = AsyncMock(side_effect=[first, second])
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_httpx_exception_path_retries(self):
+        """httpx.HTTPStatusError on a read tool retries via the exception path."""
+        import httpx
+
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("axis_get_connectors", fastmcp_tool=_fake_tool("axis"))
+
+        # Build a real HTTPStatusError with a 503 response
+        request = httpx.Request("GET", "https://x")
+        response = httpx.Response(503, request=request)
+        exc = httpx.HTTPStatusError("server error", request=request, response=response)
+
+        call_next = AsyncMock(side_effect=[exc, _toolresult_ok()])
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_httpx_exception_does_not_retry_on_write(self):
+        """5xx exception on a write tool re-raises — idempotency unsafe."""
+        import httpx
+
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("axis_manage_connector", fastmcp_tool=_fake_tool("axis", "axis_write_delete"))
+
+        request = httpx.Request("POST", "https://x")
+        response = httpx.Response(503, request=request)
+        exc = httpx.HTTPStatusError("server error", request=request, response=response)
+
+        call_next = AsyncMock(side_effect=exc)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await middleware.on_call_tool(ctx, call_next)
+        assert call_next.call_count == 1  # no retry
+
+    @pytest.mark.asyncio
+    async def test_httpx_429_retry_after_from_header(self):
+        """httpx exception path also honors Retry-After."""
+        import httpx
+
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=2, initial_delay=10.0, max_delay=60.0)
+        ctx = _make_retry_context("axis_get_connectors", fastmcp_tool=_fake_tool("axis"))
+
+        request = httpx.Request("GET", "https://x")
+        response = httpx.Response(429, headers={"Retry-After": "7"}, request=request)
+        exc = httpx.HTTPStatusError("rate limit", request=request, response=response)
+
+        call_next = AsyncMock(side_effect=[exc, _toolresult_ok()])
+
+        async def _spy_sleep(seconds):
+            _spy_sleep.last_seconds = seconds  # type: ignore[attr-defined]
+
+        from unittest.mock import patch
+
+        with patch("hpe_networking_mcp.middleware.retry.asyncio.sleep", side_effect=_spy_sleep):
+            await middleware.on_call_tool(ctx, call_next)
+
+        assert _spy_sleep.last_seconds == 7.0  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_unknown_exceptions_are_not_caught(self):
+        """Only httpx.HTTPStatusError is intercepted on the exception path —
+        other exceptions propagate to upstream handlers."""
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_retry_context("mist_get_devices", fastmcp_tool=_fake_tool("mist"))
+
+        call_next = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await middleware.on_call_tool(ctx, call_next)
+        assert call_next.call_count == 1  # no retry on unknown exception


### PR DESCRIPTION
## Summary

Adds `RetryMiddleware` so transient upstream failures retry transparently instead of surfacing to the AI as tool-level errors.

- **5xx errors on reads** — retried with exponential backoff (1s, 2s, 4s by default; 3 attempts total)
- **429 rate-limit responses** — retried on both reads and writes (always safe — server is asking us to slow down). Honors `Retry-After` response header, capped at `RETRY_MAX_DELAY`
- **Writes (5xx)** — never auto-retried for idempotency safety. The error surfaces; the AI can decide
- **4xx (other than 429) and 2xx** — pass through immediately

Closes #133. Closes #134.

## Why two shapes

Our six platforms split into two error-reporting conventions:

| Pattern | Platforms | Shape |
|---|---|---|
| Response-dict | Mist, Central, ClearPass | Tool returns `{"status_code": 503, ...}` (key varies per platform: `status_code` / `code` / `status`) |
| Exception | GreenLake, Apstra, Axis | Tool raises `httpx.HTTPStatusError` with `.response.status_code` |

The middleware handles both, plus pulls `Retry-After` from either the dict or the httpx response headers.

## Read/write classification

Reads FastMCP `tool.tags` at call time. Any tag matching `*_write` or `*_write_delete` marks the tool as a write. Cross-platform convention; works for all six platforms without a manual list.

## Configuration

| Env var | Default | Effect |
|---|---|---|
| `RETRY_MAX_ATTEMPTS` | `3` | Max attempts including the first call. Set to `1` to disable retry entirely |
| `RETRY_INITIAL_DELAY` | `1.0` | Initial backoff delay seconds (doubles per attempt up to `RETRY_MAX_DELAY`) |
| `RETRY_MAX_DELAY` | `60.0` | Cap on a single sleep — also caps `Retry-After` values |

## Middleware position

Innermost in the chain (post-rebase on v2.2.0.4):

1. `NullStripMiddleware`
2. `ValidationCatchMiddleware`
3. `SandboxErrorCatchMiddleware` (added in v2.2.0.4)
4. `ElicitationMiddleware`
5. `RetryMiddleware` ← here, so re-tries don't re-prompt elicitation after the user has already approved a write

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — 612 passed (598 → 612; 14 new RetryMiddleware tests)
- [x] Live-verified no regression on Mist + Axis + ClearPass calls before pausing for the v2.2.0.4 detour
