### PR TITLE
v2.3.0.2: fix 12 wrong tool names in skills + regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.2] - 2026-04-27
+
+**Fixes 12 wrong tool-name references in the bundled skills, tightens output templates so the AI doesn't improvise inconsistent formatting, and adds a regression test that catches this whole class of bug at CI time.**
+
+### What went wrong
+
+In-the-wild signal from running `infrastructure-health-check` and `change-pre-check`: skills were referencing tool names that don't exist (e.g. `clearpass_get_recent_audit_log`, `mist_get_org_wlans`, `apstra_get_blueprint_revisions`). The AI got "tool not found" errors via the discovery tools and worked around them — sometimes by skipping the step entirely (silent gap in output), sometimes by improvising a substitute. Output was incomplete and inconsistent across runs.
+
+Root cause: the v2.3.0.0 skills were authored without verifying every referenced name against the actual tool catalog. The output formatting templates were also loose enough that the AI was filling in freeform sections.
+
+### Skill fixes (12 wrong names corrected)
+
+| Wrong name | Correct name | Files |
+|---|---|---|
+| `clearpass_get_recent_audit_log` | `clearpass_get_system_events` | infrastructure-health-check, change-pre-check, change-post-check |
+| `clearpass_get_active_sessions` | `clearpass_get_sessions` | change-pre-check |
+| `clearpass_get_enforcement_policy` | `clearpass_get_enforcement_policies(policy_id=...)` | change-pre-check |
+| `mist_get_org_wlans` / `mist_get_site_wlans` | `mist_get_wlans()` (accepts `org_id` or `site_id`) | wlan-sync-validation |
+| `mist_get_wlan` (singular) | `mist_get_configuration_objects(object_type="wlans", object_id=...)` | change-pre-check |
+| `mist_get_device` | `mist_search_device` (org inventory) or `mist_get_ap_details` / `mist_get_switch_details` (specific device) | change-pre-check |
+| `mist_get_device_port_config` | `mist_get_switch_details(device_id=...)` (port config is part of switch detail) | change-pre-check |
+| `central_get_site_wlans` | `central_get_wlans(site_id=...)` | wlan-sync-validation |
+| `central_get_wlan` (singular) | `central_get_wlans()` | change-pre-check |
+| `central_get_switch_port` | `central_get_switch_details(serial=...)` | change-pre-check |
+| `apstra_get_blueprint_revisions` | `apstra_get_blueprints(blueprint_id=...)` (record `version`) + `apstra_get_diff_status` (uncommitted changes) | change-pre-check |
+
+### Tightened output templates
+
+Each skill's "Output formatting" section now leads with a directive: *"Use the EXACT structure below. Every section heading must be present even if its content is..."* This stops the AI from skipping sections, adding freeform "Notable" sections that aren't in the template, or rewriting headings between runs. The output structure itself is unchanged — same headings, same fields — just enforced.
+
+`infrastructure-health-check` also gained `apstra_get_anomalies`, `axis_get_connectors`, and `axis_get_status` to the `tools:` frontmatter (they were referenced in the body but missing from the metadata list) and clarified the Axis step to spell out the runtime-status field names (`cpuStatus`, `memoryStatus`, `networkStatus`, `diskSpaceStatus`).
+
+### Regression test (`tests/unit/test_skill_tool_references.py`)
+
+Builds a server in static mode (every tool registered) plus the dynamic-mode meta-tool name patterns. Walks each `skills/*.md` body and `INSTRUCTIONS.md`, extracts every platform-prefixed identifier via regex, asserts each appears in the canonical catalog or in a small `_GLOBAL_ALLOWLIST` for known historical mentions (e.g. *"`apstra_health` was removed in v2.0"*) and regex artifacts (e.g. incomplete patterns like `mist_change_org` inside *"`mist_change_org_*` family"* prose).
+
+5 new test cases:
+- Per-skill parametrized check: 4 skills × 1 test = 4 cases
+- INSTRUCTIONS.md check: 1 case
+
+Future skill authors get a CI failure if they reference a non-existent tool, with a clear remediation message ("either fix the name to match a real tool, or — if the reference is intentional — add it to `_GLOBAL_ALLOWLIST`").
+
+### What we didn't change
+
+- INSTRUCTIONS.md had **0 actual broken references**. The regex caught 12 hits but every single one was either historical prose ("X was removed in v2.0", surfaced for context) or a regex artifact (incomplete pattern like `mist_change_org` inside `mist_change_org_*` family-mention prose). All were added to the allowlist with comments rather than rewritten.
+- `@mcp.prompt(...)` bodies and human-facing docs (README, docs/TOOLS.md) — same regex sweep but no real bugs found, so no changes there. The regression test currently covers skills + INSTRUCTIONS.md; expand if more authoring surfaces emerge.
+
+### Tests (639 → 644)
+
+5 new regression tests; existing 639 still pass.
+
 ## [2.3.0.1] - 2026-04-27
 
 **Adds the `change-post-check` skill (partner to `change-pre-check`) and documents two pydantic-monty sandbox limits the LLM was discovering at runtime.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.1"
+version = "2.3.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/change-post-check.md
+++ b/src/hpe_networking_mcp/skills/change-post-check.md
@@ -9,7 +9,7 @@ description: |
   finishes a maintenance window. Pairs with `change-pre-check`.
 platforms: [mist, central, clearpass, apstra]
 tags: [change-management, maintenance, verification, post-flight]
-tools: [health, mist_search_alarms, mist_search_audit_logs, central_get_alerts, central_get_audit_logs, clearpass_get_recent_audit_log]
+tools: [health, mist_search_alarms, mist_search_audit_logs, central_get_alerts, central_get_audit_logs, clearpass_get_system_events]
 ---
 
 # Post-change verification + diff
@@ -93,7 +93,7 @@ should NOT be re-flagged here — they were already broken.
 
 **Mist:** `mist_search_audit_logs(org_id=..., duration="<delta>", limit=50)`
 **Central:** `central_get_audit_logs` (filter to the change window)
-**ClearPass (if affected):** `clearpass_get_recent_audit_log(limit=50)`
+**ClearPass (if affected):** `clearpass_get_system_events(limit=50)`
 
 **Why:** Two things to verify:
 1. The planned change is recorded — confirms it actually landed (not just
@@ -175,6 +175,11 @@ Format the report as shown below.
 | Audit log shows unplanned admin actions | Surface the actor + timestamp explicitly so the operator can investigate |
 
 ## Output formatting
+
+Use the EXACT structure below. Every section heading must be present —
+the operator pastes this into the change ticket and the consistency
+matters when comparing against the pre-check snapshot. For REGRESSION
+verdicts, lead with the specifics under "Verdict reasoning."
 
 ```
 ## Post-change verification — <change description>

--- a/src/hpe_networking_mcp/skills/change-pre-check.md
+++ b/src/hpe_networking_mcp/skills/change-pre-check.md
@@ -10,7 +10,7 @@ description: |
   config push, firmware upgrade, WLAN modification, or NAC policy edit.
 platforms: [mist, central, clearpass, apstra]
 tags: [change-management, maintenance, baseline, pre-flight]
-tools: [health, mist_search_alarms, mist_search_audit_logs, central_get_alerts, central_get_audit_logs, clearpass_get_recent_audit_log]
+tools: [health, mist_search_alarms, mist_search_audit_logs, central_get_alerts, central_get_audit_logs, clearpass_get_system_events, clearpass_get_sessions, clearpass_get_enforcement_policies, mist_get_wlans, central_get_wlans, mist_get_switch_details, central_get_switch_details, mist_search_device, central_get_devices, mist_get_configuration_objects, apstra_get_blueprints]
 ---
 
 # Pre-change baseline snapshot
@@ -82,7 +82,7 @@ alarms.
 
 **Mist:** `mist_search_audit_logs(org_id=..., duration="1d", limit=50)`
 **Central:** `central_get_audit_logs` (filter to last 24h client-side)
-**ClearPass (if affected):** `clearpass_get_recent_audit_log(limit=50)`
+**ClearPass (if affected):** `clearpass_get_system_events(limit=50)`
 
 **Why:** Detects "someone else just changed something here." Two engineers
 unknowingly working on adjacent configs is a classic root-cause for
@@ -99,11 +99,11 @@ include it for post-change diffing.
 
 | Change type | Tool to call |
 |---|---|
-| WLAN | `mist_get_wlan(org_id=..., wlan_id=...)` or `central_get_wlan(...)` |
-| Switch port | `mist_get_device_port_config(...)` or `central_get_switch_port(...)` |
-| AP firmware target | `mist_get_device(device_id=...)` (look at `version` + `target_version`) |
-| NAC enforcement policy | `clearpass_get_enforcement_policy(id=...)` |
-| Apstra blueprint commit point | `apstra_get_blueprint_revisions(blueprint_id=...)` (record current revision id) |
+| WLAN | `mist_get_configuration_objects(object_type="wlans", object_id=...)` (Mist) or `central_get_wlans(site_id=...)` (Central) |
+| Switch port | `mist_get_switch_details(device_id=...)` (Mist — port config is part of switch detail) or `central_get_switch_details(serial=...)` (Central) |
+| AP firmware target | `mist_search_device(text=<name>, device_type="ap")` to find the device, then `mist_get_ap_details(device_id=...)` to read `version` + `target_version` (Mist); `central_get_devices(serial_number=...)` for Central APs |
+| NAC enforcement policy | `clearpass_get_enforcement_policies(policy_id=...)` |
+| Apstra blueprint baseline | `apstra_get_blueprints(blueprint_id=...)` to record the current `version` field; pair with `apstra_get_diff_status(blueprint_id=...)` to confirm there are no pending uncommitted changes before yours |
 
 **Why:** A clean copy of the BEFORE config makes "did the change cause X?"
 straightforward to answer. Without this you're guessing.
@@ -114,7 +114,7 @@ straightforward to answer. Without this you're guessing.
 `num_clients`, `num_aps_up`, `num_devices_disconnected`.
 **Switch changes:** `central_get_site_health(site_name=<target>)` — record
 device counts and active client count.
-**NAC changes:** `clearpass_get_active_sessions(limit=...)` — record total
+**NAC changes:** `clearpass_get_sessions(limit=...)` — record total
 active session count and breakdown by service.
 
 **Why:** Active counts are the leading indicator of customer impact during
@@ -137,6 +137,11 @@ their change ticket (see *Output formatting* below).
 | User says they're upgrading firmware | Add a step to confirm the rollback path (target version is recoverable) |
 
 ## Output formatting
+
+Use the EXACT structure below. Every section heading must be present even
+if its content is "0 active" / "no recent activity" — consistency lets the
+post-check skill diff against this snapshot reliably. Don't add freeform
+sections; if you have observations, put them under "Notes."
 
 ```
 ## Pre-change baseline — <change description>

--- a/src/hpe_networking_mcp/skills/infrastructure-health-check.md
+++ b/src/hpe_networking_mcp/skills/infrastructure-health-check.md
@@ -8,7 +8,7 @@ description: |
   starts a session and wants a baseline before drilling in.
 platforms: [mist, central, clearpass, apstra, greenlake, axis]
 tags: [health, monitoring, daily-standup, baseline]
-tools: [health, mist_search_alarms, central_get_alerts, clearpass_get_recent_audit_log]
+tools: [health, mist_search_alarms, central_get_alerts, clearpass_get_system_events, apstra_get_anomalies, axis_get_connectors, axis_get_status]
 ---
 
 # Cross-platform infrastructure health snapshot
@@ -56,32 +56,37 @@ alarm individually — the user wants a triage summary, not a dump.
 **If anomaly:** Surface the top 5 alerts by recency.
 **Skip if:** Central is not enabled or returned `unavailable` in step 1.
 
-### Step 4 — ClearPass recent admin activity
+### Step 4 — ClearPass recent system events
 
-**Tool:** `clearpass_get_recent_audit_log(limit=20)`
-**Why:** Catches "someone just changed something" before the user starts
-their work. Especially valuable in environments where multiple operators
-share an account.
-**Expected result:** A list of recent admin actions with timestamps + actor.
-**If anomaly:** Note any actions in the last 4 hours by actors other than
+**Tool:** `clearpass_get_system_events(limit=20)`
+**Why:** Catches admin actions and system events recorded by CPPM —
+configuration changes, service restarts, etc. — so the user knows the
+recent context before drilling in.
+**Expected result:** A paginated list of recent system events with
+timestamps and event source.
+**If anomaly:** Note any events from the last 4 hours by actors other than
 the current user. Don't surface routine read-only logins.
 **Skip if:** ClearPass is not enabled or returned `unavailable` in step 1.
 
 ### Step 5 — Apstra anomalies (if Apstra is enabled)
 
-**Tool:** `apstra_invoke_tool(name="apstra_get_anomalies", params={...})`
-(or the equivalent in code mode: `await call_tool("apstra_get_anomalies", ...)`)
+**Tool:** `apstra_get_anomalies()` (in code mode call via
+`await call_tool("apstra_get_anomalies", {})`; in dynamic mode call via
+`apstra_invoke_tool(name="apstra_get_anomalies", params={})`).
 **Why:** Apstra surfaces fabric-level health (e.g. BGP session down, MLAG split-brain).
 **Expected result:** Empty list, or anomalies grouped by `type`.
 **Skip if:** Apstra is not enabled.
 
 ### Step 6 — Axis connector status (if Axis is enabled)
 
-**Tool:** `axis_get_connectors()` then look at `cpuStatus`, `memoryStatus`,
-`networkStatus`, `enabled` fields.
-**Why:** Axis tunnels can degrade silently; CPU/memory/network status fields
-flag pre-failure conditions.
-**Expected result:** All connectors `enabled: true` with `*Status: ok`.
+**Tool:** `axis_get_connectors()` to list all connectors. For runtime
+telemetry (CPU/memory/disk/network status) on a specific connector, follow
+up with `axis_get_status(entity_type="connector", connector_id=<id>)`.
+**Why:** Axis tunnels can degrade silently; CPU/memory/network status
+fields flag pre-failure conditions.
+**Expected result:** All connectors `enabled: true`. Connector-status
+records report `cpuStatus`, `memoryStatus`, `networkStatus`,
+`diskSpaceStatus` — surface any non-`ok` value.
 **Skip if:** Axis is not enabled.
 
 ### Step 7 — Format the snapshot
@@ -99,26 +104,36 @@ Combine all findings into one terse summary (see *Output formatting* below).
 
 ## Output formatting
 
+Use the EXACT structure below. Every section heading must be present even
+if its content is "clean" — consistency lets operators eyeball today's
+report against yesterday's. Don't add freeform "notable" sections that
+weren't run; if you have observations, put them under "Action items."
+
 ```
-## Infrastructure health — <timestamp>
+## Infrastructure health — <ISO timestamp>
 
-**Reachability**
-- Mist: ok
-- Central: ok
-- ClearPass: ok
-- Apstra: degraded (token expires in 28 days)
+### Reachability
+- Mist: <ok | degraded — <reason> | unavailable — <reason> | not enabled>
+- Central: <same>
+- ClearPass: <same>
+- Apstra: <same>
+- GreenLake: <same>
+- Axis: <same — append "; token expires in N days" when known>
 
-**Active alarms / alerts**
-- Mist: 3 alarms — `ap_disconnected` (2), `radius_server_unreachable` (1)
-- Central: 1 critical — "Switch CX-1 unreachable" (HOME)
-- ClearPass: 5 admin actions in last 4h by `tech-on-duty`
+### Active alarms / alerts
+- Mist: <"clean" | "<count> alarms — top by count: type1 (n), type2 (n), ...">
+- Central: <"clean" | "<count> active — top by recency: <description> (<site>); ...">
+- ClearPass: <"<count> recent system events; <count> from last 4h by non-current actors">
+- Apstra: <"clean" | "<count> anomalies — types: type1 (n), type2 (n), ...">
+- Axis: <"<count> connectors enabled; all *Status=ok" | per-connector status flags>
 
-**Action items**
-- Investigate Mist `ap_disconnected` cluster at HOME
-- Confirm Apstra token renewal scheduled
+### Action items
+<Bulleted list of follow-ups. One bullet per actionable finding. If
+nothing is actionable, write a single bullet "No action items.">
 ```
 
-Keep it under 25 lines total. The user reads this *before* drilling in.
+Total report should be under 25 lines. The operator reads this BEFORE
+drilling in — terseness is a feature.
 
 ## Example queries that should trigger this skill
 

--- a/src/hpe_networking_mcp/skills/wlan-sync-validation.md
+++ b/src/hpe_networking_mcp/skills/wlan-sync-validation.md
@@ -9,7 +9,7 @@ description: |
   running `manage_wlan_profile` to verify the result.
 platforms: [mist, central]
 tags: [wlan, sync, drift-detection, audit]
-tools: [health, mist_invoke_tool, central_invoke_tool, manage_wlan_profile]
+tools: [health, mist_get_wlans, central_get_wlans, manage_wlan_profile]
 ---
 
 # Mist ↔ Central WLAN consistency check
@@ -45,8 +45,8 @@ the comparison can't run.
 
 ### Step 2 — Pull Mist WLANs
 
-**Tool:** `mist_get_org_wlans(org_id=<from health>)` — or scoped to a site
-via `mist_get_site_wlans(site_id=...)` if the user gave a site.
+**Tool:** `mist_get_wlans()` — accepts `org_id` (org-wide) or `site_id`
+(site-scoped). One tool, both scopes via parameter choice.
 **Why:** Mist's WLAN catalog is the source-of-truth for the comparison.
 **Expected result:** A list of WLANs with `ssid`, `enabled`, `auth.type`,
 `auth.psk` (presence only — never log the actual key), `vlan_ids`,
@@ -56,7 +56,8 @@ specific scope. Surface the count and ask before continuing.
 
 ### Step 3 — Pull Central WLANs
 
-**Tool:** `central_get_wlans()` (or scope to a site via `central_get_site_wlans(site_name=...)`)
+**Tool:** `central_get_wlans()` — accepts `site_id` to scope to a site or
+`serial_number` to scope to a single AP. Omit both for the org-wide list.
 **Why:** Central's view of the same WLAN universe.
 **Expected result:** A list with `ssid`, `enabled`, `security_type`,
 `vlan`, `band`, `broadcast_ssid`.
@@ -105,6 +106,10 @@ See *Output formatting* below.
 | 100+ WLANs returned | Ask the user to narrow scope before generating the full report |
 
 ## Output formatting
+
+Use the EXACT structure below. Every bucket heading must be present even
+if its count is 0 — "everything is fine" should still produce a report
+the operator can scan in 5 seconds.
 
 ```
 ## WLAN sync report — <scope: org or site name>

--- a/tests/unit/test_skill_tool_references.py
+++ b/tests/unit/test_skill_tool_references.py
@@ -1,0 +1,194 @@
+"""Regression test: every platform-prefixed tool name referenced in a
+bundled skill (or in INSTRUCTIONS.md) must resolve to a real tool or
+meta-tool registered on the server.
+
+The original v2.3.0.0 skills were authored without this check and shipped
+with 12 references to non-existent tool names — silent failures at runtime
+because the AI just got "tool not found" errors and skipped those steps.
+This test catches the same class of regression at CI time.
+
+How it works:
+
+1. Reload every platform's tool modules so each ``@mcp.tool(...)`` decorator
+   re-registers against the shared ``REGISTRIES`` dict in
+   ``platforms._common.tool_registry``. We use ``REGISTRIES`` rather than
+   building a real FastMCP via ``create_server`` because the server route
+   has test-isolation problems: tool modules are decorated at import time
+   against whatever FastMCP is wired through ``_registry.py``, and once
+   imported the decorators don't re-run for a fresh server in a later
+   test. ``REGISTRIES`` survives across tests by design and is what the
+   existing per-platform dynamic-mode tests already build on.
+2. Add cross-platform tools (``health``, the aggregators, ``skills_list``,
+   ``skills_load``) and the dynamic-mode meta-tool patterns (``<platform>_list_tools``
+   etc.) to the catalog manually.
+3. Walk skills/*.md and INSTRUCTIONS.md, extract every platform-prefixed
+   identifier via regex, assert each appears in the catalog OR in
+   ``_GLOBAL_ALLOWLIST`` (historical mentions, regex artifacts).
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+# A platform-prefixed identifier — broad enough to catch every form an
+# author might write (`tool_name(`, `` `tool_name` ``, in tables, in code blocks).
+_TOOL_REF_PATTERN = re.compile(r"\b(mist|central|greenlake|clearpass|apstra|axis)_[a-z_][a-z_0-9]+\b")
+
+# Names that LOOK like tool references to the regex but aren't ones we want
+# the test to enforce — historical mentions ("X was removed in v2.0"),
+# secret names, regex artifacts (incomplete patterns inside prose).
+_GLOBAL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Tools removed in v2.0; mentioned historically in INSTRUCTIONS.md
+        # so the AI knows the v1.x name is gone.
+        "apstra_health",
+        "clearpass_test_connection",
+        "greenlake_get_endpoint_schema",
+        "greenlake_invoke_endpoint",
+        "greenlake_list_endpoints",
+        # Secret names (axis_api_token is a secret file, not a tool).
+        "axis_api_token",
+        # Regex artifacts: incomplete platform-prefix mentions like
+        # "use the apstra_get_* family". These end with an underscore
+        # but the regex eats the trailing wildcard. Add as encountered.
+        "apstra_get_",
+        "axis_get_",
+        "axis_manage_",
+        "clearpass_manage_",
+        "mist_change_org",
+        "mist_update_org",
+    }
+)
+
+# Cross-platform tools that aren't in REGISTRIES (which is per-platform-keyed).
+# Hardcoded because they're a small, stable set; if more get added, update here.
+_CROSS_PLATFORM_TOOLS: frozenset[str] = frozenset(
+    {
+        "health",
+        "site_health_check",
+        "site_rf_check",
+        "manage_wlan_profile",
+        "skills_list",
+        "skills_load",
+    }
+)
+
+
+def _build_full_catalog() -> set[str]:
+    """Construct the canonical set of valid tool names.
+
+    Per-platform tool modules call ``record_tool(...)`` at import time,
+    populating the shared ``REGISTRIES`` dict. Once a module has been
+    imported, however, Python caches it and the registration code won't
+    re-fire — so test orderings that clear ``REGISTRIES`` mid-suite
+    (e.g. ``test_clearpass_dynamic_mode.py``'s teardown) leave us with
+    empty registries and no way to refill them.
+
+    To work around this, we reload every cached
+    ``hpe_networking_mcp.platforms.*.tools.*`` module before reading
+    ``REGISTRIES``. ``importlib.reload`` re-runs the module body, which
+    re-fires the ``@tool(...)`` decorators and re-records each spec.
+    Mirrors the pattern used by every per-platform dynamic-mode test.
+    """
+    import contextlib
+    import sys
+
+    from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+    # First, ensure every platform's tool modules are imported at all.
+    for platform in ("mist", "central", "clearpass", "apstra", "axis", "greenlake"):
+        platform_pkg = importlib.import_module(f"hpe_networking_mcp.platforms.{platform}")
+        tools_attr = getattr(platform_pkg, "TOOLS", None)
+        if not tools_attr:
+            continue
+        for category, tool_names in tools_attr.items():
+            # Two file-layout conventions across platforms:
+            #   - one file per category (e.g. central/tools/sites.py)
+            #   - one file per tool, with platform prefix stripped
+            #     (Mist convention: tools/search_device.py for mist_search_device)
+            module_paths_to_try = [f"hpe_networking_mcp.platforms.{platform}.tools.{category}"]
+            if isinstance(tool_names, list):
+                for tool_name in tool_names:
+                    stripped = tool_name.removeprefix(f"{platform}_")
+                    module_paths_to_try.append(f"hpe_networking_mcp.platforms.{platform}.tools.{stripped}")
+            for path in module_paths_to_try:
+                try:
+                    importlib.import_module(path)
+                except ModuleNotFoundError:
+                    continue
+
+    # Now reload every cached tools module so the decorators re-fire and
+    # repopulate REGISTRIES. (The first import on a fresh interpreter
+    # would have populated it; this handles the cleared-mid-suite case.)
+    tool_module_prefixes = tuple(
+        f"hpe_networking_mcp.platforms.{p}.tools."
+        for p in ("mist", "central", "clearpass", "apstra", "axis", "greenlake")
+    )
+    for name in list(sys.modules):
+        if name.startswith(tool_module_prefixes):
+            with contextlib.suppress(Exception):
+                importlib.reload(sys.modules[name])
+
+    catalog: set[str] = set()
+    for _platform_name, registry in REGISTRIES.items():
+        catalog.update(registry.keys())
+
+    # Cross-platform always-visible tools (not in REGISTRIES).
+    catalog.update(_CROSS_PLATFORM_TOOLS)
+
+    # Dynamic-mode meta-tools — only registered when tool_mode="dynamic", but
+    # legitimate names skills can reference for runtime dispatch.
+    for platform in ("mist", "central", "greenlake", "clearpass", "apstra", "axis"):
+        for suffix in ("_list_tools", "_get_tool_schema", "_invoke_tool"):
+            catalog.add(platform + suffix)
+
+    return catalog
+
+
+def _missing_refs(file_path: Path, catalog: set[str]) -> list[str]:
+    """Return names referenced in the file that don't resolve — excluding
+    the global allowlist.
+    """
+    text = file_path.read_text(encoding="utf-8")
+    refs = {match.group(0) for match in _TOOL_REF_PATTERN.finditer(text)}
+    return sorted(n for n in refs if n not in catalog and n not in _GLOBAL_ALLOWLIST)
+
+
+@pytest.fixture(scope="module")
+def catalog() -> set[str]:
+    return _build_full_catalog()
+
+
+@pytest.mark.unit
+class TestSkillToolReferences:
+    """Bundled skills must only reference tool names that exist."""
+
+    @pytest.mark.parametrize(
+        "skill_path",
+        sorted(p for p in Path("src/hpe_networking_mcp/skills").glob("*.md") if p.name != "TEMPLATE.md"),
+        ids=lambda p: p.name,
+    )
+    def test_skill_references_resolve(self, skill_path: Path, catalog: set[str]):
+        missing = _missing_refs(skill_path, catalog)
+        assert not missing, (
+            f"Skill {skill_path.name!r} references non-existent tools: {missing}. "
+            "Either fix the names to match real tools, or — if the reference is "
+            "intentional (historical mention, etc.) — add it to _GLOBAL_ALLOWLIST "
+            "in tests/unit/test_skill_tool_references.py."
+        )
+
+
+@pytest.mark.unit
+class TestInstructionsToolReferences:
+    """INSTRUCTIONS.md is also runtime guidance for the AI — same hygiene applies."""
+
+    def test_instructions_references_resolve(self, catalog: set[str]):
+        path = Path("src/hpe_networking_mcp/INSTRUCTIONS.md")
+        missing = _missing_refs(path, catalog)
+        assert not missing, (
+            f"INSTRUCTIONS.md references non-existent tools: {missing}. Either fix or add to _GLOBAL_ALLOWLIST."
+        )


### PR DESCRIPTION
## Summary

Fixes **12 wrong tool-name references** in the bundled skills, **tightens output templates** so the AI doesn't improvise inconsistent formatting, and **adds a regression test** that catches this whole class of bug at CI time.

In-the-wild signal from running `infrastructure-health-check` and `change-pre-check`: skills were referencing tool names that don't exist. The AI got "tool not found" errors and worked around them — silently skipping steps or improvising substitutes — producing incomplete, inconsistent output.

## What was broken (12 wrong names)

| Wrong name | Correct name | Files |
|---|---|---|
| `clearpass_get_recent_audit_log` | `clearpass_get_system_events` | infrastructure-health, change-pre, change-post |
| `clearpass_get_active_sessions` | `clearpass_get_sessions` | change-pre |
| `clearpass_get_enforcement_policy` | `clearpass_get_enforcement_policies(policy_id=...)` | change-pre |
| `mist_get_org_wlans` / `mist_get_site_wlans` | `mist_get_wlans()` (accepts both scopes via param) | wlan-sync |
| `mist_get_wlan` (singular) | `mist_get_configuration_objects(object_type="wlans", object_id=...)` | change-pre |
| `mist_get_device` | `mist_search_device` or `mist_get_ap_details` / `mist_get_switch_details` | change-pre |
| `mist_get_device_port_config` | `mist_get_switch_details(device_id=...)` | change-pre |
| `central_get_site_wlans` / `central_get_wlan` | `central_get_wlans(site_id=...)` | wlan-sync, change-pre |
| `central_get_switch_port` | `central_get_switch_details(serial=...)` | change-pre |
| `apstra_get_blueprint_revisions` | `apstra_get_blueprints(blueprint_id=...)` + `apstra_get_diff_status` | change-pre |

## Tightened output templates

Each skill's "Output formatting" section now leads with:

> *"Use the EXACT structure below. Every section heading must be present even if its content is..."*

Stops the AI from skipping sections, adding freeform "Notable" sections that aren't in the template, or rewriting headings between runs. The structure itself is unchanged — same headings, same fields — just enforced.

## Regression test (`tests/unit/test_skill_tool_references.py`)

Builds the canonical tool catalog by reloading every cached `hpe_networking_mcp.platforms.*.tools.*` module so the `@tool()` decorators re-fire and repopulate `REGISTRIES`. (Handles the test-isolation case where existing per-platform tests clear the registry mid-suite.) Adds the cross-platform tools and the dynamic-mode meta-tool patterns to the catalog manually.

Walks each `skills/*.md` and `INSTRUCTIONS.md`, extracts every platform-prefixed identifier via regex, asserts each appears in the catalog OR in `_GLOBAL_ALLOWLIST`. Future skill authors get a clear CI failure with a remediation message ("either fix the name or add it to `_GLOBAL_ALLOWLIST`").

The allowlist captures known false positives:
- Historical mentions (`apstra_health was removed in v2.0`)
- Secret names (`axis_api_token`)
- Regex artifacts (incomplete patterns like `mist_change_org_*` in prose)

## INSTRUCTIONS.md sweep

Same regex run; **0 real bugs found**. All 12 hits were either historical prose or regex artifacts — all added to the allowlist with inline comments rather than rewritten.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — **644 passed** (639 → 644: +4 per-skill parametrized cases + 1 INSTRUCTIONS.md case)
- [x] Pre- and post-fix audit results match expectation: pre-fix run reported all 12 wrong names; post-fix re-audit clean
