### PR TITLE
v2.3.1.0: PII tokenization + always-on MAC normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1.0] - 2026-04-29
+
+**Adds session-stable PII tokenization for tool responses + always-on MAC normalization. Sensitive fields (PSKs, RADIUS secrets, certificates) and customer-identifying values (platform UUIDs, hostnames, emails, geographic data) get replaced with `[[KIND:uuid]]` tokens before reaching the AI; the AI can pass tokens back into write tools and the inbound side substitutes plaintext before the API call. The mapping is held in process memory keyed by `Mcp-Session-Id` and never persisted to disk. Mist ruleset only this release; Central / GreenLake / ClearPass / Apstra / Axis follow in the next minor.**
+
+### What's new
+
+- **`src/hpe_networking_mcp/redaction/` package** — five modules covering rules, MAC normalization, the per-session token store, the bidirectional tokenizer, and the recursive walker. ~700 LOC of pure logic, no platform dependencies.
+- **`src/hpe_networking_mcp/middleware/pii_tokenization.py`** — bidirectional FastMCP middleware. Inbound: walks `arguments` for `[[KIND:uuid]]` tokens and substitutes plaintext from the session keymap before the call hits the platform. Unknown tokens (model referenced something from a stale session) cause the call to fail with a JSON-RPC error rather than passing literal bracket text downstream. Outbound: walks `ToolResult.structured_content` and JSON-shaped text content blocks, applying MAC normalization (always-on) and PII tokenization (when enabled).
+- **MAC normalization is default-on regardless of the tokenization toggle** — every MAC address in tool responses gets rewritten to canonical `aa:bb:cc:dd:ee:ff` form (lowercase, colon-separated). Mist's API can return MACs in four different formats across different endpoints; normalizing to one consistent shape lets the AI correlate `aa:bb:cc:dd:ee:ff` to itself across an audit. Per the design discussion, MACs are NOT tokenized — they're observable in radio space (BSSID broadcast, client probes), so privacy tokenization adds cost without security gain.
+- **PII tokenization is opt-in via `ENABLE_PII_TOKENIZATION=true`** for this minor; default flips to on in the next minor after the Mist ruleset has been validated against real audits.
+- **Tier 1 secrets (always tokenized when enabled):** `psk`, `passphrase`, `wpa3_psk`, `sae_password`, `ppsk`, `wep_key`; `shared_secret`, `radius_secret`, `radsec_secret`, `eap_password`; `community`, `auth_password`, `priv_password` (SNMP); `admin_password`, `enable_secret`, `cli_password`; `pre_shared_key`, `ipsec_psk`, `vpn_psk`; `api_token`, `client_secret`, `bearer_token`, `access_token`, `refresh_token`, `webhook_secret`; `private_key`, `cert`, `certificate`, `client_cert`, `server_cert`, `ca_cert`, `chain`, `pkcs12`, `pem`, `kerberos_keytab`. Plus content-fingerprint detection on `-----BEGIN ` PEM blocks anywhere.
+- **Tier 2 identifiers:** platform UUIDs (`org_id`, `site_id`, `device_id`, `wlan_id`, `client_id`, etc.); operator-assigned names (`device_name`, `ap_name`, `hostname`, `fqdn`, `ssid`, `vlan_name`); user-identifying fields (`username`, `email`, `first_name`, `last_name`, `phone`); hardware identifiers (`serial`, `imei`, `imsi`, `iccid`); geographic data (`latitude`, `longitude`, `address`, `street`, `city`, `state`, `zip`, `country`). IPs in `description`/`notes`/`comment`/`remarks`/`details` free-text fields are scanned and tokenized in place (substring substitution, surrounding text preserved). Public DNS / loopback / RFC documentation IPs are exempt from tokenization.
+- **Token format: `[[KIND:550e8400-e29b-41d4-a716-446655440000]]`** — UUID4 with dashes, lowercase. 128 bits of entropy means collision probability is effectively zero across any session size. Same plaintext gets the same token within a session ("same value, same token" — enables sync, migration, and rotation workflows that depend on equality).
+- **Storage:** in-memory `TokenStore` on the FastMCP instance. Per-session `SessionKeymap` keyed by `Mcp-Session-Id`; `get_or_create()` allocates lazily. Soft cap of 10K tokens per session (configurable via `PII_MAX_TOKENS_PER_SESSION`); cap-hit logs a warning and falls through with plaintext rather than erroring out the call. **No disk persistence** — keymap dies with the process. Saved chat references to `[[KIND:uuid]]` from a dead session become unresolvable on resurrection; the operator re-runs the workflow that produced them.
+- **Audit logging:** every tokenization and detokenization event logs to stderr (`docker compose logs`) with tool name, parameter name, kind, token ID, truncated value-hash (SHA-256, first 16 hex), session prefix. **Plaintext is never logged.** The value-hash lets an operator confirm "the same value tokenized to the same token" without revealing the value.
+
+### Why it matters
+
+Pre-2.3.1.0: a Mist scope-audit response contains every WLAN's PSK, RADIUS shared secrets, admin passwords, and operator-assigned names in cleartext. The AI ingests all of it as conversation context and the AI provider sees it on every prompt. The `aos-migration-readiness` skill explicitly called this out as a known PoC limitation.
+
+Post-2.3.1.0: with `ENABLE_PII_TOKENIZATION=true`, the AI sees `[[PSK:550e8400-...]]` instead of the literal PSK, can pass that token back into `mist_create_wlan` to clone the WLAN to another site, and the middleware substitutes the real PSK at the inbound boundary. WLAN sync, AOS 8 → AOS 10 migration, and mass PSK rotation all keep working because tokenization is round-trippable. The AI's conversation context window never holds a literal secret.
+
+Compose well with code mode (`MCP_TOOL_MODE=code`): in the sandbox, the AI can call `secrets.token_urlsafe(20)` to generate a fresh PSK, pass it to `mist_create_wlan`, and only see the tokenized form in the `return` value — the literal PSK lives in the sandbox's local scope and never enters the AI's context window.
+
+### Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `ENABLE_PII_TOKENIZATION` | `false` | Master toggle. Off this release; flips to `true` in the next minor after ruleset validation. |
+| `PII_MAX_TOKENS_PER_SESSION` | `10000` | Soft cap on keymap size per session. Cap-hit returns plaintext rather than erroring. |
+
+### Tests
+
+- 712 passing (was 653) — 59 new tests covering MAC normalization, field classification, credential-shape heuristics, token-store lifecycle, tokenizer round-trip, walker recursion, free-text scan, public-IP allowlist, and a realistic Mist WLAN fixture.
+
+### Known limitations
+
+- **Mist ruleset only.** Central / GreenLake / ClearPass / Apstra / Axis tools work but their platform-specific field names (e.g. Central's `radius_servers[*].secret` shape, ClearPass's certificate model) aren't fully covered. Next minor.
+- **Paste-into-chat is still exposed.** A user typing `psk=Welcome2024` into the AI prompt has the literal PSK in their context immediately — outside our threat model. We tokenize the API echo back when the response comes through, so subsequent references stop leaking, but the originating turn does. Documented behavior.
+- **No reveal mechanism.** There is no tool to retrieve the plaintext for a token. Operators see the audit log if they need to confirm what a token references; the platform UI is the source of truth for the actual values.
+
 ## [2.3.0.9] - 2026-04-29
 
 **Closes the MCP Streamable HTTP spec's Origin-validation requirement (DNS rebinding defense) and tightens the host port publish to loopback by default. Both changes are transport-layer hardening; no tools or APIs are affected.**

--- a/README.md
+++ b/README.md
@@ -306,6 +306,23 @@ Add to your `.vscode/mcp.json` (create the file if it doesn't exist) or VS Code 
 
 ---
 
+## PII Tokenization (v2.3.1.0+)
+
+Tool responses are walked before reaching the AI:
+
+- **MAC normalization (always-on, no toggle)** — every MAC address in tool responses is rewritten to canonical `aa:bb:cc:dd:ee:ff` form (lowercase, colon-separated). Mist's API returns MACs in four different formats across endpoints; consistent format means the AI can correlate `aa:bb:cc:dd:ee:ff` to itself across audits.
+- **PII tokenization (opt-in via `ENABLE_PII_TOKENIZATION=true`)** — sensitive fields (PSKs, RADIUS secrets, certificates) and customer-identifying values (platform UUIDs, hostnames, emails, geographic data) are replaced with session-stable `[[KIND:uuid]]` tokens before reaching the AI. The AI can pass tokens back into write tools and the inbound side substitutes plaintext before the API call. Storage is in-memory only; the keymap is keyed by `Mcp-Session-Id` and never touches disk.
+
+**MACs are deliberately NOT tokenized.** They're observable to anyone in radio range (BSSID broadcast, client probe requests), so privacy-tokenizing them adds cost without security gain. The normalization step is still useful for consistency.
+
+**Round-trip works for every kind.** Same plaintext → same token within a session. WLAN sync, AOS 8 → AOS 10 migration, and mass PSK rotation all work because tokenization is round-trippable.
+
+**What the AI never sees in its context window:** WPA / SAE / WEP keys; RADIUS / RadSec / SNMP / admin / VPN secrets; API tokens; certificates and private keys; email addresses; embedded secrets in description/notes fields. **What it does see:** tokens for those values, MACs (normalized), public infrastructure IPs (Google DNS, Cloudflare, etc., preserved verbatim), and unchanged metric/enum/timestamp fields.
+
+Audit logging fires on every tokenize/detokenize event in `docker compose logs` — kind, token ID, value-hash (SHA-256 truncated), but never the plaintext.
+
+> **Limitations:** Mist ruleset only this release; Central / GreenLake / ClearPass / Apstra / Axis follow in the next minor. Anything the user pastes into the AI prompt is outside our threat model — that turn already has the literal in conversation context. The keymap dies on server restart; saved chat references to old tokens become unresolvable.
+
 ## Network Security
 
 The MCP HTTP transport ships with two layers of defense out of the box:
@@ -477,6 +494,8 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
+| `ENABLE_PII_TOKENIZATION` | `false` | Tokenize sensitive fields (PSKs, RADIUS secrets, hostnames, emails, etc.) in tool responses before they reach the AI. Round-trips: AI passes tokens back into write tools and the middleware substitutes plaintext. MAC normalization is always-on regardless of this toggle. See [PII Tokenization](#pii-tokenization-v2310) above. |
+| `PII_MAX_TOKENS_PER_SESSION` | `10000` | Soft cap on the per-session keymap size. Cap-hit logs a warning and falls through with plaintext rather than erroring out the call. |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.0.9"
+version = "2.3.1.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -82,6 +82,19 @@ If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front wi
 
 After `skills_list()`, call `skills_load(name=...)` to get the runbook, then follow its steps — including its output format. Don't reinvent the procedure from scratch when one's bundled. If `skills_list()` returns no relevant match, fall back to manual.
 
+## Tokens you may see in tool results
+
+When `ENABLE_PII_TOKENIZATION=true` (operator-controlled, off by default), the MCP server replaces sensitive values in tool responses with **session-stable placeholders** of the form `[[KIND:550e8400-e29b-41d4-a716-446655440000]]` before they reach you. Treat these tokens as opaque handles.
+
+- **You do not have access to the plaintext.** A token is a reference, not the value itself. Never attempt to "guess" or "decode" what's behind a token.
+- **The same plaintext gets the same token within a session.** If two WLANs return the same `[[PSK:...]]` token, they share a PSK — useful for findings like *"three sites use the same key, recommend rotation."*
+- **Tokens are round-trippable into write tools.** Pass the token verbatim as the parameter value (e.g. `manage_wlan_profile(psk="[[PSK:550e8400-...]]", ...)`); the middleware substitutes the real plaintext before calling the platform API. This is how WLAN sync, migration, and rotation flows work without exposing secrets to you.
+- **Common kinds:** `PSK` (WPA/SAE keys, passphrases), `RADSEC` (RADIUS shared secrets, EAP passwords), `SNMP` (SNMP communities, v3 auth/priv), `PASSWORD` (admin/manager/CLI passwords), `APITOKEN` (API tokens, OAuth credentials in configs), `CERT` (certificates), `KEY` (private keys, keytabs), `VPNPSK` (VPN/IPSec PSKs), `ORG`/`SITE`/`DEVICE`/`AP`/`SWITCH`/`GATEWAY`/`WLAN`/`TEMPLATE`/`POLICY`/`TENANT`/`WORKSPACE`/`SUBSCRIPTION`/`CLIENT` (platform UUIDs), `HOSTNAME`/`SSID`/`NAME` (operator-assigned names), `USER`/`EMAIL`/`PHONE` (user-identifying), `SERIAL`/`IMEI`/`IMSI`/`ICCID` (hardware), `IP` (non-public IPs — public DNS is preserved), `GEO` (latitude/longitude/address fields).
+- **MAC addresses are NOT tokenized** — they are normalized to `aa:bb:cc:dd:ee:ff` format (lowercase, colon-separated). When a tool returns a MAC in a different format, you'll see the canonical form.
+- **If you see "Tokenization error: the following tokens are not valid in the current session..."** it means you tried to pass a token that wasn't issued in this session (likely copy-pasted from an old chat). Re-fetch the source data with a read tool, then use the freshly issued tokens.
+
+When tokenization is off, tool responses contain plaintext values — your behavior is unchanged.
+
 ---
 
 # JUNIPER MIST (mist_* tools)

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -123,6 +123,17 @@ class ServerConfig:
     #             to opt out.
     tool_mode: str = "dynamic"
 
+    # PII tokenization (v2.3.1.0). When enabled, sensitive fields (PSKs,
+    # RADIUS secrets, certificates) and identifiers (UUIDs, hostnames,
+    # emails, etc.) in tool responses are replaced with session-stable
+    # ``[[KIND:uuid]]`` tokens before reaching the AI. The AI can pass
+    # the tokens back into write tools; the inbound side substitutes
+    # plaintext before the API call. MAC address normalization is
+    # always-on regardless of this toggle (no security impact, just
+    # consistency). Off by default this release; flip default in PR 2.
+    enable_pii_tokenization: bool = False
+    pii_max_tokens_per_session: int = 10_000
+
     # Platform secrets — None means platform is disabled
     mist: MistSecrets | None = None
     central: CentralSecrets | None = None
@@ -387,6 +398,18 @@ def load_config() -> ServerConfig:
     else:
         allowed_origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
 
+    # PII tokenization (v2.3.1.0). MAC normalization runs regardless;
+    # full tokenization is opt-in via ENABLE_PII_TOKENIZATION while the
+    # ruleset matures.
+    enable_pii_tokenization = os.getenv("ENABLE_PII_TOKENIZATION", "false").lower() in _truthy
+    try:
+        pii_max_tokens = int(os.getenv("PII_MAX_TOKENS_PER_SESSION", "10000"))
+    except ValueError:
+        logger.warning(
+            "Invalid PII_MAX_TOKENS_PER_SESSION; defaulting to 10000",
+        )
+        pii_max_tokens = 10_000
+
     # Load platform credentials from Docker secrets
     mist = _load_mist()
     central = _load_central()
@@ -409,6 +432,8 @@ def load_config() -> ServerConfig:
         log_file=log_file,
         tool_mode=tool_mode,
         allowed_origins=allowed_origins,
+        enable_pii_tokenization=enable_pii_tokenization,
+        pii_max_tokens_per_session=pii_max_tokens,
         mist=mist,
         central=central,
         greenlake=greenlake,
@@ -430,4 +455,11 @@ def load_config() -> ServerConfig:
         logger.warning("Origin validation: DISABLED (ALLOWED_ORIGINS contains '*')")
     else:
         logger.info("Origin validation: allowlist = {}", allowed_origins)
+    if enable_pii_tokenization:
+        logger.info(
+            "PII tokenization: ENABLED (max {} tokens/session, MAC normalization always-on)",
+            pii_max_tokens,
+        )
+    else:
+        logger.info("PII tokenization: disabled (MAC normalization still applied)")
     return config

--- a/src/hpe_networking_mcp/middleware/pii_tokenization.py
+++ b/src/hpe_networking_mcp/middleware/pii_tokenization.py
@@ -1,0 +1,276 @@
+"""FastMCP middleware that wires PII tokenization into the tool-call lifecycle.
+
+Two-sided middleware:
+
+1. **Inbound (request)**: walk ``arguments`` for any ``[[KIND:uuid]]``
+   tokens the AI passed in, replace them with plaintext from the
+   session keymap before the call hits the platform tool. Unknown
+   tokens (e.g. references from a different session) cause the call
+   to fail with a JSON-RPC error rather than passing literal bracket
+   text downstream.
+
+2. **Outbound (response)**: walk the returned ``ToolResult`` —
+   ``structured_content`` and any JSON-shaped text content blocks —
+   and apply MAC normalization (always-on) and PII tokenization (when
+   the toggle is enabled).
+
+The middleware is a no-op when neither tokenization nor normalization
+applies (e.g. tool returned no JSON-shaped content) — overhead on a
+quiet path is just the dict-walk recursion.
+
+Audit logging happens inside the tokenizer; the middleware adds one
+event per tool call summarizing how many tokens were materialized
+and how many were detokenized, again without revealing values.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import mcp.types
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from loguru import logger
+from mcp.types import TextContent
+
+from hpe_networking_mcp.redaction.tokenizer import Tokenizer
+from hpe_networking_mcp.redaction.walker import (
+    detokenize_arguments,
+    iter_kinds_in_string,
+    tokenize_response,
+)
+
+if TYPE_CHECKING:
+    from hpe_networking_mcp.redaction.token_store import TokenStore
+
+
+# A short, low-entropy session ID prefix shown in audit logs so engineers
+# can correlate events across log lines without exposing the full ID.
+_SESSION_ID_LOG_LEN = 12
+
+
+class PIITokenizationMiddleware(Middleware):
+    """Bidirectional PII middleware.
+
+    Args:
+        token_store: The shared per-process ``TokenStore`` (created in
+            the FastMCP lifespan handler). One keymap per Mcp-Session-Id
+            is allocated lazily inside.
+        enabled: If False, the middleware applies *only* MAC
+            normalization on outbound responses and skips both
+            tokenization and detokenization. Lets operators leave the
+            middleware wired in without committing to tokenization.
+    """
+
+    def __init__(self, token_store: TokenStore, *, enabled: bool) -> None:
+        self._store = token_store
+        self._enabled = enabled
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next,
+    ) -> ToolResult:
+        session_id = self._resolve_session_id(context)
+        tool_name = context.message.name
+
+        # --- Inbound: detokenize arguments ---
+        if self._enabled and session_id:
+            inbound_keymap = self._store.get(session_id)
+            if inbound_keymap is not None and context.message.arguments:
+                inbound_tokenizer = Tokenizer(
+                    inbound_keymap,
+                    session_id=session_id,
+                    max_entries=self._store.max_entries_per_session,
+                )
+                new_args, unknown = detokenize_arguments(context.message.arguments, inbound_tokenizer)
+                if unknown:
+                    logger.warning(
+                        "pii.unknown_inbound_tokens session={} tool={} tokens={}",
+                        session_id[:_SESSION_ID_LOG_LEN],
+                        tool_name,
+                        sorted(set(unknown)),
+                    )
+                    return _make_unknown_token_error(unknown)
+
+                if new_args is not context.message.arguments:
+                    logger.info(
+                        "pii.detokenize session={} tool={} kinds={}",
+                        session_id[:_SESSION_ID_LOG_LEN],
+                        tool_name,
+                        sorted(_kinds_used_in_args(context.message.arguments)),
+                    )
+                    new_message = context.message.model_copy(update={"arguments": new_args})
+                    context = context.copy(message=new_message)
+
+        # --- Forward to next middleware / handler ---
+        result = await call_next(context)
+
+        # --- Outbound: normalize MACs + (optionally) tokenize PII ---
+        # MAC normalization runs even when ``self._enabled`` is False;
+        # tokenization requires both the toggle on AND a session ID.
+        outbound_tokenizer: Tokenizer | None = None
+        if self._enabled and session_id:
+            outbound_keymap = self._store.get_or_create(session_id)
+            outbound_tokenizer = Tokenizer(
+                outbound_keymap,
+                session_id=session_id,
+                max_entries=self._store.max_entries_per_session,
+            )
+
+        return _process_outbound_result(result, outbound_tokenizer)
+
+    @staticmethod
+    def _resolve_session_id(
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+    ) -> str | None:
+        """Return the Mcp-Session-Id for this call, or None if unavailable."""
+        fastmcp_ctx = context.fastmcp_context
+        if fastmcp_ctx is None:
+            return None
+        try:
+            return fastmcp_ctx.session_id
+        except Exception:  # pragma: no cover — defensive against API shifts
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers — outbound result transformation
+# ---------------------------------------------------------------------------
+
+
+def _process_outbound_result(
+    result: ToolResult,
+    tokenizer: Tokenizer | None,
+) -> ToolResult:
+    """Apply MAC normalization + (optional) tokenization to a ToolResult."""
+    if not isinstance(result, ToolResult):
+        # Defensive: some FastMCP middleware returns raw values during
+        # error paths. Pass through unchanged.
+        return result
+
+    new_structured = _process_structured(result.structured_content, tokenizer)
+    new_content = _process_content_blocks(result.content, tokenizer)
+
+    structured_changed = new_structured is not result.structured_content
+    content_changed = new_content is not result.content
+
+    if not structured_changed and not content_changed:
+        return result
+
+    return ToolResult(
+        content=new_content,
+        structured_content=new_structured,
+        meta=result.meta,
+    )
+
+
+def _process_structured(
+    structured: dict | None,
+    tokenizer: Tokenizer | None,
+) -> dict | None:
+    if structured is None:
+        return None
+    walked = tokenize_response(structured, tokenizer)
+    return walked if isinstance(walked, dict) else structured
+
+
+def _process_content_blocks(
+    blocks: list,
+    tokenizer: Tokenizer | None,
+) -> list:
+    """Walk ``content`` blocks. For each TextContent, try JSON-parse the
+    text; if it parses, walk and re-serialize. Otherwise leave as-is.
+
+    Non-text blocks (image, audio, embedded resources) pass through
+    unchanged — those payloads aren't structured customer data in this
+    server's context.
+    """
+    out: list = []
+    changed = False
+    for block in blocks:
+        if isinstance(block, TextContent) and block.text:
+            new_text = _process_text_block(block.text, tokenizer)
+            if new_text is not block.text:
+                out.append(TextContent(type="text", text=new_text))
+                changed = True
+            else:
+                out.append(block)
+        else:
+            out.append(block)
+    return out if changed else blocks
+
+
+def _process_text_block(text: str, tokenizer: Tokenizer | None) -> str:
+    """Parse text as JSON; if it parses, walk + re-serialize; else return as-is.
+
+    Mist / Central / etc. tools serialize structured responses with
+    ``json.dumps(data)`` so most text blocks ARE JSON. The free-text
+    sweep would still catch in-text secrets even when the block is
+    plain prose, but we apply it only on the JSON-parsed path so we
+    don't re-tokenize values that the structured walker already
+    handled.
+    """
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return text
+
+    if not isinstance(parsed, (dict, list)):
+        # JSON scalar — no structure to walk
+        return text
+
+    walked = tokenize_response(parsed, tokenizer)
+    return json.dumps(walked)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — inbound argument inspection
+# ---------------------------------------------------------------------------
+
+
+def _kinds_used_in_args(arguments: dict) -> set[str]:
+    """Return the set of token KIND strings present in any string arg.
+
+    Used for the audit log entry summarizing what kinds of tokens the
+    AI dereferenced for this call. We log kinds, not full tokens, so an
+    operator can see "model used PSK and SITE tokens here" without the
+    log itself becoming sensitive.
+    """
+    kinds: set[str] = set()
+
+    def _scan(value: object) -> None:
+        if isinstance(value, str):
+            kinds.update(iter_kinds_in_string(value))
+        elif isinstance(value, dict):
+            for v in value.values():
+                _scan(v)
+        elif isinstance(value, list):
+            for v in value:
+                _scan(v)
+
+    _scan(arguments)
+    return kinds
+
+
+def _make_unknown_token_error(unknown_tokens: list[str]) -> ToolResult:
+    """Build a ToolResult error when the AI references unknown tokens.
+
+    The model gets a short string explanation in the tool's content
+    block. We deliberately list the unknown tokens (they're not
+    sensitive — they don't map to anything) so the model can correct
+    itself if it copy-pasted from a stale conversation.
+    """
+    distinct = sorted(set(unknown_tokens))
+    msg = (
+        "Tokenization error: the following tokens are not valid in the "
+        "current session and cannot be detokenized. They may be from a "
+        f"previous session that has ended: {distinct}. "
+        "Re-fetch the source data so a fresh tokenization can be issued."
+    )
+    return ToolResult(content=[TextContent(type="text", text=msg)])

--- a/src/hpe_networking_mcp/redaction/__init__.py
+++ b/src/hpe_networking_mcp/redaction/__init__.py
@@ -1,0 +1,70 @@
+"""PII tokenization and MAC normalization for tool responses.
+
+This package implements the response-side data protection layer described
+in the v2.3.0.10 design discussion:
+
+* **MAC normalization** — always-on. Every MAC address in a tool response
+  is rewritten to canonical ``aa:bb:cc:dd:ee:ff`` form (lowercase,
+  colon-separated) regardless of the upstream platform's preferred
+  format, so the AI sees a single consistent representation across
+  Mist / Central / etc.
+
+* **PII tokenization** — opt-in via ``ENABLE_PII_TOKENIZATION=true``.
+  Sensitive fields (PSKs, RADIUS secrets, certificates) and identifiers
+  (platform UUIDs, hostnames, user identifiers, geographic data) are
+  replaced with session-stable ``[[KIND:uuid]]`` tokens before reaching
+  the AI. Tokens round-trip: when the AI passes a token into a write
+  tool, the inbound side substitutes the real value back before the API
+  call. The mapping is held in process memory keyed by Mcp-Session-Id;
+  it never touches disk and dies with the process or session.
+
+The middleware (`hpe_networking_mcp.middleware.pii_tokenization`) is the
+single integration point — everything else here is pure functions that
+the middleware composes.
+"""
+
+from hpe_networking_mcp.redaction.mac_normalizer import (
+    canonicalize_mac,
+    is_mac_address,
+    normalize_macs_in_value,
+)
+from hpe_networking_mcp.redaction.rules import (
+    PUBLIC_IP_ALLOWLIST,
+    SECRET_FIELD_NAMES,
+    TOKENIZED_IDENTIFIER_FIELDS,
+    TokenKind,
+    classify_field,
+)
+from hpe_networking_mcp.redaction.token_store import (
+    SessionKeymap,
+    TokenEntry,
+    TokenStore,
+)
+from hpe_networking_mcp.redaction.tokenizer import (
+    Tokenizer,
+    detokenize_string,
+    tokenize_value,
+)
+from hpe_networking_mcp.redaction.walker import (
+    detokenize_arguments,
+    tokenize_response,
+)
+
+__all__ = [
+    "PUBLIC_IP_ALLOWLIST",
+    "SECRET_FIELD_NAMES",
+    "TOKENIZED_IDENTIFIER_FIELDS",
+    "SessionKeymap",
+    "TokenEntry",
+    "TokenKind",
+    "TokenStore",
+    "Tokenizer",
+    "canonicalize_mac",
+    "classify_field",
+    "detokenize_arguments",
+    "detokenize_string",
+    "is_mac_address",
+    "normalize_macs_in_value",
+    "tokenize_response",
+    "tokenize_value",
+]

--- a/src/hpe_networking_mcp/redaction/mac_normalizer.py
+++ b/src/hpe_networking_mcp/redaction/mac_normalizer.py
@@ -1,0 +1,104 @@
+"""MAC address normalization — always-on, regardless of tokenization toggle.
+
+Every MAC the AI sees is rewritten to canonical ``aa:bb:cc:dd:ee:ff``
+form (lowercase, colon-separated, six groups of two hex digits).
+Reasons:
+
+* Most universal in network-engineering tooling (Linux / macOS /
+  Wireshark / ``arp`` / ``ip neigh`` all default to this form).
+* Mist's API accepts colon-separated MACs in write paths.
+* Lets the AI correlate the same physical NIC across audits without
+  wondering whether ``aabb.ccdd.eeff`` and ``aa:bb:cc:dd:ee:ff`` are the
+  same device.
+
+Per the v2.3.0.10 design, MACs are explicitly **not tokenized** — they
+are observable by anyone in radio range, so privacy-tokenizing them
+would add cost (tokens in the AI context) without security gain. The
+normalization step IS still useful for consistency.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# MAC format detection
+# ---------------------------------------------------------------------------
+
+# Accepts the four common MAC formats:
+#   aa:bb:cc:dd:ee:ff  (colon-separated, lowercase or uppercase)
+#   aa-bb-cc-dd-ee-ff  (hyphen-separated)
+#   aabb.ccdd.eeff     (Cisco dot-separated)
+#   aabbccddeeff       (no separators)
+#
+# Anchored with word boundaries so it doesn't match the middle of a UUID
+# (UUIDs contain stretches of hex that could otherwise match
+# ``aabbccddeeff``-style MACs as a substring).
+_MAC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b([0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5})\b"),
+    re.compile(r"\b([0-9a-fA-F]{2}(?:-[0-9a-fA-F]{2}){5})\b"),
+    re.compile(r"\b([0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})\b"),
+    re.compile(r"\b([0-9a-fA-F]{12})\b"),
+)
+
+
+def is_mac_address(value: str) -> bool:
+    """Return True if ``value`` is exactly a MAC address in any common format.
+
+    The whole string must match — partial matches return False so we
+    don't classify ``"aa:bb:cc:dd:ee:ff is offline"`` as a bare MAC.
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    for pattern in _MAC_PATTERNS:
+        match = pattern.fullmatch(stripped)
+        if match:
+            # Plain-12-hex needs an additional sanity check — guard against
+            # matching a 12-character hex string that's actually part of a
+            # serial number or random hash. We accept it as a MAC only when
+            # the surrounding context (caller) thinks it should be one. The
+            # walker calls this only on values from MAC-named fields, so
+            # the additional check happens implicitly.
+            return True
+    return False
+
+
+def canonicalize_mac(value: str) -> str:
+    """Normalize ``value`` to canonical ``aa:bb:cc:dd:ee:ff`` form.
+
+    If the value isn't a recognizable MAC, it is returned unchanged so
+    callers can chain this safely.
+    """
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    hex_only = "".join(c for c in stripped if c.isalnum())
+    if len(hex_only) != 12 or not all(c in "0123456789abcdefABCDEF" for c in hex_only):
+        return value
+    lower = hex_only.lower()
+    return ":".join(lower[i : i + 2] for i in range(0, 12, 2))
+
+
+def normalize_macs_in_value(value: str) -> str:
+    """Find every MAC inside ``value`` and rewrite it to canonical form.
+
+    Used for free-text fields where a MAC might be embedded in a larger
+    string like ``"client aa:bb:cc:dd:ee:ff failed auth"``. Only
+    rewrites *the matched span*; surrounding text is preserved.
+
+    The bare-12-hex pattern is intentionally NOT applied here because it
+    has too many false positives in free text (any 12-char hex string in
+    a description would get rewritten). The structured-field path
+    (``canonicalize_mac``) handles bare-hex MACs because the caller
+    already knows it's a MAC field.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+
+    result = value
+    # Apply the formats with explicit separators only — they have low
+    # false-positive rates inside free text.
+    for pattern in _MAC_PATTERNS[:3]:
+        result = pattern.sub(lambda m: canonicalize_mac(m.group(1)), result)
+    return result

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -38,9 +38,9 @@ class TokenKind(StrEnum):
     PSK = "PSK"  # WPA2/WPA3/SAE pre-shared keys, passphrases, PPSKs
     RADSEC = "RADSEC"  # RADIUS / RadSec / TACACS+ shared secrets, EAP passwords
     SNMP_COMMUNITY = "SNMP"  # SNMPv1/v2c communities, SNMPv3 auth/priv passwords
-    ADMIN_PASSWORD = "PASSWORD"  # admin/manager/enable passwords, CLI passwords
+    ADMIN_PASSWORD = "PASSWORD"  # nosec B105 — token-kind label, not a credential
     VPN_PSK = "VPNPSK"  # IPSec PSK, VPN PSK
-    API_TOKEN = "APITOKEN"  # api_token, api_key, client_secret, bearer/access/refresh tokens
+    API_TOKEN = "APITOKEN"  # nosec B105 — token-kind label, not a credential
     CERT = "CERT"  # certificates (PEM blocks)
     PRIVATE_KEY = "KEY"  # private keys (PEM blocks), keytabs
 
@@ -76,7 +76,7 @@ class FieldClassification(StrEnum):
     """The walker's decision for a given (field_name, value)."""
 
     SKIP = "skip"
-    TOKENIZE_SECRET = "tokenize_secret"
+    TOKENIZE_SECRET = "tokenize_secret"  # nosec B105 — enum classification label, not a credential
     TOKENIZE_IDENTIFIER = "tokenize_identifier"
     SCAN_FREE_TEXT = "scan_free_text"
 

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -1,0 +1,494 @@
+"""Tokenization rules — what to tokenize and as what kind.
+
+The rules are pure data: dictionaries and frozensets keyed by JSON field
+name. The walker (``walker.py``) calls ``classify_field()`` on each
+``(field_name, value)`` it encounters to decide:
+
+* **SKIP**: leave the value alone (default for unknown fields).
+* **TOKENIZE_SECRET**: this is a credential; tokenize as one of the
+  secret kinds (``PSK``, ``RADSEC``, ``SNMP_COMMUNITY``, etc.).
+* **TOKENIZE_IDENTIFIER**: this is a customer-identifying value; tokenize
+  as one of the identifier kinds (``SITE``, ``HOSTNAME``, ``EMAIL``,
+  etc.). MACs are not in this set — they are *normalized* by the MAC
+  module, not tokenized.
+* **SCAN_FREE_TEXT**: descriptive text field that operators sometimes
+  paste secrets/identifiers into; the walker runs the regex sweep over
+  the value's contents.
+
+Per the v2.3.0.10 design, MACs are never tokenized (just normalized) and
+the public-IP allowlist exempts well-known DNS / NTP / loopback /
+documentation IPs from tokenization.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+
+class TokenKind(StrEnum):
+    """The kinds of tokens issued by the tokenizer.
+
+    The string value becomes the prefix in the rendered token form
+    ``[[KIND:uuid]]`` — keep these short and ALL CAPS so the regex stays
+    tight (``[A-Z_]+``).
+    """
+
+    # --- Secrets (Tier 1) ---
+    PSK = "PSK"  # WPA2/WPA3/SAE pre-shared keys, passphrases, PPSKs
+    RADSEC = "RADSEC"  # RADIUS / RadSec / TACACS+ shared secrets, EAP passwords
+    SNMP_COMMUNITY = "SNMP"  # SNMPv1/v2c communities, SNMPv3 auth/priv passwords
+    ADMIN_PASSWORD = "PASSWORD"  # admin/manager/enable passwords, CLI passwords
+    VPN_PSK = "VPNPSK"  # IPSec PSK, VPN PSK
+    API_TOKEN = "APITOKEN"  # api_token, api_key, client_secret, bearer/access/refresh tokens
+    CERT = "CERT"  # certificates (PEM blocks)
+    PRIVATE_KEY = "KEY"  # private keys (PEM blocks), keytabs
+
+    # --- Identifiers (Tier 2) ---
+    ORG = "ORG"
+    SITE = "SITE"
+    DEVICE = "DEVICE"
+    AP = "AP"
+    SWITCH = "SWITCH"
+    GATEWAY = "GATEWAY"
+    WLAN = "WLAN"
+    TEMPLATE = "TEMPLATE"
+    POLICY = "POLICY"
+    TENANT = "TENANT"
+    WORKSPACE = "WORKSPACE"
+    SUBSCRIPTION = "SUBSCRIPTION"
+    CLIENT = "CLIENT"
+    HOSTNAME = "HOSTNAME"
+    SSID = "SSID"
+    USER = "USER"
+    EMAIL = "EMAIL"
+    PHONE = "PHONE"
+    SERIAL = "SERIAL"
+    IMEI = "IMEI"
+    IMSI = "IMSI"
+    ICCID = "ICCID"
+    IP = "IP"
+    GEO = "GEO"  # latitude/longitude/address fields
+    NAME = "NAME"  # generic operator-assigned name (vlan_name, subnet_name, room, etc.)
+
+
+class FieldClassification(StrEnum):
+    """The walker's decision for a given (field_name, value)."""
+
+    SKIP = "skip"
+    TOKENIZE_SECRET = "tokenize_secret"
+    TOKENIZE_IDENTIFIER = "tokenize_identifier"
+    SCAN_FREE_TEXT = "scan_free_text"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Secret field names (case-insensitive exact match)
+# ---------------------------------------------------------------------------
+# Maps lowercase field name -> TokenKind. Field names are matched at any
+# nesting depth, regardless of parent context. The walker also runs a
+# value-shape heuristic on the generic catch-alls (``password``, ``secret``,
+# ``token``, ``key``) to avoid tokenizing template-style placeholder values
+# like ``{"key": "ssid"}``.
+
+SECRET_FIELD_NAMES: dict[str, TokenKind] = {
+    # WPA / SAE / WEP keys
+    "psk": TokenKind.PSK,
+    "passphrase": TokenKind.PSK,
+    "wpa_passphrase": TokenKind.PSK,
+    "wpa2_passphrase": TokenKind.PSK,
+    "wpa3_psk": TokenKind.PSK,
+    "sae_password": TokenKind.PSK,
+    "sae_pwd": TokenKind.PSK,
+    "ppsk": TokenKind.PSK,
+    "wep_key": TokenKind.PSK,
+    "wep_passphrase": TokenKind.PSK,
+    # RADIUS / RadSec / 802.1X
+    "shared_secret": TokenKind.RADSEC,
+    "radius_secret": TokenKind.RADSEC,
+    "radsec_secret": TokenKind.RADSEC,
+    "eap_password": TokenKind.RADSEC,
+    "inner_password": TokenKind.RADSEC,
+    # SNMP
+    "community": TokenKind.SNMP_COMMUNITY,
+    "community_string": TokenKind.SNMP_COMMUNITY,
+    "auth_password": TokenKind.SNMP_COMMUNITY,
+    "priv_password": TokenKind.SNMP_COMMUNITY,
+    "snmp_v3_auth_pass": TokenKind.SNMP_COMMUNITY,
+    "snmp_v3_priv_pass": TokenKind.SNMP_COMMUNITY,
+    # Admin / management
+    "admin_password": TokenKind.ADMIN_PASSWORD,
+    "manager_password": TokenKind.ADMIN_PASSWORD,
+    "support_user_password": TokenKind.ADMIN_PASSWORD,
+    "enable_password": TokenKind.ADMIN_PASSWORD,
+    "enable_secret": TokenKind.ADMIN_PASSWORD,
+    "cli_password": TokenKind.ADMIN_PASSWORD,
+    # VPN / IPSec
+    "pre_shared_key": TokenKind.VPN_PSK,
+    "ipsec_psk": TokenKind.VPN_PSK,
+    "vpn_psk": TokenKind.VPN_PSK,
+    # API tokens / OAuth in configs
+    "api_token": TokenKind.API_TOKEN,
+    "apitoken": TokenKind.API_TOKEN,
+    "api_key": TokenKind.API_TOKEN,
+    "apikey": TokenKind.API_TOKEN,
+    "client_secret": TokenKind.API_TOKEN,
+    "bearer_token": TokenKind.API_TOKEN,
+    "access_token": TokenKind.API_TOKEN,
+    "refresh_token": TokenKind.API_TOKEN,
+    "webhook_secret": TokenKind.API_TOKEN,
+    "webhook_token": TokenKind.API_TOKEN,
+    # Certificates & keys (also content-fingerprint detected via PEM regex)
+    "private_key": TokenKind.PRIVATE_KEY,
+    "privkey": TokenKind.PRIVATE_KEY,
+    "kerberos_keytab": TokenKind.PRIVATE_KEY,
+    "keytab": TokenKind.PRIVATE_KEY,
+    "cert": TokenKind.CERT,
+    "certificate": TokenKind.CERT,
+    "client_cert": TokenKind.CERT,
+    "server_cert": TokenKind.CERT,
+    "ca_cert": TokenKind.CERT,
+    "chain": TokenKind.CERT,
+    "pkcs12": TokenKind.CERT,
+    "p12_data": TokenKind.CERT,
+    "pem": TokenKind.CERT,
+}
+
+# Generic credential-shaped field names. Only tokenized when the value's
+# *shape* looks credential-like (length >= 8, mixed character classes).
+# Avoids false positives like ``{"key": "ssid"}`` where ``key`` is a
+# template field name, not a credential.
+GENERIC_CREDENTIAL_FIELD_NAMES: dict[str, TokenKind] = {
+    "password": TokenKind.ADMIN_PASSWORD,
+    "pwd": TokenKind.ADMIN_PASSWORD,
+    "secret": TokenKind.RADSEC,  # most commonly a RADIUS/auth secret
+    "token": TokenKind.API_TOKEN,
+    "key": TokenKind.API_TOKEN,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — Identifier field names
+# ---------------------------------------------------------------------------
+
+TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
+    # Platform UUIDs
+    "org_id": TokenKind.ORG,
+    "msp_id": TokenKind.ORG,
+    "site_id": TokenKind.SITE,
+    "siteid": TokenKind.SITE,
+    "device_id": TokenKind.DEVICE,
+    "ap_id": TokenKind.AP,
+    "switch_id": TokenKind.SWITCH,
+    "gateway_id": TokenKind.GATEWAY,
+    "mxedge_id": TokenKind.GATEWAY,
+    "wlan_id": TokenKind.WLAN,
+    "wxlan_id": TokenKind.WLAN,
+    "wxtag_id": TokenKind.WLAN,
+    "wxtunnel_id": TokenKind.WLAN,
+    "wxrule_id": TokenKind.WLAN,
+    "wxlan_tunnel_id": TokenKind.WLAN,
+    "client_id": TokenKind.CLIENT,
+    "mobile_id": TokenKind.CLIENT,
+    "mac_id": TokenKind.CLIENT,
+    "template_id": TokenKind.TEMPLATE,
+    "assignment_id": TokenKind.TEMPLATE,
+    "policy_id": TokenKind.POLICY,
+    "psk_id": TokenKind.POLICY,
+    "tenant_id": TokenKind.TENANT,
+    "workspace_id": TokenKind.WORKSPACE,
+    "subscription_id": TokenKind.SUBSCRIPTION,
+    # Operator-assigned names
+    "device_name": TokenKind.HOSTNAME,
+    "ap_name": TokenKind.HOSTNAME,
+    "hostname": TokenKind.HOSTNAME,
+    "fqdn": TokenKind.HOSTNAME,
+    "ssid": TokenKind.SSID,
+    "essid": TokenKind.SSID,
+    "site_name": TokenKind.NAME,
+    "org_name": TokenKind.NAME,
+    "vlan_name": TokenKind.NAME,
+    "subnet_name": TokenKind.NAME,
+    # User-identifying
+    "username": TokenKind.USER,
+    "user": TokenKind.USER,
+    "login": TokenKind.USER,
+    "email": TokenKind.EMAIL,
+    "first_name": TokenKind.USER,
+    "last_name": TokenKind.USER,
+    "full_name": TokenKind.USER,
+    "display_name": TokenKind.USER,
+    "phone": TokenKind.PHONE,
+    "phone_number": TokenKind.PHONE,
+    "mobile": TokenKind.PHONE,
+    # Hardware
+    "serial": TokenKind.SERIAL,
+    "serial_number": TokenKind.SERIAL,
+    "sn": TokenKind.SERIAL,
+    "imei": TokenKind.IMEI,
+    "imsi": TokenKind.IMSI,
+    "iccid": TokenKind.ICCID,
+    # Geographic
+    "latitude": TokenKind.GEO,
+    "longitude": TokenKind.GEO,
+    "address": TokenKind.GEO,
+    "street": TokenKind.GEO,
+    "city": TokenKind.GEO,
+    "state": TokenKind.GEO,
+    "zip": TokenKind.GEO,
+    "postal_code": TokenKind.GEO,
+    "country": TokenKind.GEO,
+    "room": TokenKind.GEO,
+    "floor": TokenKind.GEO,
+    "building": TokenKind.GEO,
+}
+
+# Field names where ``name`` should be tokenized as HOSTNAME — only when
+# the parent object looks like a device (has device-shaped sibling fields).
+# The walker checks for these sibling hints before tokenizing a bare ``name``
+# field, since ``name`` is an enormously common field that we'd otherwise
+# tokenize too aggressively.
+DEVICE_CONTEXT_HINTS: frozenset[str] = frozenset(
+    {
+        "mac",
+        "model",
+        "serial",
+        "device_type",
+        "hw_rev",
+        "firmware",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — Free-text fields scanned for embedded secrets/identifiers
+# ---------------------------------------------------------------------------
+
+FREE_TEXT_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "description",
+        "notes",
+        "comment",
+        "comments",
+        "remarks",
+        "details",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Public IP allowlist — well-known infrastructure IPs preserved verbatim
+# ---------------------------------------------------------------------------
+
+PUBLIC_IP_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Loopback / unspecified
+        "127.0.0.1",
+        "0.0.0.0",
+        "::1",
+        "::",
+        # Google Public DNS
+        "8.8.8.8",
+        "8.8.4.4",
+        "2001:4860:4860::8888",
+        "2001:4860:4860::8844",
+        # Cloudflare DNS
+        "1.1.1.1",
+        "1.0.0.1",
+        "2606:4700:4700::1111",
+        "2606:4700:4700::1001",
+        # Quad9
+        "9.9.9.9",
+        "149.112.112.112",
+        # OpenDNS
+        "208.67.222.222",
+        "208.67.220.220",
+        # RFC 5737 documentation
+        "192.0.2.0",
+        "198.51.100.0",
+        "203.0.113.0",
+    }
+)
+
+# Documentation / reserved address ranges that are also preserved.
+# These are CIDR-checked rather than equality-checked.
+PUBLIC_IP_ALLOWLIST_RANGES: tuple[str, ...] = (
+    "192.0.2.0/24",  # RFC 5737 TEST-NET-1
+    "198.51.100.0/24",  # RFC 5737 TEST-NET-2
+    "203.0.113.0/24",  # RFC 5737 TEST-NET-3
+    "224.0.0.0/4",  # IPv4 multicast (mDNS, link-local)
+    "ff00::/8",  # IPv6 multicast (NDP etc.)
+    "fe80::/10",  # IPv6 link-local
+)
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns (compiled once at import)
+# ---------------------------------------------------------------------------
+
+# IPv4 address (does not validate octet ranges; that's handled by the
+# ipaddress module on match candidates).
+IPV4_RE: re.Pattern[str] = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?\b")
+
+# IPv6 address — conservative; matches typical full + compressed forms.
+# Combined with ipaddress.ip_address() validation in the walker to weed
+# out false positives. Includes optional CIDR.
+IPV6_RE: re.Pattern[str] = re.compile(
+    r"\b("
+    r"(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}"  # full form
+    r"|(?:[0-9a-fA-F]{1,4}:)+:(?:[0-9a-fA-F]{1,4}:?)+"  # compressed
+    r"|::(?:[0-9a-fA-F]{1,4}:?)+"  # leading ::
+    r")(?:/\d{1,3})?\b"
+)
+
+# Email
+EMAIL_RE: re.Pattern[str] = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# PEM block (certificate or key) — match the entire block including markers.
+# Used for content-fingerprint detection so PEM data in unexpected fields
+# still gets tokenized.
+PEM_BLOCK_RE: re.Pattern[str] = re.compile(r"-----BEGIN [A-Z0-9 ]+-----[\s\S]+?-----END [A-Z0-9 ]+-----")
+
+# UUID (canonical 8-4-4-4-12 hex form, lowercase or uppercase).
+UUID_RE: re.Pattern[str] = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+
+# Token form: ``[[KIND:uuid]]`` — kind is uppercase letters/underscores,
+# UUID is canonical.
+TOKEN_RE: re.Pattern[str] = re.compile(
+    r"\[\[([A-Z_]+):"
+    r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+    r"\]\]"
+)
+
+
+# ---------------------------------------------------------------------------
+# Value-shape heuristics
+# ---------------------------------------------------------------------------
+
+
+def looks_like_credential(value: str) -> bool:
+    """Heuristic: does ``value`` look like a credential rather than an enum?
+
+    Used as a guard on the generic catch-all field names (``password``,
+    ``secret``, ``token``, ``key``) to suppress tokenization of
+    template-style placeholder values like ``{"key": "ssid"}`` or
+    ``{"secret": "auto"}``.
+
+    Returns True when:
+    * length >= 8, AND
+    * contains at least two of {lowercase, uppercase, digit, special}, OR
+    * contains at least one non-alphanumeric character
+
+    Length-only check is too lax (an 8-char enum like ``disabled`` slips
+    through); character-class diversity is the discriminator.
+    """
+    if not isinstance(value, str) or len(value) < 8:
+        return False
+    has_lower = any(c.islower() for c in value)
+    has_upper = any(c.isupper() for c in value)
+    has_digit = any(c.isdigit() for c in value)
+    has_special = any(not c.isalnum() and not c.isspace() for c in value)
+    classes = sum((has_lower, has_upper, has_digit, has_special))
+    return classes >= 2 or has_special
+
+
+def is_known_enum_value(value: str) -> bool:
+    """Quick sanity check: is ``value`` an obvious enum/keyword?
+
+    Returns True for short uppercase tokens or known network-config
+    keywords. Used to short-circuit ``looks_like_credential`` for very
+    short obvious-non-secret strings.
+    """
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    return lowered in _COMMON_ENUM_VALUES
+
+
+_COMMON_ENUM_VALUES: frozenset[str] = frozenset(
+    {
+        "auto",
+        "manual",
+        "none",
+        "default",
+        "enabled",
+        "disabled",
+        "true",
+        "false",
+        "any",
+        "all",
+        "open",
+        "closed",
+        "wpa2",
+        "wpa3",
+        "psk",
+        "eap",
+        "sae",
+        "online",
+        "offline",
+        "connected",
+        "disconnected",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Field classification API
+# ---------------------------------------------------------------------------
+
+
+def classify_field(
+    field_name: str,
+    value: object,
+    *,
+    parent_keys: frozenset[str] | None = None,
+) -> tuple[FieldClassification, TokenKind | None]:
+    """Decide how the walker should handle this (field, value).
+
+    Args:
+        field_name: The JSON key. Compared case-insensitively.
+        value: The value at that key — used for shape heuristics on
+            generic credential field names.
+        parent_keys: The set of sibling keys in the same dict, used to
+            disambiguate ambiguous fields (``name`` is a hostname only
+            when the parent object also has device-shaped fields).
+
+    Returns:
+        ``(classification, kind)`` where ``kind`` is None for SKIP/SCAN
+        results.
+    """
+    if not isinstance(field_name, str):
+        return FieldClassification.SKIP, None
+    name = field_name.lower()
+
+    # Exact-match secret fields
+    if name in SECRET_FIELD_NAMES:
+        return FieldClassification.TOKENIZE_SECRET, SECRET_FIELD_NAMES[name]
+
+    # Generic credential field names — only tokenize when value passes shape check
+    if name in GENERIC_CREDENTIAL_FIELD_NAMES:
+        if isinstance(value, str) and looks_like_credential(value) and not is_known_enum_value(value):
+            return (
+                FieldClassification.TOKENIZE_SECRET,
+                GENERIC_CREDENTIAL_FIELD_NAMES[name],
+            )
+        return FieldClassification.SKIP, None
+
+    # Identifier fields
+    if name in TOKENIZED_IDENTIFIER_FIELDS:
+        return (
+            FieldClassification.TOKENIZE_IDENTIFIER,
+            TOKENIZED_IDENTIFIER_FIELDS[name],
+        )
+
+    # Bare ``name`` becomes HOSTNAME only when the parent object looks like a device
+    if name == "name" and parent_keys and (parent_keys & DEVICE_CONTEXT_HINTS):
+        return FieldClassification.TOKENIZE_IDENTIFIER, TokenKind.HOSTNAME
+
+    # Free-text fields
+    if name in FREE_TEXT_FIELD_NAMES:
+        return FieldClassification.SCAN_FREE_TEXT, None
+
+    return FieldClassification.SKIP, None

--- a/src/hpe_networking_mcp/redaction/token_store.py
+++ b/src/hpe_networking_mcp/redaction/token_store.py
@@ -1,0 +1,140 @@
+"""Per-session token keymap — sensitive process memory, never persisted.
+
+The store lives on the FastMCP lifespan context as
+``ctx.lifespan_context["token_store"]``. Each MCP session
+(``Mcp-Session-Id``) gets its own ``SessionKeymap``, holding the
+plaintext-to-token and token-to-plaintext mappings for that session.
+
+Storage is in-memory only by design. Persisting plaintext secrets to
+disk would dramatically expand blast radius — a stolen volume becomes
+a stolen master keymap. The current trust boundary matches the
+container's existing credential exposure (Mist API token, Central
+client secret, etc. are already in process memory).
+
+When the FastMCP session ends — explicit ``DELETE /mcp`` from the
+client, idle timeout, or server restart — the keymap is purged. Saved
+chat references to ``[[KIND:uuid]]`` from a dead session become
+unresolvable on resurrection; the operator re-runs the workflow that
+produced them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+
+from hpe_networking_mcp.redaction.rules import TokenKind
+
+
+@dataclass(frozen=True)
+class TokenEntry:
+    """One token <-> plaintext mapping.
+
+    Frozen so callers can't mutate the plaintext column accidentally.
+    The plaintext is sensitive — never log this dataclass directly;
+    the audit log uses ``kind`` + ``token`` only.
+    """
+
+    kind: TokenKind
+    token: str  # rendered form: "[[KIND:uuid]]"
+    plaintext: str
+
+
+@dataclass
+class SessionKeymap:
+    """The bidirectional token map for one MCP session.
+
+    Two indices for O(1) lookup in both directions:
+
+    * ``by_plaintext[(kind, plaintext)]`` -> entry, used during
+      tokenization so the same plaintext value gets the same token
+      every time within a session ("same value, same token" — the user
+      requirement from the v2.3.0.10 design).
+    * ``by_token[token_string]`` -> entry, used during detokenization
+      when the AI passes a token back into a write tool.
+    """
+
+    by_plaintext: dict[tuple[TokenKind, str], TokenEntry] = field(default_factory=dict)
+    by_token: dict[str, TokenEntry] = field(default_factory=dict)
+
+    # An asyncio lock per session — defensive against future code paths
+    # that introduce an ``await`` mid-allocation. Today the operations
+    # are all pure dict ops with no awaits, so they're atomic under
+    # asyncio's cooperative scheduling. Belt and suspenders.
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False, compare=False)
+
+    def __len__(self) -> int:
+        return len(self.by_token)
+
+    def kind_counts(self) -> dict[TokenKind, int]:
+        """Return per-kind counts of entries — used by the audit tool to
+        report coverage without revealing values.
+        """
+        counts: dict[TokenKind, int] = {}
+        for entry in self.by_token.values():
+            counts[entry.kind] = counts.get(entry.kind, 0) + 1
+        return counts
+
+
+class TokenStore:
+    """Top-level, multi-session keymap.
+
+    Sessions are allocated lazily on first ``get_or_create()`` call;
+    explicit ``end_session()`` is called when FastMCP signals session
+    teardown (or by the middleware when an InitializeRequest arrives
+    with no prior session — a fresh client connection should never see
+    stale keymap state).
+
+    A soft cap (``max_entries_per_session``) prevents runaway memory.
+    Cap-hit triggers a ``KeymapFullError``; the middleware logs the
+    failure and returns the original value untokenized rather than
+    erroring out the tool call. The cap is intentionally generous (10K
+    by default — typical sessions tokenize hundreds of values).
+    """
+
+    def __init__(self, *, max_entries_per_session: int = 10_000) -> None:
+        self._sessions: dict[str, SessionKeymap] = {}
+        self._max_entries_per_session = max_entries_per_session
+
+    @property
+    def max_entries_per_session(self) -> int:
+        return self._max_entries_per_session
+
+    def get(self, session_id: str) -> SessionKeymap | None:
+        """Return the keymap for ``session_id`` if one exists, else None."""
+        return self._sessions.get(session_id)
+
+    def get_or_create(self, session_id: str) -> SessionKeymap:
+        """Return the keymap for ``session_id``, creating it lazily."""
+        keymap = self._sessions.get(session_id)
+        if keymap is None:
+            keymap = SessionKeymap()
+            self._sessions[session_id] = keymap
+        return keymap
+
+    def end_session(self, session_id: str) -> int:
+        """Purge ``session_id``'s keymap. Returns the number of entries dropped."""
+        keymap = self._sessions.pop(session_id, None)
+        return len(keymap) if keymap else 0
+
+    def session_count(self) -> int:
+        return len(self._sessions)
+
+    def total_entries(self) -> int:
+        return sum(len(km) for km in self._sessions.values())
+
+
+class KeymapFullError(RuntimeError):
+    """Raised when a session has hit ``max_entries_per_session``."""
+
+
+def allocate_token(kind: TokenKind, plaintext: str) -> str:
+    """Build a fresh ``[[KIND:uuid]]`` token. Pure function, no state.
+
+    The keymap caller is responsible for collision detection (UUID4
+    collisions are mathematically near-impossible at session scale, but
+    the keymap re-rolls if the freshly generated UUID happens to
+    already be in use — belt and suspenders).
+    """
+    return f"[[{kind.value}:{uuid.uuid4()}]]"

--- a/src/hpe_networking_mcp/redaction/tokenizer.py
+++ b/src/hpe_networking_mcp/redaction/tokenizer.py
@@ -1,0 +1,196 @@
+"""Bidirectional tokenize/detokenize against a session keymap.
+
+The tokenizer operates on **single string values**. The walker
+(``walker.py``) handles the recursive structure traversal; this module
+just answers "what's the token for this string?" and "what's the
+plaintext behind this token?".
+
+Tokenization is idempotent: re-tokenizing an already-tokenized string
+returns it unchanged. Detokenization on an unknown token returns None,
+which the middleware uses to decide whether to error out the call.
+
+Audit logging happens here too — every allocation logs ``kind`` +
+``token`` + truncated ``value_hash`` (SHA-256 of the plaintext, first
+16 hex chars) so an operator can verify "the same plaintext consistently
+mapped to the same token" without ever seeing the plaintext column.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from hpe_networking_mcp.redaction.rules import TOKEN_RE, TokenKind
+from hpe_networking_mcp.redaction.token_store import (
+    KeymapFullError,
+    SessionKeymap,
+    TokenEntry,
+    allocate_token,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+def _value_hash(plaintext: str) -> str:
+    """Truncated SHA-256 of the plaintext for audit-log fingerprinting."""
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()[:16]
+
+
+class Tokenizer:
+    """Stateful tokenizer bound to one ``SessionKeymap``.
+
+    The session keymap is a constructor argument so the walker can
+    keep a single tokenizer instance for the duration of one tool call
+    (avoids passing the keymap around as a separate parameter).
+
+    Args:
+        keymap: The per-session ``SessionKeymap``.
+        session_id: For audit logging — keeps logs scoped per session.
+        max_entries: Soft cap from ``TokenStore.max_entries_per_session``.
+            Hitting the cap raises ``KeymapFullError`` once per call;
+            subsequent calls in the same tool response return plaintext
+            unchanged so the response still goes through.
+    """
+
+    def __init__(
+        self,
+        keymap: SessionKeymap,
+        *,
+        session_id: str,
+        max_entries: int,
+    ) -> None:
+        self._keymap = keymap
+        self._session_id = session_id
+        self._max_entries = max_entries
+        self._cap_hit_logged = False
+
+    @property
+    def keymap(self) -> SessionKeymap:
+        return self._keymap
+
+    def tokenize(self, kind: TokenKind, plaintext: str) -> str:
+        """Return the token for ``(kind, plaintext)``, allocating if new.
+
+        Idempotent on already-tokenized inputs: passing
+        ``"[[PSK:550e8400-...]]"`` back in returns it unchanged (the
+        regex match short-circuits).
+
+        Raises ``KeymapFullError`` when the session has hit the soft cap
+        on a *new* allocation. Existing tokens still round-trip even
+        post-cap.
+        """
+        if not isinstance(plaintext, str) or not plaintext:
+            return plaintext
+
+        # Idempotency: don't double-tokenize a string that already is one.
+        if TOKEN_RE.fullmatch(plaintext):
+            return plaintext
+
+        key = (kind, plaintext)
+        existing = self._keymap.by_plaintext.get(key)
+        if existing is not None:
+            return existing.token
+
+        # Need to allocate. Soft-cap check.
+        if len(self._keymap) >= self._max_entries:
+            if not self._cap_hit_logged:
+                logger.warning(
+                    "pii.cap_hit session={} entries={} max={} — "
+                    "further values pass through untokenized for the rest of this call",
+                    self._session_id[:12],
+                    len(self._keymap),
+                    self._max_entries,
+                )
+                self._cap_hit_logged = True
+            raise KeymapFullError(f"Session keymap full ({len(self._keymap)}/{self._max_entries})")
+
+        # Allocate a fresh token. UUID4 collisions are mathematically
+        # near-impossible, but re-roll defensively.
+        for _ in range(8):
+            token = allocate_token(kind, plaintext)
+            if token not in self._keymap.by_token:
+                break
+        else:  # pragma: no cover — collision in 8 UUID4 draws is statistically impossible
+            raise RuntimeError("UUID4 collision in 8 attempts; entropy source compromised?")
+
+        entry = TokenEntry(kind=kind, token=token, plaintext=plaintext)
+        self._keymap.by_plaintext[key] = entry
+        self._keymap.by_token[token] = entry
+
+        logger.info(
+            "pii.tokenize session={} kind={} token={} value_hash={} entries={}",
+            self._session_id[:12],
+            kind.value,
+            token,
+            _value_hash(plaintext),
+            len(self._keymap),
+        )
+        return token
+
+    def detokenize(self, token: str) -> str | None:
+        """Return the plaintext for ``token``, or None if unknown.
+
+        Logs the lookup attempt — successful detokenization is the
+        critical audit event because that's when a real secret leaves
+        the MCP container's memory and goes to a platform API.
+        """
+        entry = self._keymap.by_token.get(token)
+        if entry is None:
+            logger.warning(
+                "pii.detokenize_unknown session={} token={}",
+                self._session_id[:12],
+                token,
+            )
+            return None
+        return entry.plaintext
+
+
+def tokenize_value(
+    tokenizer: Tokenizer,
+    kind: TokenKind,
+    value: object,
+) -> object:
+    """Convenience wrapper: tokenize when ``value`` is a non-empty string.
+
+    Returns the value unchanged for None / non-string / empty / already-token
+    inputs. Used by the walker so it doesn't have to inline these guards
+    at every call site.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+    try:
+        return tokenizer.tokenize(kind, value)
+    except KeymapFullError:
+        return value
+
+
+def detokenize_string(tokenizer: Tokenizer, value: str) -> tuple[str, list[str]]:
+    """Replace every ``[[KIND:uuid]]`` occurrence in ``value`` with plaintext.
+
+    Returns ``(replaced_string, unknown_tokens)`` so the caller can
+    distinguish between "fully detokenized" (empty list) and "model
+    referenced a token from a different session" (non-empty list — the
+    middleware should error the tool call rather than passing literal
+    bracket text downstream).
+
+    Idempotent on inputs that contain no tokens (returns unchanged with
+    empty unknown list).
+    """
+    if not isinstance(value, str) or not value:
+        return value, []
+
+    unknown: list[str] = []
+
+    def _sub(match: object) -> str:
+        full = match.group(0)  # type: ignore[attr-defined]
+        plaintext = tokenizer.detokenize(full)
+        if plaintext is None:
+            unknown.append(full)
+            return full
+        return plaintext
+
+    replaced = TOKEN_RE.sub(_sub, value)
+    return replaced, unknown

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -1,0 +1,343 @@
+"""Recursive JSON walker — applies rules + tokenizer to tool responses.
+
+Two top-level entry points:
+
+* ``tokenize_response(structured_content, tokenizer)`` — walks the tool
+  response tree and returns a NEW dict/list with sensitive values
+  tokenized and MACs normalized. Idempotent: walking an already-walked
+  structure is a no-op.
+
+* ``detokenize_arguments(arguments, tokenizer)`` — walks the inbound
+  tool argument tree and substitutes ``[[KIND:uuid]]`` references back
+  to plaintext before the call hits the platform API. Returns
+  ``(new_args, unknown_tokens)`` so the middleware can refuse the call
+  if the model referenced a token that doesn't exist in the session
+  keymap.
+
+The walker never mutates inputs in place — every recursion returns a
+new dict/list. This is intentional: tool responses can be referenced
+elsewhere in FastMCP's pipeline, and silently editing them would
+violate caller expectations.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from hpe_networking_mcp.redaction.mac_normalizer import (
+    canonicalize_mac,
+    is_mac_address,
+    normalize_macs_in_value,
+)
+from hpe_networking_mcp.redaction.rules import (
+    EMAIL_RE,
+    IPV4_RE,
+    IPV6_RE,
+    PEM_BLOCK_RE,
+    PUBLIC_IP_ALLOWLIST,
+    PUBLIC_IP_ALLOWLIST_RANGES,
+    FieldClassification,
+    TokenKind,
+    classify_field,
+)
+from hpe_networking_mcp.redaction.tokenizer import (
+    detokenize_string,
+    tokenize_value,
+)
+
+if TYPE_CHECKING:
+    from hpe_networking_mcp.redaction.tokenizer import Tokenizer
+
+
+# Maximum recursion depth — defensive against pathologically nested input.
+# Mist config payloads top out around 8 levels in practice; 32 gives us
+# plenty of margin while still preventing stack-overflow on malformed input.
+_MAX_DEPTH = 32
+
+# Field names whose containing dict signals a MAC field — used to pull
+# bare-12-hex MACs (no separators) out without false-positive risk.
+_MAC_FIELD_HINTS: frozenset[str] = frozenset(
+    {
+        "mac",
+        "device_mac",
+        "client_mac",
+        "ap_mac",
+        "wired_mac",
+        "bssid",
+        "src_mac",
+        "dst_mac",
+        "switch_mac",
+        "gateway_mac",
+    }
+)
+
+
+def _is_public_allowlisted_ip(value: str) -> bool:
+    """Return True when ``value`` is a well-known public IP we preserve."""
+    if value in PUBLIC_IP_ALLOWLIST:
+        return True
+    try:
+        addr = ipaddress.ip_address(value.split("/", 1)[0])
+    except ValueError:
+        return False
+    return any(addr in ipaddress.ip_network(cidr) for cidr in PUBLIC_IP_ALLOWLIST_RANGES)
+
+
+def _is_routable_ip(value: str) -> bool:
+    """Return True when ``value`` parses as a valid IPv4/IPv6 address.
+
+    The IP regex catches octet shapes that aren't valid IPs (e.g.
+    ``999.999.999.999``); this guard runs ``ipaddress.ip_address()`` to
+    confirm validity before tokenization.
+    """
+    try:
+        ipaddress.ip_address(value.split("/", 1)[0])
+        return True
+    except ValueError:
+        return False
+
+
+def _scan_free_text(text: str, tokenizer: Tokenizer) -> str:
+    """Apply the secret-pattern + identifier-pattern sweep over ``text``.
+
+    Order matters: PEM blocks first (they contain colons that would
+    otherwise match IPv6 patterns), then emails, then IPs (so we don't
+    re-scan IPs that are inside PEM signatures), then MACs.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    result = text
+
+    # Tier 1 — PEM blocks. Any PEM-shaped block in free text is treated
+    # as a CERT regardless of the kind; we don't try to distinguish
+    # certificate from private-key in description fields.
+    def _pem_sub(match: object) -> str:
+        block = match.group(0)  # type: ignore[attr-defined]
+        kind = TokenKind.PRIVATE_KEY if "PRIVATE KEY" in block else TokenKind.CERT
+        replacement = tokenize_value(tokenizer, kind, block)
+        return replacement if isinstance(replacement, str) else block
+
+    result = PEM_BLOCK_RE.sub(_pem_sub, result)
+
+    # Tier 2 identifiers — email, IP, MAC
+    def _email_sub(match: object) -> str:
+        addr = match.group(0)  # type: ignore[attr-defined]
+        replacement = tokenize_value(tokenizer, TokenKind.EMAIL, addr)
+        return replacement if isinstance(replacement, str) else addr
+
+    result = EMAIL_RE.sub(_email_sub, result)
+
+    def _ipv4_sub(match: object) -> str:
+        addr = match.group(0)  # type: ignore[attr-defined]
+        if not _is_routable_ip(addr) or _is_public_allowlisted_ip(addr):
+            return addr
+        replacement = tokenize_value(tokenizer, TokenKind.IP, addr)
+        return replacement if isinstance(replacement, str) else addr
+
+    result = IPV4_RE.sub(_ipv4_sub, result)
+
+    def _ipv6_sub(match: object) -> str:
+        addr = match.group(0)  # type: ignore[attr-defined]
+        if not _is_routable_ip(addr) or _is_public_allowlisted_ip(addr):
+            return addr
+        replacement = tokenize_value(tokenizer, TokenKind.IP, addr)
+        return replacement if isinstance(replacement, str) else addr
+
+    result = IPV6_RE.sub(_ipv6_sub, result)
+
+    # MACs — normalize in place (no tokenization per the v2.3.0.10 design)
+    result = normalize_macs_in_value(result)
+
+    return result
+
+
+def _walk_dict(
+    data: dict,
+    tokenizer: Tokenizer | None,
+    *,
+    depth: int,
+) -> dict:
+    """Recursively walk a dict, applying classification rules to each pair.
+
+    ``tokenizer`` is None when only MAC normalization is requested
+    (tokenization disabled). In that mode the walker still recurses to
+    apply MAC normalization but skips all tokenization paths.
+    """
+    if depth > _MAX_DEPTH:
+        return data
+
+    parent_keys = frozenset(data.keys()) if isinstance(data, dict) else frozenset()
+    out: dict = {}
+
+    for key, value in data.items():
+        new_value = _walk_pair(
+            key,
+            value,
+            tokenizer,
+            depth=depth,
+            parent_keys=parent_keys,
+        )
+        out[key] = new_value
+    return out
+
+
+def _walk_pair(
+    key: object,
+    value: object,
+    tokenizer: Tokenizer | None,
+    *,
+    depth: int,
+    parent_keys: frozenset[str],
+) -> object:
+    """Apply classification + recursion to one key/value pair."""
+    # Recursion into nested structures comes first
+    if isinstance(value, dict):
+        return _walk_dict(value, tokenizer, depth=depth + 1)
+    if isinstance(value, list):
+        return _walk_list(key, value, tokenizer, depth=depth + 1, parent_keys=parent_keys)
+
+    # MAC normalization — always-on regardless of tokenizer presence
+    field_name_lower = str(key).lower() if isinstance(key, str) else ""
+    if field_name_lower in _MAC_FIELD_HINTS and isinstance(value, str) and is_mac_address(value):
+        value = canonicalize_mac(value)
+
+    # Tokenization — only when a tokenizer was passed
+    if tokenizer is None or not isinstance(key, str):
+        return value
+
+    classification, kind = classify_field(key, value, parent_keys=parent_keys)
+
+    if classification == FieldClassification.SKIP:
+        return value
+    if classification == FieldClassification.TOKENIZE_SECRET and kind is not None:
+        return tokenize_value(tokenizer, kind, value)
+    if classification == FieldClassification.TOKENIZE_IDENTIFIER and kind is not None:
+        # IPs need allowlist + validity check before tokenization
+        if (
+            kind == TokenKind.IP
+            and isinstance(value, str)
+            and (not _is_routable_ip(value) or _is_public_allowlisted_ip(value))
+        ):
+            return value
+        return tokenize_value(tokenizer, kind, value)
+    if classification == FieldClassification.SCAN_FREE_TEXT and isinstance(value, str):
+        return _scan_free_text(value, tokenizer)
+
+    return value
+
+
+def _walk_list(
+    parent_key: object,
+    data: list,
+    tokenizer: Tokenizer | None,
+    *,
+    depth: int,
+    parent_keys: frozenset[str],
+) -> list:
+    """Recursively walk a list. Lists inherit the parent's field name for
+    classification purposes — e.g. ``ip_addresses: ["10.1.1.1", "10.1.1.2"]``
+    each element is treated as if it were under ``ip_addresses``.
+    """
+    if depth > _MAX_DEPTH:
+        return data
+
+    out: list = []
+    for item in data:
+        if isinstance(item, dict):
+            out.append(_walk_dict(item, tokenizer, depth=depth + 1))
+        elif isinstance(item, list):
+            out.append(_walk_list(parent_key, item, tokenizer, depth=depth + 1, parent_keys=parent_keys))
+        else:
+            # Apply the parent key's classification to the list element
+            out.append(
+                _walk_pair(
+                    parent_key,
+                    item,
+                    tokenizer,
+                    depth=depth,
+                    parent_keys=parent_keys,
+                )
+            )
+    return out
+
+
+def tokenize_response(
+    data: object,
+    tokenizer: Tokenizer | None,
+) -> object:
+    """Return a new structure with PII tokenized and MACs normalized.
+
+    Pass ``tokenizer=None`` to apply MAC normalization only — useful in
+    the default configuration where ``ENABLE_PII_TOKENIZATION=false``
+    but normalization is still on.
+
+    Idempotent: walking already-tokenized output produces the same
+    output.
+    """
+    if isinstance(data, dict):
+        return _walk_dict(data, tokenizer, depth=0)
+    if isinstance(data, list):
+        return _walk_list("", data, tokenizer, depth=0, parent_keys=frozenset())
+    return data
+
+
+def _detokenize_walk(
+    data: object,
+    tokenizer: Tokenizer,
+    unknown: list[str],
+    *,
+    depth: int,
+) -> object:
+    """Recursive helper for detokenizing inbound arguments."""
+    if depth > _MAX_DEPTH:
+        return data
+
+    if isinstance(data, dict):
+        return {key: _detokenize_walk(value, tokenizer, unknown, depth=depth + 1) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_detokenize_walk(item, tokenizer, unknown, depth=depth + 1) for item in data]
+    if isinstance(data, str):
+        replaced, missing = detokenize_string(tokenizer, data)
+        unknown.extend(missing)
+        return replaced
+    return data
+
+
+def detokenize_arguments(
+    arguments: dict | None,
+    tokenizer: Tokenizer,
+) -> tuple[dict, list[str]]:
+    """Replace token references in inbound arguments with plaintext.
+
+    Returns ``(new_arguments, unknown_tokens)``. The middleware checks
+    ``unknown_tokens`` and refuses the call (returns a JSON-RPC error)
+    if it is non-empty — passing literal ``[[KIND:uuid]]`` strings to a
+    platform API would be confusing at best and silently accept them as
+    real values at worst.
+    """
+    if not arguments:
+        return arguments or {}, []
+
+    unknown: list[str] = []
+    new_args = _detokenize_walk(arguments, tokenizer, unknown, depth=0)
+    if not isinstance(new_args, dict):  # pragma: no cover — arguments always a dict
+        return arguments, []
+    return new_args, unknown
+
+
+def iter_kinds_in_string(value: str) -> Iterable[str]:
+    """Yield every ``KIND`` string in ``value`` — used by audit tooling.
+
+    Returns the bare kind names (e.g. ``"PSK"``), one per token
+    occurrence, in order. Useful for "the AI passed N tokens, of these
+    kinds" telemetry without revealing the token IDs themselves.
+    """
+    from hpe_networking_mcp.redaction.rules import TOKEN_RE  # local to avoid cycle
+
+    if not isinstance(value, str):
+        return
+    for match in TOKEN_RE.finditer(value):
+        yield match.group(1)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -192,19 +192,31 @@ def create_server(config: ServerConfig) -> FastMCP:
         ElicitationMiddleware,
     )
     from hpe_networking_mcp.middleware.null_strip import NullStripMiddleware
+    from hpe_networking_mcp.middleware.pii_tokenization import (
+        PIITokenizationMiddleware,
+    )
     from hpe_networking_mcp.middleware.retry import RetryMiddleware
     from hpe_networking_mcp.middleware.sandbox_error_catch import (
         SandboxErrorCatchMiddleware,
     )
     from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
+    from hpe_networking_mcp.redaction.token_store import TokenStore
+
+    # The token store is process-scoped (one TokenStore per FastMCP
+    # instance, with per-session keymaps inside). It is passed to the
+    # middleware so it survives across tool calls within a session.
+    token_store = TokenStore(max_entries_per_session=config.pii_max_tokens_per_session)
 
     # Middleware order (outermost → innermost):
-    #   NullStrip          — drop nulls before validation
-    #   ValidationCatch    — Pydantic ValidationError → readable string return
-    #   SandboxErrorCatch  — code-mode MontyRuntimeError on execute → string return
-    #   Elicitation        — write-tool confirmation gate
-    #   Retry              — transient failures retry transparently after elicitation
-    #                        has approved (re-tries don't re-prompt)
+    #   NullStrip           — drop nulls before validation
+    #   ValidationCatch     — Pydantic ValidationError → readable string return
+    #   SandboxErrorCatch   — code-mode MontyRuntimeError on execute → string return
+    #   PIITokenization     — detokenize inbound args / tokenize outbound results
+    #                         (always normalizes MACs even when toggle is off)
+    #   Elicitation         — write-tool confirmation gate; user sees real values
+    #                         post-detokenization, which is correct (the user is
+    #                         the trust boundary holder, not the AI)
+    #   Retry               — transient failures retry transparently after elicit
     mcp = FastMCP(
         name="HPE Networking MCP",
         instructions=_INSTRUCTIONS,
@@ -215,10 +227,16 @@ def create_server(config: ServerConfig) -> FastMCP:
             NullStripMiddleware(),
             ValidationCatchMiddleware(),
             SandboxErrorCatchMiddleware(),
+            PIITokenizationMiddleware(token_store, enabled=config.enable_pii_tokenization),
             ElicitationMiddleware(),
             RetryMiddleware(),
         ],
     )
+
+    # Stash the token store on the FastMCP instance so future tooling
+    # (e.g. an audit/reveal endpoint) can access it without going
+    # through the middleware.
+    mcp._hpe_token_store = token_store  # type: ignore[attr-defined]
 
     # Attach config for lifespan to access
     mcp._hpe_config = config  # type: ignore[attr-defined]

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -1,0 +1,499 @@
+"""Unit tests for the PII tokenization + MAC normalization layer."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from hpe_networking_mcp.redaction.mac_normalizer import (
+    canonicalize_mac,
+    is_mac_address,
+    normalize_macs_in_value,
+)
+from hpe_networking_mcp.redaction.rules import (
+    PUBLIC_IP_ALLOWLIST,
+    TOKEN_RE,
+    FieldClassification,
+    TokenKind,
+    classify_field,
+    is_known_enum_value,
+    looks_like_credential,
+)
+from hpe_networking_mcp.redaction.token_store import (
+    SessionKeymap,
+    TokenStore,
+    allocate_token,
+)
+from hpe_networking_mcp.redaction.tokenizer import Tokenizer, detokenize_string
+from hpe_networking_mcp.redaction.walker import (
+    detokenize_arguments,
+    tokenize_response,
+)
+
+UUID_PART = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+
+# ---------------------------------------------------------------------------
+# MAC normalization
+# ---------------------------------------------------------------------------
+
+
+class TestMacNormalization:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:ff"),
+            ("AA:BB:CC:DD:EE:FF", "aa:bb:cc:dd:ee:ff"),
+            ("aabb.ccdd.eeff", "aa:bb:cc:dd:ee:ff"),
+            ("AABB.CCDD.EEFF", "aa:bb:cc:dd:ee:ff"),
+            ("AA-BB-CC-DD-EE-FF", "aa:bb:cc:dd:ee:ff"),
+            ("aabbccddeeff", "aa:bb:cc:dd:ee:ff"),
+            ("AABBCCDDEEFF", "aa:bb:cc:dd:ee:ff"),
+        ],
+    )
+    def test_canonicalize_every_format(self, value: str, expected: str) -> None:
+        assert canonicalize_mac(value) == expected
+
+    def test_non_mac_passes_through(self) -> None:
+        assert canonicalize_mac("not-a-mac") == "not-a-mac"
+        assert canonicalize_mac("") == ""
+
+    def test_is_mac_recognizes_each_format(self) -> None:
+        assert is_mac_address("aa:bb:cc:dd:ee:ff")
+        assert is_mac_address("AABB.CCDD.EEFF")
+        assert is_mac_address("aa-bb-cc-dd-ee-ff")
+        assert is_mac_address("aabbccddeeff")
+
+    def test_is_mac_rejects_invalid(self) -> None:
+        assert not is_mac_address("aa:bb:cc:dd:ee:gg")  # 'g' not hex
+        assert not is_mac_address("aa:bb:cc:dd:ee")  # too short
+        assert not is_mac_address("not-a-mac")
+        assert not is_mac_address("")
+
+    def test_normalize_inside_free_text(self) -> None:
+        text = "Client AA-BB-CC-DD-EE-FF disconnected from AP aabb.ccdd.eeff at 12:00"
+        result = normalize_macs_in_value(text)
+        assert "aa:bb:cc:dd:ee:ff" in result
+        assert "AA-BB-CC-DD-EE-FF" not in result
+        assert "aabb.ccdd.eeff" not in result
+        # Surrounding text preserved
+        assert "Client" in result
+        assert "disconnected from AP" in result
+        assert "at 12:00" in result
+
+    def test_bare_hex_not_normalized_in_free_text(self) -> None:
+        # A 12-char hex string in free text could be a serial, hash, etc.
+        # Free-text normalization explicitly skips bare-hex.
+        text = "ID 0123456789ab is interesting"
+        assert normalize_macs_in_value(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Field classification
+# ---------------------------------------------------------------------------
+
+
+class TestFieldClassification:
+    def test_psk_classified_as_secret(self) -> None:
+        cls, kind = classify_field("psk", "Welcome2024!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.PSK
+
+    def test_passphrase_classified_as_psk(self) -> None:
+        cls, kind = classify_field("passphrase", "longSecret!23")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.PSK
+
+    def test_ssid_classified_as_identifier(self) -> None:
+        cls, kind = classify_field("ssid", "Corp-Wifi")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.SSID
+
+    def test_org_id_classified_as_org(self) -> None:
+        cls, kind = classify_field("org_id", "abc-123")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.ORG
+
+    def test_unknown_field_skipped(self) -> None:
+        cls, _ = classify_field("status", "online")
+        assert cls == FieldClassification.SKIP
+
+    def test_description_marked_as_free_text(self) -> None:
+        cls, _ = classify_field("description", "anything")
+        assert cls == FieldClassification.SCAN_FREE_TEXT
+
+    def test_generic_key_with_short_value_skipped(self) -> None:
+        # 'key': 'ssid' is a template-style use, NOT a credential
+        cls, _ = classify_field("key", "ssid")
+        assert cls == FieldClassification.SKIP
+
+    def test_generic_secret_with_credential_shape_tokenized(self) -> None:
+        cls, kind = classify_field("secret", "L0ng-StRong-S3cret!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.RADSEC
+
+    def test_generic_password_with_enum_value_skipped(self) -> None:
+        # 'password': 'disabled' would be a config flag, not a credential
+        cls, _ = classify_field("password", "disabled")
+        assert cls == FieldClassification.SKIP
+
+    def test_bare_name_in_device_context_becomes_hostname(self) -> None:
+        cls, kind = classify_field(
+            "name",
+            "AP-Floor-3",
+            parent_keys=frozenset({"name", "mac", "model", "serial"}),
+        )
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.HOSTNAME
+
+    def test_bare_name_outside_device_context_skipped(self) -> None:
+        cls, _ = classify_field(
+            "name",
+            "TestThing",
+            parent_keys=frozenset({"name", "value", "type"}),
+        )
+        assert cls == FieldClassification.SKIP
+
+
+class TestCredentialShapeHeuristic:
+    def test_long_mixed_string_looks_credential(self) -> None:
+        assert looks_like_credential("Welcome2024!")
+        assert looks_like_credential("MyP@ssw0rd123")
+
+    def test_short_string_does_not(self) -> None:
+        assert not looks_like_credential("short")
+        assert not looks_like_credential("abc")
+
+    def test_long_uniform_string_does_not(self) -> None:
+        # No character-class diversity, no special chars
+        assert not looks_like_credential("alllowercase")
+        assert not looks_like_credential("ALLUPPERCASE")
+        assert not looks_like_credential("12345678")
+
+    def test_special_char_alone_is_enough(self) -> None:
+        assert looks_like_credential("password!23")  # special bumps it past length
+
+    def test_known_enum_values_recognized(self) -> None:
+        assert is_known_enum_value("auto")
+        assert is_known_enum_value("DISABLED")
+        assert not is_known_enum_value("Welcome2024!")
+
+
+# ---------------------------------------------------------------------------
+# TokenStore + Tokenizer
+# ---------------------------------------------------------------------------
+
+
+class TestTokenStoreLifecycle:
+    def test_session_isolation(self) -> None:
+        store = TokenStore()
+        keymap_a = store.get_or_create("session-a")
+        keymap_b = store.get_or_create("session-b")
+        assert keymap_a is not keymap_b
+        assert store.session_count() == 2
+
+    def test_get_or_create_idempotent(self) -> None:
+        store = TokenStore()
+        first = store.get_or_create("session-a")
+        again = store.get_or_create("session-a")
+        assert first is again
+
+    def test_end_session_purges(self) -> None:
+        store = TokenStore()
+        keymap = store.get_or_create("session-a")
+        keymap.by_token["[[PSK:abc]]"] = None  # type: ignore[assignment]
+        dropped = store.end_session("session-a")
+        assert dropped == 1
+        assert store.get("session-a") is None
+
+    def test_allocate_token_format(self) -> None:
+        token = allocate_token(TokenKind.PSK, "anything")
+        assert re.match(rf"\[\[PSK:{UUID_PART}\]\]", token)
+
+
+class TestTokenizer:
+    def _make(self, max_entries: int = 100) -> Tokenizer:
+        keymap = SessionKeymap()
+        return Tokenizer(keymap, session_id="test-session-12345", max_entries=max_entries)
+
+    def test_same_value_same_token(self) -> None:
+        tk = self._make()
+        a = tk.tokenize(TokenKind.PSK, "Welcome2024!")
+        b = tk.tokenize(TokenKind.PSK, "Welcome2024!")
+        assert a == b
+
+    def test_different_values_different_tokens(self) -> None:
+        tk = self._make()
+        a = tk.tokenize(TokenKind.PSK, "First!")
+        b = tk.tokenize(TokenKind.PSK, "Second!")
+        assert a != b
+
+    def test_different_kinds_different_tokens_for_same_value(self) -> None:
+        tk = self._make()
+        psk = tk.tokenize(TokenKind.PSK, "shared-value-12345")
+        api = tk.tokenize(TokenKind.API_TOKEN, "shared-value-12345")
+        assert psk != api
+        assert TOKEN_RE.fullmatch(psk).group(1) == "PSK"
+        assert TOKEN_RE.fullmatch(api).group(1) == "APITOKEN"
+
+    def test_idempotent_on_existing_token(self) -> None:
+        tk = self._make()
+        token = tk.tokenize(TokenKind.PSK, "abc12345!")
+        again = tk.tokenize(TokenKind.PSK, token)
+        assert again == token
+
+    def test_empty_or_none_pass_through(self) -> None:
+        tk = self._make()
+        assert tk.tokenize(TokenKind.PSK, "") == ""
+        # Type ignored — runtime should still safely handle.
+        assert tk.tokenize(TokenKind.PSK, None) is None  # type: ignore[arg-type]
+
+    def test_detokenize_returns_plaintext(self) -> None:
+        tk = self._make()
+        token = tk.tokenize(TokenKind.PSK, "Welcome2024!")
+        assert tk.detokenize(token) == "Welcome2024!"
+
+    def test_detokenize_unknown_returns_none(self) -> None:
+        tk = self._make()
+        assert tk.detokenize("[[PSK:ffffffff-ffff-ffff-ffff-ffffffffffff]]") is None
+
+    def test_cap_hit_falls_through(self) -> None:
+        tk = self._make(max_entries=2)
+        tk.tokenize(TokenKind.PSK, "first1234")
+        tk.tokenize(TokenKind.PSK, "second12345")
+        # Third allocation should hit the cap. Tokenizer raises;
+        # walker layer catches and returns plaintext unchanged.
+        from hpe_networking_mcp.redaction.token_store import KeymapFullError
+
+        with pytest.raises(KeymapFullError):
+            tk.tokenize(TokenKind.PSK, "third12345")
+
+
+class TestDetokenizeString:
+    def test_replaces_token_in_string(self) -> None:
+        keymap = SessionKeymap()
+        tk = Tokenizer(keymap, session_id="s", max_entries=10)
+        token = tk.tokenize(TokenKind.PSK, "Welcome2024!")
+        replaced, unknown = detokenize_string(tk, f"PSK is {token} for site")
+        assert "Welcome2024!" in replaced
+        assert "[[PSK:" not in replaced
+        assert unknown == []
+
+    def test_unknown_token_collected(self) -> None:
+        keymap = SessionKeymap()
+        tk = Tokenizer(keymap, session_id="s", max_entries=10)
+        bogus = "[[PSK:00000000-0000-0000-0000-000000000000]]"
+        replaced, unknown = detokenize_string(tk, f"reference {bogus}")
+        # Unknown token is preserved in the string (not substituted to garbage)
+        assert bogus in replaced
+        assert unknown == [bogus]
+
+
+# ---------------------------------------------------------------------------
+# Walker (recursive structure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tokenizer() -> Tokenizer:
+    return Tokenizer(SessionKeymap(), session_id="walker-tests", max_entries=1000)
+
+
+class TestTokenizeResponse:
+    def test_psk_in_dict_replaced(self, tokenizer: Tokenizer) -> None:
+        result = tokenize_response({"psk": "Welcome2024!"}, tokenizer)
+        assert isinstance(result, dict)
+        assert result["psk"] != "Welcome2024!"
+        assert TOKEN_RE.fullmatch(result["psk"]).group(1) == "PSK"
+
+    def test_nested_psk_replaced(self, tokenizer: Tokenizer) -> None:
+        data = {"wlan": {"auth": {"psk": "DeepNested!Pass"}}}
+        result = tokenize_response(data, tokenizer)
+        assert result["wlan"]["auth"]["psk"] != "DeepNested!Pass"
+
+    def test_list_of_secrets_each_tokenized(self, tokenizer: Tokenizer) -> None:
+        data = {"radius_servers": [{"shared_secret": "first1234!"}, {"shared_secret": "second12345!"}]}
+        result = tokenize_response(data, tokenizer)
+        a = result["radius_servers"][0]["shared_secret"]
+        b = result["radius_servers"][1]["shared_secret"]
+        assert a != b
+        assert TOKEN_RE.fullmatch(a)
+        assert TOKEN_RE.fullmatch(b)
+
+    def test_same_psk_same_token(self, tokenizer: Tokenizer) -> None:
+        data = {"a": {"psk": "Welcome2024!"}, "b": {"psk": "Welcome2024!"}}
+        result = tokenize_response(data, tokenizer)
+        assert result["a"]["psk"] == result["b"]["psk"]
+
+    def test_macs_normalized_not_tokenized(self, tokenizer: Tokenizer) -> None:
+        data = {"mac": "AA-BB-CC-DD-EE-FF", "client_mac": "aabb.ccdd.eeff"}
+        result = tokenize_response(data, tokenizer)
+        assert result["mac"] == "aa:bb:cc:dd:ee:ff"
+        assert result["client_mac"] == "aa:bb:cc:dd:ee:ff"
+        # No token brackets
+        assert "[[" not in result["mac"]
+        assert "[[" not in result["client_mac"]
+
+    def test_public_dns_ip_preserved(self, tokenizer: Tokenizer) -> None:
+        data = {"dns_servers": ["8.8.8.8", "1.1.1.1"]}
+        # IP isn't in a tokenized field name (`dns_servers` isn't in the
+        # ruleset) so it passes through. But also test that even *if* the
+        # field name caused tokenization, the public allowlist would skip:
+        result = tokenize_response({"ip": "8.8.8.8"}, tokenizer)
+        assert result == {"ip": "8.8.8.8"}
+        # And confirm the public allowlist entry is intact
+        assert "8.8.8.8" in PUBLIC_IP_ALLOWLIST
+        assert data["dns_servers"] == ["8.8.8.8", "1.1.1.1"]
+
+    def test_internal_ip_tokenized_in_known_field(self, tokenizer: Tokenizer) -> None:
+        # `ip` in PUBLIC_IP_ALLOWLIST is preserved, but a corporate IP isn't.
+        # We use a field that maps to TokenKind.IP via the rules. Right now
+        # `ip` is not in the identifier ruleset directly — IPs are tokenized
+        # via free-text scan. So test in that path:
+        data = {"description": "Gateway is 10.50.10.1 inside the LAN"}
+        result = tokenize_response(data, tokenizer)
+        assert "10.50.10.1" not in result["description"]
+        # Public IPs in free text are preserved
+        data2 = {"description": "Tested with DNS 8.8.8.8 and 1.1.1.1"}
+        result2 = tokenize_response(data2, tokenizer)
+        assert "8.8.8.8" in result2["description"]
+        assert "1.1.1.1" in result2["description"]
+
+    def test_email_in_free_text_tokenized(self, tokenizer: Tokenizer) -> None:
+        result = tokenize_response(
+            {"description": "contact admin@example.com for help"},
+            tokenizer,
+        )
+        assert "admin@example.com" not in result["description"]
+        assert "[[EMAIL:" in result["description"]
+
+    def test_idempotent_walk(self, tokenizer: Tokenizer) -> None:
+        once = tokenize_response({"psk": "TwicePassed!"}, tokenizer)
+        twice = tokenize_response(once, tokenizer)
+        assert once == twice
+
+    def test_mac_normalization_works_without_tokenizer(self) -> None:
+        # tokenizer=None means tokenization off but MAC normalization on
+        result = tokenize_response({"mac": "AABB.CCDD.EEFF"}, None)
+        assert result["mac"] == "aa:bb:cc:dd:ee:ff"
+
+    def test_unknown_fields_pass_through(self, tokenizer: Tokenizer) -> None:
+        data = {"channel": 36, "rssi": -55, "ssid_string": "Corp"}
+        result = tokenize_response(data, tokenizer)
+        # `ssid_string` is NOT in the ruleset (only `ssid`), should pass through
+        assert result == data
+
+
+class TestDetokenizeArguments:
+    def test_substitutes_token_in_args(self, tokenizer: Tokenizer) -> None:
+        token = tokenizer.tokenize(TokenKind.PSK, "RoundTripMe!")
+        args = {"psk": token, "ssid": "static"}
+        new_args, unknown = detokenize_arguments(args, tokenizer)
+        assert new_args["psk"] == "RoundTripMe!"
+        assert new_args["ssid"] == "static"
+        assert unknown == []
+
+    def test_unknown_token_returns_in_list(self, tokenizer: Tokenizer) -> None:
+        bogus = "[[PSK:00000000-0000-0000-0000-000000000000]]"
+        new_args, unknown = detokenize_arguments({"psk": bogus}, tokenizer)
+        assert unknown == [bogus]
+
+    def test_token_inside_substring(self, tokenizer: Tokenizer) -> None:
+        token = tokenizer.tokenize(TokenKind.PSK, "MyPsk1234!")
+        args = {"description": f"WLAN uses {token} for auth"}
+        new_args, _ = detokenize_arguments(args, tokenizer)
+        assert "MyPsk1234!" in new_args["description"]
+        assert "[[PSK:" not in new_args["description"]
+
+    def test_nested_args(self, tokenizer: Tokenizer) -> None:
+        token = tokenizer.tokenize(TokenKind.SITE, "abc-123-uuid")
+        args = {"filters": {"site_id": token}}
+        new_args, unknown = detokenize_arguments(args, tokenizer)
+        assert new_args["filters"]["site_id"] == "abc-123-uuid"
+        assert unknown == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fixture: a Mist-shaped WLAN response
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticMistFixture:
+    """Walk a redacted-but-realistic Mist WLAN config through the pipeline."""
+
+    @pytest.fixture
+    def mist_wlan_response(self) -> dict:
+        return {
+            "id": "00000000-0000-0000-0000-aaaaaaaaaaaa",
+            "site_id": "11111111-1111-1111-1111-bbbbbbbbbbbb",
+            "ssid": "Corp-Wifi",
+            "auth": {
+                "type": "psk",
+                "psk": "OurOfficeWifi2024!",
+                "wpa3_psk": "OurOfficeWifi2024!",  # same value — should get same token
+            },
+            "radius_servers": [
+                {
+                    "host": "10.50.10.10",
+                    "port": 1812,
+                    "shared_secret": "RadiusSecret123!",
+                },
+                {
+                    "host": "10.50.10.11",
+                    "port": 1812,
+                    "shared_secret": "RadiusSecret456!",
+                },
+            ],
+            "description": "Tested with admin@corp.com on AP aa-bb-cc-dd-ee-ff",
+            "schedule": {"enabled": True, "hours": []},
+            "device_name": "AP-Floor3-Conf",
+            "client_mac": "AABB.CCDD.EEFF",
+            "channel": 36,
+            "rssi": -55,
+        }
+
+    def test_full_walk(self, tokenizer: Tokenizer, mist_wlan_response: dict) -> None:
+        result = tokenize_response(mist_wlan_response, tokenizer)
+
+        # Tier 1 secrets — tokenized
+        assert "OurOfficeWifi2024!" not in str(result)
+        assert "RadiusSecret123!" not in str(result)
+        assert "RadiusSecret456!" not in str(result)
+        # Same value -> same token
+        assert result["auth"]["psk"] == result["auth"]["wpa3_psk"]
+        # Different secrets -> different tokens
+        assert result["radius_servers"][0]["shared_secret"] != result["radius_servers"][1]["shared_secret"]
+
+        # Tier 2 identifiers — tokenized
+        assert result["site_id"] != "11111111-1111-1111-1111-bbbbbbbbbbbb"
+        assert TOKEN_RE.fullmatch(result["site_id"]).group(1) == "SITE"
+        assert result["ssid"] != "Corp-Wifi"
+        assert TOKEN_RE.fullmatch(result["ssid"]).group(1) == "SSID"
+        assert result["device_name"] != "AP-Floor3-Conf"
+        assert TOKEN_RE.fullmatch(result["device_name"]).group(1) == "HOSTNAME"
+
+        # MAC — normalized, NOT tokenized
+        assert result["client_mac"] == "aa:bb:cc:dd:ee:ff"
+        assert "[[" not in result["client_mac"]
+
+        # Free-text scan — embedded email + MAC handled in description
+        assert "admin@corp.com" not in result["description"]
+        assert "[[EMAIL:" in result["description"]
+        assert "aa:bb:cc:dd:ee:ff" in result["description"]  # MAC normalized in place
+        assert "aa-bb-cc-dd-ee-ff" not in result["description"]
+
+        # Pass-through values preserved
+        assert result["channel"] == 36
+        assert result["rssi"] == -55
+        assert result["schedule"] == {"enabled": True, "hours": []}
+
+    def test_round_trip_secrets(self, tokenizer: Tokenizer, mist_wlan_response: dict) -> None:
+        tokenized = tokenize_response(mist_wlan_response, tokenizer)
+        psk_token = tokenized["auth"]["psk"]
+        # Now imagine the AI passes that token back to a write tool
+        outbound_args = {"site_id": tokenized["site_id"], "psk": psk_token}
+        detokenized, unknown = detokenize_arguments(outbound_args, tokenizer)
+        assert detokenized["psk"] == "OurOfficeWifi2024!"
+        assert detokenized["site_id"] == "11111111-1111-1111-1111-bbbbbbbbbbbb"
+        assert unknown == []


### PR DESCRIPTION
## Summary

Adds **session-stable PII tokenization** for tool responses + **always-on MAC normalization**. Sensitive fields (PSKs, RADIUS secrets, certs) and customer-identifying values (platform UUIDs, hostnames, emails, geographic data) are replaced with `[[KIND:uuid]]` tokens before reaching the AI; the AI can pass tokens back into write tools and the inbound side substitutes plaintext before the API call. Mapping held in process memory keyed by `Mcp-Session-Id`, never persisted to disk.

This is the v2.3.1.0 minor — the architecture for a long-discussed concern. Mist ruleset only this release; Central / GreenLake / ClearPass / Apstra / Axis follow in the next minor.

## What's new

- **`src/hpe_networking_mcp/redaction/` package** — five modules (rules, mac_normalizer, token_store, tokenizer, walker), ~700 LOC of pure logic with no platform dependencies.
- **`src/hpe_networking_mcp/middleware/pii_tokenization.py`** — bidirectional FastMCP middleware hooking `on_call_tool`. Inbound: walks `arguments` for `[[KIND:uuid]]` tokens, substitutes plaintext from the session keymap. Unknown tokens fail the call with a JSON-RPC error. Outbound: walks `ToolResult.structured_content` and JSON-shaped text content blocks; applies MAC normalization (always-on) and PII tokenization (when toggle is on).
- **`ENABLE_PII_TOKENIZATION=true`** to enable — off by default this minor; default flips to on in the next minor after Mist ruleset validation against real audits.
- **`PII_MAX_TOKENS_PER_SESSION=10000`** soft cap on per-session keymap size — cap-hit logs a warning and falls through with plaintext rather than erroring out the call.
- **MAC normalization is default-on regardless of the tokenization toggle.** Canonical form: `aa:bb:cc:dd:ee:ff` (lowercase, colon-separated). MACs are explicitly **not tokenized** per the design — observable to anyone in radio range, no security gain from privacy-tokenizing them.
- **Same plaintext gets the same token within a session** — enables WLAN sync, AOS 8 → AOS 10 migration, and mass PSK rotation workflows that need equality comparisons.
- **Token format: `[[KIND:550e8400-e29b-41d4-a716-446655440000]]`** — UUID4, 128 bits, collision probability effectively zero across any session size.
- **Audit logging** on every tokenize/detokenize event: tool name, param, kind, token ID, truncated SHA-256 value-hash, session prefix. Plaintext never logged.

## Tier 1 (secrets, always tokenized when enabled)

WPA / SAE / WEP keys, RADIUS / RadSec / SNMP / admin / VPN secrets, API tokens, OAuth credentials, certificates and private keys, keytabs, plus generic catch-alls (`password`, `secret`, `token`, `key`) gated by a credential-shape heuristic so template-style values like `{"key": "ssid"}` aren't tokenized.

## Tier 2 (identifiers)

Platform UUIDs (`org_id`, `site_id`, `device_id`, `wlan_id`, `client_id`, ...), operator-assigned names (`hostname`, `fqdn`, `ssid`, `device_name`, ...), user-identifying fields (`username`, `email`, `phone`, `first_name`, `last_name`), hardware identifiers (`serial`, `imei`, `imsi`), geographic data (`latitude`, `longitude`, `address`, `city`, ...).

## Tier 3 (free-text scan)

`description` / `notes` / `comment` / `remarks` / `details` are scanned for embedded secrets/identifiers. Substrings replaced; surrounding text preserved. Public DNS / loopback / RFC-documentation IPs preserved verbatim.

## Why now

Pre-2.3.1.0: a Mist scope-audit response contains every WLAN's PSK, RADIUS shared secrets, admin passwords, and operator-assigned names in cleartext. The AI ingests all of it and the AI provider sees it on every prompt. The `aos-migration-readiness` skill explicitly called this out as a known limitation.

Post-2.3.1.0: with `ENABLE_PII_TOKENIZATION=true`, the AI sees `[[PSK:550e8400-...]]` instead of the literal PSK, can pass that token into another write tool to clone or rotate, and the middleware substitutes the real PSK at the inbound boundary. WLAN sync, migration, and rotation all keep working because tokenization is round-trippable.

Composes well with code mode: the AI can call `secrets.token_urlsafe(20)` in the sandbox to generate a fresh PSK, pass it to a write tool, and only see the tokenized form in the `return` value — the literal lives in the sandbox's local scope and never enters the AI's context.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — `Success: no issues found in 197 source files`
- [x] `pytest tests/ -q` — **712 passed** (was 653; added 59 PII tests)
- [ ] After merge & `:latest` rebuild + `docker compose up -d --force-recreate`:
  - [ ] With `ENABLE_PII_TOKENIZATION=false` (default): MAC normalization still applies — `mist_get_wlans` returns `client_mac` in `aa:bb:cc:dd:ee:ff` form regardless of source format.
  - [ ] With `ENABLE_PII_TOKENIZATION=true`: `mist_get_wlans` returns `psk: "[[PSK:<uuid>]]"`, `radius_servers[*].shared_secret: "[[RADSEC:<uuid>]]"`, `site_id: "[[SITE:<uuid>]]"`. Same WLAN at two sites with the same PSK gets the same token.
  - [ ] Round-trip: with the same chat session, pass the `[[PSK:<uuid>]]` value into `manage_wlan_profile` and confirm the destination platform receives the real PSK (cross-check via Mist UI).
  - [ ] Audit log: `docker compose logs hpe-networking-mcp | grep pii` — every tokenize/detokenize event present, no plaintext, value-hash entries consistent for repeated values.

## Docs touched

- `CHANGELOG.md` — full v2.3.1.0 entry
- `README.md` — new "PII Tokenization (v2.3.1.0+)" section + `ENABLE_PII_TOKENIZATION` and `PII_MAX_TOKENS_PER_SESSION` rows in the Configuration table
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — new "Tokens you may see in tool results" section explaining `[[KIND:uuid]]` semantics to the AI (token kinds, round-trip, error response on unknown tokens)
- `pyproject.toml` — `2.3.0.9` → `2.3.1.0` (minor — substantial new feature, not a fix)

## Notes

- **Defaults off this release** — give us one minor to validate the Mist ruleset against real audit responses before flipping.
- **Other platforms next minor** — Central / GreenLake / ClearPass / Apstra / Axis tools work today (their responses pass through MAC normalization), but their platform-specific field names aren't fully covered in the ruleset yet. PR 2 extends.
- **Paste-into-chat is still exposed** — when the user types `psk=Welcome2024` into the prompt, the literal sits in the AI's context immediately. Outside our threat model. The API echo back gets tokenized so subsequent references stop leaking, but the originating turn does. Documented in INSTRUCTIONS.md.
- **No reveal mechanism** — there is no tool to retrieve plaintext for a token. Operators consult the audit log if they need to confirm what a token references; the platform UI is the source of truth.