### PR TITLE
v2.3.1.3: extend PII ruleset to Aruba Central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1.3] - 2026-04-30
+
+**Extends the PII tokenization ruleset to cover Aruba Central response shapes. Three new identifier fields (`user_name`, `updated_by`, `created_by`), one one-line normalization fix that lets hyphen-cased keys (`wpa-passphrase`, `shared-secret`) match the same ruleset entries as their snake_case equivalents. No protocol or API change; existing Mist tokenization is unaffected.**
+
+### What changed
+
+1. **`user_name`, `updated_by`, `created_by` added to `TOKENIZED_IDENTIFIER_FIELDS`** as `USER`. Central exposes these in audit log entries (`updated_by` = the operator who modified config, `created_by` = the operator who created it) and uses `user_name` as the snake_case variant alongside Mist-style `username`.
+
+2. **Hyphen normalization in `classify_field`** — field names are now lowercased AND have hyphens collapsed to underscores at lookup time (`field_name.lower().replace("-", "_")`). This makes the ruleset match Central's hyphenated keys without enumerating every variant. Concretely: `wpa-passphrase` now matches `wpa_passphrase` and tokenizes as `PSK`; `shared-secret` matches `shared_secret` and tokenizes as `RADSEC`.
+
+### Deliberately NOT added
+
+Per the v2.3.1.3 design discussion:
+
+- **`device_group_name`** — Central's group hierarchy. Organizational structure, not customer-identifying.
+- **`scope_name`** — Central's scope tree. Same reasoning.
+
+Both pass through as cleartext. Audit utility benefits from operators being able to read which group / scope was affected.
+
+### Tests
+
+- 732 passing (was 721) — net +11: 7 new field-classification tests covering `user_name`, `updated_by`, `created_by`, `device_group_name` passthrough, `scope_name` passthrough, hyphenated `wpa-passphrase`, hyphenated `shared-secret`; 4 new Central-shaped fixture tests covering WLAN profile walk, audit-log user-field tokenization, server-group RADIUS-secret tokenization, and a round-trip through hyphenated PSK fields.
+
+### What this unlocks
+
+Running an audit on Central with `ENABLE_PII_TOKENIZATION=true` should now produce useful output:
+
+- WLAN profile PSKs (`wpa-passphrase` inside `personal-security`) tokenize as `[[PSK:...]]`
+- Server group RADIUS shared secrets (`shared-secret`) tokenize as `[[RADSEC:...]]`
+- Audit log `updated_by` / `created_by` / `user_name` tokenize as `[[USER:...]]`
+- Device names / AP names (via the device-context heuristic) tokenize as `[[HOSTNAME:...]]`
+- Scope names, device group names, IPs, MACs, SSIDs, platform UUIDs all pass through cleartext
+
+### Cross-platform note
+
+GreenLake, ClearPass, Apstra, Axis still need their own ruleset extensions. Each likely follows the same shape (small set of platform-specific identifier fields + verify the existing secret rules cover their auth fields). One platform per follow-up patch.
+
 ## [2.3.1.2] - 2026-04-29
 
 **Closes four leaks / false positives surfaced by the first real Mist audit run with v2.3.1.1. Email addresses now tokenize anywhere they appear (not just in `email` fields), AWS-signed URLs are tokenized whole as APITOKEN credentials, the wxtag → HOSTNAME false positive is fixed, and IP addresses pass through as cleartext everywhere. No protocol or API change; existing PSK / RADSEC / cert / hostname tokenization continues unchanged.**

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ Tool responses are walked before reaching the AI:
 - **Email addresses** — caught even when the field is named `name`, `username`, or anything else. Mist's MPSK pattern of using the user's email as the PSK display name was a leak before this.
 - **AWS-signed URL credentials** — any string containing `X-Amz-Security-Token`, `X-Amz-Credential`, or `X-Amz-Signature` is treated as a temporary AWS credential and tokenized whole as `APITOKEN`. Catches the `portal_template_url` leak from Mist's S3-backed captive-portal previews.
 
+**Central coverage (v2.3.1.3):** the ruleset now also covers Central response shapes — `user_name`, `updated_by`, `created_by` (audit-log fields) tokenize as `USER`; hyphenated keys like `wpa-passphrase` and `shared-secret` match the same secret rules as their snake_case equivalents. Central organizational structure (`device_group_name`, `scope_name`) passes through as cleartext.
+
 **Round-trip works for every kind.** Same plaintext → same token within a session. WLAN sync, AOS 8 → AOS 10 migration, and mass PSK rotation all work because tokenization is round-trippable.
 
 **What the AI never sees in its context window:** WPA / SAE / WEP keys; RADIUS / RadSec / SNMP / admin / VPN secrets; API tokens (including AWS-signed URLs); certificates and private keys; hostnames / FQDNs / device names; **email addresses (anywhere they appear)**; usernames and personal names; phone numbers; hardware serial numbers / IMEI / IMSI / ICCID; embedded secrets in description/notes fields. **What it does see:** tokens for those values, MACs (normalized), SSIDs, platform UUIDs, geographic data, **all IP addresses (internal + public)**, and unchanged metric/enum/timestamp fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.1.2"
+version = "2.3.1.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -201,12 +201,15 @@ TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
     # User-identifying
     "username": TokenKind.USER,
     "user": TokenKind.USER,
+    "user_name": TokenKind.USER,  # Central uses snake_case alongside camelCase userName
     "login": TokenKind.USER,
     "email": TokenKind.EMAIL,
     "first_name": TokenKind.USER,
     "last_name": TokenKind.USER,
     "full_name": TokenKind.USER,
     "display_name": TokenKind.USER,
+    "updated_by": TokenKind.USER,  # Central audit logs: who modified config
+    "created_by": TokenKind.USER,  # Central audit logs: who created
     "phone": TokenKind.PHONE,
     "phone_number": TokenKind.PHONE,
     "mobile": TokenKind.PHONE,
@@ -218,11 +221,14 @@ TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
     "imsi": TokenKind.IMSI,
     "iccid": TokenKind.ICCID,
     # NOTE: platform UUID *_id fields (org_id, site_id, device_id,
-    # template_id, ...) are intentionally absent — they are already
-    # opaque random UUIDs in Mist's API; replacing one UUID with another
-    # adds no privacy. Geographic fields (address, city, state, zip,
-    # latitude, longitude, etc.) are also absent — addresses for
-    # business sites are typically findable on the company's website.
+    # template_id, scope_id, ...) are intentionally absent — they are
+    # already opaque random UUIDs in Mist's and Central's APIs; replacing
+    # one UUID with another adds no privacy. Geographic fields (address,
+    # city, state, zip, latitude, longitude, etc.) are also absent —
+    # addresses for business sites are typically findable on the company's
+    # website. Central-specific organizational structures (device_group_name,
+    # scope_name) are also absent — they describe network architecture
+    # rather than people, and audit utility benefits from cleartext.
 }
 
 # Field names where ``name`` should be tokenized as HOSTNAME — only when
@@ -383,7 +389,11 @@ def classify_field(
     """Decide how the walker should handle this (field, value).
 
     Args:
-        field_name: The JSON key. Compared case-insensitively.
+        field_name: The JSON key. Compared case-insensitively, with
+            hyphens normalized to underscores so that hyphenated API
+            keys (e.g. Aruba Central's ``wpa-passphrase`` inside
+            ``personal-security``) match the same ruleset entries as
+            their snake_case equivalents (added in v2.3.1.3).
         value: The value at that key — used for shape heuristics on
             generic credential field names.
         parent_keys: The set of sibling keys in the same dict, used to
@@ -396,7 +406,7 @@ def classify_field(
     """
     if not isinstance(field_name, str):
         return FieldClassification.SKIP, None
-    name = field_name.lower()
+    name = field_name.lower().replace("-", "_")
 
     # Exact-match secret fields
     if name in SECRET_FIELD_NAMES:

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -244,6 +244,49 @@ class TestFieldClassification:
         assert cls == FieldClassification.TOKENIZE_IDENTIFIER
         assert kind == TokenKind.HOSTNAME
 
+    # --- Central additions (v2.3.1.3) ---
+
+    def test_central_user_name_tokenized(self) -> None:
+        # Central uses snake_case `user_name` alongside Mist-style `username`
+        cls, kind = classify_field("user_name", "alice")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.USER
+
+    def test_central_updated_by_tokenized(self) -> None:
+        cls, kind = classify_field("updated_by", "admin@corp.com")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.USER
+
+    def test_central_created_by_tokenized(self) -> None:
+        cls, kind = classify_field("created_by", "automation-bot")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.USER
+
+    def test_central_device_group_name_passes_through(self) -> None:
+        # Per v2.3.1.3 design discussion: organizational structure, not
+        # customer-identifying. Operators benefit from cleartext.
+        cls, _ = classify_field("device_group_name", "Indianapolis Stores")
+        assert cls == FieldClassification.SKIP
+
+    def test_central_scope_name_passes_through(self) -> None:
+        cls, _ = classify_field("scope_name", "Global")
+        assert cls == FieldClassification.SKIP
+
+    def test_hyphenated_wpa_passphrase_tokenized_as_psk(self) -> None:
+        # Central's central_get_wlan_profiles returns raw API payloads
+        # with hyphenated keys (e.g. `wpa-passphrase` inside
+        # `personal-security`). The v2.3.1.3 hyphen normalization in
+        # classify_field maps these to the same ruleset entries as
+        # their snake_case equivalents.
+        cls, kind = classify_field("wpa-passphrase", "Welcome2024!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.PSK
+
+    def test_hyphenated_shared_secret_tokenized(self) -> None:
+        cls, kind = classify_field("shared-secret", "RadiusSharedSecret123!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.RADSEC
+
 
 class TestCredentialShapeHeuristic:
     def test_long_mixed_string_looks_credential(self) -> None:
@@ -663,4 +706,146 @@ class TestRealisticMistFixture:
         detokenized, unknown = detokenize_arguments(outbound_args, tokenizer)
         assert detokenized["psk"] == "OurOfficeWifi2024!"
         assert detokenized["site_id"] == "11111111-1111-1111-1111-bbbbbbbbbbbb"
+        assert unknown == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fixture: Central-shaped responses (v2.3.1.3)
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticCentralFixture:
+    """Walk Central-shaped tool responses through the pipeline."""
+
+    @pytest.fixture
+    def central_wlan_profile_response(self) -> dict:
+        # Shape mirrors central_get_wlan_profiles — raw API payload with
+        # Central's hyphenated camelCase-derived field names. The
+        # personal-security/wpa-passphrase nesting is the leak the
+        # v2.3.1.3 hyphen-normalization fixes.
+        return {
+            "scope_id": "22222222-2222-2222-2222-cccccccccccc",
+            "scope_name": "Indianapolis Office",
+            "device_group_name": "Indiana Stores",
+            "profile_data": {
+                "wlan_name": "Corp-Wifi",
+                "essid": "Corp-Wifi",
+                "personal-security": {
+                    "wpa-passphrase": "OurCentralWifi2024!",
+                    "wpa-passphrase-mode": "wpa3-personal",
+                },
+                "auth-server-group": "RadiusGroup-1",
+                "vlan_name": "Corporate",
+            },
+        }
+
+    @pytest.fixture
+    def central_audit_log_entry(self) -> dict:
+        # Shape mirrors central_get_audit_log_detail
+        return {
+            "id": "33333333-3333-3333-3333-dddddddddddd",
+            "scope_id": "22222222-2222-2222-2222-cccccccccccc",
+            "scope_name": "Global",
+            "device_group_name": "All Sites",
+            "action": "config_update",
+            "target_resource": "wlan-profile/Corp-Wifi",
+            "user_name": "alice.smith",
+            "updated_by": "alice.smith@corp.com",
+            "created_by": "automation-bot",
+            "created_at": "2026-04-30T10:00:00Z",
+            "updated_at": "2026-04-30T10:05:00Z",
+        }
+
+    @pytest.fixture
+    def central_server_group_response(self) -> dict:
+        # Shape mirrors central_get_server_groups — RADIUS server config
+        return {
+            "name": "RadiusGroup-1",
+            "scope_id": "22222222-2222-2222-2222-cccccccccccc",
+            "radius_servers": [
+                {
+                    "host": "10.50.10.10",
+                    "port": 1812,
+                    "shared-secret": "CentralRadiusSecret123!",
+                },
+                {
+                    "host": "10.50.10.11",
+                    "port": 1812,
+                    "shared-secret": "CentralRadiusSecret456!",
+                },
+            ],
+        }
+
+    def test_wlan_profile_walk(self, tokenizer: Tokenizer, central_wlan_profile_response: dict) -> None:
+        result = tokenize_response(central_wlan_profile_response, tokenizer)
+
+        # Hyphenated PSK field — caught by v2.3.1.3 hyphen normalization
+        assert "OurCentralWifi2024!" not in str(result)
+        psk_token = result["profile_data"]["personal-security"]["wpa-passphrase"]
+        assert TOKEN_RE.fullmatch(psk_token).group(1) == "PSK"
+
+        # Platform UUIDs — pass through (refined v2.3.1.1)
+        assert result["scope_id"] == "22222222-2222-2222-2222-cccccccccccc"
+
+        # Central organizational structure — pass through (per v2.3.1.3 design)
+        assert result["scope_name"] == "Indianapolis Office"
+        assert result["device_group_name"] == "Indiana Stores"
+
+        # SSID family — pass through (broadcast)
+        assert result["profile_data"]["wlan_name"] == "Corp-Wifi"
+        assert result["profile_data"]["essid"] == "Corp-Wifi"
+
+        # vlan_name — still tokenized as NAME
+        assert result["profile_data"]["vlan_name"] != "Corporate"
+        assert TOKEN_RE.fullmatch(result["profile_data"]["vlan_name"]).group(1) == "NAME"
+
+    def test_audit_log_user_fields_tokenized(self, tokenizer: Tokenizer, central_audit_log_entry: dict) -> None:
+        result = tokenize_response(central_audit_log_entry, tokenizer)
+
+        # New v2.3.1.3 user-identifying fields
+        assert result["user_name"] != "alice.smith"
+        assert TOKEN_RE.fullmatch(result["user_name"]).group(1) == "USER"
+        # updated_by has an email — universal email scan substring-tokenizes
+        assert "alice.smith@corp.com" not in str(result)
+        assert "[[USER:" in result["updated_by"] or "[[EMAIL:" in result["updated_by"]
+        assert result["created_by"] != "automation-bot"
+        assert TOKEN_RE.fullmatch(result["created_by"]).group(1) == "USER"
+
+        # Central organizational structure — pass through
+        assert result["scope_name"] == "Global"
+        assert result["device_group_name"] == "All Sites"
+
+        # Action / target resource / timestamps — pass through (operational metadata)
+        assert result["action"] == "config_update"
+        assert result["target_resource"] == "wlan-profile/Corp-Wifi"
+
+    def test_server_group_radius_secrets_tokenized(
+        self, tokenizer: Tokenizer, central_server_group_response: dict
+    ) -> None:
+        result = tokenize_response(central_server_group_response, tokenizer)
+
+        # Hyphenated shared-secret — caught by v2.3.1.3 hyphen normalization
+        assert "CentralRadiusSecret123!" not in str(result)
+        assert "CentralRadiusSecret456!" not in str(result)
+        for server in result["radius_servers"]:
+            secret_token = server["shared-secret"]
+            assert TOKEN_RE.fullmatch(secret_token).group(1) == "RADSEC"
+
+        # IPs — pass through everywhere (v2.3.1.2)
+        assert result["radius_servers"][0]["host"] == "10.50.10.10"
+        assert result["radius_servers"][1]["host"] == "10.50.10.11"
+
+        # Different secrets get different tokens
+        assert result["radius_servers"][0]["shared-secret"] != result["radius_servers"][1]["shared-secret"]
+
+    def test_round_trip_central_psk(self, tokenizer: Tokenizer, central_wlan_profile_response: dict) -> None:
+        # Verify the AI can take a tokenized PSK from a hyphenated-field
+        # response and pass it back into a write tool with the same
+        # field name.
+        tokenized = tokenize_response(central_wlan_profile_response, tokenizer)
+        psk_token = tokenized["profile_data"]["personal-security"]["wpa-passphrase"]
+
+        outbound_args = {"profile_data": {"personal-security": {"wpa-passphrase": psk_token}}}
+        detokenized, unknown = detokenize_arguments(outbound_args, tokenizer)
+        assert detokenized["profile_data"]["personal-security"]["wpa-passphrase"] == "OurCentralWifi2024!"
         assert unknown == []


### PR DESCRIPTION
## Summary

Extends the PII tokenization ruleset to cover Aruba Central response shapes. Three new identifier fields + one one-line normalization fix that lets hyphen-cased keys (`wpa-passphrase`, `shared-secret`) match the same ruleset entries as their snake_case equivalents. No protocol or API change; existing Mist tokenization is unaffected.

## What changed

1. **`user_name`, `updated_by`, `created_by` added to `TOKENIZED_IDENTIFIER_FIELDS`** as `USER`. Central exposes these in audit log entries (`updated_by` = the operator who modified config, `created_by` = the operator who created it) and uses `user_name` as the snake_case variant alongside Mist-style `username`.

2. **Hyphen normalization in `classify_field`** — field names are now lowercased AND have hyphens collapsed to underscores at lookup time (`field_name.lower().replace("-", "_")`). This lets the existing ruleset match Central's hyphenated keys without enumerating every variant. Concretely: `wpa-passphrase` now matches `wpa_passphrase` and tokenizes as `PSK`; `shared-secret` matches `shared_secret` and tokenizes as `RADSEC`.

## Deliberately NOT added

Per the v2.3.1.3 design discussion:

- **`device_group_name`** — Central's group hierarchy. Organizational structure, not customer-identifying.
- **`scope_name`** — Central's scope tree. Same reasoning.

Both pass through as cleartext. Audit utility benefits from operators being able to read which group / scope was affected.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `bandit -r src/ -c pyproject.toml` — `No issues identified`
- [x] `pytest tests/ -q` — **732 passed** (was 721; net +11)
- [ ] After merge & `:latest` rebuild + `docker compose down && pull && up -d`, with `ENABLE_PII_TOKENIZATION=true`:
  - [ ] Run a Central audit. Confirm WLAN profile PSKs (`wpa-passphrase` inside `personal-security`) tokenize as `[[PSK:...]]`.
  - [ ] Confirm server group RADIUS shared secrets (`shared-secret`) tokenize as `[[RADSEC:...]]`.
  - [ ] Confirm audit log `updated_by` / `created_by` / `user_name` tokenize as `[[USER:...]]`.
  - [ ] Confirm device names (via the device-context heuristic) tokenize as `[[HOSTNAME:...]]`.
  - [ ] Confirm scope names, device group names, IPs, MACs, SSIDs, platform UUIDs all pass through cleartext.

## Docs touched

- `CHANGELOG.md` — `[2.3.1.3]` entry covering both changes
- `README.md` — added "Central coverage" subsection to PII Tokenization
- `pyproject.toml` — `2.3.1.2` → `2.3.1.3` (patch — small ruleset extension)

## Cross-platform note (deferred)

GreenLake, ClearPass, Apstra, Axis still need their own ruleset extensions. Each likely follows the same shape (small set of platform-specific identifier fields + verify the existing secret rules cover their auth fields). One platform per follow-up patch.