### PR TITLE
v2.3.0.7: fix mist-scope-audit reauth-vs-interim confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.7] - 2026-04-28
+
+**Fixes a content bug in `mist-scope-audit`: the skill conflated 802.1X reauthentication interval with RADIUS accounting interim-update interval. The Mist Wired guide §2660-§2663 recommendation of 6-12 hours (21600-43200s) applies to *reauthentication* (`reauth_interval` on dot1x-enabled port profiles), not to `acct_interim_interval` (RADIUS accounting interim updates) — but the audit was citing it against the latter. Caught in the wild when a user's audit flagged `acct_interim_interval: 60` with the §2662 reauth recommendation.**
+
+### What changed
+
+- **`mist-scope-audit.md`** — three locations corrected:
+  - Per-port-profile structural-checks table: row renamed from "RADIUS interim-update" to "802.1X reauthentication interval (`reauth_interval` on dot1x-enabled port profiles)" with the full §2660-§2663 quote and an explicit *"Do NOT confuse this with `acct_interim_interval`"* warning.
+  - Drift findings list: same correction with note that `acct_interim_interval` should be flagged as INFO (not DRIFT) without citing §2662 since the Mist Wired guide doesn't give a recommended value for it.
+  - Output-formatting rollup: counter renamed to "802.1X `reauth_interval` outside 6-12 hour range".
+
+### Why it mattered
+
+Reauthentication interval (how often a 802.1X client must re-prove identity to RADIUS) and accounting interim interval (how often accounting status updates are sent to the accounting server) are two different fields with different purposes. The Mist Wired guide §1803 describes accounting interim updates as a frequency setting without prescribing a value; §2660-§2663 describes reauthentication with the 6-12 hour recommendation. Conflating them would either generate false-positive drift findings (flagging perfectly fine accounting intervals) or, worse, push operators to set accounting intervals to multi-hour values they shouldn't.
+
+### Tests
+
+- 653 passing, 0 failing — no test changes (skill body is content; reference test still validates every platform-prefixed tool name resolves).
+
 ## [2.3.0.6] - 2026-04-28
 
 **Adds `aos-migration-readiness` skill — VSG-anchored AOS 6 / AOS 8 / Instant AP → AOS 10 migration readiness audit (PoC). Operator pastes a fixed bundle of CLI command outputs from the source platform into chat; the audit parses the bundle, runs Central-side API checks, applies ~50 granular VSG-anchored rules across source-platform × target-mode combinations, and emits a GO / BLOCKED / PARTIAL verdict with cutover sequencing and rollback validation.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.6"
+version = "2.3.0.7"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/mist-scope-audit.md
+++ b/src/hpe_networking_mcp/skills/mist-scope-audit.md
@@ -380,7 +380,7 @@ These are not "config that breaks the template model" — they're below the temp
 | BPDU Guard | Enable on access ports | Disabled (DRIFT) |
 | Native VLAN | Should not be VLAN 1 in production | VLAN 1 (DRIFT) |
 | MAC address limit / port security | Only when all WLANs bridged | Enabled on AP ports (REGRESSION per §4016) |
-| RADIUS interim-update | 21600-43200 seconds (Mist Wired §2662: *"recommended value is 6 to 12 hours"*) | Outside that range (DRIFT) |
+| 802.1X reauthentication interval (`reauth_interval` on dot1x-enabled port profiles) | 21600-43200 seconds, i.e. 6-12 hours (Mist Wired §2660-§2663: *"In a switch port profile that uses dot1x authentication, you can configure a timer that controls how often a client reauthenticates itself with the RADIUS server. The recommended value is 6 to 12 hours (21600 to 43200 seconds). The default value is 65000 seconds."*) | Outside that range (DRIFT). **Do NOT confuse this with `acct_interim_interval`** — that's the RADIUS accounting interim-update timer (how often accounting updates are sent to the accounting server) and the 6-12 hour recommendation does NOT apply to it. |
 
 **Static vs Dynamic — per Mist Wired guidance:**
 - Static port profiles: manually pin a port to a profile. Fine for stable infrastructure (uplinks, AP ports).
@@ -398,7 +398,7 @@ These are not "config that breaks the template model" — they're below the temp
 - **DRIFT — PoE enabled on uplink-to-switch port** (§2738).
 - **DRIFT — Speed/duplex hardcoded** without reason.
 - **DRIFT — VLAN 1 as native** on a production trunk.
-- **DRIFT — RADIUS interim-update outside 6-12 hour window** (§2662).
+- **DRIFT — 802.1X `reauth_interval` outside 6-12 hour window** (§2662). NOT `acct_interim_interval` — those are different fields; §2662's recommendation only applies to reauthentication. If you see `acct_interim_interval` set aggressively (e.g. 60 s) and want to flag it, do so as INFO without citing §2662.
 - **DRIFT — no restricted network profile** for unrecognized devices on DPC-enabled ports.
 - **INFO — DPC rule audit table**: rules + matching criteria + assigned profile.
 
@@ -552,7 +552,7 @@ Use the EXACT structure below. Every section must be present even if its content
 - **Device-level firmware pin**: <N> findings.
 - **PoE on switch-to-switch ports**: <N> findings.
 - **Speed/duplex hardcoded**: <N> findings.
-- **RADIUS interim-update outside 6-12 hour range**: <N> findings.
+- **802.1X `reauth_interval` outside 6-12 hour range**: <N> findings.
 - **Maintenance window during business hours**: 1 finding.
 - **No pilot site group for firmware**: 1 finding.
 


### PR DESCRIPTION
## Summary

The `mist-scope-audit` skill conflated **802.1X reauthentication interval** (`reauth_interval` on dot1x-enabled port profiles) with **RADIUS accounting interim-update interval** (`acct_interim_interval`). The Mist Wired guide §2660–§2663 recommendation of 6–12 hours / 21600–43200 seconds applies to *reauthentication*, **not** to accounting interim updates — but the audit was citing it against the latter.

## How we found it

A user's in-the-wild audit flagged `acct_interim_interval: 60` with the §2662 reauth recommendation:

> "Switch template Access settings worth tuning. acct_interim_interval: 60 — Mist Wired §2662 recommends 21600–43200 (6–12 hours); 60 seconds will spam the RADIUS accounting servers."

The actual §2660–§2663 text is:

> "Reauthentication interval—In a switch port profile that uses dot1x authentication, you can configure a timer that controls how often a client reauthenticates itself with the RADIUS server. The recommended value is 6 to 12 hours (21600 to 43200 seconds). The default value is 65000 seconds."

Two different fields with two different purposes, conflated in the audit.

## Why it matters

If left in place, this would either generate false-positive DRIFT findings (flagging perfectly fine accounting intervals) or — worse — push operators to set their accounting interim interval to multi-hour values they shouldn't. The accounting interim is a separate setting for how often RADIUS accounting *status updates* are sent to the accounting server (§1803 describes it without giving a recommended value).

## What changed

Three locations in `skills/mist-scope-audit.md`:

1. **Per-port-profile structural-checks table** — row renamed from "RADIUS interim-update" to **"802.1X reauthentication interval (`reauth_interval` on dot1x-enabled port profiles)"**. Full §2660–§2663 quote included. Explicit *"Do NOT confuse this with `acct_interim_interval`"* warning baked into the recommendation column.
2. **Drift findings list** — corrected to **"DRIFT — 802.1X `reauth_interval` outside 6-12 hour window"**. Adds an explicit note that `acct_interim_interval` should be flagged as INFO (not DRIFT) without citing §2662.
3. **Output-formatting rollup** — counter renamed to **"802.1X `reauth_interval` outside 6-12 hour range"**.

## Test plan

- [x] `tests/unit/test_skill_tool_references.py` — 8/8 passing (tool-name catalog still resolves)
- [x] Sweep of other skills (`central-scope-audit`, `aos-migration-readiness`) for the same confusion — none found
- [x] No new tools, no new dependencies, no schema changes