### PR TITLE
v2.3.1.7: documentation refresh — pull stale tool counts and structure refs to current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1.7] - 2026-04-30
+
+**Documentation refresh — pulls stale tool counts and structural references in `README.md`, `docs/TOOLS.md`, `CLAUDE.md`, `INSTRUCTIONS.md`, and `docs/MIGRATING_TO_V2.md` up to v2.3.1.6 reality. No code changes; one bandit/ruff/mypy/pytest run confirms 742 still passing.**
+
+### What changed
+
+**README.md:**
+- Comparison table: Aruba Central tool count `73 + 12 prompts` → `83 + 12 prompts`.
+- Architecture diagram: Central `73 tools` → `83 tools`.
+- "Verify" troubleshooting section: corrected the per-platform tool counts surfaced in `docker compose logs` output, and the dynamic-mode tool surface (`24` exposed, `312` underlying — was `22` / `300+`).
+- "Tool Surface Looks Wrong" troubleshooting: explicit `24 tools / 312 underlying` framing including the 2 skills tools (was missing from the breakdown).
+- Project structure: test count `639+` → `740+` unit tests.
+
+**docs/TOOLS.md:**
+- Dynamic-mode opener: `19 tools` → `24 tools` (added the 2 skills tools, expanded from 5 platforms to 6 to include Axis).
+- Code-mode tag-list example: Mist `31 tools` → `35`, Central `73` → `83` to match reality.
+- Overview table: Aruba Central row `60 / 13 / 12 / 85` → `63 / 20 / 12 / 95` (covers v2.3.1.5 alert-action + v2.3.1.6 alert-config tools).
+- Section headers: `Aruba Central (73 tools + 12 prompts)` → `83 tools`, `Juniper Apstra (21 tools)` → `19 tools`, added missing `(10 tools)` to the GreenLake section.
+
+**CLAUDE.md (substantial rewrite of three sections):**
+- "Project Overview" now lists all 6 platforms (was 4 — missed Apstra and Axis).
+- "Current State (as of 2026-03-28)" → "Current State (as of 2026-04-30, v2.3.1.6)". Replaced "49 tools registered: 29 Mist + 10 Central + 10 GreenLake" with the real `312 tools across 6 platforms` breakdown plus tool-mode summary, PII tokenization, and skills bullet points.
+- "Project Structure" rewritten to reflect v2.3.1.x reality: middleware now lists all 7 modules (added `origin_validation`, `pii_tokenization`, `retry`, `sandbox_error_catch`, `validation_catch`); new `redaction/` package documented; `skills/` directory listed; platform sections updated to current tool counts; Apstra and Axis sections added.
+- "Conventions" — corrected `ENABLE_WRITE_TOOLS=true` (singular) to the real per-platform env vars (`ENABLE_MIST_WRITE_TOOLS`, `ENABLE_CENTRAL_WRITE_TOOLS`, etc.); noted `OPERATIONAL` annotation tools aren't gated by these; added `ALLOWED_ORIGINS` reference.
+- "Known Issues" replaced with current "Open Items / Known Quirks" — the v0.5-era issues (2 Mist tools failing to load, pycentral API surprises, GreenLake meta-tools deferred) are all resolved.
+- "Testing (not yet implemented)" comment fixed; bandit added to commands.
+- "Secrets File Reference" extended with `apstra_*` and `axis_api_token`.
+
+**INSTRUCTIONS.md (AI-facing):**
+- Tool-discovery opener: `18 tools` → `24 tools` (added skills tools and 6th platform).
+- Central tool category: split single `Alerts: central_get_alerts` line into two well-described entries — `Alerts (instances)` covering the v2.3.1.5 list/classification/state-transition tools, and `Alert configurations (rules)` covering the v2.3.1.6 read/create/update/reset tools, with a clear note about which is which.
+
+**docs/MIGRATING_TO_V2.md:**
+- Added a "this document is a v1→v2.0 snapshot" note at the top so readers don't mistake the v2.0-era counts for current.
+
+**Skipped (per scope agreement):**
+- Skill markdown files — INSTRUCTIONS.md is the authoritative trigger source; per-skill descriptions are descriptive rather than load-bearing.
+- `docs/PRD.md` and `docs/PRP.md` — internal planning artifacts, not user-facing.
+
+### Tests
+
+- 742 passing (unchanged) — no code touched. Pre-push checks confirm clean ruff/format/mypy/bandit/pytest.
+
 ## [2.3.1.6] - 2026-04-30
 
 **Adds Aruba Central alert *configuration* management — the rules that determine when alerts fire — wrapping the four `/network-notifications/v1/alert-config` endpoints. Distinct from v2.3.1.5's alert *action* tools (clear / defer / reactivate / set-priority) which act on already-fired alert instances; these manage the alert system's threshold definitions. New module `tools/alert_configs.py`; the existing `tools/alerts.py` is left at its current size below the 500-line cap.**

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **73 + 12 prompts** | **10** | **140** | **19** | **25** |
+| **Underlying tools (static mode)** | **35 + 2 prompts** | **83 + 12 prompts** | **10** | **140** | **19** | **25** |
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — |
 
@@ -182,7 +182,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 tools registered`, `ClearPass: 140 tools registered`, `Axis: 25 underlying tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 22 tools are exposed to the AI when all six platforms are enabled — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
+Look for lines like `Mist: 35 tools registered`, `Central: 83 tools registered`, `ClearPass: 140 tools registered`, `Axis: 25 underlying tools registered`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, **24 tools** are exposed to the AI when all six platforms are enabled (6 × 3 per-platform meta-tools + 4 cross-platform static tools + 2 skills tools) — the 312 underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist also registers 2 guided prompts for site provisioning workflows.
 
 ### Docker Image
 
@@ -425,7 +425,7 @@ Docker Compose reads these files and mounts them at `/run/secrets/<name>` inside
 │ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐    │
 │ │   Mist   │ │ Central  │ │GreenLake │ │ClearPass │ │  Apstra  │ │   Axis   │    │
 │ │  mist_*  │ │central_* │ │greenlake │ │clearpass │ │ apstra_* │ │ axis_*   │    │
-│ │ 35 tools │ │ 73 tools │ │ 10 tools │ │140 tools │ │ 19 tools │ │ 25 tools │    │
+│ │ 35 tools │ │ 83 tools │ │ 10 tools │ │140 tools │ │ 19 tools │ │ 25 tools │    │
 │ │ + 2 prmt │ │+ 12 prmt │ │          │ │          │ │          │ │          │    │
 │ │          │ │          │ │          │ │          │ │          │ │          │    │
 │ │  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.       │
@@ -577,7 +577,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (639+ unit tests)
+├── tests/                       # Unit and integration tests (740+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish
@@ -695,16 +695,16 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (22 tools vs. 300+)
+### Tool Surface Looks Wrong (24 tools vs. 312)
 
-Since v2.0.0.0, every platform runs in dynamic mode by default: each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) and the underlying tools are discoverable through them. A correctly configured server with all 6 platforms enabled will advertise **22 tools** to the AI client — 18 meta-tools + 4 cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`).
+Since v2.0.0.0, every platform runs in dynamic mode by default: each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) and the underlying tools are discoverable through them. A correctly configured server with all 6 platforms enabled will advertise **24 tools** to the AI client — 18 meta-tools + 4 cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) + 2 skills tools (`skills_list`, `skills_load`).
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: dynamic"   → default (18 exposed tools)
-# "Tool mode: static"    → every underlying tool visible (260+)
+# "Tool mode: dynamic"   → default (24 exposed tools)
+# "Tool mode: static"    → every underlying tool visible (312)
 ```
 
 To restore v1.x-style surface (every tool registered individually), set `MCP_TOOL_MODE=static` in `docker-compose.yml` under `environment`:

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -2,6 +2,8 @@
 
 Released 2026-04-23. Umbrella issue: [#157](https://github.com/nowireless4u/hpe-networking-mcp/issues/157).
 
+> **Note:** This document describes the v1.x → v2.0.0.0 migration. Numbers in this doc reflect the surface at the v2.0.0.0 release (5 platforms, 18 exposed tools in dynamic mode, 261 static tools). The surface has grown since — current counts (6 platforms, 24 exposed in dynamic mode, 312 static) are in [`docs/TOOLS.md`](TOOLS.md) and [`CHANGELOG.md`](../CHANGELOG.md). The migration steps and behavior described here remain accurate for upgrading from v1.x.
+
 ## The short version
 
 The default tool surface drops from 261 static tools to **18 exposed tools**. Every per-platform tool still exists — it's just discovered on demand via three meta-tools per platform instead of advertised up front. Behavior and return shapes are unchanged when invoked. Small local LLMs (gpt-oss:20b / 32K context) now fit the tool schema in their context window with room to spare.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -2,26 +2,29 @@
 
 Complete reference for all tools registered by the HPE Networking MCP Server.
 Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Central),
-`greenlake_*` (HPE GreenLake), `clearpass_*` (Aruba ClearPass), and `apstra_*`
-(Juniper Apstra).
+`greenlake_*` (HPE GreenLake), `clearpass_*` (Aruba ClearPass), `apstra_*`
+(Juniper Apstra), and `axis_*` (Axis Atmos Cloud).
 
 ## Dynamic mode (default since v2.0.0.0)
 
-The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the AI sees **19 tools**:
+The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the AI sees **24 tools**:
 
 - **4 cross-platform static tools**
   - `health(platform=...)`
   - `site_health_check(site_name=...)`
   - `site_rf_check(site_name=...)`
   - `manage_wlan_profile(...)`
-- **3 meta-tools per platform** (× 5 platforms = 15)
+- **3 meta-tools per platform** (× 6 platforms = 18)
   - `<platform>_list_tools(filter=...)` — list candidates
   - `<platform>_get_tool_schema(name=...)` — fetch parameter schema
   - `<platform>_invoke_tool(name=..., arguments={...})` — invoke by name
+- **2 skills tools** (since v2.3.0.0)
+  - `skills_list(filter=...)` — list bundled multi-step runbooks
+  - `skills_load(name=...)` — load a runbook to execute
 
-All the per-platform tools documented below still exist and are discoverable through the meta-tools. Their names, parameters, and return shapes are unchanged from v1.x. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the meta-tools.
+All 312 per-platform tools documented below still exist and are discoverable through the meta-tools. Their names, parameters, and return shapes are unchanged from v1.x. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the meta-tools.
 
-Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform tool registers individually (260+ visible). Set `MCP_TOOL_MODE=code` for an experimental four-tier discovery + sandboxed Python execution surface — see the next section.
+Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform tool registers individually (312 visible). Set `MCP_TOOL_MODE=code` for an experimental four-tier discovery + sandboxed Python execution surface — see the next section.
 
 ## Code mode (experimental, opt-in since v2.1.0.0)
 
@@ -31,7 +34,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (83)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |
@@ -86,7 +89,7 @@ If you're not sure, stay on `dynamic`. Code mode is meant for measurement + eval
 | Platform | Read-Only Tools | Write Tools | Prompts | Total |
 |----------|----------------|-------------|---------|-------|
 | Juniper Mist | 31 | 4 | 2 | 37 |
-| Aruba Central | 60 | 13 | 12 | 85 |
+| Aruba Central | 63 | 20 | 12 | 95 |
 | Aruba ClearPass | 65 | 75 | -- | 140 |
 | Juniper Apstra | 12 | 7 | -- | 19 |
 | HPE GreenLake | 10 | -- | -- | 10 |
@@ -650,7 +653,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (73 tools + 12 prompts)
+## Aruba Central (83 tools + 12 prompts)
 
 ### Sites
 
@@ -1521,7 +1524,7 @@ Tools that span multiple platforms. Each replaces several individual tool calls 
 
 ---
 
-## HPE GreenLake
+## HPE GreenLake (10 tools)
 
 GreenLake uses the same dynamic-mode meta-tool pattern as every other platform since v2.0.0.0. In the default `MCP_TOOL_MODE=dynamic`, the AI sees `greenlake_list_tools`, `greenlake_get_tool_schema`, and `greenlake_invoke_tool` and discovers the 10 underlying tools below through them. The v1.x endpoint-dispatch tools (`greenlake_list_endpoints`, `greenlake_get_endpoint_schema`, `greenlake_invoke_endpoint`) are **removed** in v2.0.
 
@@ -1864,7 +1867,7 @@ For ClearPass API reachability, use the cross-platform `health(platform="clearpa
 
 ---
 
-## Juniper Apstra (21 tools)
+## Juniper Apstra (19 tools)
 
 Ported from a standalone Apstra MCP server. Requires Apstra credentials in
 Docker secrets (`apstra_server`, `apstra_username`, `apstra_password`, plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.3.1.6"
+version = "2.3.1.7"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -12,9 +12,10 @@ Tools are namespaced by platform:
 
 # TOOL DISCOVERY (dynamic mode — default since v2.0)
 
-Only 18 tools are directly visible at session start:
-- **3 cross-platform static tools**: `health`, `site_health_check`, `manage_wlan_profile`
-- **3 meta-tools per platform × 5 platforms** = 15: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
+Only 24 tools are directly visible at session start:
+- **4 cross-platform static tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
+- **3 meta-tools per platform × 6 platforms** = 18: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
+- **2 skills tools** (since v2.3.0.0): `skills_list`, `skills_load`
 
 Every per-platform tool listed below this section is reachable through the meta-tools. **Use this discovery pattern:**
 
@@ -206,7 +207,8 @@ When asked to create a new site based on an existing site:
   - Use `central_get_wlan_stats` for throughput trends (tx/rx time-series) for a specific SSID over a time window
   - Use `central_get_ap_wlans` (in AP Monitoring) to see which WLANs a specific AP is broadcasting
 - **Clients**: central_get_clients, central_find_client
-- **Alerts**: central_get_alerts
+- **Alerts (instances)**: central_get_alerts (list), central_get_alert_classification (counts grouped by severity/status/etc.). State transitions on already-fired alerts: central_clear_alerts, central_defer_alerts, central_reactivate_alerts, central_set_alert_priority — all batch (list of `keys`), all async (return a `task_id` to poll via central_get_alert_action_status). Operational annotation; fires elicitation. Each alert returned by central_get_alerts has a `key` field — pass to the action tools.
+- **Alert configurations (rules)**: central_get_alert_configs (list rules at a scope), central_create_alert_config / central_update_alert_config / central_reset_alert_config — write-tool surface (requires `ENABLE_CENTRAL_WRITE_TOOLS=true`). Distinct from alerts/instances above: these manage the *definitions* that determine when alerts fire.
 - **Events**: central_get_events, central_get_events_count
 - **Audit Logs**: central_get_audit_logs, central_get_audit_log_detail
 - **Applications**: central_get_applications


### PR DESCRIPTION
## Summary

Documentation-only refresh after v2.3.1.5 (alert action tools) and v2.3.1.6 (alert config tools) added 10 tools to Central. Also pulled stale structural references and tool-mode counts that hadn't been touched since v2.0/v2.1 era. No code changes — pre-push checks confirm 742 still passing.

## Files changed

### `README.md`
- Comparison table: Aruba Central tool count `73 + 12 prompts` → `83 + 12 prompts`.
- Architecture diagram: Central `73 tools` → `83 tools`.
- "Verify" troubleshooting section: corrected per-platform counts surfaced in `docker compose logs`, dynamic-mode surface `22` → `24`, underlying `~300+` → `312`, added the 2 skills tools to the breakdown.
- "Tool Surface Looks Wrong" troubleshooting: same `24 / 312` correction.
- Project structure: test count `639+` → `740+` unit tests.

### `docs/TOOLS.md`
- Dynamic-mode opener: `19 tools` → `24 tools` (added 2 skills tools, 5 → 6 platforms).
- Code-mode tag-list example: Mist `31` → `35`, Central `73` → `83`.
- Overview table: Aruba Central row `60 / 13 / 12 / 85` → `63 / 20 / 12 / 95` (covers v2.3.1.5 + v2.3.1.6).
- Section headers: `Aruba Central (73 → 83 tools + 12 prompts)`, `Juniper Apstra (21 → 19 tools)`, added missing `(10 tools)` to the GreenLake section header.

### `src/hpe_networking_mcp/INSTRUCTIONS.md` (AI-facing)
- Tool-discovery opener: `18 tools` → `24 tools` (added skills tools and 6th platform).
- Central tool category: split single `Alerts: central_get_alerts` line into two well-described entries — `Alerts (instances)` covering the v2.3.1.5 list/classification/state-transition tools (with `key` field guidance), and `Alert configurations (rules)` covering the v2.3.1.6 read/create/update/reset tools.

### `docs/MIGRATING_TO_V2.md`
- Added a "this document describes the v1.x → v2.0.0.0 migration; numbers reflect the v2.0 snapshot, current counts in `docs/TOOLS.md` and `CHANGELOG.md`" note at the top so readers don't mistake the v2.0-era counts for current.

### `pyproject.toml`
- `2.3.1.6` → `2.3.1.7` (patch — docs touch INSTRUCTIONS.md which is AI-facing behavior content; consistent with prior INSTRUCTIONS.md-touching patches).

## Skipped (per scope agreement)

- **Skill markdown bodies** — INSTRUCTIONS.md is the authoritative trigger source, per-skill descriptions are descriptive rather than load-bearing.
- **`docs/PRD.md`** and **`docs/PRP.md`** — internal planning artifacts, not user-facing.
- **`CLAUDE.md`** — gitignored (developer-local). I refreshed it locally for the maintainer's session but it's not part of the public repo.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `bandit -r src/ -c pyproject.toml` — `No issues identified`
- [x] `pytest tests/ -q` — **742 passed** (unchanged)
- [ ] After merge: spot-check the rendered Central section in `docs/TOOLS.md` for the new alert and alert-config subsections (added in v2.3.1.5 + v2.3.1.6).