### PR TITLE
v2.3.0.4: broaden Mist WLAN scope + add Central best practices section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.4] - 2026-04-28
+
+**Fixes the AI generalizing Mist-only WLAN best practices onto Central, plus broadens the Mist WLAN-template assignment scope guidance.**
+
+### What went wrong
+
+In-the-wild signal: a user asked their AI for a Central config / scope audit and got back:
+
+> *"WLANs should live in templates assigned to site groups (Global or Site-Collection scope), never at site or device level."*
+
+That sentence is wrong on multiple counts:
+- *"templates"* — Central does **not** have WLAN templates. That's Mist terminology. Central uses WLAN profiles.
+- *"never at site or device level"* — too restrictive even for Mist (templates can target a single site) and Central (WLAN profiles can be assigned at site or device-group scope).
+- *"Global or Site-Collection scope"* — Central terminology mashed onto Mist guidance.
+
+Two compounding root causes:
+
+1. **Mist guidance overreach.** INSTRUCTIONS.md `Mist Best Practices > WLANs` said *"assign templates to site groups"* — implying site groups were the *only* valid template-assignment target. The actual rule is **org-wide / site groups / specific sites — never device level**. The same too-narrow language was repeated in `platforms/mist/tools/guardrails.py:_check_site_wlan_creation`'s warning text.
+
+2. **Missing Aruba Central Best Practices section.** When asked for a Central audit, the AI had no Central-specific guidance to anchor on. It generalized Mist's *"push config high, use templates"* rule onto Central, picked up Central terminology along the way (*"Site-Collection scope"*), and produced a hybrid that's wrong on both platforms.
+
+### What's fixed
+
+**Mist guidance broadened** (matches the actual platform model):
+
+- `INSTRUCTIONS.md > Mist Best Practices > WLANs` — *"assign each template at the appropriate scope: org-wide, to a site group, or to specific sites. Never at the device level."* The rule against bare site-level WLANs (i.e. WLANs created without a template) stays — that's still correct shorthand for *"WLANs without a template should never be created"*.
+- `INSTRUCTIONS.md > Site Groups` — site groups are now described as one of three valid assignment targets, not the only valid one. Site-level template assignment is explicitly endorsed for site-specific cases.
+- `INSTRUCTIONS.md > Site Provisioning` — broadened the same way.
+- `platforms/mist/tools/guardrails.py:_check_site_wlan_creation` — warning text now lists all three valid scopes (org / site group / specific sites) and explicitly notes "never at device level" instead of implying site groups are the only target.
+
+**Aruba Central Best Practices section added** (mirrors Mist structure but uses correct Central terminology):
+
+- Configuration Hierarchy: *Global → Site Collections → Sites → Device Groups → Devices*
+- WLAN Profiles: assign at *Global*, *site collection*, *site*, or *device group* (Mist has no device-group equivalent — this scope is Central-only)
+- **Local overrides — use local profiles, not direct configs**: explicitly explains that bare local-scope configs lead to drift and orphan when the parent profile changes. The correct override pattern is a **local profile** assigned at the lower scope, which falls back to inherited config cleanly when deleted.
+- Naming: keep Mist site groups and Central site collections in sync by name so cross-platform sync workflows pair up.
+
+**Mist ↔ Central terminology table** added under the Central section:
+
+| Concept | Mist | Central |
+|---|---|---|
+| Reusable config bundle for SSIDs | WLAN **template** | WLAN **profile** |
+| Top of the hierarchy | **Org** | **Global** |
+| Group of sites | **Site group** | **Site collection** |
+| Individual site | **Site** | **Site** |
+| Group of devices | *(no equivalent)* | **Device group** |
+| Override at lower scope | Bare site-level config (avoid) | Local profile (correct) / bare local config (avoid) |
+
+The table is preceded by an explicit *"do NOT generalize a rule from one platform onto the other"* directive — meant to defang the exact AI behavior that produced the original bad answer.
+
+### Tests (649 → 650)
+
+One new guardrail-message-content test in `tests/unit/test_guardrails.py::TestSiteWlanCreation::test_site_wlan_create_warning_lists_all_valid_scopes`:
+
+- Asserts the warning mentions org-wide assignment
+- Asserts the warning mentions site-group assignment
+- Asserts the warning mentions site-level assignment (not just site groups)
+- Asserts the warning calls out "never at device level" explicitly
+
+Catches a regression where someone narrows the scope guidance back to site-groups-only.
+
+### Live-tested
+
+Verified via direct probe of the running server's `instructions` field over the MCP `initialize` response that the new sections (`Aruba Central Best Practices`, `Local Overrides`, `Mist ↔ Central terminology`, `Device Groups`, `Configuration Manager`) are all loaded and reach the AI client at session start.
+
 ## [2.3.0.3] - 2026-04-28
 
 **Fixes a top-level visibility bug that hid `skills_list` and `skills_load` in code mode since v2.3.0.0, and strengthens INSTRUCTIONS.md rule #8 to make the AI proactively check skills first.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.3"
+version = "2.3.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -119,9 +119,9 @@ When a Mist tool response includes a `_next` field, use `mist_get_next_page(url=
 Push configuration as high as possible: Org-level templates → Site group assignment → Site-level → Device-level. Device-level overrides are a last resort — they cannot be managed in bulk and cause drift.
 
 ### WLANs
-- **ALWAYS** create SSIDs as org-level WLANs inside WLAN templates. Assign templates to site groups.
-- **NEVER** create site-level WLANs. If asked to create a WLAN at a site, create an org-level WLAN in a WLAN template and assign the template to the site's site group instead.
-- When cloning or copying a site's config, do NOT copy site-level WLANs. Ensure all SSIDs come from org-level WLAN templates.
+- **ALWAYS** create SSIDs as org-level WLANs inside WLAN templates. The template itself is the unit of reuse — assign each template at the appropriate scope: **org-wide**, to a **site group**, or to **specific sites**. Never assign at the device level.
+- **NEVER** create site-level WLANs (i.e. WLANs created at a site without going through a template). If a WLAN should apply only to one site, put it in a template and assign that template to that single site — don't create a bare site-level WLAN.
+- When cloning or copying a site's config, do NOT copy bare site-level WLANs. Ensure all SSIDs come from org-level WLAN templates.
 - Organize WLAN templates by function: Corporate/Dot1X, MPSK/IoT, Guest, Onboarding.
 
 ### RADIUS / Template Variables
@@ -136,7 +136,7 @@ Push configuration as high as possible: Org-level templates → Site group assig
 - Prefer Cloud PSK (per-user unique passphrase with VLAN assignment) over static shared PSKs. Cloud PSK allows individual key rotation and per-device segmentation.
 
 ### Site Groups
-- Assign WLAN templates and RF templates to site groups, not individual sites. New sites added to a group automatically inherit all templates.
+- Site groups exist so a single template assignment can target multiple sites at once — new sites added to a group automatically inherit all templates assigned to that group. Prefer site-group assignment when a template applies to multiple sites; fall back to individual site assignment for site-specific cases. Both are valid; org-level assignment fits when the template applies everywhere.
 
 ### Firmware
 - Auto-upgrade should be enabled at the org level with a maintenance window.
@@ -145,7 +145,7 @@ Push configuration as high as possible: Org-level templates → Site group assig
 When asked to create a new site based on an existing site:
 - Use the `provision_site_from_template` prompt for single sites
 - Use the `bulk_provision_sites` prompt for multiple sites
-- NEVER copy site-level WLANs — always use org-level WLAN templates assigned via site groups
+- NEVER copy bare site-level WLANs — always use org-level WLAN templates assigned at the right scope (org / site group / site)
 
 ---
 
@@ -221,6 +221,35 @@ When asked to create a new site based on an existing site:
   - Filter with `device_type`, `site_id`, `site_name`, or `serial_number`. Default behavior omits devices already on Central's recommended version; pass `include_up_to_date=True` to see them too.
   - The `release_type` field reflects the API's `firmwareClassification` directly — values are `LSR`, `SSR`, or `UNCLASSIFIED` (AOS 8 and other builds the API doesn't classify fall into the last bucket and pass Central's recommendation through).
   - Narrowing `device_type` restricts the pool used to mine the newest LSR target for SSR devices — leave it unset when you want the tool to make SSR→LSR recommendations.
+
+## Aruba Central Best Practices
+
+### Configuration Hierarchy
+Central uses Configuration Manager scopes: **Global → Site Collections → Sites → Device Groups → Devices**. Push configuration as high in the hierarchy as practical. Lower scopes inherit from higher ones and can override.
+
+### WLAN Profiles
+- Define each SSID as a **WLAN profile**, then assign the profile at the right scope: **Global**, **site collection**, **site**, or **device group**. Pick the broadest scope that matches the intent (Global > Site collection > Site > Device group).
+- Central does **not** have "WLAN templates" — that's Mist terminology. Central has profiles. Mapping these one-to-one across platforms is wrong; see the *Mist ↔ Central terminology* table below.
+
+### Local Overrides — use local profiles, not direct configs
+- It *is* possible to create configuration directly at a lower scope (a site-level setting that doesn't come from a profile). **Do not do this.** It leads to configuration drift.
+- When a per-site / per-device-group override is needed, create it as a **local profile** assigned at that scope. If the local profile is later deleted, the parent-scope inherited configuration takes over automatically. Bare local configs have no fallback and orphan.
+
+### Naming convention
+Match Central scope names to Mist scope names where possible (Mist site group "Corporate" ↔ Central site collection "Corporate") so cross-platform sync workflows pair them up.
+
+## Mist ↔ Central terminology
+
+These two platforms have similar concepts with different names. Do NOT generalize a rule from one platform onto the other — the mechanisms differ. When the user asks about a Central-only audit, do not mention WLAN templates, site groups, or org-level WLANs (those are Mist concepts). When the user asks about a Mist-only audit, do not mention WLAN profiles, site collections, Global scope, or device groups (those are Central concepts).
+
+| Concept | Mist | Central |
+|---|---|---|
+| Reusable config bundle for SSIDs | WLAN **template** | WLAN **profile** |
+| Top of the hierarchy | **Org** (org-level) | **Global** (Global scope) |
+| Group of sites | **Site group** | **Site collection** |
+| Individual site | **Site** | **Site** |
+| Group of devices | *(no equivalent)* | **Device group** |
+| Override at lower scope | Bare site-level config (avoid) | Local profile (correct) / bare local config (avoid) |
 
 ## Cross-Platform WLAN Management
 

--- a/src/hpe_networking_mcp/platforms/mist/tools/guardrails.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/guardrails.py
@@ -83,11 +83,16 @@ def _check_site_wlan_creation(object_type: str, action_type: str, result: Guardr
             "BEST PRACTICE: SSIDs should be defined in org-level WLAN templates, "
             "not as site-level WLANs. Use mist_change_org_configuration_objects "
             "with object_type=wlans and a template_id to create the WLAN in an "
-            "org-level template, then assign the template to the site's site group."
+            "org-level template, then assign that template at the appropriate "
+            "scope: org-wide (`applies.org_id`), to a site group "
+            "(`applies.sitegroup_ids`), or to specific sites (`applies.site_ids`). "
+            "Never assign at device level."
         )
         result.suggestions.append(
             "Create this WLAN as an org-level WLAN inside a WLAN template instead. "
-            "Site-level WLANs cannot be centrally managed and cause configuration drift."
+            "Site-level WLANs (created without a template) cannot be centrally "
+            "managed and cause configuration drift. The template itself can target "
+            "a single site if that's the desired scope."
         )
 
 

--- a/tests/unit/test_guardrails.py
+++ b/tests/unit/test_guardrails.py
@@ -16,6 +16,25 @@ class TestSiteWlanCreation:
         assert "org-level WLAN templates" in result.warnings[0]
         assert len(result.suggestions) == 1
 
+    def test_site_wlan_create_warning_lists_all_valid_scopes(self):
+        """The warning text should list every valid template-assignment scope
+        (org, site group, specific sites) — NOT just site groups. The original
+        wording said 'assign the template to the site's site group' which an
+        AI would interpret as 'site groups are the only valid target'. Closes
+        the WLAN-scope correction in v2.3.0.4."""
+        result = validate_site_write("wlans", "create", {})
+        warning = result.warnings[0]
+        assert "org" in warning.lower(), "must mention org-wide assignment"
+        assert "site group" in warning.lower(), "must mention site-group assignment"
+        assert "specific sites" in warning.lower() or "site_ids" in warning, (
+            "must mention site-level assignment as a valid target — not just site groups"
+        )
+        # The "never at device level" rule belongs here too: it's the only
+        # scope the user said was off-limits.
+        assert "device level" in warning.lower() or "device_ids" in warning, (
+            "must call out 'never at device level' explicitly"
+        )
+
     def test_site_wlan_update_no_warn(self):
         result = validate_site_write("wlans", "update", {})
         assert len(result.warnings) == 0


### PR DESCRIPTION
## Summary

Fixes the AI generalizing Mist-only WLAN best practices onto Central and broadens the Mist WLAN-template assignment scope guidance to allow org / site groups / specific sites (not just site groups).

In-the-wild signal: a user asked their AI for a Central config audit and got back:

> *"WLANs should live in templates assigned to site groups (Global or Site-Collection scope), never at site or device level."*

Wrong on multiple counts:
- *"templates"* — Central doesn't have WLAN templates (Mist terminology mashed onto Central)
- *"never at site or device level"* — too restrictive even for Mist (templates can target a single site)
- *"Global or Site-Collection scope"* — Central terminology mashed onto Mist guidance

## Root cause (two compounding issues)

**1. Mist guidance overreach.** INSTRUCTIONS.md said *"assign templates to site groups"* — implying site groups are the *only* valid target. Actual rule is **org / site group / specific sites — never device level**. Same too-narrow language was repeated in `platforms/mist/tools/guardrails.py`'s warning text.

**2. Missing Aruba Central Best Practices section.** When asked for a Central audit, the AI had no Central-specific guidance and generalized the Mist *"push config high, use templates"* rule onto Central — picking up Central terminology along the way and producing a hybrid wrong on both platforms.

## Fix

**Mist guidance broadened** (matches the actual platform model):
- `INSTRUCTIONS.md > Mist Best Practices > WLANs` — lists all three valid scopes (org / site group / specific sites) and explicitly notes "never at device level"
- `INSTRUCTIONS.md > Site Groups` — site groups now described as one of three valid targets
- `INSTRUCTIONS.md > Site Provisioning` — same broadening
- `platforms/mist/tools/guardrails.py:_check_site_wlan_creation` — warning text now lists all three valid scopes

**Aruba Central Best Practices section added** to INSTRUCTIONS.md mirroring the Mist structure but with correct Central terminology:
- Configuration Hierarchy: *Global → Site Collections → Sites → Device Groups → Devices*
- WLAN Profiles: assign at Global / site collection / site / device group (Mist has no device-group equivalent)
- **Local overrides — use local profiles, not bare local-scope configs**: local profiles fall back to inherited config when deleted; bare local configs orphan
- Naming: keep Mist site groups and Central site collections in sync by name

**Mist ↔ Central terminology table** added with explicit *"do NOT generalize a rule from one platform onto the other"* directive — meant to defang the exact behavior that produced the bad answer.

| Concept | Mist | Central |
|---|---|---|
| Reusable config bundle | WLAN **template** | WLAN **profile** |
| Top of hierarchy | **Org** | **Global** |
| Group of sites | **Site group** | **Site collection** |
| Group of devices | *(no equivalent)* | **Device group** |

## Tests

**649 → 650.** New `test_site_wlan_create_warning_lists_all_valid_scopes` in `tests/unit/test_guardrails.py` — asserts the warning mentions org-wide, site-group, AND site-level assignment (catches if someone narrows back to site-groups-only) plus the "never at device level" rule.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — **650 passed**
- [x] Live verification: probed the running server's `instructions` field via MCP `initialize` — confirmed `Aruba Central Best Practices`, `Local Overrides`, `Configuration Manager`, `Mist ↔ Central terminology`, `Device Groups` are all present in the loaded instructions reaching AI clients

## What this PR doesn't do

- No new tools, no behavior changes — purely guidance/text + the guardrail warning rewording
- The "WLANs without a template should never be created" rule stays as-is — still correct
- Existing skills aren't touched (the regression test from v2.3.0.2 still passes)
- Central WLAN-profile / scope handling isn't audited at the tool layer in this PR — just documented
