### PR TITLE
v2.3.0.1: change-post-check skill + sandbox-limits documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.1] - 2026-04-27
+
+**Adds the `change-post-check` skill (partner to `change-pre-check`) and documents two pydantic-monty sandbox limits the LLM was discovering at runtime.**
+
+### `change-post-check` skill
+
+The `change-pre-check` skill captures a baseline before a planned change; this new skill re-pulls the same data afterward and diffs against the baseline to produce a verdict:
+
+| Verdict | Trigger |
+|---|---|
+| `CLEAN` | Reachability unchanged + 0 new alarms + config diff matches plan + metric deltas <5% |
+| `IMPACT-OBSERVED` | At least one IMPACT signal but no REGRESSION (new minor alarm, 5-15% client delta, etc.) |
+| `REGRESSION` | Platform unreachable / planned change didn't land / unplanned config drift / >15% delta |
+
+**Baseline-discovery design:** the skill checks conversation context first for the `## Pre-change baseline — ...` block and only asks the user to paste it back if it's not in scope. Operators working in the same chat as the pre-check don't need to copy-paste anything.
+
+`change-pre-check.md` gains a "After the change — run the post-check" section so the AI tells the operator about the partner skill on its way out, with the in-context-vs-paste-back distinction called out explicitly.
+
+### Documented sandbox limits
+
+In-the-wild observation: the AI ran `change-pre-check` in code mode and tripped on two pydantic-monty sandbox limits, recovering each time via the `SandboxErrorCatchMiddleware` (v2.2.0.4) error string but burning a turn each:
+
+1. **`asyncio.gather()`** fails with `TypeError: 'list' object is not an iterator` — the sandbox treats the awaitable list as a non-iterator.
+2. **`datetime.now()`** is blocked as an OS-access call (`NotImplementedError`).
+
+The `SandboxErrorCatchMiddleware` did its job (the LLM saw the actual error and self-corrected), but the LLM shouldn't have to *discover* these limits per-session. So:
+
+- The custom `execute_description` (`server.py:_register_code_mode`) gains a "Known sandbox limits" line listing both — `asyncio.gather()` unavailable, OS-access functions blocked, and the practical workaround (sequential awaits, ISO strings as parameters or hardcoded literals).
+- `docs/TOOLS.md`'s "Sandbox limits" section gains the same content.
+
+### Tests
+
+No new tests — the skill is content; the bundled-skills sanity test added in v2.3.0.0 auto-picks up the new file. 639 tests still pass.
+
+### Bumped to a patch version
+
+Adding a skill is purely additive content (no schema change, no new tool surface). Same versioning logic as adding a new middleware. Patch.
+
 ## [2.3.0.0] - 2026-04-27
 
 **Adds a Skills system: markdown-defined multi-step procedures discoverable via two MCP tools.** Closes #189.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -59,7 +59,13 @@ Three tool calls inside one `execute`. In dynamic mode this same workflow would 
 
 ### Sandbox limits
 
-The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recursion depth (50). Some Python builtins (`hasattr`, `type`, most introspection) aren't available — the LLM learns these via error messages.
+The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recursion depth (50). Several Python features the LLM may reach for are also unavailable:
+
+- **`asyncio.gather()`** — fails with `TypeError: 'list' object is not an iterator`. Use sequential `await` calls instead.
+- **OS-access functions** — `datetime.now()`, `time.time()`, file I/O (`open`, `Path.read_text`), `os.environ`, and `subprocess` all raise `NotImplementedError`. For timestamps, accept ISO strings as parameters or hardcode literal ISO-8601 strings.
+- **Some introspection** — `hasattr`, `type`, and parts of the introspection surface aren't available; the LLM discovers these via error messages.
+
+The `execute` tool description tells the LLM these limits up front so it shouldn't waste turns rediscovering them.
 
 ### What `call_tool` can dispatch to
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.0"
+version = "2.3.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -350,7 +350,13 @@ def _register_code_mode(mcp: FastMCP) -> None:
         "The discovery tools `tags`, `search`, and `get_schema` are NOT "
         "callable from inside execute(). They live at the outer MCP surface "
         "for planning. Call them BEFORE writing your code block to find "
-        "tool names + schemas, then chain those tools inside execute()."
+        "tool names + schemas, then chain those tools inside execute().\n\n"
+        "Known sandbox limits: `asyncio.gather()` is unavailable — use "
+        "sequential `await` calls. OS-access functions are blocked, "
+        "including `datetime.now()`, `time.time()`, file I/O, `os.environ`, "
+        "and `subprocess`. For timestamps, accept ISO strings as parameters "
+        "or hardcode literal ISO-8601 strings rather than computing them "
+        "inside the sandbox."
     )
     mcp.add_transform(
         CodeMode(

--- a/src/hpe_networking_mcp/skills/change-post-check.md
+++ b/src/hpe_networking_mcp/skills/change-post-check.md
@@ -1,0 +1,223 @@
+---
+name: change-post-check
+title: Post-change verification + diff
+description: |
+  Re-run the same checks captured in `change-pre-check` after a planned
+  configuration change has completed, then diff against the baseline to
+  produce a verdict (CLEAN / IMPACT-OBSERVED / REGRESSION). Use this when
+  the user says "the change is done — verify it", "post-change check", or
+  finishes a maintenance window. Pairs with `change-pre-check`.
+platforms: [mist, central, clearpass, apstra]
+tags: [change-management, maintenance, verification, post-flight]
+tools: [health, mist_search_alarms, mist_search_audit_logs, central_get_alerts, central_get_audit_logs, clearpass_get_recent_audit_log]
+---
+
+# Post-change verification + diff
+
+## Objective
+
+Confirm the planned change landed cleanly by re-pulling the same data
+captured in `change-pre-check` and diffing the two snapshots. Output a
+verdict — `CLEAN`, `IMPACT-OBSERVED`, or `REGRESSION` — that the operator
+pastes into the change ticket as the post-change verification entry.
+
+This skill is the partner to `change-pre-check`. The pre-check captures
+the BEFORE; this captures the AFTER and shows the delta.
+
+## Prerequisites
+
+- A `change-pre-check` snapshot for the SAME target / scope must be
+  available — either in the current conversation or pasted back by the
+  user. **Without a baseline this skill can't run.** A post-check that
+  isn't comparing against a baseline is just another pre-check.
+- The change should actually be complete. If the user is still mid-change,
+  ask them to confirm the change landed before continuing — running
+  post-check during the change produces a misleading delta.
+
+## Procedure
+
+### Step 1 — Locate the baseline snapshot
+
+**Look in conversation context first.** If you can see a `change-pre-check`
+snapshot earlier in this chat covering the same target/scope, use it
+directly — you don't need to ask the user to re-paste it. The pre-check
+output has a recognizable shape:
+
+```
+## Pre-change baseline — <description>
+**Captured:** <timestamp>
+**Target:** <scope>
+**Affected platforms:** ...
+```
+
+**Otherwise ask the user to paste it back.** Say:
+> "I don't see a pre-check snapshot in this conversation. Paste the
+> baseline output here (the block starting with `## Pre-change baseline`)
+> and I'll diff against it."
+
+Record the baseline's `Captured:` timestamp, target, and platform list —
+those scope every later step.
+
+### Step 2 — Re-run reachability
+
+**Tool:** `health(platform=<same as baseline>)`
+**Why:** Confirms the change didn't break reachability to any of the
+involved platforms. A platform that was `ok` in pre-check and is now
+`degraded` is a major red flag.
+**Compare to:** Baseline reachability section.
+**Verdict contribution:**
+- All platforms still `ok` → CLEAN signal
+- Any platform now `degraded` / `unavailable` that was `ok` → REGRESSION
+  signal (lead with this)
+
+### Step 3 — New alarms / alerts since baseline
+
+**Mist:** `mist_search_alarms(org_id=..., site_id=<target>, duration="<delta>")`
+where `<delta>` is approximately the time elapsed since the pre-check
+`Captured:` timestamp (round up to nearest hour and add 30 minutes of
+buffer). Filter to alarms matching the change target.
+
+**Central:** `central_get_alerts(severity="Major,Critical")` then filter
+to alerts on the affected device(s)/site that are NOT in the baseline.
+
+**Why:** New alarms in the change window are correlated with the change
+unless proven otherwise. Pre-existing alarms documented in the baseline
+should NOT be re-flagged here — they were already broken.
+**Compare to:** Baseline pre-existing alarms section.
+**Verdict contribution:**
+- 0 new alarms / alerts → CLEAN signal
+- New alarms within 10 minutes of the change → IMPACT-OBSERVED, list them
+- New critical alarms after the change → REGRESSION
+
+### Step 4 — Audit log confirmation
+
+**Mist:** `mist_search_audit_logs(org_id=..., duration="<delta>", limit=50)`
+**Central:** `central_get_audit_logs` (filter to the change window)
+**ClearPass (if affected):** `clearpass_get_recent_audit_log(limit=50)`
+
+**Why:** Two things to verify:
+1. The planned change is recorded — confirms it actually landed (not just
+   "the API returned 200" but "the system recorded the action").
+2. **No unplanned admin actions in the change window.** If someone else
+   pushed an unrelated change concurrently, that's a finding — flag it
+   even if it didn't cause a problem, because it complicates root-cause
+   analysis if something does break later.
+
+**Verdict contribution:**
+- Planned change recorded + no unplanned activity → CLEAN signal
+- Planned change recorded + unrelated admin actions in the window → note
+  in the report (not necessarily a regression; informational)
+- Planned change NOT recorded → REGRESSION (the change didn't actually
+  apply or wasn't audited correctly)
+
+### Step 5 — Current configuration vs baseline
+
+Re-read the affected resource's *current* config using the same tool the
+pre-check used (see the "Current configuration" section of the baseline).
+
+**Compare line-by-line to the baseline's captured config.** Show the diff
+inline. Highlight:
+- Lines that match the operator's change description → expected
+- Lines that don't match the change description → unplanned drift
+- Lines that the change description said WOULD change but didn't →
+  potential failure-to-apply
+
+**Verdict contribution:**
+- Diff matches change description exactly → CLEAN signal
+- Diff includes unplanned changes → REGRESSION (something else got
+  changed beyond what was planned)
+- Diff is missing planned changes → REGRESSION (the change didn't fully
+  apply)
+
+### Step 6 — Active impact metrics
+
+Re-pull the same metrics the pre-check captured (Wi-Fi: client count,
+APs up, disconnected; Switch: device count, active client count; NAC:
+active session count by service).
+
+**Compute the delta vs baseline:**
+
+| Metric | Baseline | Now | Delta % |
+|---|---|---|---|
+| Clients (HOME) | 38 | 35 | -7.9% |
+| APs up (HOME) | 17 | 17 | 0% |
+| Active NAC sessions | 1240 | 1198 | -3.4% |
+
+**Verdict contribution by delta magnitude:**
+- |delta| < 5% on all metrics → CLEAN signal (likely just normal churn)
+- 5-15% drop on one metric → IMPACT-OBSERVED, attribute to the change
+- 15%+ drop on any metric → REGRESSION; lead the report with this
+
+Wi-Fi changes have a 5-15 minute settling window — if the post-check
+happens within 5 minutes of the change landing, mention that the
+delta may not be fully meaningful yet.
+
+### Step 7 — Compute verdict + format the report
+
+Aggregate the verdict signals from steps 2-6 into one of three values:
+
+| Verdict | Trigger |
+|---|---|
+| **CLEAN** | Every step contributed CLEAN signals (no new alarms, reachability unchanged, config diff matches plan, deltas <5%) |
+| **IMPACT-OBSERVED** | At least one IMPACT signal but no REGRESSION signals (new minor alarm, 5-15% client delta, etc.) — change landed but had user-visible effect |
+| **REGRESSION** | Any REGRESSION signal (platform unreachable, planned change didn't land, unplanned config drift, >15% delta) |
+
+Format the report as shown below.
+
+## Decision matrix
+
+| Condition | Action |
+|---|---|
+| No baseline available in chat or paste | STOP. Ask user for the pre-check snapshot. Don't run blind. |
+| Baseline target ≠ current scope | STOP. Pre-check covered site `HOME`, post-check shouldn't run against site `OFFICE`. Confirm with user. |
+| Change landed less than 5 minutes ago + Wi-Fi affected | Note that client/RF metrics may still be settling; consider a follow-up post-check in 10 minutes |
+| Verdict is REGRESSION | Lead the report with the regression specifics. Suggest the operator consider rollback. |
+| Audit log shows unplanned admin actions | Surface the actor + timestamp explicitly so the operator can investigate |
+
+## Output formatting
+
+```
+## Post-change verification — <change description>
+**Captured:** <ISO timestamp>
+**Baseline:** <baseline timestamp from pre-check>
+**Target:** <site / device / WLAN / policy>
+**Verdict:** CLEAN / IMPACT-OBSERVED / REGRESSION
+
+### Reachability diff
+- Mist: ok → ok ✓
+- Central: ok → ok ✓
+
+### New alarms / alerts since baseline
+- Mist: 0 new on target ✓
+- Central: 1 new minor — "AP-12 fan speed warning" — but PRE-EXISTING in baseline (NOT caused by change)
+
+### Audit log
+- Planned change recorded at 14:31 UTC by current user ✓
+- No unplanned admin actions in window ✓
+
+### Configuration diff
+<inline diff vs baseline — highlight what changed>
+
+### Impact metrics
+| Metric | Baseline | Now | Delta |
+|---|---|---|---|
+| Clients (HOME) | 38 | 35 | -7.9% (within normal churn) |
+| APs up (HOME) | 17 | 17 | 0% |
+
+### Verdict reasoning
+- Reachability unchanged
+- 0 new alarms in change window
+- Config diff matches change description
+- Metric deltas within normal churn range
+- → CLEAN
+```
+
+For REGRESSION verdicts, lead with the specifics; the operator needs to
+decide whether to roll back.
+
+## Example queries that should trigger this skill
+
+> "the WLAN change is done — verify it"
+> "run the change-post-check now"
+> "post-change checks for the AP firmware push that just finished"
+> "is the change clean?"

--- a/src/hpe_networking_mcp/skills/change-pre-check.md
+++ b/src/hpe_networking_mcp/skills/change-pre-check.md
@@ -169,6 +169,15 @@ their change ticket (see *Output formatting* below).
 
 Save this snapshot before proceeding with the change.
 
+## After the change — run the post-check
+
+End the response by reminding the operator:
+
+> "Save this snapshot. After the change lands, run the `change-post-check`
+> skill to diff against this baseline and get a CLEAN / IMPACT-OBSERVED /
+> REGRESSION verdict. If you stay in this same chat, the AI will read
+> this snapshot directly from context — you won't need to paste it back."
+
 ## Example queries that should trigger this skill
 
 > "I'm about to push a config change to the HOME WLAN — give me a baseline"


### PR DESCRIPTION
## Summary

Adds the **`change-post-check`** skill — partner to `change-pre-check`. Re-runs the same checks after a planned change has completed, diffs against the baseline, and produces a verdict (`CLEAN` / `IMPACT-OBSERVED` / `REGRESSION`) the operator pastes into the change ticket.

Plus documents two pydantic-monty sandbox limits the LLM was discovering at runtime.

## change-post-check skill

**Baseline-discovery design** (per the design discussion): the skill looks in conversation context FIRST for a `## Pre-change baseline — ...` block. Only if it's not in scope does it ask the user to paste it back. Operators staying in the same chat as the pre-check don't need to copy-paste — operators starting a new session do.

The verdict logic:

| Verdict | Trigger |
|---|---|
| `CLEAN` | Reachability unchanged + 0 new alarms + config diff matches plan + metric deltas <5% |
| `IMPACT-OBSERVED` | At least one IMPACT signal but no REGRESSION (new minor alarm, 5-15% client delta, etc.) |
| `REGRESSION` | Platform unreachable / planned change didn't land / unplanned config drift / >15% delta |

`change-pre-check.md` gains a closing section telling the operator about the partner skill so the post-check is discoverable from the pre-check output.

## Sandbox-limits documentation

Real in-the-wild observation while running `change-pre-check` in code mode: the AI tripped on two pydantic-monty sandbox limits, recovered each time via `SandboxErrorCatchMiddleware` (v2.2.0.4) — but each discovery cost a turn. Documenting them up front:

1. **`asyncio.gather()`** fails with `TypeError: 'list' object is not an iterator`. Use sequential `await` calls.
2. **`datetime.now()`** (and other OS-access functions) is blocked with `NotImplementedError`. Accept timestamps as ISO strings or hardcode literal ISO-8601 strings.

Both noted in:
- Custom `execute_description` in `server.py:_register_code_mode` — so every code-mode session sees them in the tool catalog
- `docs/TOOLS.md` "Sandbox limits" section

The `SandboxErrorCatchMiddleware` (#208 fix) did exactly what it was supposed to — surfaced the actual error so the LLM could self-correct. Documenting the limits is preventive; the recovery layer remains.

## Live-tested

- `skills_list(tag="change-management")` now returns both `change-pre-check` and `change-post-check`
- `skills_load("change-post-check")` returns 8397-char body
- Verified the file shows up in the registry after restarting with the dev override

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — 639 passed (no new tests; bundled-skills sanity test from v2.3.0.0 auto-picks up the new skill)
- [x] Live verification against running container in code mode — 4 skills now register; new skill loads cleanly

## Versioning

Bumped to **v2.3.0.1** (patch). Adding skill content + description copy-edit is purely additive — same versioning logic as new-middleware additions in v2.2.0.x. v2.3.0.0 was the new tool surface (minor); subsequent additions to the skill library are patch.
