### PR TITLE
v2.3.1.6: Central alert configuration tools (create / update / reset / list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1.6] - 2026-04-30
+
+**Adds Aruba Central alert *configuration* management — the rules that determine when alerts fire — wrapping the four `/network-notifications/v1/alert-config` endpoints. Distinct from v2.3.1.5's alert *action* tools (clear / defer / reactivate / set-priority) which act on already-fired alert instances; these manage the alert system's threshold definitions. New module `tools/alert_configs.py`; the existing `tools/alerts.py` is left at its current size below the 500-line cap.**
+
+### What's new
+
+One read tool (`READ_ONLY` annotation):
+
+- **`central_get_alert_configs(scope_id, scope_type?)`** — list the alert configurations defined at a scope. Each item carries `inherited: true/false` (whether this scope has its own override or is using a parent's config) and `ruleSource: SYSTEM | USER` (Central built-in vs. operator-customized). Hits `GET /alert-config`.
+
+Three write tools (`WRITE_DELETE` annotation, tagged `central_write_delete`, gated behind `ENABLE_CENTRAL_WRITE_TOOLS`, fire elicitation):
+
+- **`central_create_alert_config(type_id, scope_id, enabled, clear_timeout?, rules?, scope_type?)`** — create a custom alert configuration. Hits `POST /alert-config/create`.
+- **`central_update_alert_config(type_id, scope_id, enabled?, clear_timeout?, rules?, scope_type?)`** — update existing. Despite using HTTP PUT, the API behaves like PATCH: fields you omit are preserved. Hits `PUT /alert-config/update`.
+- **`central_reset_alert_config(type_id, scope_id, scope_type?)`** — remove the scope-level override and revert to inherited (parent-scope) configuration. The alert *type* is not deleted; only the override at this scope. Hits `DELETE /alert-config/delete`.
+
+### Annotation choice
+
+These tools are `WRITE_DELETE` (gated behind `ENABLE_CENTRAL_WRITE_TOOLS`) — different from v2.3.1.5's alert-action tools which were `OPERATIONAL`. Reasoning:
+
+- v2.3.1.5 tools act on alert *instances* — operational state transitions, like rebooting a switch.
+- v2.3.1.6 tools act on alert *definitions* — config writes that change what the system tracks. Same threat model as managing roles, policies, WLAN profiles. Belongs in the gated write surface.
+
+### Rule shape
+
+Both `create` and `update` accept a `rules: list[dict] | None` parameter with the API's literal camelCase shape:
+
+```python
+rules=[
+    {
+        "ruleNumber": 0,
+        "duration": 300,                 # seconds metric must stay over threshold
+        "conditions": [
+            {"severity": "CRITICAL", "operator": "GT", "threshold": 90.0},
+            {"severity": "MAJOR",    "operator": "GT", "threshold": 80.0},
+        ],
+        "additionalConditions": [],
+    },
+]
+```
+
+- Severity values: `CRITICAL`, `MAJOR`, `MINOR`, `INFO`.
+- Operator values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`.
+- `clearTimeout` format: `<number><unit>` where unit is `H`/`h` (hours), `D`/`d` (days), or `M`/`m` (minutes) — e.g. `1H`, `30D`, `15m`.
+
+The tool docstrings include the full shape + enum reference inline so the AI can construct rules without consulting external docs.
+
+### Scope semantics
+
+The `scope_type` parameter on every tool accepts `GLOBAL` (tenant-wide, default), `SITE` (per-site), or `DEVICE` (per-device). `GLOBAL` is the default if omitted, matching the API.
+
+### Tests
+
+- 741 passing (was 739). Net +2: catalog assertions for the four new tools (no fixture — avoids the v2.3.1.5 `importlib.reload` clash with `configuration.py`'s `ActionType` enum identity); the existing `test_central_dynamic_mode.py` `test_write_tools_carry_write_delete_tag` test was extended to cover the three new write tools, plus a new `test_alert_config_read_has_no_write_tag` for the read tool.
+
 ## [2.3.1.5] - 2026-04-30
 
 **Adds Aruba Central alert state-management tools — clear, defer, reactivate, set-priority — plus alert classification and async-task status. Six new tools, all in the existing `central_*` alerts surface. Requested feature; existing `central_get_alerts` tool gains a `key` field on each returned `Alert` so the AI can pass keys through to the new action tools.**

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -858,6 +858,72 @@ Each returned `Alert` includes a `key` field — pass to the action tools below.
 | keys | list[str] | Yes | Alert keys. |
 | priority | str | Yes | One of `Very High`, `High`, `Medium`, `Low`, `Very Low`. |
 
+### Alert Configurations (v2.3.1.6+)
+
+Manage alert *definitions* — the rules that determine when alerts fire (thresholds, durations, severity buckets). Distinct from the alert action tools above which act on already-fired alert instances.
+
+#### `central_get_alert_configs`
+
+> List alert configurations defined at the given scope. Each item shows `inherited` (using parent's config?) and `ruleSource` (`SYSTEM` vs. `USER`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | Yes | Scope identifier. From `central_get_scope_tree` or `central_get_scope_resources`. |
+| scope_type | str | No | Default: `GLOBAL`. Also `SITE` or `DEVICE`. |
+
+#### `central_create_alert_config`
+
+> Create a custom alert configuration. **Write** — fires elicitation, gated behind `ENABLE_CENTRAL_WRITE_TOOLS`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| type_id | str | Yes | Alert type identifier (e.g. `1250` or `CUSTOM-AP-CPU-HIGH`). |
+| scope_id | str | Yes | Where to apply the config. |
+| enabled | bool | Yes | Whether the alert fires when conditions are met. |
+| clear_timeout | str | No | Duration for auto-clear (`1H`, `30D`, `15m`). Pass None to omit. |
+| rules | list[dict] | No | Threshold rules. See shape below. |
+| scope_type | str | No | Default: `GLOBAL`. Also `SITE` or `DEVICE`. |
+
+Rule shape:
+
+```python
+{
+    "ruleNumber": 0,
+    "duration": 300,
+    "conditions": [
+        {"severity": "CRITICAL", "operator": "GT", "threshold": 90.0},
+        {"severity": "MAJOR",    "operator": "GT", "threshold": 80.0},
+    ],
+    "additionalConditions": [],
+}
+```
+
+- Severity: `CRITICAL`, `MAJOR`, `MINOR`, `INFO`
+- Operator: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`
+
+#### `central_update_alert_config`
+
+> Update an existing alert configuration. Partial update — fields you omit are left unchanged. **Write** — fires elicitation.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| type_id | str | Yes | Alert type identifier. |
+| scope_id | str | Yes | Scope where the config currently lives. |
+| enabled | bool | No | Toggle on/off. Omit to leave unchanged. |
+| clear_timeout | str | No | New auto-clear duration. Omit to leave unchanged. |
+| rules | list[dict] | No | Replace the rule set. Omit to leave unchanged. |
+| scope_type | str | No | Default: `GLOBAL`. Also `SITE` or `DEVICE`. |
+
+#### `central_reset_alert_config`
+
+> Reset to inherited (parent scope) — removes the scope-level override. The alert type is NOT deleted. **Write** — fires elicitation.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| type_id | str | Yes | Alert type identifier of the override to reset. |
+| scope_id | str | Yes | Scope where the override currently lives. |
+| scope_type | str | No | Default: `GLOBAL`. Also `SITE` or `DEVICE`. |
+
 ### Events
 
 #### `central_get_events`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.1.5"
+version = "2.3.1.6"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -21,6 +21,12 @@ TOOLS = {
         "central_reactivate_alerts",
         "central_set_alert_priority",
     ],
+    "alert_configs": [
+        "central_get_alert_configs",
+        "central_create_alert_config",
+        "central_update_alert_config",
+        "central_reset_alert_config",
+    ],
     "events": ["central_get_events", "central_get_events_count"],
     "monitoring": [
         "central_get_aps",

--- a/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
@@ -1,0 +1,274 @@
+"""Aruba Central alert configuration tools (v2.3.1.6+).
+
+Manages alert *definitions* — the rules that determine what triggers an
+alert, the threshold values, durations, and severity buckets. Distinct
+from `alerts.py` which manages alert *instances* (clear / defer /
+reactivate fired alerts).
+
+The four endpoints under `/network-notifications/v1/alert-config`:
+
+* GET  `/alert-config`         — list configs for a scope
+* POST `/alert-config/create`  — create a custom config for a typeId+scope
+* PUT  `/alert-config/update`  — update an existing config (partial — only
+                                  fields in the body change)
+* DEL  `/alert-config/delete`  — reset to inherited (removes the
+                                  scope-level override; the parent
+                                  scope's config takes effect again)
+
+Scope semantics (from the spec):
+
+* GLOBAL — applies to all sites and devices under the tenant. Default.
+* SITE   — applies to a specific site identified by `scope_id`.
+* DEVICE — applies to a specific device identified by `scope_id`.
+
+The write tools are tagged `central_write_delete` (gated behind
+`ENABLE_CENTRAL_WRITE_TOOLS`) and use `WRITE_DELETE` annotation —
+different from the v2.3.1.5 alert-action tools (clear / defer / etc.)
+which are operational. These four configure the alert *system itself*,
+which is a config write equivalent to managing roles / policies / WLAN
+profiles.
+"""
+
+from typing import Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from hpe_networking_mcp.platforms.central._registry import tool
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+WRITE_DELETE = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)
+
+ScopeType = Literal["GLOBAL", "SITE", "DEVICE"]
+
+
+def _scope_query_params(scope_id: str, scope_type: ScopeType) -> dict[str, str]:
+    """Build the standard scope query-param dict shared by all four endpoints."""
+    return {"scopeId": scope_id, "scopeType": scope_type}
+
+
+def _typed_scope_query_params(type_id: str, scope_id: str, scope_type: ScopeType) -> dict[str, str]:
+    """Same as ``_scope_query_params`` plus a ``typeId`` (used by create/update/delete)."""
+    return {"typeId": type_id, "scopeId": scope_id, "scopeType": scope_type}
+
+
+# ---------------------------------------------------------------------------
+# READ
+# ---------------------------------------------------------------------------
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_alert_configs(
+    ctx: Context,
+    scope_id: str,
+    scope_type: ScopeType = "GLOBAL",
+) -> list | dict | str:
+    """
+    Retrieve all alert configurations defined at the given scope.
+
+    Returns alert *definitions* — the rules that determine when an alert
+    fires (thresholds, durations, severity buckets). Distinct from
+    `central_get_alerts` which returns currently fired/cleared/deferred
+    alert instances.
+
+    Each item carries `inherited: true/false` showing whether this scope
+    has its own override (`false`) or is using a parent scope's config
+    (`true`), plus `ruleSource: SYSTEM | USER` showing whether it's
+    Central's built-in rule or an operator-customized one.
+
+    Parameters:
+        - scope_id: The scope identifier. Get scope IDs from
+          `central_get_scope_tree(...)` or
+          `central_get_scope_resources(...)`.
+        - scope_type: One of `GLOBAL` (tenant-wide, default), `SITE`
+          (per-site), or `DEVICE` (per-device).
+
+    Returns:
+        The raw response payload from Central (typically a list of
+        AlertConfigItem objects). Common fields per item: `name`,
+        `description`, `typeId`, `category`, `deviceType`, `enabled`,
+        `ruleSource`, `clearTimeout`, `inherited`, `scopeId`,
+        `scopeType`, `scopeName`, `rules` (response-shape: each rule has
+        `rule_number`, `rule.duration`, `rule.condition[].severity`,
+        `rule.condition[].expression.operator`, etc.).
+    """
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="GET",
+        api_path="network-notifications/v1/alert-config",
+        api_params=_scope_query_params(scope_id, scope_type),
+    )
+    msg = response.get("msg", response)
+    return msg if msg else "No alert configurations returned"
+
+
+# ---------------------------------------------------------------------------
+# WRITE — create, update, reset (delete)
+# ---------------------------------------------------------------------------
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_create_alert_config(
+    ctx: Context,
+    type_id: str,
+    scope_id: str,
+    enabled: bool,
+    clear_timeout: str | None = None,
+    rules: list[dict] | None = None,
+    scope_type: ScopeType = "GLOBAL",
+) -> dict | str:
+    """
+    Create a custom alert configuration for a specific alert type at a scope.
+
+    Defines threshold rules that determine when this alert type fires.
+    Use this to override Central's built-in (`SYSTEM`) rules for a
+    particular site/device, or to enable/disable an alert at a non-global
+    scope.
+
+    Parameters:
+        - type_id: The alert type identifier. Numeric for built-in types
+          (e.g. `1250`) or string for custom types (e.g.
+          `CUSTOM-AP-CPU-HIGH`). Find type IDs by listing existing
+          configs with `central_get_alert_configs(scope_type="GLOBAL")`
+          and reading each item's `typeId`.
+        - scope_id: Where to apply the config. From `central_get_scope_tree`.
+        - enabled: Whether the alert fires when conditions are met.
+          Required by Central on create.
+        - clear_timeout: How long after the condition clears before the
+          alert auto-clears. Format `<number><unit>` where unit is
+          `H`/`h` (hours), `D`/`d` (days), or `M`/`m` (minutes) —
+          examples: `1H`, `30D`, `15m`. Pass `None` (the default) to
+          omit auto-clear; pass `null` from the AI side as a literal
+          `None` to disable an existing auto-clear on update.
+        - rules: Ordered list of threshold rules. Each rule has the shape:
+
+          ```python
+          {
+              "ruleNumber": 0,                # zero-based index
+              "duration": 300,                # seconds metric must stay over threshold
+              "conditions": [
+                  {"severity": "CRITICAL", "operator": "GT", "threshold": 90.0},
+                  {"severity": "MAJOR",    "operator": "GT", "threshold": 80.0},
+              ],
+              "additionalConditions": [
+                  # Optional extra filters; same operator set, plus
+                  # value_number / value_string / value_bool. Each entry
+                  # also has `index` (zero-based, non-negative).
+              ],
+          }
+          ```
+
+          Severity values: `CRITICAL`, `MAJOR`, `MINOR`, `INFO`.
+          Operator values: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`.
+        - scope_type: One of `GLOBAL` (default), `SITE`, `DEVICE`.
+
+    Returns: A mutation response — `{success, message, name, typeId}` on
+    success.
+    """
+    body: dict = {"enabled": enabled}
+    if clear_timeout is not None:
+        body["clearTimeout"] = clear_timeout
+    if rules is not None:
+        body["rules"] = rules
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="POST",
+        api_path="network-notifications/v1/alert-config/create",
+        api_params=_typed_scope_query_params(type_id, scope_id, scope_type),
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg if msg else f"Alert config create submitted for typeId={type_id}; response was empty"
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_update_alert_config(
+    ctx: Context,
+    type_id: str,
+    scope_id: str,
+    enabled: bool | None = None,
+    clear_timeout: str | None = None,
+    rules: list[dict] | None = None,
+    scope_type: ScopeType = "GLOBAL",
+) -> dict | str:
+    """
+    Update an existing alert configuration. Partial — fields you omit are
+    left unchanged.
+
+    Despite using HTTP PUT, the API behaves like PATCH: only the fields
+    you include in the request body overwrite the current configuration;
+    fields you don't include are preserved.
+
+    Parameters:
+        - type_id: Alert type identifier of the config to update.
+        - scope_id: Scope where the config currently lives.
+        - enabled: Toggle the alert on/off. Omit to leave unchanged.
+        - clear_timeout: New auto-clear duration (`<number><unit>`,
+          e.g. `2H`). Omit to leave unchanged.
+        - rules: Replace the rule set. Omit to leave the rules
+          unchanged. See `central_create_alert_config` for the rule
+          shape.
+        - scope_type: One of `GLOBAL` (default), `SITE`, `DEVICE`.
+
+    Returns: A mutation response — `{success, message, name, typeId}`.
+    """
+    body: dict = {}
+    if enabled is not None:
+        body["enabled"] = enabled
+    if clear_timeout is not None:
+        body["clearTimeout"] = clear_timeout
+    if rules is not None:
+        body["rules"] = rules
+
+    if not body:
+        return "No fields to update — pass at least one of `enabled`, `clear_timeout`, or `rules`."
+
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="PUT",
+        api_path="network-notifications/v1/alert-config/update",
+        api_params=_typed_scope_query_params(type_id, scope_id, scope_type),
+        api_data=body,
+    )
+    msg = response.get("msg", response)
+    return msg if msg else f"Alert config update submitted for typeId={type_id}; response was empty"
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_reset_alert_config(
+    ctx: Context,
+    type_id: str,
+    scope_id: str,
+    scope_type: ScopeType = "GLOBAL",
+) -> dict | str:
+    """
+    Reset an alert configuration back to its inherited (parent-scope) state.
+
+    Removes the custom override at the given scope. The alert type itself
+    is NOT deleted — the parent scope's config takes effect again
+    (typically the GLOBAL config). Use this to "undo" a site/device-level
+    customization and return to the inherited rule.
+
+    Parameters:
+        - type_id: Alert type identifier of the config to reset.
+        - scope_id: Scope where the override currently lives.
+        - scope_type: One of `GLOBAL` (default), `SITE`, `DEVICE`.
+
+    Returns: A mutation response. Note: this endpoint typically does NOT
+    return `name` in the response (per the Central spec).
+    """
+    response = retry_central_command(
+        ctx.lifespan_context["central_conn"],
+        api_method="DELETE",
+        api_path="network-notifications/v1/alert-config/delete",
+        api_params=_typed_scope_query_params(type_id, scope_id, scope_type),
+    )
+    msg = response.get("msg", response)
+    return msg if msg else f"Alert config reset submitted for typeId={type_id}; response was empty"

--- a/tests/unit/test_central_alert_configs.py
+++ b/tests/unit/test_central_alert_configs.py
@@ -1,0 +1,42 @@
+"""Catalog tests for the v2.3.1.6 Central alert-config tools.
+
+Static-only checks against ``TOOLS`` to avoid the ``importlib.reload``
+clash with ``configuration.py``'s ``ActionType`` enum identity that we
+hit in v2.3.1.5 alert-action tests. Actual tool registration is
+exercised by ``test_central_dynamic_mode.py``'s fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.central import TOOLS
+
+
+@pytest.mark.unit
+class TestAlertConfigToolCatalog:
+    """All four v2.3.1.6 alert-config tools are listed under TOOLS['alert_configs']."""
+
+    EXPECTED_TOOLS = (
+        "central_get_alert_configs",
+        "central_create_alert_config",
+        "central_update_alert_config",
+        "central_reset_alert_config",
+    )
+
+    def test_all_four_tools_in_catalog(self) -> None:
+        listed = set(TOOLS["alert_configs"])
+        for name in self.EXPECTED_TOOLS:
+            assert name in listed, f"{name} missing from TOOLS['alert_configs']"
+
+    def test_alerts_category_unchanged_by_split(self) -> None:
+        # Sanity: the v2.3.1.5 alert-action tools still live under
+        # TOOLS['alerts'] — splitting alert configs into a new module
+        # didn't accidentally move them.
+        listed = set(TOOLS["alerts"])
+        assert "central_get_alerts" in listed
+        assert "central_clear_alerts" in listed
+        assert "central_get_alert_classification" in listed
+        # And confirm none of the alert-config tools landed in the wrong bucket
+        for name in self.EXPECTED_TOOLS:
+            assert name not in listed, f"{name} should be under alert_configs, not alerts"

--- a/tests/unit/test_central_dynamic_mode.py
+++ b/tests/unit/test_central_dynamic_mode.py
@@ -43,9 +43,23 @@ class TestCentralRegistryPopulation:
         assert len(central_registry_populated) > 60
 
     def test_write_tools_carry_write_delete_tag(self, central_registry_populated):
-        """The three configuration CRUD tools are the flagship write_delete surface."""
-        for name in ("central_manage_site", "central_manage_site_collection", "central_manage_device_group"):
+        """Sample write tools — config CRUD plus the v2.3.1.6 alert-config writes —
+        all carry the central_write_delete tag so they're gated behind
+        ENABLE_CENTRAL_WRITE_TOOLS."""
+        for name in (
+            "central_manage_site",
+            "central_manage_site_collection",
+            "central_manage_device_group",
+            "central_create_alert_config",
+            "central_update_alert_config",
+            "central_reset_alert_config",
+        ):
             assert "central_write_delete" in central_registry_populated[name].tags
+
+    def test_alert_config_read_has_no_write_tag(self, central_registry_populated):
+        """The v2.3.1.6 alert-config list tool is read-only — must NOT carry the gating tag."""
+        tags = central_registry_populated["central_get_alert_configs"].tags
+        assert "central_write_delete" not in tags
 
     def test_read_tool_has_no_write_tag(self, central_registry_populated):
         read = central_registry_populated["central_get_sites"]


### PR DESCRIPTION
## Summary

Adds Aruba Central alert *configuration* management — the rules that determine when alerts fire — wrapping the four `/network-notifications/v1/alert-config` endpoints. Distinct from v2.3.1.5's alert *action* tools (clear / defer / reactivate / set-priority) which act on already-fired alert instances; these manage the alert system's threshold definitions.

## What's new

**One read tool** (`READ_ONLY` annotation):
- `central_get_alert_configs(scope_id, scope_type?)` — list configs at a scope. Each item carries `inherited` (using parent's config?) and `ruleSource: SYSTEM | USER`.

**Three write tools** (`WRITE_DELETE`, tagged `central_write_delete`, gated behind `ENABLE_CENTRAL_WRITE_TOOLS`, fire elicitation):
- `central_create_alert_config(type_id, scope_id, enabled, clear_timeout?, rules?, scope_type?)`
- `central_update_alert_config(type_id, scope_id, enabled?, clear_timeout?, rules?, scope_type?)` — partial update; despite HTTP PUT, the API behaves like PATCH (omitted fields preserved).
- `central_reset_alert_config(type_id, scope_id, scope_type?)` — remove scope-level override; revert to inherited.

## Annotation choice (different from v2.3.1.5)

| Release | Tools | Annotation | Why |
|---|---|---|---|
| v2.3.1.5 | clear / defer / reactivate / set_priority | `OPERATIONAL` | State transitions on alert *instances* — like rebooting a switch |
| v2.3.1.6 | create / update / reset / list configs | `WRITE_DELETE` | Config writes that change what the system tracks — same threat model as roles/policies/WLAN profiles |

## Module split

The existing `tools/alerts.py` was ~370 lines after v2.3.1.5. Adding 4 more tools would push past the 500-line cap. New module `tools/alert_configs.py` keeps things clean — alert *instances* vs alert *configs* are different surfaces conceptually too.

## Rule shape

Both `create` and `update` accept `rules: list[dict] | None` with the API's literal camelCase shape. Docstrings include the full shape + enum reference inline:

```python
rules=[
    {
        "ruleNumber": 0,
        "duration": 300,
        "conditions": [
            {"severity": "CRITICAL", "operator": "GT", "threshold": 90.0},
            {"severity": "MAJOR",    "operator": "GT", "threshold": 80.0},
        ],
        "additionalConditions": [],
    },
]
```

- Severity: `CRITICAL`, `MAJOR`, `MINOR`, `INFO`
- Operator: `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`, `IN`, `NIN`
- `clearTimeout` format: `<number><unit>` — e.g. `1H`, `30D`, `15m`

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `bandit -r src/ -c pyproject.toml` — `No issues identified`
- [x] `pytest tests/ -q` — **742 passed** (was 739; net +3)
- [ ] After merge & `:latest` rebuild + `docker compose down && pull && up -d`:
  - [ ] `central_get_alert_configs(scope_id="<global scope id>", scope_type="GLOBAL")` — confirm returns list of alert configs.
  - [ ] Pick a low-risk built-in alert (`ruleSource: SYSTEM`) and try `central_update_alert_config(type_id="<id>", scope_id="<global>", enabled=True)` to confirm the write path works and the elicitation fires.
  - [ ] Try `central_reset_alert_config(...)` on the same to roll back.
  - [ ] Try `central_create_alert_config(...)` for a site-level override on a specific alert type.

## Docs touched

- `CHANGELOG.md` — `[2.3.1.6]` entry covering the four tools, annotation rationale, and module split
- `docs/TOOLS.md` — new "Alert Configurations (v2.3.1.6+)" subsection with parameter tables for all four tools, rule shape and enum reference
- `pyproject.toml` — `2.3.1.5` → `2.3.1.6` (patch — small contained module addition)