### PR TITLE
v2.3.0.9: validate Origin header + bind host port to loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0.9] - 2026-04-29
+
+**Closes the MCP Streamable HTTP spec's Origin-validation requirement (DNS rebinding defense) and tightens the host port publish to loopback by default. Both changes are transport-layer hardening; no tools or APIs are affected.**
+
+### Security
+
+- **`Origin` header validation** — new ASGI middleware (`src/hpe_networking_mcp/middleware/origin_validation.py`) rejects HTTP requests whose `Origin` header is set to anything outside the allowlist with `403 Forbidden`. Browsers always send `Origin` and cannot lie about it (it is a forbidden header in the Fetch spec), so a server-side allowlist is sufficient defense against DNS rebinding attacks. Non-browser clients (supergateway, curl, native MCP clients) typically don't send `Origin` and are passed through unchanged. The MCP spec (2025-06-18 §Streamable HTTP) requires this check.
+- **Host port publish now binds loopback by default** — `docker-compose.yml` changes `ports: "${MCP_PORT:-8000}:8000"` → `"127.0.0.1:${MCP_PORT:-8000}:8000"`. Previously the published port answered on every host interface (`0.0.0.0:8000`, `[::]:8000`), which meant any host on the same LAN could reach the unauthenticated MCP endpoint. Loopback-only publishing eliminates that exposure. The container's internal bind (`MCP_HOST=0.0.0.0`) is unchanged — that controls binding *inside* the container's network namespace, which is correct for Docker's port-forwarder to reach the app.
+
+### What's new
+
+- **New env var: `ALLOWED_ORIGINS`** (comma-separated). Defaults to `http://localhost:<MCP_PORT>,http://127.0.0.1:<MCP_PORT>` — covers Claude Desktop / supergateway / Claude Code / curl from the host. Set `ALLOWED_ORIGINS=*` to disable the check entirely (use only when fronted by an auth proxy that already validates origins).
+- Origin allowlist is logged at startup so misconfiguration is visible. A `*` wildcard is logged as a `WARNING`.
+
+### Why it matters
+
+Before this release: a malicious page in any browser tab on the operator's machine could DNS-rebind its own domain to `127.0.0.1` and POST to `/mcp`, driving the entire fleet (Mist, Central, GreenLake, ClearPass, Apstra, Axis) without ever crossing the supergateway/Claude Desktop trust boundary. With `0.0.0.0:8000` exposure also active, the same attack worked from any host on the LAN.
+
+After this release: the published port answers only on loopback (eliminates LAN exposure), and the Origin allowlist blocks browser-driven cross-origin POSTs (eliminates DNS rebinding from tabs on the same machine). Defense in depth — both controls are applied.
+
+### How to verify after upgrade
+
+```bash
+docker compose up -d --force-recreate
+docker ps --format '{{.Names}}\t{{.Ports}}' | grep hpe-networking
+# Expect: 127.0.0.1:8000->8000/tcp   (no [::]:8000 line)
+
+# Allowed (no Origin) → 200/SSE
+curl -i -X POST http://127.0.0.1:8000/mcp \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' -d '{}'
+
+# Disallowed Origin → 403
+curl -i -X POST http://127.0.0.1:8000/mcp \
+  -H 'Origin: http://evil.example' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+### Tests
+
+- 653 passing — no test changes; behavior unit-testable end-to-end via curl above.
+
 ## [2.3.0.8] - 2026-04-28
 
 **Fixes a content gap in `central-scope-audit`: when an alias has a placeholder default value (e.g. `1.1.1.1`, RFC-5737 documentation block) at Global, the audit was flagging it as REGRESSION without first checking whether the alias is *overridden* at consuming scopes (Site Collection / Site / Device Group / per-device via `Save as local profile`). In Aruba Central's two-layer alias model, a placeholder at the definition scope is the canonical pattern — what matters is whether each consumer (Static Routes, profiles, ACLs, etc.) has an override at scope-or-below. Caught in the wild when the audit flagged four `Default Gateway -*` aliases all defaulting to `1.1.1.1` at Global as REGRESSION without confirming whether the consuming static routes had per-site / per-device overrides.**

--- a/README.md
+++ b/README.md
@@ -306,6 +306,17 @@ Add to your `.vscode/mcp.json` (create the file if it doesn't exist) or VS Code 
 
 ---
 
+## Network Security
+
+The MCP HTTP transport ships with two layers of defense out of the box:
+
+1. **Loopback-only port publish** — `docker-compose.yml` publishes `127.0.0.1:8000:8000`, so only processes on the host can reach the MCP endpoint. No LAN host can connect, even if it knows the IP. (Inside the container the app still binds `0.0.0.0` — that's the container's *own* network namespace and is what Docker's port-forwarder forwards into; do not change it.)
+2. **`Origin` header allowlist** — required by the MCP Streamable HTTP spec to defend against browser-driven DNS rebinding. The server rejects any request whose `Origin` is set to a value outside `ALLOWED_ORIGINS` (default: `localhost` and `127.0.0.1`). Non-browser clients (supergateway, curl, native MCP clients) don't send `Origin` and pass through.
+
+If you put the server behind an authenticating reverse proxy that already validates origins, set `ALLOWED_ORIGINS=*` to bypass the in-process check. See the [Configuration](#configuration) table for details.
+
+> **Multi-host / remote access is not a supported configuration.** The server has no built-in authentication on `/mcp` — anyone who can reach the port has full admin of every connected platform. If you need remote access, terminate at a reverse proxy (nginx + mTLS / OIDC, Cloudflare Access, Tailscale Funnel, etc.) and never expose the published port directly.
+
 ## Secrets
 
 This project uses **Docker Compose secrets** for credential management — the most secure native Docker approach:
@@ -452,6 +463,8 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
 | `MCP_PORT` | `8000` | Port the MCP server listens on |
+| `MCP_HOST` | `0.0.0.0` | Bind address **inside the container's namespace** — leave at `0.0.0.0` so Docker's port-forwarder can reach the app. Restrict who can reach the host port via `ports:` in compose, not this. |
+| `ALLOWED_ORIGINS` | `http://localhost:<MCP_PORT>,http://127.0.0.1:<MCP_PORT>` | Comma-separated allowlist for the `Origin` request header (DNS-rebinding defense per MCP spec). Browsers always send `Origin`; non-browser clients (supergateway, curl) don't and pass through. Set to `*` to disable the check (use only behind an auth proxy). |
 | `SECRETS_DIR` | `/run/secrets` | Directory containing Docker secret files |
 | `LOG_LEVEL` | `info` | Logging level (`debug`, `info`, `warning`, `error`) |
 | `ENABLE_MIST_WRITE_TOOLS` | `false` | Enable Mist write/mutation tools |
@@ -618,11 +631,13 @@ docker compose ps                          # Check container is running
 docker compose restart                     # Restart the container
 ```
 
-If port 8000 is already in use by another service, change the port in `docker-compose.yml`:
+If port 8000 is already in use by another service, change the port in `docker-compose.yml` (keep the `127.0.0.1:` prefix):
 ```yaml
 ports:
-  - "8080:8000"    # Map to port 8080 instead
+  - "127.0.0.1:8080:8000"    # Map to port 8080 instead, loopback-only
 ```
+
+If you change the host port, also update `ALLOWED_ORIGINS` so it matches (e.g. `ALLOWED_ORIGINS=http://localhost:8080,http://127.0.0.1:8080`) — the default tracks `MCP_PORT` (which is the *container* port, 8000), not the host port.
 
 ### Tools Not Appearing in AI Client
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # To build from source instead, comment out 'image' and uncomment 'build':
     # build: .
     ports:
-      - "${MCP_PORT:-8000}:8000"
+      - "127.0.0.1:${MCP_PORT:-8000}:8000"
     environment:
       - MCP_PORT=8000
       - MCP_HOST=0.0.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.8"
+version = "2.3.0.9"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/__main__.py
+++ b/src/hpe_networking_mcp/__main__.py
@@ -69,10 +69,26 @@ def main() -> None:
     )
 
     try:
+        from starlette.middleware import Middleware as ASGIMiddleware
+
+        from hpe_networking_mcp.middleware.origin_validation import (
+            OriginValidationMiddleware,
+        )
         from hpe_networking_mcp.server import create_server
 
         mcp = create_server(config)
-        mcp.run(transport="streamable-http", host=config.host, port=config.port)
+        http_middleware = [
+            ASGIMiddleware(
+                OriginValidationMiddleware,
+                allowed_origins=config.allowed_origins,
+            ),
+        ]
+        mcp.run(
+            transport="streamable-http",
+            host=config.host,
+            port=config.port,
+            middleware=http_middleware,
+        )
     except KeyboardInterrupt:
         logger.info("Server stopped by user")
     except Exception as e:

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -30,7 +30,7 @@ Secret file mapping:
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from loguru import logger
@@ -107,6 +107,13 @@ class ServerConfig:
     disable_elicitation: bool = False
     debug: bool = False
     log_file: str | None = None
+
+    # Origin allowlist for the streamable-HTTP transport. Defends against
+    # browser-driven DNS rebinding (MCP spec requirement). Matches the
+    # ``Origin`` request header literally; ``*`` disables the check entirely.
+    # Non-browser clients (supergateway, curl, native MCP clients) don't
+    # send Origin and are always allowed.
+    allowed_origins: list[str] = field(default_factory=lambda: ["http://localhost:8000", "http://127.0.0.1:8000"])
 
     # Tool exposure mode (generalized from GreenLake's original setting, #151).
     # "static"  — every tool registers with FastMCP individually; all visible.
@@ -372,6 +379,14 @@ def load_config() -> ServerConfig:
         logger.warning("Ignoring unknown MCP_TOOL_MODE={!r}, defaulting to 'dynamic'", tool_mode)
         tool_mode = "dynamic"
 
+    # ALLOWED_ORIGINS — comma-separated. Empty value falls back to the
+    # localhost defaults (most users). ``*`` disables the check.
+    allowed_origins_env = os.getenv("ALLOWED_ORIGINS")
+    if allowed_origins_env is None:
+        allowed_origins = [f"http://localhost:{port}", f"http://127.0.0.1:{port}"]
+    else:
+        allowed_origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+
     # Load platform credentials from Docker secrets
     mist = _load_mist()
     central = _load_central()
@@ -393,6 +408,7 @@ def load_config() -> ServerConfig:
         debug=debug,
         log_file=log_file,
         tool_mode=tool_mode,
+        allowed_origins=allowed_origins,
         mist=mist,
         central=central,
         greenlake=greenlake,
@@ -410,4 +426,8 @@ def load_config() -> ServerConfig:
 
     logger.info("Enabled platforms: {}", ", ".join(config.enabled_platforms))
     logger.info("Tool mode: {}", tool_mode)
+    if "*" in allowed_origins:
+        logger.warning("Origin validation: DISABLED (ALLOWED_ORIGINS contains '*')")
+    else:
+        logger.info("Origin validation: allowlist = {}", allowed_origins)
     return config

--- a/src/hpe_networking_mcp/middleware/origin_validation.py
+++ b/src/hpe_networking_mcp/middleware/origin_validation.py
@@ -1,0 +1,116 @@
+"""Origin header validation — defends against browser-driven DNS rebinding.
+
+This is **ASGI/Starlette HTTP-layer middleware**, not a FastMCP protocol
+middleware. It runs on the raw HTTP request before any MCP handling. The
+other modules in this directory (``null_strip``, ``elicitation``, ``retry``,
+etc.) are FastMCP middleware that run inside the MCP request lifecycle —
+they don't see HTTP headers.
+
+The MCP Streamable HTTP spec
+(https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#origin-validation)
+requires servers to validate the ``Origin`` header to prevent DNS rebinding
+attacks: a malicious page that tricks DNS into resolving its domain to
+``127.0.0.1`` and POSTs to the local MCP endpoint. Browsers always send
+``Origin`` on such requests and cannot lie about it (it's a forbidden
+header), so a server-side allowlist is sufficient defense.
+
+Non-browser clients (supergateway, curl, native MCP clients) typically do
+not send ``Origin`` at all. Those requests are allowed through — there's
+no security gain from blocking them since the DNS rebinding vector is
+browser-only.
+
+Wildcard ``*`` in the allowlist disables the check entirely; useful when
+the server sits behind an authenticating reverse proxy that already
+validates origins.
+"""
+
+from collections.abc import Awaitable, Callable, Iterable
+
+from loguru import logger
+
+ASGIScope = dict
+ASGIMessage = dict
+ASGIReceive = Callable[[], Awaitable[ASGIMessage]]
+ASGISend = Callable[[ASGIMessage], Awaitable[None]]
+ASGIApp = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class OriginValidationMiddleware:
+    """ASGI middleware that rejects requests whose ``Origin`` header is not allowlisted.
+
+    Behavior matrix:
+
+    +--------------------+------------------+----------------------+
+    | Request has Origin | Origin allowed?  | Result               |
+    +====================+==================+======================+
+    | No                 | n/a              | Pass through (allow) |
+    +--------------------+------------------+----------------------+
+    | Yes                | Yes              | Pass through (allow) |
+    +--------------------+------------------+----------------------+
+    | Yes                | No               | 403 Forbidden        |
+    +--------------------+------------------+----------------------+
+
+    If ``"*"`` is in ``allowed_origins`` the check is bypassed and every
+    request — Origin or not — passes through.
+
+    Args:
+        app: The downstream ASGI application.
+        allowed_origins: Iterable of allowed origin strings (e.g.
+            ``"http://localhost:8000"``). May contain ``"*"`` to disable
+            the check entirely.
+    """
+
+    def __init__(self, app: ASGIApp, allowed_origins: Iterable[str] | None = None) -> None:
+        self.app = app
+        origins = list(allowed_origins or [])
+        self._wildcard = "*" in origins
+        self._allowed = {o for o in origins if o != "*"}
+
+    async def __call__(self, scope: ASGIScope, receive: ASGIReceive, send: ASGISend) -> None:
+        if scope["type"] != "http" or self._wildcard:
+            await self.app(scope, receive, send)
+            return
+
+        origin = self._extract_origin(scope.get("headers", []))
+
+        if origin is None or origin in self._allowed:
+            await self.app(scope, receive, send)
+            return
+
+        client = scope.get("client") or ("?", 0)
+        path = scope.get("path", "")
+        logger.warning(
+            "Origin validation: rejected request from {}:{} for {} (origin={!r}, allowed={})",
+            client[0],
+            client[1],
+            path,
+            origin,
+            sorted(self._allowed),
+        )
+        await self._send_forbidden(send)
+
+    @staticmethod
+    def _extract_origin(headers: Iterable[tuple[bytes, bytes]]) -> str | None:
+        """Return the ``Origin`` header value as a str, or None if absent."""
+        for key, value in headers:
+            if key == b"origin":
+                try:
+                    return value.decode("latin-1")
+                except UnicodeDecodeError:
+                    return None
+        return None
+
+    @staticmethod
+    async def _send_forbidden(send: ASGISend) -> None:
+        body = b'{"jsonrpc":"2.0","error":{"code":-32600,"message":"Origin not allowed"},"id":null}'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})


### PR DESCRIPTION
## Summary

Closes the MCP Streamable HTTP spec's Origin-validation requirement (DNS rebinding defense) and tightens the host port publish to loopback by default. Both changes are transport-layer hardening; no tools or APIs are affected.

- **New ASGI middleware `OriginValidationMiddleware`** rejects HTTP requests whose `Origin` header is outside `ALLOWED_ORIGINS` with `403 Forbidden`. Browsers always send `Origin` and cannot lie about it (forbidden header in the Fetch spec); a server-side allowlist is sufficient defense. Non-browser clients (supergateway, curl, native MCP clients) don't send `Origin` and pass through unchanged.
- **Loopback-only host port publish** — `docker-compose.yml` changes `ports: "${MCP_PORT:-8000}:8000"` → `"127.0.0.1:${MCP_PORT:-8000}:8000"`. Eliminates LAN exposure; the container's internal bind (`MCP_HOST=0.0.0.0`) is unchanged because that controls binding inside the container's namespace, which is required for Docker's port-forwarder to reach the app.
- **New env var: `ALLOWED_ORIGINS`** (comma-separated). Default tracks `MCP_PORT`: `http://localhost:<MCP_PORT>,http://127.0.0.1:<MCP_PORT>`. Set `ALLOWED_ORIGINS=*` to disable the check (only when fronted by an auth proxy that already validates origins).

### Why it matters

Before this PR: a malicious page in any browser tab on the operator's machine could DNS-rebind its own domain to `127.0.0.1` and POST to `/mcp`, driving the entire fleet (Mist, Central, GreenLake, ClearPass, Apstra, Axis) without ever crossing the supergateway/Claude Desktop trust boundary. With `0.0.0.0:8000` exposure also active, the same attack worked from any host on the LAN.

After this PR: the published port answers only on loopback (eliminates LAN exposure), and the Origin allowlist blocks browser-driven cross-origin POSTs (eliminates DNS rebinding from tabs on the same machine).

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — `Success: no issues found in 190 source files`
- [x] `pytest tests/ -q` — 653 passed
- [ ] After merge & `:latest` rebuild + `docker compose up -d --force-recreate`:
  - [ ] `docker ps` shows `127.0.0.1:8000->8000/tcp` (no `[::]:8000`)
  - [ ] Plain POST with no Origin → 200/SSE: `curl -i -X POST http://127.0.0.1:8000/mcp -H 'Accept: application/json, text/event-stream' -H 'Content-Type: application/json' -d '{}'`
  - [ ] Disallowed Origin → 403: `curl -i -X POST http://127.0.0.1:8000/mcp -H 'Origin: http://evil.example' -H 'Accept: application/json, text/event-stream' -H 'Content-Type: application/json' -d '{}'`
  - [ ] Allowed Origin → 200/SSE: same as above with `Origin: http://localhost:8000`
  - [ ] Startup log contains `Origin validation: allowlist = [...]`

## Docs touched

- `CHANGELOG.md` — new `v2.3.0.9` entry under Security
- `README.md` — new "Network Security" section + `MCP_HOST` and `ALLOWED_ORIGINS` rows in the Configuration table + loopback-aware troubleshooting
- `pyproject.toml` — `2.3.0.8` → `2.3.0.9`

## Notes

- `INSTRUCTIONS.md` and `docs/TOOLS.md` intentionally unchanged — this is transport-layer hardening, not a tool/prompt change.
- `MCP_HOST` semantics clarified in the Configuration table: it's the *in-container* bind. To restrict who can reach the host port, use `ports:` in compose, not `MCP_HOST`.