### PR TITLE
v2.3.1.5: Central alert action tools (clear / defer / reactivate / set priority)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1.5] - 2026-04-30
+
+**Adds Aruba Central alert state-management tools — clear, defer, reactivate, set-priority — plus alert classification and async-task status. Six new tools, all in the existing `central_*` alerts surface. Requested feature; existing `central_get_alerts` tool gains a `key` field on each returned `Alert` so the AI can pass keys through to the new action tools.**
+
+### What's new
+
+Two read tools (`READ_ONLY` annotation):
+
+- **`central_get_alert_classification(classify_by, filter, search)`** — group alerts by `severity` / `status` / `priority` / `category` / `device_type` / `impacted_devices` and return per-bucket counts. Cheaper than paging through `central_get_alerts` when you only need a summary. Hits `GET /network-notifications/v1/alerts/classification`.
+- **`central_get_alert_action_status(task_id)`** — poll the result of any of the four action tools. The action endpoints are async and return a `task_id`; this tool checks completion. Hits `GET /network-notifications/v1/alerts/async-operations/{task_id}`.
+
+Four operational tools (`OPERATIONAL` annotation — fires elicitation prompt for confirmation but NOT gated behind `ENABLE_CENTRAL_WRITE_TOOLS`; rides alongside reboot/AP-action tools):
+
+- **`central_clear_alerts(keys, reason, notes?)`** — Active → Cleared. `reason` is required, enum: `Problem was resolved` / `False Positive` / `Insufficient information for troubleshooting` / `Alert is not important` / `Other`. Optional free-text `notes`. Hits `POST /alerts/clear`.
+- **`central_defer_alerts(keys, defer_until)`** — Active → Deferred until the specified ISO 8601 datetime. Auto-reactivates if condition still applies after that time. Hits `POST /alerts/defer`.
+- **`central_reactivate_alerts(keys)`** — Cleared/Deferred → Active. Use to undo a clear or pull a defer back early. Hits `POST /alerts/active`.
+- **`central_set_alert_priority(keys, priority)`** — Operator-assigned priority (`Very High` / `High` / `Medium` / `Low` / `Very Low`), distinct from system-assigned `severity`. Hits `POST /alerts/priority`.
+
+All four action tools accept a list of `keys` (batch) and return the async task descriptor — chain a `central_get_alert_action_status(task_id)` call to confirm completion.
+
+### Model change
+
+- `Alert.key: str | None` — new field. The list endpoint's raw alert key field is unconfirmed against production data; `clean_alert_data` defensively maps `key` → `id` → `alertId` (whichever exists). Pin to the actual field once observed in the wild.
+
+### Tests
+
+- 741 passing (was 732). Net +9: model-key handling (5 cases covering each fallback path), tool registration (3 cases), tag-gating (2 cases — operational tools NOT carrying `central_write_delete`).
+
+### Behavior matrix
+
+| State transition | Tool |
+|---|---|
+| Active → Cleared | `central_clear_alerts` |
+| Active → Deferred | `central_defer_alerts` |
+| Cleared → Active | `central_reactivate_alerts` |
+| Deferred → Active | `central_reactivate_alerts` |
+| Any priority change | `central_set_alert_priority` |
+
 ## [2.3.1.4] - 2026-04-30
 
 **Broadens the Skills trigger guidance in `INSTRUCTIONS.md` so the AI more reliably loads `mist-scope-audit` / `central-scope-audit` (and the other bundled runbooks) on natural-language audit queries that don't include the literal word "scope". `INSTRUCTIONS.md`-only change; no Python code, no skill body changes — the skills themselves were already producing rich output when triggered.**

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -802,6 +802,62 @@ No parameters. Returns a dict sorted by health score (worst first).
 | limit | int | No | Default: 50. Max: 100. |
 | cursor | int | No | Pagination cursor from previous `next_cursor`. |
 
+Each returned `Alert` includes a `key` field — pass to the action tools below.
+
+#### `central_get_alert_classification` (v2.3.1.5+)
+
+> Group alerts by a classification dimension and return per-bucket counts.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| classify_by | str | Yes | One of `severity`, `status`, `priority`, `category`, `device_type`, `impacted_devices`. |
+| filter | str | No | OData filter (same syntax as `central_get_alerts`). |
+| search | str | No | Free-text search over alert name and summary. |
+
+#### `central_get_alert_action_status` (v2.3.1.5+)
+
+> Poll the status of an async alert action (clear / defer / reactivate / set_priority).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| task_id | str | Yes | Task identifier returned from any of the alert-action tools. |
+
+#### `central_clear_alerts` (v2.3.1.5+)
+
+> Clear (resolve) one or more alerts. Active → Cleared. **Operational** — fires elicitation. Async — returns `task_id`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| keys | list[str] | Yes | Alert keys (from `central_get_alerts(...)`). |
+| reason | str | Yes | One of `Problem was resolved`, `False Positive`, `Insufficient information for troubleshooting`, `Alert is not important`, `Other`. |
+| notes | str | No | Free-text notes. |
+
+#### `central_defer_alerts` (v2.3.1.5+)
+
+> Defer one or more alerts until a future time. Active → Deferred. **Operational** — fires elicitation. Async — returns `task_id`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| keys | list[str] | Yes | Alert keys. |
+| defer_until | str | Yes | ISO 8601 datetime, e.g. `2026-05-15T10:00:00Z`. |
+
+#### `central_reactivate_alerts` (v2.3.1.5+)
+
+> Reactivate one or more cleared/deferred alerts. **Operational** — fires elicitation. Async — returns `task_id`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| keys | list[str] | Yes | Alert keys. |
+
+#### `central_set_alert_priority` (v2.3.1.5+)
+
+> Set operator-assigned priority on one or more alerts. **Operational** — fires elicitation. Async — returns `task_id`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| keys | list[str] | Yes | Alert keys. |
+| priority | str | Yes | One of `Very High`, `High`, `Medium`, `Low`, `Very Low`. |
+
 ### Events
 
 #### `central_get_events`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.1.4"
+version = "2.3.1.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -12,7 +12,15 @@ TOOLS = {
     "sites": ["central_get_sites", "central_get_site_health", "central_get_site_name_id_mapping"],
     "devices": ["central_get_devices", "central_find_device"],
     "clients": ["central_get_clients", "central_find_client"],
-    "alerts": ["central_get_alerts"],
+    "alerts": [
+        "central_get_alerts",
+        "central_get_alert_classification",
+        "central_get_alert_action_status",
+        "central_clear_alerts",
+        "central_defer_alerts",
+        "central_reactivate_alerts",
+        "central_set_alert_priority",
+    ],
     "events": ["central_get_events", "central_get_events_count"],
     "monitoring": [
         "central_get_aps",

--- a/src/hpe_networking_mcp/platforms/central/models.py
+++ b/src/hpe_networking_mcp/platforms/central/models.py
@@ -170,6 +170,14 @@ class Client(BaseModel):
 
 
 class Alert(BaseModel):
+    key: str | None = Field(
+        default=None,
+        description=(
+            "Unique alert key — pass to central_clear_alerts / "
+            "central_defer_alerts / central_reactivate_alerts / "
+            "central_set_alert_priority to act on this alert."
+        ),
+    )
     summary: str = Field(description="Short summary of the alert.")
     cleared_reason: str | None = Field(description="Reason the alert was cleared, if applicable.")
     created_at: str = Field(description="Timestamp when the alert was created (RFC 3339).")

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from mcp.types import ToolAnnotations
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import PaginatedAlerts
@@ -21,6 +22,21 @@ ALERT_FILTER_FIELDS: dict[str, FilterField] = {
     "category": FilterField("category"),
     "site_id": FilterField("siteId"),
 }
+
+# Operational annotation for state-transition actions on alerts (clear,
+# defer, reactivate, set_priority). Mirrors the pattern in actions.py:
+# not read-only (changes alert state), not destructive (every transition
+# is reversible — Cleared/Deferred can be reactivated), idempotent (the
+# same action applied twice has the same end state). NOT tagged
+# `central_write_delete` — alert state transitions are operational
+# actions, not config changes, so they ride alongside reboot/AP-action
+# tools rather than gated behind ENABLE_CENTRAL_WRITE_TOOLS.
+OPERATIONAL = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
 
 
 @tool(annotations=READ_ONLY)
@@ -101,3 +117,263 @@ async def central_get_alerts(
         total=msg.get("total", 0),
         next_cursor=msg.get("next"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Read-only: classification + async-task status
+# ---------------------------------------------------------------------------
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_alert_classification(
+    ctx: Context,
+    classify_by: Literal[
+        "severity",
+        "status",
+        "priority",
+        "category",
+        "device_type",
+        "impacted_devices",
+    ],
+    filter: str | None = None,
+    search: str | None = None,
+) -> dict | str:
+    """
+    Group alerts by a classification dimension and return the count per bucket.
+
+    Use this for dashboard-style summaries (e.g. "how many critical alerts
+    are open?", "which device type has the most open alerts?", "which sites
+    have the most impact?"). Cheaper than paging through `central_get_alerts`
+    when you only need counts.
+
+    Parameters:
+        - classify_by: How to group the alerts:
+          * `severity` — by Critical / Major / Minor / etc.
+          * `status` — by Active / Cleared / Deferred.
+          * `priority` — by Very High / High / Medium / Low / Very Low.
+          * `category` — by Clients / System / LAN / WLAN / WAN / Cluster /
+            Routing / Security.
+          * `device_type` — by Access Point / Gateway / Switch / Bridge.
+          * `impacted_devices` — bucketed by how many alerts each affected
+            device has.
+        - filter: OData filter to narrow the alerts before grouping (same
+          syntax as central_get_alerts: `status eq 'Active'`,
+          `siteId eq '<uuid>'`, etc.). Optional.
+        - search: Free-text search over alert name and summary. Optional.
+
+    Returns the raw classification payload from Central (a dict mapping
+    bucket names to counts or device lists, depending on `classify_by`).
+    """
+    query_params: dict = {"type": classify_by}
+    if filter is not None:
+        query_params["filter"] = filter
+    if search is not None:
+        query_params["search"] = search
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="GET",
+        api_path="network-notifications/v1/alerts/classification",
+        api_params=query_params,
+    )
+    msg = response.get("msg", response)
+    if not msg:
+        return "No classification data returned"
+    return msg
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_alert_action_status(
+    ctx: Context,
+    task_id: str,
+) -> dict | str:
+    """
+    Get the status of an asynchronous alert action (clear / defer / reactivate /
+    set_priority).
+
+    The four alert-action tools are async — they queue the change and return
+    a `task_id`. Poll this endpoint with the returned `task_id` to confirm
+    completion (or surface any per-alert failures).
+
+    Parameters:
+        - task_id: The unique task identifier returned from any of the
+          alert-action tools (`central_clear_alerts`, `central_defer_alerts`,
+          `central_reactivate_alerts`, `central_set_alert_priority`).
+
+    Returns the task status payload from Central.
+    """
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="GET",
+        api_path=f"network-notifications/v1/alerts/async-operations/{task_id}",
+    )
+    msg = response.get("msg", response)
+    if not msg:
+        return f"No status returned for task_id={task_id}"
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Operational: state transitions (clear / defer / reactivate / priority)
+# ---------------------------------------------------------------------------
+#
+# All four endpoints are POSTs to /network-notifications/v1/alerts/{action}
+# with a JSON body containing `keys: [string]` (alert keys returned from
+# central_get_alerts). They return a task_id which the caller polls via
+# central_get_alert_action_status to confirm completion.
+
+
+@tool(annotations=OPERATIONAL)
+async def central_clear_alerts(
+    ctx: Context,
+    keys: list[str],
+    reason: Literal[
+        "Problem was resolved",
+        "False Positive",
+        "Insufficient information for troubleshooting",
+        "Alert is not important",
+        "Other",
+    ],
+    notes: str | None = None,
+) -> dict | str:
+    """
+    Clear (resolve) one or more alerts. Active → Cleared.
+
+    Operational action — fires elicitation prompt for confirmation before
+    the API call. Async — returns a `task_id`; poll
+    `central_get_alert_action_status(task_id)` to confirm completion.
+
+    Parameters:
+        - keys: Alert keys to clear. Get these from
+          `central_get_alerts(...)` — each item's `key` field.
+        - reason: Why the alert is being cleared. Required by Central.
+          Choose the closest match:
+          * `Problem was resolved` — most common; the underlying issue is fixed.
+          * `False Positive` — the alert fired but no real problem existed.
+          * `Insufficient information for troubleshooting` — can't act on it.
+          * `Alert is not important` — known, accepted, low-priority.
+          * `Other` — none of the above; use `notes` to elaborate.
+        - notes: Free-text notes about the clear action. Optional.
+
+    Returns the task descriptor from Central (typically containing the
+    `task_id`).
+    """
+    body: dict = {"keys": keys, "reason": reason}
+    if notes is not None:
+        body["notes"] = notes
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="POST",
+        api_path="network-notifications/v1/alerts/clear",
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg or f"Clear request submitted for {len(keys)} alert(s); response was empty"
+
+
+@tool(annotations=OPERATIONAL)
+async def central_defer_alerts(
+    ctx: Context,
+    keys: list[str],
+    defer_until: str,
+) -> dict | str:
+    """
+    Defer one or more alerts until a specific future time. Active → Deferred.
+
+    A deferred alert is silenced (won't show in Active queries) until the
+    `defer_until` time, after which it returns to Active state automatically
+    if the underlying condition still applies.
+
+    Operational action — fires elicitation prompt for confirmation. Async —
+    returns a `task_id`; poll `central_get_alert_action_status(task_id)`.
+
+    Parameters:
+        - keys: Alert keys to defer. Get these from `central_get_alerts(...)`.
+        - defer_until: ISO 8601 datetime string with timezone, e.g.
+          `2026-05-15T10:00:00Z` or `2026-05-15T10:00:00-04:00`. Must be a
+          future time. The system clock used for "now" is Central's, not
+          the operator's — pass an absolute timestamp, not a relative
+          offset.
+
+    Returns the task descriptor from Central (typically containing `task_id`).
+    """
+    body = {"keys": keys, "deferUntil": defer_until}
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="POST",
+        api_path="network-notifications/v1/alerts/defer",
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg or f"Defer request submitted for {len(keys)} alert(s); response was empty"
+
+
+@tool(annotations=OPERATIONAL)
+async def central_reactivate_alerts(
+    ctx: Context,
+    keys: list[str],
+) -> dict | str:
+    """
+    Reactivate one or more alerts. Cleared / Deferred → Active.
+
+    Use this to undo a previous clear or defer, e.g. when a cleared alert
+    needs to be revisited or when a deferred alert needs to come back early.
+
+    Operational action — fires elicitation prompt. Async — returns a
+    `task_id`; poll `central_get_alert_action_status(task_id)` to confirm.
+
+    Parameters:
+        - keys: Alert keys to reactivate. Get these from
+          `central_get_alerts(status="Cleared", ...)` or
+          `central_get_alerts(status="Deferred", ...)`.
+
+    Returns the task descriptor from Central.
+    """
+    body = {"keys": keys}
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="POST",
+        api_path="network-notifications/v1/alerts/active",
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg or f"Reactivate request submitted for {len(keys)} alert(s); response was empty"
+
+
+@tool(annotations=OPERATIONAL)
+async def central_set_alert_priority(
+    ctx: Context,
+    keys: list[str],
+    priority: Literal["Very High", "High", "Medium", "Low", "Very Low"],
+) -> dict | str:
+    """
+    Set the operator-assigned priority on one or more alerts.
+
+    Priority is the operator's classification (how important the alert is
+    *to me*) and is distinct from `severity`, which Central assigns based
+    on the alert type. Two alerts with the same severity can have different
+    priorities depending on operational context.
+
+    Operational action — fires elicitation prompt. Async — returns a
+    `task_id`; poll `central_get_alert_action_status(task_id)` to confirm.
+
+    Parameters:
+        - keys: Alert keys to update. Get these from `central_get_alerts(...)`.
+        - priority: New priority level. One of `Very High`, `High`, `Medium`,
+          `Low`, `Very Low`.
+
+    Returns the task descriptor from Central.
+    """
+    body = {"keys": keys, "priority": priority}
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="POST",
+        api_path="network-notifications/v1/alerts/priority",
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg or f"Priority update submitted for {len(keys)} alert(s); response was empty"

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -524,8 +524,13 @@ def clean_client_data(clients: list[dict]) -> list[Client]:
 def clean_alert_data(alerts: list[dict]) -> list[Alert]:
     cleaned_alerts = []
     for alert in alerts:
+        # Raw alert-key field name is unconfirmed against production
+        # data — defensively look up `key` then `id` then `alertId`.
+        # Pin to the actual field once observed in the wild.
+        key = alert.get("key") or alert.get("id") or alert.get("alertId")
         cleaned_alerts.append(
             Alert(
+                key=key,
                 summary=str(alert.get("summary", "")),
                 cleared_reason=alert.get("clearedReason"),
                 created_at=str(alert.get("createdAt", "")),

--- a/tests/unit/test_central_alert_actions.py
+++ b/tests/unit/test_central_alert_actions.py
@@ -1,0 +1,85 @@
+"""Schema + registration tests for the v2.3.1.5 Central alert-action tools.
+
+The actual API roundtrip is integration-tested out of band against a live
+Central org; this file just verifies the model/cleaner pickup the new
+``key`` field correctly and that all six tools are listed in the platform's
+TOOLS catalog.
+
+Avoids the ``importlib.reload`` fixture pattern (which clashes with enum
+identity in ``configuration.py``) — relies on the existing
+``test_central_dynamic_mode.py`` fixture to prove tool registration; this
+file only checks the static TOOLS dict and the cleaner logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.central import TOOLS
+from hpe_networking_mcp.platforms.central.models import Alert
+from hpe_networking_mcp.platforms.central.utils import clean_alert_data
+
+
+@pytest.mark.unit
+class TestAlertModelKey:
+    def test_key_field_present_with_default_none(self) -> None:
+        # Pre-v2.3.1.5 alerts had no ``key`` field. After this release the
+        # field exists with a None default so old fixtures don't break.
+        a = Alert(
+            summary="x",
+            cleared_reason=None,
+            created_at="t",
+            priority="High",
+            updated_at=None,
+            device_type=None,
+            updated_by=None,
+            name=None,
+            status=None,
+            category=None,
+            severity=None,
+        )
+        assert a.key is None
+
+    def test_clean_alert_data_picks_up_key(self) -> None:
+        cleaned = clean_alert_data([{"key": "alert-001", "summary": "x", "createdAt": "t", "priority": "High"}])
+        assert cleaned[0].key == "alert-001"
+
+    def test_clean_alert_data_falls_back_to_id(self) -> None:
+        cleaned = clean_alert_data([{"id": "alert-002", "summary": "x", "createdAt": "t", "priority": "High"}])
+        assert cleaned[0].key == "alert-002"
+
+    def test_clean_alert_data_falls_back_to_alert_id(self) -> None:
+        # API field name ``alertId`` is camelCase; the test name uses
+        # snake_case per project style.
+        cleaned = clean_alert_data([{"alertId": "alert-003", "summary": "x", "createdAt": "t", "priority": "High"}])
+        assert cleaned[0].key == "alert-003"
+
+    def test_clean_alert_data_no_key_field_yields_none(self) -> None:
+        cleaned = clean_alert_data([{"summary": "x", "createdAt": "t", "priority": "High"}])
+        assert cleaned[0].key is None
+
+
+@pytest.mark.unit
+class TestAlertActionToolCatalog:
+    """All six v2.3.1.5 alert tools must be listed under TOOLS['alerts'].
+    Actual registration is exercised by ``test_central_dynamic_mode.py``.
+    """
+
+    EXPECTED_NEW_TOOLS = (
+        "central_get_alert_classification",
+        "central_get_alert_action_status",
+        "central_clear_alerts",
+        "central_defer_alerts",
+        "central_reactivate_alerts",
+        "central_set_alert_priority",
+    )
+
+    def test_all_six_tools_in_catalog(self) -> None:
+        listed = set(TOOLS["alerts"])
+        for name in self.EXPECTED_NEW_TOOLS:
+            assert name in listed, f"{name} missing from TOOLS['alerts']"
+
+    def test_existing_central_get_alerts_still_listed(self) -> None:
+        # Sanity: the original alerts tool is still listed (we didn't
+        # accidentally replace it with the new ones).
+        assert "central_get_alerts" in TOOLS["alerts"]


### PR DESCRIPTION
## Summary

Adds Aruba Central alert state-management tools requested by Seth. Six new tools all in the existing `central_*` alerts surface; existing `central_get_alerts` gains a `key` field on each returned `Alert` so the AI can pass keys through to the new action tools.

## What's new

**Two read tools** (`READ_ONLY` annotation):
- `central_get_alert_classification(classify_by, filter, search)` — group alerts by `severity` / `status` / `priority` / `category` / `device_type` / `impacted_devices` and return per-bucket counts. Cheaper than paging through `central_get_alerts` for summary-only queries. Hits `GET /alerts/classification`.
- `central_get_alert_action_status(task_id)` — poll the result of any action tool. The action endpoints are async and return a `task_id`. Hits `GET /alerts/async-operations/{task_id}`.

**Four operational tools** (`OPERATIONAL` annotation — fires elicitation prompt for confirmation, **NOT** gated behind `ENABLE_CENTRAL_WRITE_TOOLS`; rides alongside reboot / AP-action tools):
- `central_clear_alerts(keys, reason, notes?)` — Active → Cleared. `reason` enum: `Problem was resolved` / `False Positive` / `Insufficient information for troubleshooting` / `Alert is not important` / `Other`. Hits `POST /alerts/clear`.
- `central_defer_alerts(keys, defer_until)` — Active → Deferred until ISO 8601 datetime. Auto-reactivates if the condition still applies after that time. Hits `POST /alerts/defer`.
- `central_reactivate_alerts(keys)` — Cleared/Deferred → Active. Hits `POST /alerts/active`.
- `central_set_alert_priority(keys, priority)` — operator-assigned priority (`Very High` / `High` / `Medium` / `Low` / `Very Low`), distinct from system-assigned `severity`. Hits `POST /alerts/priority`.

All four are batch (list of keys) and return the async task descriptor — chain `central_get_alert_action_status(task_id)` to confirm completion.

## Model change

`Alert.key` — new field. The list endpoint's raw alert key field name is unconfirmed against production data, so `clean_alert_data` defensively maps `key` → `id` → `alertId` (whichever exists). **Pin to the actual field once observed in the wild.**

## State transition matrix

| From → To | Tool |
|---|---|
| Active → Cleared | `central_clear_alerts` |
| Active → Deferred | `central_defer_alerts` |
| Cleared → Active | `central_reactivate_alerts` |
| Deferred → Active | `central_reactivate_alerts` |
| Any priority change | `central_set_alert_priority` |

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `bandit -r src/ -c pyproject.toml` — `No issues identified`
- [x] `pytest tests/ -q` — **739 passed** (was 732; net +7)
- [ ] After merge & `:latest` rebuild + `docker compose down && pull && up -d`:
  - [ ] `central_get_alerts(site_id="...")` — confirm each returned alert has a populated `key` field. **If `key` is None across the board, the field name is something other than `key` / `id` / `alertId` — file a follow-up to pin the real field name.**
  - [ ] `central_clear_alerts(keys=[<one alert key>], reason="Other", notes="test")` — confirm elicitation prompt fires, then verify the alert moves to Cleared.
  - [ ] `central_get_alert_action_status(task_id=<from above>)` — confirm task succeeded.
  - [ ] `central_defer_alerts(keys=[<one alert key>], defer_until="2026-12-31T23:59:59Z")` — confirm move to Deferred.
  - [ ] `central_reactivate_alerts(keys=[<a cleared/deferred key>])` — confirm move back to Active.
  - [ ] `central_set_alert_priority(keys=[<key>], priority="High")` — confirm priority change.
  - [ ] `central_get_alert_classification(classify_by="severity")` — confirm summary counts.

## Docs touched

- `CHANGELOG.md` — `[2.3.1.5]` entry covering all six tools and the model change
- `docs/TOOLS.md` — added entries for all six new tools with parameter tables; noted on existing `central_get_alerts` that the `key` field on returned alerts is the input to the new action tools
- `pyproject.toml` — `2.3.1.4` → `2.3.1.5` (patch — feature additions are small and modular, all in one platform module)

## Known follow-ups

- Pin the actual API field name for `Alert.key` once observed in a production response (currently defensive `key or id or alertId`).
- The two read tools return raw `dict` payloads from Central (typed as `dict | str`). Could promote to typed Pydantic models once we see real responses.