### PR TITLE
v2.4.0.4: redact UIDARUBA + SESSION in AOS 8 transport logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0.4] - 2026-05-03
+
+**Security patch — AOS 8 UIDARUBA session token was being written to INFO-level logs on every API request. Fix scope: redact `UIDARUBA=` query values and `SESSION=` cookie values in the AOS 8 transport request/response logging hooks; close the test blind spot that let the leak ship undetected.** Tracks issue [#233](https://github.com/nowireless4u/hpe-networking-mcp/issues/233). Affects every release in the v2.4.0.x series before this one running with AOS 8 secrets configured. Operators without AOS 8 enabled are unaffected (the platform is gated off when `aos8_*` secrets are missing or empty, and the leaking code never executes).
+
+### Fixed
+
+- **`src/hpe_networking_mcp/platforms/aos8/client.py`** — added a `SESSION=<value>` cookie regex to complement the existing `UIDARUBA=<value>` regex, and applied both via a new unified `_sanitize_for_log()` helper to the `Cookie` request header, the request query string, and the `Set-Cookie` response header in `_log_request` / `_log_response`. The previous slicing-only "redaction" (`[:40]`, `[:60]`, `[:80]`) chopped the end off the secret but left the leading entropy fully exposed. The login line continues to use `mask_secret()` for the head-and-tail-with-ellipsis form so operators can correlate sessions in logs without exposing the token.
+- **`tests/unit/test_aos8_client.py`** and **`tests/unit/test_aos8_security.py`** — fixed `_install_mock_transport` / `_install` to swap only the transport on the persistent `client._http` (`client._http._transport = MockTransport(...)`) instead of constructing a fresh `AsyncClient`. The fresh-client pattern silently dropped the request/response event hooks defined in `_make_http_client`, which is why the existing leak tests passed against vulnerable code — the leaking log statements never fired during the test. This change mirrors the production code path the round-1 PR #230 review fix B1 established (persistent `_http`).
+- **Tightened the existing leak assertions and added a new one** — every log line that mentions `UIDARUBA=` OR `SESSION=` must now also contain `<redacted>` (positive assertion, complementing the prior negative-only "bait token not in log" check). New `test_set_cookie_session_value_redacted_in_response_log` directly drives a `Set-Cookie: SESSION=<token>` header through the response hook and asserts the response-log line contains `SESSION=<redacted>`.
+
+### Mitigation if you've been running v2.4.0.0–v2.4.0.3 with AOS 8 enabled
+
+See issue #233 for detection (`docker compose logs | grep 'AOS8 HTTP.*UIDARUBA='`) and pre-fix mitigation (`LOG_LEVEL=warning`). Operators who collected logs and want to invalidate already-leaked tokens can rotate `aos8_username` / `aos8_password` Docker secrets; UIDARUBA tokens issued under the old credentials become unusable once the new credentials are first used.
+
 ## [2.4.0.3] - 2026-05-03
 
 **Final polish on the AOS 8 / Mobility Conductor platform module from PR #230 — the last 3 test failures, an `INSTRUCTIONS.md` doc gap, and a compose-default revert. Lands together with @dendyc's contribution rather than as a separate follow-up. No functional change to AOS8 itself.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.4.0.3"
+version = "2.4.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/aos8/client.py
+++ b/src/hpe_networking_mcp/platforms/aos8/client.py
@@ -32,18 +32,33 @@ _REQUEST_TIMEOUT = 30.0
 _HEALTH_TIMEOUT = 10.0
 
 _UIDARUBA_RE = re.compile(r"(UIDARUBA=)[^&\s]+", re.IGNORECASE)
+# AOS 8 carries the same UIDARUBA token in a SESSION cookie on every
+# request and rotates it via Set-Cookie on every response. Match the
+# value through the next `;`, `,`, or whitespace so a redacted Set-Cookie
+# header keeps its trailing attributes (`path=/`, `HttpOnly`, ...) intact.
+_SESSION_COOKIE_RE = re.compile(r"(SESSION=)[^;,\s]+", re.IGNORECASE)
 
 
-def _sanitize_url_for_log(url: str | httpx.URL) -> str:
-    """Redact any UIDARUBA token value in a URL string before logging.
+def _sanitize_for_log(value: str | httpx.URL) -> str:
+    """Redact UIDARUBA query values and SESSION cookie values for logging.
+
+    Applies to URLs, raw query strings, ``Cookie`` request headers, and
+    ``Set-Cookie`` response headers — every place the AOS 8 session token
+    can appear in transport metadata.
 
     Args:
-        url: The URL to sanitize (string or httpx.URL).
+        value: The string (URL, header, or query) to sanitize.
 
     Returns:
-        URL string with UIDARUBA=<value> replaced by UIDARUBA=<redacted>.
+        Same string with ``UIDARUBA=<value>`` and ``SESSION=<value>``
+        replaced by ``UIDARUBA=<redacted>`` and ``SESSION=<redacted>``.
     """
-    return _UIDARUBA_RE.sub(r"\1<redacted>", str(url))
+    sanitized = _UIDARUBA_RE.sub(r"\1<redacted>", str(value))
+    return _SESSION_COOKIE_RE.sub(r"\1<redacted>", sanitized)
+
+
+# Back-compat alias — older import sites may still reference this name.
+_sanitize_url_for_log = _sanitize_for_log
 
 
 class AOS8AuthError(RuntimeError):
@@ -85,22 +100,28 @@ class AOS8Client:
         """Create a fresh httpx.AsyncClient with debug event hooks."""
 
         async def _log_request(request: httpx.Request) -> None:
-            cookie_hdr = request.headers.get("cookie", "<none>")
-            params_str = str(request.url.params)
+            # The Cookie header carries SESSION=<UIDARUBA> and the query
+            # string carries UIDARUBA=<UIDARUBA>; both must be redacted
+            # before reaching the log sink. See issue #233.
+            cookie_hdr = _sanitize_for_log(request.headers.get("cookie", "<none>"))
+            params_str = _sanitize_for_log(str(request.url.params))
             logger.info(
                 "AOS8 HTTP → {} {} | cookie={!r} | params={}",
                 request.method,
                 request.url.path,
-                cookie_hdr[:40] if len(cookie_hdr) > 40 else cookie_hdr,
-                params_str[:80] if len(params_str) > 80 else params_str,
+                cookie_hdr,
+                params_str,
             )
 
         async def _log_response(response: httpx.Response) -> None:
+            # AOS 8 rotates the SESSION cookie on every successful response,
+            # so the Set-Cookie header carries a fresh UIDARUBA each time.
+            set_cookie = _sanitize_for_log(response.headers.get("set-cookie", "<none>"))
             logger.info(
                 "AOS8 HTTP ← {} {} | set-cookie={}",
                 response.status_code,
                 response.url.path,
-                response.headers.get("set-cookie", "<none>")[:60],
+                set_cookie,
             )
 
         return httpx.AsyncClient(

--- a/tests/unit/test_aos8_client.py
+++ b/tests/unit/test_aos8_client.py
@@ -41,19 +41,21 @@ def _make_secrets(**overrides: Any) -> AOS8Secrets:
 
 
 def _install_mock_transport(client: AOS8Client, handler) -> list[httpx.Request]:
-    """Replace client._http with one driven by MockTransport. Returns request log."""
+    """Swap the transport on the persistent client. Returns request log.
+
+    Mirrors the production code path: the persistent ``client._http`` (with
+    its event hooks attached) is preserved; only the underlying transport is
+    replaced with a ``MockTransport``. Replacing the entire ``AsyncClient``
+    here would silently drop the request/response logging hooks defined in
+    ``_make_http_client``, hiding any log-side leaks (see issue #233).
+    """
     calls: list[httpx.Request] = []
 
     def _wrapper(request: httpx.Request) -> httpx.Response:
         calls.append(request)
         return handler(request)
 
-    transport = httpx.MockTransport(_wrapper)
-    client._http = httpx.AsyncClient(
-        base_url=f"https://{client._config.host}:{client._config.port}",
-        transport=transport,
-        verify=client._config.verify_ssl,
-    )
+    client._http._transport = httpx.MockTransport(_wrapper)
     return calls
 
 
@@ -205,6 +207,55 @@ class TestAOS8ClientLogging:
         await client.aclose()
         joined = "\n".join(loguru_capture)
         assert "tok-supersecret-12345" not in joined, f"UIDARUBA token leaked into log output: {joined!r}"
+        # Positive assertion (issue #233): every log line that mentions
+        # UIDARUBA= or SESSION= must also contain ``<redacted>``. Without
+        # this, a future change that swaps ``UIDARUBA=<token>`` for an
+        # unredacted ``SESSION=<token>`` (or vice versa) would still pass
+        # the negative-only assertion above as long as the bait token
+        # itself wasn't in the line. See issue #233.
+        for line in loguru_capture:
+            if "UIDARUBA=" in line or "SESSION=" in line:
+                assert "<redacted>" in line, f"Token marker present without redaction: {line!r}"
+
+    async def test_set_cookie_session_value_redacted_in_response_log(self, loguru_capture):
+        """Regression for issue #233: AOS 8 rotates ``Set-Cookie: SESSION=<token>``
+        on every response, and the response logger must redact it.
+
+        Distinct from ``test_uidaruba_never_in_logs`` — that test exercises
+        the request-side leak (cookie + query-param). This one drives a
+        ``Set-Cookie`` header through the response hook, which the prior
+        log statement printed verbatim (truncated, but with the leading
+        token entropy fully exposed).
+        """
+        client = AOS8Client(_make_secrets())
+        leak_bait = "rotated-session-token-leak-bait-9b2c"
+
+        def handler(request):
+            if request.url.path == "/v1/api/login":
+                return httpx.Response(200, json=_LOGIN_OK)
+            if request.url.path == "/v1/api/logout":
+                return httpx.Response(200, json={"_global_result": {"status": "0"}})
+            return httpx.Response(
+                200,
+                json={"_global_result": {"status": "0"}, "ok": True},
+                headers={"set-cookie": f"SESSION={leak_bait}; path=/; HttpOnly"},
+            )
+
+        _install_mock_transport(client, handler)
+        await client.request("GET", "/v1/configuration/object/foo")
+        await client.aclose()
+
+        joined = "\n".join(loguru_capture)
+        assert leak_bait not in joined, f"Rotated SESSION cookie leaked into log output: {joined!r}"
+        # And the response-log line for the API call must contain the
+        # redaction marker, proving the hook fired and substituted.
+        api_response_lines = [
+            line for line in loguru_capture if "AOS8 HTTP ←" in line and "/v1/configuration/object/foo" in line
+        ]
+        assert api_response_lines, f"Expected an AOS8 response log line, captured: {loguru_capture}"
+        assert any("SESSION=<redacted>" in line for line in api_response_lines), (
+            f"Set-Cookie SESSION value was not redacted in response log: {api_response_lines!r}"
+        )
 
 
 class TestAOS8ClientMisc:

--- a/tests/unit/test_aos8_security.py
+++ b/tests/unit/test_aos8_security.py
@@ -33,12 +33,13 @@ def _make_secrets(**overrides):
 
 
 def _install(client: AOS8Client, handler):
-    transport = httpx.MockTransport(handler)
-    client._http = httpx.AsyncClient(
-        base_url=f"https://{client._config.host}:{client._config.port}",
-        transport=transport,
-        verify=client._config.verify_ssl,
-    )
+    """Swap the transport on the persistent client so event hooks survive.
+
+    Replacing the entire ``AsyncClient`` would drop the request/response
+    logging hooks defined in ``_make_http_client``, hiding the very leak
+    these tests are meant to detect (see issue #233).
+    """
+    client._http._transport = httpx.MockTransport(handler)
 
 
 async def test_uidaruba_value_not_logged_during_read_tool(loguru_capture):
@@ -62,10 +63,11 @@ async def test_uidaruba_value_not_logged_during_read_tool(loguru_capture):
 
     joined = "\n".join(loguru_capture)
     assert _LEAK_BAIT_TOKEN not in joined, f"UIDARUBA token value leaked: {joined!r}"
-    # Per Pitfall 1: any line referencing UIDARUBA must redact it
+    # Per Pitfall 1 (and issue #233): any line referencing the UIDARUBA
+    # query param OR the SESSION cookie must redact the value.
     for line in loguru_capture:
-        if "UIDARUBA" in line:
-            assert "<redacted>" in line, f"UIDARUBA appeared without redaction: {line!r}"
+        if "UIDARUBA=" in line or "SESSION=" in line:
+            assert "<redacted>" in line, f"Token marker appeared without redaction: {line!r}"
 
 
 async def test_uidaruba_value_not_logged_during_write_tool(loguru_capture):
@@ -97,6 +99,7 @@ async def test_uidaruba_value_not_logged_during_write_tool(loguru_capture):
 
     joined = "\n".join(loguru_capture)
     assert _LEAK_BAIT_TOKEN not in joined
+    # Issue #233: cover both query-param and rotated-cookie leak vectors.
     for line in loguru_capture:
-        if "UIDARUBA" in line:
+        if "UIDARUBA=" in line or "SESSION=" in line:
             assert "<redacted>" in line


### PR DESCRIPTION
## Summary
- **Security fix.** AOS 8 was logging the live UIDARUBA session token at INFO level on every API request in three places per request: the outgoing `Cookie` header, the outgoing `UIDARUBA=` query parameter, and the response `Set-Cookie` header. Affected v2.4.0.0–v2.4.0.3 when AOS 8 was configured. Operators without AOS 8 enabled are unaffected (the platform is gated off and the leaking code never executes).
- **Test blind-spot fix.** The existing leak tests passed against vulnerable code because their `_install_mock_transport` helpers were constructing a fresh `httpx.AsyncClient` and dropping the event hooks defined in `_make_http_client`. Helpers now swap only the transport on the persistent `client._http` so hooks survive — matching the production code path the round-1 PR #230 review fix B1 established.
- **New positive-assertion test** drives a `Set-Cookie: SESSION=<token>` header through the response hook and asserts the response-log line reads `SESSION=<redacted>`.

Closes #233.

## Test plan
- [x] `_install_mock_transport` / `_install` helpers updated to preserve event hooks; **rerun confirms the existing 3 leak tests fail against unfixed production code** (regression baseline).
- [x] Production fix applied: `_sanitize_for_log()` redacts both `UIDARUBA=<value>` and `SESSION=<value>` patterns, applied in `_log_request` (cookie header + query string) and `_log_response` (set-cookie header).
- [x] Same 3 tests now pass with the production fix. New `test_set_cookie_session_value_redacted_in_response_log` asserts redaction marker is *present* (not just bait token absent).
- [x] Full pre-push: `ruff check` ✅, `ruff format --check` ✅, `mypy src/` ✅, `pytest tests/` 901 passed / 11 skipped (one new test added).
- [x] Manually verified against running container: after `docker compose pull && up -d --force-recreate`, the leaking lines now read `cookie='SESSION=<redacted>'` / `params=UIDARUBA=<redacted>&command=show+version` / `set-cookie=SESSION=<redacted>; path=/; HttpOnly`.

## Backwards compatibility
- `_sanitize_url_for_log` alias preserved — the one existing call site at `client.py:316` (an error-log line) keeps working unchanged.
- Login-time log line `AOS8: obtained session token <masked>` continues to use `mask_secret()` for the head-and-tail-with-ellipsis form. Operators can still correlate sessions across log lines without exposing the token.

## Mitigation for operators on v2.4.0.0–v2.4.0.3 with AOS 8 enabled
See issue #233 for detection (`docker compose logs | grep 'AOS8 HTTP.*UIDARUBA='`) and pre-fix mitigation (`LOG_LEVEL=warning`). Rotating `aos8_username` / `aos8_password` Docker secrets invalidates UIDARUBA tokens issued under the old credentials.