### PR TITLE
v2.3.0.3: skills_list / skills_load top-level visible in code mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.3] - 2026-04-28
+
+**Fixes a top-level visibility bug that hid `skills_list` and `skills_load` in code mode since v2.3.0.0, and strengthens INSTRUCTIONS.md rule #8 to make the AI proactively check skills first.**
+
+### What was broken
+
+In **code mode**, the actual MCP-exposed surface was 4 tools (`tags`, `search`, `get_schema`, `execute`) — `skills_list` and `skills_load` were nowhere to be found in `tools/list`. The AI had no top-level signal that skills existed, so it never reached for them on questions like *"how's my infrastructure in Central?"*.
+
+Confirmed via direct wire-protocol probe (`tools/list` over the streaming-HTTP MCP endpoint) — not just inferred. Verified the regression had been present since v2.3.0.0 by reading git history; nothing in server.py or skills/ ever passed skills as discovery tools.
+
+### Why it happened
+
+`skills_list` / `skills_load` were registered via `@mcp.tool` before `_register_code_mode(mcp)` ran. CodeMode's `transform_tools()` then *replaces* the visible catalog with `[*discovery_tools, execute]` — it doesn't merge with the existing catalog, it substitutes. So skills were callable from inside `execute()` via `await call_tool("skills_list", {})` (their `@mcp.tool` registration kept them in the backend catalog), but invisible to the AI at the top level. I tested skills via `execute()` during v2.3.0.0 development and didn't notice they weren't visible at the top.
+
+### The fix
+
+`skills/_engine.py` now exposes two discovery-tool factories matching `CodeMode.discovery_tools`'s signature (same shape as fastmcp's `GetTags` / `Search` / `GetSchemas`):
+
+- `SkillsListDiscoveryTool(registry)` — produces a `skills_list` Tool
+- `SkillsLoadDiscoveryTool(registry)` — produces a `skills_load` Tool
+
+`server.py:_register_code_mode` builds a `SkillRegistry` once and hands the factories into `discovery_tools` alongside the standard `GetTags`/`Search`/`GetSchemas`. In code mode the exposed surface is now **6 tools**: `tags`, `search`, `get_schema`, `skills_list`, `skills_load`, `execute`.
+
+`server.py:create_server` skips the `@mcp.tool` registration path (`_register_skills(mcp)`) when `tool_mode == "code"` to avoid registering them twice. Dynamic and static modes still use `register(mcp)` — `@mcp.tool` works correctly there because no transform replaces the catalog.
+
+### Trade-off accepted
+
+Skills are now **discovery-only** in code mode — same shape as `tags`/`search`/`get_schema`. They're callable at the top level but NOT from inside `execute()` (the sandbox's `call_tool` only resolves backend platform tools). That matches their semantic role: planning tools, not dispatch tools. The `execute_description` is updated to call this out explicitly, alongside the existing note about `tags`/`search`/`get_schema` not being callable inside `execute()`. If any LLM tries `await call_tool("skills_list", {})` from inside the sandbox, the existing `SandboxErrorCatchMiddleware` (v2.2.0.4) will surface `Sandbox error: Unknown tool: skills_list` as a string so the LLM can self-correct.
+
+### INSTRUCTIONS.md rule #8 strengthened
+
+The previous rule said *"call `skills_list` first when the user asks for a known runbook"* — too passive, required the AI to recognize the runbook shape. New rule:
+
+> *"**Always check Skills FIRST for multi-step / cross-platform questions.** Even when the user names a specific platform (e.g. *"how's my infrastructure in Central?"*), call `skills_list()` BEFORE reaching for per-platform tools..."*
+
+Plus a query→skill table giving concrete pattern → skill mappings:
+
+| User query shape | Likely skill |
+|---|---|
+| *"how's my infrastructure?"*, *"is everything healthy?"*, *"how is health in &lt;platform&gt;?"* | `infrastructure-health-check` |
+| *"about to push a change"*, *"give me a baseline"* | `change-pre-check` |
+| *"the change is done — verify"*, *"post-change check"* | `change-post-check` |
+| *"are WLANs in sync?"*, *"WLAN drift audit"* | `wlan-sync-validation` |
+
+### Tests (644 → 649)
+
+- `TestDiscoveryToolFactories` × 5 cases — factories produce Tools with the right name + working body, support filter args, accept custom names, return clean errors on no-match
+- `TestCodeModeAggregatorGating` extended — asserts `skills.register` is called in dynamic/static and NOT called in code mode (with a comment pointing at this CHANGELOG entry so future contributors don't "fix" the assertion the wrong way)
+
+Plus an end-to-end live verification via the wire-protocol `tools/list`:
+- code mode → 6 top-level tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`, `execute`)
+- dynamic mode → 109 visible (per-platform meta-tools + cross-platform statics + skills_list + skills_load)
+
+### Live-tested
+
+- `tools/call` for `skills_list` at the top level in code mode → returns all 4 bundled skills
+- `tools/call` for `skills_load` at the top level in code mode → returns infrastructure-health-check body
+- Dynamic-mode wire probe confirms skills_list / skills_load still appear there
+
 ## [2.3.0.2] - 2026-04-27
 
 **Fixes 12 wrong tool-name references in the bundled skills, tightens output templates so the AI doesn't improvise inconsistent formatting, and adds a regression test that catches this whole class of bug at CI time.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.2"
+version = "2.3.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -68,7 +68,16 @@ If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front wi
 5. **MANDATORY: use the information you already have from `<platform>_list_tools` before invoking.** Every tool entry from `list_tools` includes a `params` map showing parameter names + types (and `?` suffix for optional) — always check it before calling `invoke_tool`. Never invoke with `params={}` or guessed names when the `list_tools` output already told you what's required.
 6. **Call `<platform>_get_tool_schema(name=...)` when the `list_tools` params map isn't sufficient.** Specifically: when a param's type is an enum class name (e.g. `"Action_type"`) and you don't yet know its valid values, when you need field descriptions to understand parameter semantics, or when a `dict`/`payload` param needs a nested schema. You do NOT need to re-read a schema you've already fetched in the same conversation; cache it mentally.
 7. **Don't manually retry transient API failures.** The server auto-retries 5xx errors on read tools (3 attempts, exponential backoff) and 429 rate-limit responses on both reads and writes (honors `Retry-After` header). If a tool returns a 5xx or 429 to you, it has *already* exhausted retries — don't loop calling the same tool. 4xx errors (other than 429) and 5xx errors on write tools are NOT auto-retried; surface those to the user with the actual error message.
-8. **Use Skills for multi-step procedures.** When the user asks for something that's a known *runbook* — "infra health check", "pre-change baseline", "WLAN sync audit", "are X and Y in sync?", "give me a daily standup" — call `skills_list()` first to see whether a skill matches, then `skills_load(name=...)` to fetch the markdown runbook and follow its steps. Skills are step-by-step procedures authored as markdown — they tell you which platform tools to call in what order and how to format the result. Don't reinvent a multi-step procedure from scratch when one is bundled.
+8. **Always check Skills FIRST for multi-step / cross-platform questions.** Even when the user names a specific platform (e.g. *"how's my infrastructure in Central?"*), call `skills_list()` BEFORE reaching for per-platform tools. A skill might cover the question better than a manual sequence — and the check is cheap (~1 round-trip). Common triggers — call `skills_list()` for ANY query in this shape:
+
+| User query shape | Likely skill |
+|---|---|
+| *"how's my infrastructure?"*, *"is everything healthy?"*, *"infra status / overview / standup"*, *"what's broken?"*, *"how is health in &lt;platform&gt;?"* | `infrastructure-health-check` |
+| *"about to push a change"*, *"give me a baseline before X"*, *"pre-flight for change window"*, *"snapshot before maintenance"* | `change-pre-check` |
+| *"the change is done — verify"*, *"post-change check"*, *"is it still healthy after the change?"* | `change-post-check` |
+| *"are WLANs in sync?"*, *"WLAN drift audit"*, *"compare WLANs across Mist and Central"* | `wlan-sync-validation` |
+
+After `skills_list()`, call `skills_load(name=...)` to get the runbook, then follow its steps — including its output format. Don't reinvent the procedure from scratch when one's bundled. If `skills_list()` returns no relevant match, fall back to manual.
 
 ---
 

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -260,9 +260,16 @@ def create_server(config: ServerConfig) -> FastMCP:
     _register_health(mcp)
 
     # --- Skills (markdown-defined multi-step procedures, always visible) ---
-    from hpe_networking_mcp.skills import register as _register_skills
+    # In dynamic / static modes, register via @mcp.tool — they appear at the
+    # top level via the standard catalog. In CODE mode, we deliberately skip
+    # this path and instead pass discovery-tool factories to CodeMode below
+    # (see _register_code_mode); CodeMode's transform_tools replaces the
+    # visible catalog with [discovery_tools, execute] only, which would
+    # otherwise hide @mcp.tool registrations.
+    if config.tool_mode != "code":
+        from hpe_networking_mcp.skills import register as _register_skills
 
-    _register_skills(mcp)
+        _register_skills(mcp)
 
     # --- Write tool visibility (per-platform) ---
     from fastmcp.server.transforms import Visibility
@@ -347,10 +354,10 @@ def _register_code_mode(mcp: FastMCP) -> None:
         "`call_tool` ONLY dispatches to platform tools — names start with one "
         "of: `mist_`, `central_`, `greenlake_`, `clearpass_`, `apstra_`, "
         "`axis_` — plus the cross-platform `health` tool.\n\n"
-        "The discovery tools `tags`, `search`, and `get_schema` are NOT "
-        "callable from inside execute(). They live at the outer MCP surface "
-        "for planning. Call them BEFORE writing your code block to find "
-        "tool names + schemas, then chain those tools inside execute().\n\n"
+        "The discovery tools `tags`, `search`, `get_schema`, `skills_list`, and "
+        "`skills_load` are NOT callable from inside execute(). They live at the "
+        "outer MCP surface for planning. Call them BEFORE writing your code "
+        "block, then chain platform tools inside execute().\n\n"
         "Known sandbox limits: `asyncio.gather()` is unavailable — use "
         "sequential `await` calls. OS-access functions are blocked, "
         "including `datetime.now()`, `time.time()`, file I/O, `os.environ`, "
@@ -358,6 +365,21 @@ def _register_code_mode(mcp: FastMCP) -> None:
         "or hardcode literal ISO-8601 strings rather than computing them "
         "inside the sandbox."
     )
+
+    # Build the skills registry once and hand factories to CodeMode so the
+    # skills surface sits at the discovery layer alongside tags/search/etc.
+    # (See skills/_engine.py — discovery factories are needed because
+    # CodeMode.transform_tools replaces the visible catalog with
+    # [discovery_tools, execute] only.)
+    from hpe_networking_mcp.skills import (
+        SkillRegistry,
+        SkillsListDiscoveryTool,
+        SkillsLoadDiscoveryTool,
+    )
+
+    skill_registry = SkillRegistry.from_directory()
+    logger.info("Skills: registered {} skill(s) (code mode discovery layer)", len(skill_registry.all()))
+
     mcp.add_transform(
         CodeMode(
             sandbox_provider=MontySandboxProvider(limits=limits),
@@ -365,11 +387,13 @@ def _register_code_mode(mcp: FastMCP) -> None:
                 GetTags(default_detail="brief"),
                 Search(default_detail="brief"),
                 GetSchemas(default_detail="detailed"),
+                SkillsListDiscoveryTool(skill_registry),
+                SkillsLoadDiscoveryTool(skill_registry),
             ],
             execute_description=execute_description,
         )
     )
-    logger.info("Code mode enabled — exposed surface: get_tags + search + get_schema + execute")
+    logger.info("Code mode enabled — exposed surface: tags + search + get_schema + skills_list + skills_load + execute")
 
 
 def _register_mist_tools(mcp: FastMCP, config: ServerConfig) -> None:

--- a/src/hpe_networking_mcp/skills/__init__.py
+++ b/src/hpe_networking_mcp/skills/__init__.py
@@ -6,6 +6,16 @@ The AI calls ``skills_list()`` to browse and ``skills_load(name)`` to fetch
 the full runbook body, then follows the steps. Closes #189.
 """
 
-from hpe_networking_mcp.skills._engine import register
+from hpe_networking_mcp.skills._engine import (
+    SkillRegistry,
+    SkillsListDiscoveryTool,
+    SkillsLoadDiscoveryTool,
+    register,
+)
 
-__all__ = ["register"]
+__all__ = [
+    "SkillRegistry",
+    "SkillsListDiscoveryTool",
+    "SkillsLoadDiscoveryTool",
+    "register",
+]

--- a/src/hpe_networking_mcp/skills/_engine.py
+++ b/src/hpe_networking_mcp/skills/_engine.py
@@ -9,10 +9,20 @@ all ``*.md`` files at server startup, parses frontmatter, and exposes:
 - ``skills_load(name)`` — full body, with case-insensitive substring fallback
   if no exact match is found
 
-Skills are always visible (in every ``MCP_TOOL_MODE``) — they're an entry
-point, not an implementation detail.
+Skills are always visible at the top level in every ``MCP_TOOL_MODE``:
 
-Closes #189.
+- **dynamic / static** modes: ``register(mcp)`` registers them via
+  ``@mcp.tool``. They appear in the catalog like any other top-level tool.
+- **code** mode: ``SkillsListDiscoveryTool`` and ``SkillsLoadDiscoveryTool``
+  factory classes plug into ``CodeMode.discovery_tools`` so they sit at
+  the top level alongside ``tags`` / ``search`` / ``get_schema`` / ``execute``.
+  The ``@mcp.tool`` registration would otherwise be hidden by ``CodeMode``'s
+  ``transform_tools`` (which replaces the visible catalog with just the
+  discovery tools and ``execute``).
+
+Closes #189. The discovery-tool path was added in v2.3.0.3 after we caught
+the visibility regression in code mode — skills were callable inside
+``execute()`` via ``call_tool`` but invisible at the top level.
 """
 
 from __future__ import annotations
@@ -23,6 +33,7 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 from fastmcp import Context, FastMCP
+from fastmcp.tools.tool import Tool
 from loguru import logger
 
 # Skills are bundled inside the package so they ship in the Docker image.
@@ -202,27 +213,28 @@ class SkillRegistry:
         return None
 
 
-def register(mcp: FastMCP) -> None:
-    """Register ``skills_list`` and ``skills_load`` on the FastMCP server.
+# Tool descriptions — shared between the @mcp.tool path (dynamic / static)
+# and the discovery-tool factory path (code mode).
+_SKILLS_LIST_DESC = (
+    "List available skills (markdown-defined multi-step procedures). "
+    "Returns metadata only; call `skills_load(name)` for the full runbook. "
+    "Optional `platform` / `tag` filters each accept a string or list of "
+    "strings and narrow the result to skills tagged accordingly."
+)
 
-    Skills are always-visible (no ``dynamic_managed`` tag) so they appear
-    as top-level tools in every ``MCP_TOOL_MODE``.
-    """
-    registry = SkillRegistry.from_directory()
-    skill_count = len(registry.all())
-    logger.info("Skills: registered {} skill(s)", skill_count)
+_SKILLS_LOAD_DESC = (
+    "Load a skill's full markdown body — a step-by-step runbook for a "
+    "multi-step network operations procedure. Pass the skill `name` "
+    "(from `skills_list`); a case-insensitive substring match is tried "
+    "if there's no exact match."
+)
 
-    @mcp.tool(
-        name="skills_list",
-        description=(
-            "List available skills (markdown-defined multi-step procedures). "
-            "Returns metadata only; call `skills_load(name)` for the full runbook. "
-            "Optional `platform` / `tag` filters each accept a string or list of "
-            "strings and narrow the result to skills tagged accordingly."
-        ),
-    )
+
+def _make_skills_list_fn(registry: SkillRegistry):
+    """Build the async ``skills_list`` body that closes over a registry."""
+
     async def skills_list(
-        ctx: Context,
+        ctx: Context = None,  # type: ignore[assignment]
         platform: str | list[str] | None = None,
         tag: str | list[str] | None = None,
     ) -> dict[str, Any]:
@@ -232,16 +244,13 @@ def register(mcp: FastMCP) -> None:
             "skills": [s.to_metadata() for s in results],
         }
 
-    @mcp.tool(
-        name="skills_load",
-        description=(
-            "Load a skill's full markdown body — a step-by-step runbook for a "
-            "multi-step network operations procedure. Pass the skill `name` "
-            "(from `skills_list`); a case-insensitive substring match is tried "
-            "if there's no exact match."
-        ),
-    )
-    async def skills_load(ctx: Context, name: str) -> dict[str, Any]:
+    return skills_list
+
+
+def _make_skills_load_fn(registry: SkillRegistry):
+    """Build the async ``skills_load`` body that closes over a registry."""
+
+    async def skills_load(name: str, ctx: Context = None) -> dict[str, Any]:  # type: ignore[assignment]
         match = registry.lookup(name)
         if match is None:
             return {"error": (f"No skill matches {name!r}. Call `skills_list()` to see available skills.")}
@@ -262,3 +271,60 @@ def register(mcp: FastMCP) -> None:
             "tools": list(match.tools),
             "body": match.body,
         }
+
+    return skills_load
+
+
+class SkillsListDiscoveryTool:
+    """Discovery-tool factory for ``CodeMode.discovery_tools``.
+
+    Same shape as fastmcp's ``GetTags`` / ``Search`` / ``GetSchemas``: takes
+    a ``get_catalog`` callable when invoked (which we ignore — skills have
+    their own registry) and returns a ready-to-expose ``Tool``. Lets the
+    skills surface sit at the top level in code mode.
+    """
+
+    def __init__(self, registry: SkillRegistry, *, name: str = "skills_list") -> None:
+        self._registry = registry
+        self._name = name
+
+    def __call__(self, get_catalog: Any) -> Tool:
+        fn = _make_skills_list_fn(self._registry)
+        return Tool.from_function(fn=fn, name=self._name, description=_SKILLS_LIST_DESC)
+
+
+class SkillsLoadDiscoveryTool:
+    """Discovery-tool factory for ``CodeMode.discovery_tools``."""
+
+    def __init__(self, registry: SkillRegistry, *, name: str = "skills_load") -> None:
+        self._registry = registry
+        self._name = name
+
+    def __call__(self, get_catalog: Any) -> Tool:
+        fn = _make_skills_load_fn(self._registry)
+        return Tool.from_function(fn=fn, name=self._name, description=_SKILLS_LOAD_DESC)
+
+
+def register(mcp: FastMCP) -> SkillRegistry:
+    """Register ``skills_list`` and ``skills_load`` as ``@mcp.tool``s.
+
+    Use this in dynamic / static modes — skills appear at the top level
+    via the standard FastMCP catalog. In code mode, do NOT call this;
+    instead pass ``SkillsListDiscoveryTool`` / ``SkillsLoadDiscoveryTool``
+    factories to ``CodeMode.discovery_tools`` so the same surface sits at
+    the discovery layer (the ``@mcp.tool`` path would otherwise be hidden
+    by ``CodeMode.transform_tools``).
+
+    Returns the underlying ``SkillRegistry`` in case the caller wants to
+    inspect or reuse it.
+    """
+    registry = SkillRegistry.from_directory()
+    logger.info("Skills: registered {} skill(s)", len(registry.all()))
+
+    skills_list_fn = _make_skills_list_fn(registry)
+    skills_load_fn = _make_skills_load_fn(registry)
+
+    mcp.tool(name="skills_list", description=_SKILLS_LIST_DESC)(skills_list_fn)
+    mcp.tool(name="skills_load", description=_SKILLS_LOAD_DESC)(skills_load_fn)
+
+    return registry

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -108,6 +108,9 @@ class TestCodeModeCrossPlatformGating:
             "sync_tools": "hpe_networking_mcp.server._register_sync_tools",
             "sync_prompts": "hpe_networking_mcp.server._register_sync_prompts",
             "code_mode": "hpe_networking_mcp.server._register_code_mode",
+            # Skills registration — patched at source because server.py
+            # imports skills.register lazily inside create_server.
+            "skills_register": "hpe_networking_mcp.skills.register",
         }
         patchers = {key: patch(path) for key, path in targets.items()}
         mocks = {key: p.start() for key, p in patchers.items()}
@@ -127,6 +130,9 @@ class TestCodeModeCrossPlatformGating:
         assert mocks["sync_tools"].call_count == 1
         assert mocks["sync_prompts"].call_count == 1
         assert mocks["code_mode"].call_count == 0
+        assert mocks["skills_register"].call_count == 1, (
+            "skills.register must be called in dynamic mode (skills via @mcp.tool)"
+        )
 
     def test_static_mode_registers_all_aggregators(self):
         mocks = self._run_create_server("static")
@@ -135,6 +141,9 @@ class TestCodeModeCrossPlatformGating:
         assert mocks["sync_tools"].call_count == 1
         assert mocks["sync_prompts"].call_count == 1
         assert mocks["code_mode"].call_count == 0
+        assert mocks["skills_register"].call_count == 1, (
+            "skills.register must be called in static mode (skills via @mcp.tool)"
+        )
 
     def test_code_mode_skips_every_aggregator_and_invokes_code_mode_hook(self):
         mocks = self._run_create_server("code")
@@ -143,6 +152,14 @@ class TestCodeModeCrossPlatformGating:
         assert mocks["sync_tools"].call_count == 0, "manage_wlan_profile must NOT register in code mode"
         assert mocks["sync_prompts"].call_count == 0, "sync prompts must NOT register in code mode"
         assert mocks["code_mode"].call_count == 1, "CodeMode transform hook must be invoked"
+        assert mocks["skills_register"].call_count == 0, (
+            "skills.register must NOT be called in code mode — skills are wired "
+            "through CodeMode.discovery_tools via SkillsListDiscoveryTool / "
+            "SkillsLoadDiscoveryTool factories instead. The @mcp.tool path "
+            "would otherwise be hidden by CodeMode.transform_tools and skills "
+            "would never appear at the top level (the v2.3.0.0 → v2.3.0.2 bug "
+            "we shipped before realizing it). See _register_code_mode."
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -279,3 +279,85 @@ class TestBundledSkills:
         names = {s.name for s in registry.all()}
         assert "TEMPLATE" not in names
         assert "my-skill-name" not in names  # the placeholder name in TEMPLATE.md
+
+
+# ---------------------------------------------------------------------------
+# Discovery-tool factories (code-mode top-level visibility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDiscoveryToolFactories:
+    """Verify that the SkillsListDiscoveryTool / SkillsLoadDiscoveryTool
+    factory classes produce Tools with the right name + working body.
+
+    Catches a regression where skills are hidden in code mode (the
+    v2.3.0.0 bug: skills_list and skills_load were registered as
+    ``@mcp.tool`` only, which CodeMode.transform_tools then hides at the
+    top level — they were callable from inside execute() via call_tool
+    but invisible to the AI). The fix in v2.3.0.3 plugs them into
+    ``CodeMode.discovery_tools`` via these factories so they sit at the
+    discovery layer alongside ``tags`` / ``search`` / ``get_schema``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_skills_list_factory_produces_callable_tool(self):
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry(
+            [
+                _skill("alpha", platforms=("mist",), tags=("health",)),
+                _skill("beta", platforms=("central",), tags=("audit",)),
+            ]
+        )
+        tool = SkillsListDiscoveryTool(reg)(get_catalog=None)
+
+        assert tool.name == "skills_list"
+        # Tool.from_function wraps the body — invoking through the tool's
+        # `.fn` attribute exercises the same path the MCP layer uses.
+        result = await tool.fn()
+        assert result["count"] == 2
+        names = {s["name"] for s in result["skills"]}
+        assert names == {"alpha", "beta"}
+
+    @pytest.mark.asyncio
+    async def test_skills_list_factory_filters_by_platform(self):
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry(
+            [
+                _skill("a", platforms=("mist",)),
+                _skill("b", platforms=("central",)),
+            ]
+        )
+        tool = SkillsListDiscoveryTool(reg)(get_catalog=None)
+        result = await tool.fn(platform="mist")
+        assert {s["name"] for s in result["skills"]} == {"a"}
+
+    @pytest.mark.asyncio
+    async def test_skills_load_factory_produces_callable_tool(self, tmp_path):
+        from hpe_networking_mcp.skills._engine import SkillsLoadDiscoveryTool
+
+        reg = SkillRegistry([_skill("my-skill")])
+        tool = SkillsLoadDiscoveryTool(reg)(get_catalog=None)
+
+        assert tool.name == "skills_load"
+        result = await tool.fn(name="my-skill")
+        assert result["name"] == "my-skill"
+
+    @pytest.mark.asyncio
+    async def test_skills_load_factory_returns_error_on_no_match(self):
+        from hpe_networking_mcp.skills._engine import SkillsLoadDiscoveryTool
+
+        reg = SkillRegistry([_skill("alpha")])
+        tool = SkillsLoadDiscoveryTool(reg)(get_catalog=None)
+        result = await tool.fn(name="nonexistent")
+        assert "error" in result
+        assert "No skill matches" in result["error"]
+
+    def test_factory_accepts_custom_tool_name(self):
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry([])
+        tool = SkillsListDiscoveryTool(reg, name="custom_list_name")(get_catalog=None)
+        assert tool.name == "custom_list_name"


### PR DESCRIPTION
## Summary

Fixes a top-level visibility bug that's been present since v2.3.0.0: in **code mode**, the AI could not see `skills_list` / `skills_load` at the top level. The MCP-exposed surface was just `tags` / `search` / `get_schema` / `execute` — when the user asked *"how's my infrastructure in Central?"*, the AI never thought to check skills and went straight to manual `central_*` calls.

Confirmed via direct wire-protocol probe (`tools/list` over the streaming-HTTP MCP endpoint) — not just inferred. Skills were callable from inside `execute()` via `await call_tool("skills_list", {})`, but invisible at the top level.

## Why this happened

Skills were registered via `@mcp.tool` *before* `_register_code_mode(mcp)` ran. `CodeMode.transform_tools()` then **replaces** the visible catalog with `[*discovery_tools, execute]` — it doesn't merge. So:

- Skills stayed in the backend catalog (callable inside `execute()`)
- But never appeared at the top level

I tested skills via `execute()` during v2.3.0.0 development and the `await call_tool("skills_list", {})` path worked, so I missed that they weren't visible at the top.

## The fix

`skills/_engine.py` exposes two discovery-tool factories matching `CodeMode.discovery_tools`'s signature (same shape as fastmcp's `GetTags` / `Search` / `GetSchemas`):

- `SkillsListDiscoveryTool(registry)` → `skills_list` Tool
- `SkillsLoadDiscoveryTool(registry)` → `skills_load` Tool

`server.py:_register_code_mode` passes both factories to `CodeMode.discovery_tools` alongside the standard discovery tools. In code mode the surface is now **6 tools**: `tags`, `search`, `get_schema`, `skills_list`, `skills_load`, `execute`.

`server.py:create_server` skips the `@mcp.tool` registration path (`_register_skills(mcp)`) when `tool_mode == "code"` to avoid registering twice. Dynamic and static modes still use `register(mcp)` — `@mcp.tool` works correctly there because no transform replaces the catalog.

## Trade-off accepted

Skills are now **discovery-only** in code mode — callable at the top level but **not** from inside `execute()`. Matches their semantic role: planning tools, not dispatch tools. `execute_description` calls this out explicitly. If an LLM still tries `await call_tool("skills_list", {})` from inside the sandbox, `SandboxErrorCatchMiddleware` (v2.2.0.4) surfaces the actual error as a string for self-correction.

## INSTRUCTIONS.md rule #8 strengthened

Old rule was passive: *"call `skills_list` when you recognize a runbook"*. The user's *"how's my infrastructure in Central?"* didn't pattern-match the AI's runbook recognition.

New rule is proactive:

> *"**Always check Skills FIRST for multi-step / cross-platform questions.** Even when the user names a specific platform..."*

Plus a query→skill table giving concrete pattern → skill mappings:

| User query shape | Likely skill |
|---|---|
| *"how's my infrastructure?"*, *"how is health in &lt;platform&gt;?"* | `infrastructure-health-check` |
| *"about to push a change"*, *"give me a baseline"* | `change-pre-check` |
| *"the change is done — verify"* | `change-post-check` |
| *"are WLANs in sync?"* | `wlan-sync-validation` |

## Tests

644 → **649**:

- 5 new `TestDiscoveryToolFactories` cases — factories produce Tools with the right name + working body, support filter args, accept custom names, return clean errors on no-match
- `TestCodeModeAggregatorGating` extended to assert `skills.register` is called in dynamic/static and **NOT** called in code mode (with a comment pointing at the CHANGELOG so future contributors don't "fix" the assertion the wrong way)

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — **649 passed**
- [x] Live wire-protocol probe in code mode → 6 top-level tools, skills_list returns all 4 skills, skills_load returns full body
- [x] Live wire-protocol probe in dynamic mode → skills_list / skills_load still visible

## Lesson learned

Took two attempts to ship: I almost refactored on theory before verifying the actual symptom via the wire protocol. Caught by user pushback (*"are you not going to check why?"*) — useful reminder to investigate before assuming.
