### PR TITLE
v2.4.0.5: normalize spaces in PII tokenization field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0.5] - 2026-05-03
+
+**PII tokenization improvement for AOS 8 — extend the field-name normalizer to treat spaces the same as hyphens, so AOS 8's space-separated `showcommand` headers (`"AP name"`, `"Host Name"`, `"Wired MAC Address"`) match the existing snake_case rules. Closes the *flat-record* tokenization gap on AOS 8 responses; the transposed key/value shape used by `show <foo> detail` commands (RADIUS / TACACS / LDAP server detail) is tracked separately as issue [#235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235).** Mist and Central are not affected — their APIs use snake_case / camelCase exclusively, so the change is a no-op there.
+
+### Why
+
+When AOS 8 was added in v2.4.0.0 it inherited the Mist/Central PII rules unchanged. Live traffic against a real Mobility Conductor showed that AOS 8 responses use space-separated column headers, which our normalizer (lowercased + hyphen→underscore only) didn't reach. Result: AP names, host names, and `Mac Address`/`Wired MAC Address` columns were arriving cleartext to the AI even though Mist/Central rules already existed for those concepts.
+
+Live verification against a real `show switches` response confirmed `"Name": "MM-01"` survived as cleartext because:
+1. `"Name"` lowercased to `"name"` — bare, requires sibling-context to fire.
+2. The sibling `"Model"` was a valid hint, but `"IP Address"`, `"Type"`, etc. weren't normalizing for the parent-key intersection check, so only one device-context hint matched (need ≥2).
+
+### What changed
+
+- **`src/hpe_networking_mcp/redaction/rules.py`** — extracted the field-name normalizer into a `_normalize_field_name()` helper that does `lower() + "-" → "_" + " " → "_"`. `classify_field()` uses it for the field name being classified, AND for the parent-keys set when checking the bare-`name` heuristic. Added three identifier-field aliases: `host_name` (AOS 8 client tables), `controller_name`, `switch_name` — all → HOSTNAME.
+- **`src/hpe_networking_mcp/redaction/walker.py`** — MAC-field detection in `_walk_pair` now goes through the same normalizer. Added `mac_address` and `wired_mac_address` to `_MAC_FIELD_HINTS` to cover AOS 8's column-header form.
+- **`tests/unit/test_pii_redaction.py`** — added 6 regression tests using the actual live `aos8_get_controllers` response shape so future changes can't silently regress: `test_aos8_ip_address_field_normalizes`, `test_aos8_ap_name_with_space_tokenizes_as_hostname`, `test_aos8_host_name_field_tokenizes_as_hostname`, `test_aos8_controller_name_via_bare_name_with_device_siblings`, `test_aos8_controller_record_tokenizes_name`, `test_aos8_mac_address_with_space_normalized`.
+
+### Not addressed in this patch (tracked in #235)
+
+The transposed key/value shape used by `show <foo> detail` commands — where the actual JSON field names are literally `"Parameter"` and `"Value"` — defeats field-name-based classification entirely. RADIUS/TACACS server hosts/IPs visible in those responses still come through cleartext. AOS 8 itself masks the shared secret server-side (`'********'`), so secrets aren't at risk; the residual gap is server identifiers. Issue #235 covers the response-flattening work and the new `host` / `rad_server_name` / `tacacs_server_name` rules needed to close it.
+
 ## [2.4.0.4] - 2026-05-03
 
 **Security patch — AOS 8 UIDARUBA session token was being written to INFO-level logs on every API request. Fix scope: redact `UIDARUBA=` query values and `SESSION=` cookie values in the AOS 8 transport request/response logging hooks; close the test blind spot that let the leak ship undetected.** Tracks issue [#233](https://github.com/nowireless4u/hpe-networking-mcp/issues/233). Affects every release in the v2.4.0.x series before this one running with AOS 8 secrets configured. Operators without AOS 8 enabled are unaffected (the platform is gated off when `aos8_*` secrets are missing or empty, and the leaking code never executes).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.4.0.4"
+version = "2.4.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -193,6 +193,9 @@ TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
     "device_name": TokenKind.HOSTNAME,
     "ap_name": TokenKind.HOSTNAME,
     "hostname": TokenKind.HOSTNAME,
+    "host_name": TokenKind.HOSTNAME,  # AOS 8 client tables use "Host Name"
+    "controller_name": TokenKind.HOSTNAME,  # AOS 8 controller / MM identifier
+    "switch_name": TokenKind.HOSTNAME,  # AOS 8 / Central switch identifier
     "fqdn": TokenKind.HOSTNAME,
     "site_name": TokenKind.NAME,
     "org_name": TokenKind.NAME,
@@ -380,6 +383,17 @@ _COMMON_ENUM_VALUES: frozenset[str] = frozenset(
 # ---------------------------------------------------------------------------
 
 
+def _normalize_field_name(field_name: str) -> str:
+    """Lower-case, hyphen→underscore, space→underscore.
+
+    AOS 8 ``showcommand`` responses use space-separated headers
+    (``"IP Address"``, ``"AP name"``, ``"Wired MAC Address"``) — treat
+    those identically to snake_case. Mist/Central API responses don't
+    ship space-separated keys, so this is a no-op for them. (Issue #235.)
+    """
+    return field_name.lower().replace("-", "_").replace(" ", "_")
+
+
 def classify_field(
     field_name: str,
     value: object,
@@ -406,7 +420,7 @@ def classify_field(
     """
     if not isinstance(field_name, str):
         return FieldClassification.SKIP, None
-    name = field_name.lower().replace("-", "_")
+    name = _normalize_field_name(field_name)
 
     # Exact-match secret fields
     if name in SECRET_FIELD_NAMES:
@@ -432,8 +446,14 @@ def classify_field(
     # like a device — at least 2 device-shaped sibling fields (refined
     # in v2.3.1.2 from "any 1 hint" to fix wxtag false positives, where
     # the parent has a single ``mac`` field for client-MAC matching).
-    if name == "name" and parent_keys and len(parent_keys & DEVICE_CONTEXT_HINTS) >= 2:
-        return FieldClassification.TOKENIZE_IDENTIFIER, TokenKind.HOSTNAME
+    # Parent keys come in raw and may carry AOS 8 spacing/casing
+    # (e.g. ``"Model"``, ``"IP Address"``); normalize them before the
+    # intersection so the heuristic fires on AOS 8 controller / AP
+    # records (issue #235).
+    if name == "name" and parent_keys:
+        normalized_parents = frozenset(_normalize_field_name(k) for k in parent_keys if isinstance(k, str))
+        if len(normalized_parents & DEVICE_CONTEXT_HINTS) >= 2:
+            return FieldClassification.TOKENIZE_IDENTIFIER, TokenKind.HOSTNAME
 
     # Free-text fields
     if name in FREE_TEXT_FIELD_NAMES:

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -36,6 +36,7 @@ from hpe_networking_mcp.redaction.rules import (
     PEM_BLOCK_RE,
     FieldClassification,
     TokenKind,
+    _normalize_field_name,
     classify_field,
 )
 from hpe_networking_mcp.redaction.tokenizer import (
@@ -54,13 +55,18 @@ _MAX_DEPTH = 32
 
 # Field names whose containing dict signals a MAC field — used to pull
 # bare-12-hex MACs (no separators) out without false-positive risk.
+# AOS 8 form variants (``"MAC Address"``, ``"Wired MAC Address"``) are
+# handled by the same space → underscore normalization that classify_field
+# uses (issue #235); the post-normalization keys are listed here.
 _MAC_FIELD_HINTS: frozenset[str] = frozenset(
     {
         "mac",
+        "mac_address",
         "device_mac",
         "client_mac",
         "ap_mac",
         "wired_mac",
+        "wired_mac_address",
         "bssid",
         "src_mac",
         "dst_mac",
@@ -196,8 +202,11 @@ def _walk_pair(
     if isinstance(value, list):
         return _walk_list(key, value, tokenizer, depth=depth + 1, parent_keys=parent_keys)
 
-    # MAC normalization — always-on regardless of tokenizer presence
-    field_name_lower = str(key).lower() if isinstance(key, str) else ""
+    # MAC normalization — always-on regardless of tokenizer presence.
+    # Apply the same field-name normalization the classifier uses so AOS 8
+    # space-separated headers (``"MAC Address"``, ``"Wired MAC Address"``)
+    # match the underscore-keyed hint set (issue #235).
+    field_name_lower = _normalize_field_name(str(key)) if isinstance(key, str) else ""
     if field_name_lower in _MAC_FIELD_HINTS and isinstance(value, str) and is_mac_address(value):
         value = canonicalize_mac(value)
 

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -158,6 +158,56 @@ class TestFieldClassification:
         assert cls == FieldClassification.TOKENIZE_IDENTIFIER
         assert kind == TokenKind.HOSTNAME
 
+    # ---- AOS 8 space-separated-key normalization (issue #235) ------------
+
+    def test_aos8_ip_address_field_normalizes(self) -> None:
+        """AOS 8 ``"IP Address"`` lookalike normalizes to the same key as
+        ``ip-address`` / ``ip_address``. IPs are intentionally not in any
+        rule, so all three resolve to SKIP — but they must all resolve to
+        the *same* SKIP, not behave as different fields."""
+        a, _ = classify_field("IP Address", "172.23.4.21")
+        b, _ = classify_field("ip-address", "172.23.4.21")
+        c, _ = classify_field("ip_address", "172.23.4.21")
+        assert a == b == c == FieldClassification.SKIP
+
+    def test_aos8_ap_name_with_space_tokenizes_as_hostname(self) -> None:
+        """AOS 8 ``show ap database`` returns ``"AP name"`` as the column
+        header; with space normalization that becomes ``ap_name`` and
+        matches the existing HOSTNAME rule."""
+        cls, kind = classify_field("AP name", "Building1-Floor2-AP-07")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.HOSTNAME
+
+    def test_aos8_host_name_field_tokenizes_as_hostname(self) -> None:
+        """AOS 8 client tables use ``"Host Name"``."""
+        cls, kind = classify_field("Host Name", "alice-laptop")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.HOSTNAME
+
+    def test_aos8_controller_name_via_bare_name_with_device_siblings(self) -> None:
+        """AOS 8 ``show switches`` returns a flat record where the controller
+        identifier is just ``"Name"``, with siblings ``"Model"`` and
+        (effectively) ``"firmware"`` via ``"Version"``. The bare-``name``
+        heuristic must accept space-separated sibling keys after
+        normalization (issue #235)."""
+        cls, kind = classify_field(
+            "Name",
+            "MM-01",
+            parent_keys=frozenset(
+                {
+                    "Config ID",
+                    "IP Address",
+                    "Model",
+                    "Name",
+                    "Status",
+                    "Type",
+                    "firmware",
+                }
+            ),
+        )
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.HOSTNAME
+
     def test_unknown_field_skipped(self) -> None:
         cls, _ = classify_field("status", "online")
         assert cls == FieldClassification.SKIP
@@ -457,6 +507,57 @@ class TestTokenizeResponse:
         data = {"a": {"psk": "Welcome2024!"}, "b": {"psk": "Welcome2024!"}}
         result = tokenize_response(data, tokenizer)
         assert result["a"]["psk"] == result["b"]["psk"]
+
+    def test_aos8_controller_record_tokenizes_name(self, tokenizer: Tokenizer) -> None:
+        """End-to-end regression for issue #235.
+
+        This is the exact shape live ``aos8_get_controllers`` returns:
+        space-separated keys, ``"Name"`` as the controller identifier,
+        ``"Model"`` as a device-context sibling, ``"Version"`` (which
+        normalizes alongside but isn't a context hint by itself). With
+        the fix, ``"Name"`` tokenizes as HOSTNAME because ``Model``
+        + ``firmware``-equivalent siblings are now matched after the
+        space normalization.
+        """
+        data = {
+            "All Switches": [
+                {
+                    "Config ID": "1728",
+                    "Configuration State": "UPDATE SUCCESSFUL",
+                    "IP Address": "172.23.4.21",
+                    "Location": "Building1.floor1",
+                    "Model": "ArubaMM-VA",
+                    "Name": "MM-01",
+                    "Status": "up",
+                    "Type": "conductor",
+                    "firmware": "8.12.0.5",
+                }
+            ]
+        }
+        result = tokenize_response(data, tokenizer)
+        record = result["All Switches"][0]
+        # Name tokenized — does not equal cleartext, matches HOSTNAME prefix.
+        assert record["Name"] != "MM-01"
+        match = TOKEN_RE.fullmatch(record["Name"])
+        assert match is not None
+        assert match.group(1) == "HOSTNAME"
+        # IP Address remains cleartext (intentional: IPs not tokenized).
+        assert record["IP Address"] == "172.23.4.21"
+        # Geographic / model / status fields remain cleartext.
+        assert record["Model"] == "ArubaMM-VA"
+        assert record["Location"] == "Building1.floor1"
+
+    def test_aos8_mac_address_with_space_normalized(self, tokenizer: Tokenizer) -> None:
+        """AOS 8 ``"MAC Address"`` and ``"Wired MAC Address"`` columns
+        should reach the MAC canonicalizer the same as ``mac`` /
+        ``wired_mac`` (issue #235)."""
+        data = {
+            "Mac Address": "AA-BB-CC-DD-EE-FF",
+            "Wired MAC Address": "aabb.ccdd.eeff",
+        }
+        result = tokenize_response(data, tokenizer)
+        assert result["Mac Address"] == "aa:bb:cc:dd:ee:ff"
+        assert result["Wired MAC Address"] == "aa:bb:cc:dd:ee:ff"
 
     def test_macs_normalized_not_tokenized(self, tokenizer: Tokenizer) -> None:
         data = {"mac": "AA-BB-CC-DD-EE-FF", "client_mac": "aabb.ccdd.eeff"}


### PR DESCRIPTION
## Summary

Closes the **flat-record** PII tokenization gap on AOS 8 surfaced by the v2.4.0.4 audit. AOS 8's `showcommand` responses use space-separated column headers (`"AP name"`, `"Host Name"`, `"Wired MAC Address"`) that didn't match the existing Mist/Central snake_case rules. The fix extends our field-name normalizer to treat spaces the same as hyphens.

The **transposed key/value shape** used by `show <foo> detail` commands (RADIUS / TACACS / LDAP server detail, where field names are literally `"Parameter"` and `"Value"`) is not addressed here — tracked in #235.

Mist and Central are not affected — their public APIs use snake_case / camelCase exclusively.

## Live verification — what was leaking

Against a real Mobility Conductor on v2.4.0.4:

```python
>>> await call_tool("aos8_get_controllers", {})
{
  'All Switches': [{
    'Config ID': '1728',
    'IP Address': '172.23.4.21',
    'Location': 'Building1.floor1',
    'Model': 'ArubaMM-VA',
    'Name': 'MM-01',          # ← came through cleartext
    'Type': 'conductor',
    'Version': '8.12.0.5_92330',
  }]
}
```

`"Name": "MM-01"` is the controller hostname — it should tokenize as `HOSTNAME`. But:
1. `"Name"` lowercased to `"name"` (the bare form) needs sibling-context to fire.
2. `"Model"` is a valid device-context hint — but only one match. The heuristic requires ≥2 (defended in v2.3.1.2 against wxtag false positives). The space-separated sibling keys (`"IP Address"`, `"Type"`, etc.) weren't being normalized for the intersection check.

## Changes

- **`redaction/rules.py`** — extracted normalizer into `_normalize_field_name()` doing `lower()` + hyphen→underscore + space→underscore. `classify_field()` uses it for both the field name being classified AND for `parent_keys` when checking the bare-`name` heuristic. Added 3 identifier-field aliases: `host_name`, `controller_name`, `switch_name` → HOSTNAME.
- **`redaction/walker.py`** — `_walk_pair()` MAC field detection now routes through the same `_normalize_field_name()`. Added `mac_address` and `wired_mac_address` to `_MAC_FIELD_HINTS` for AOS 8's column-header form.
- **`tests/unit/test_pii_redaction.py`** — 6 new regression tests using the actual live `aos8_get_controllers` response shape so future changes can't silently regress.

## Test plan
- [x] 6 new unit tests added; `uv run pytest tests/unit/test_pii_redaction.py -k aos8` → all pass
- [x] Full suite: 907 passed (was 901; 6 new), 11 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/ --ignore-missing-imports` all clean
- [x] Test names map directly to live AOS 8 response shapes — `test_aos8_controller_record_tokenizes_name` uses the exact `{Config ID, IP Address, Model, Name, ...}` shape from production

## Not addressed (tracked in #235)

The transposed `[{'Parameter': 'Host', 'Value': '<ip>'}, ...]` shape from `show <foo> detail` commands — RADIUS/TACACS server hosts/IPs visible there still come through cleartext. AOS 8 masks the shared secret server-side, so secret leakage is not the concern; the residual gap is server identifiers. Issue #235 covers the response-flattening + new `host` / `rad_server_name` / `tacacs_server_name` rules needed.