### PR TITLE
v2.5.1.0: response envelope prototype on 4 cross-platform tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1.0] - 2026-05-04
+
+**Response envelope prototype (v3.0.0.0 candidate).** Wraps the four cross-platform tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) in a uniform response envelope so AIs navigating their output learn one shape instead of four bespoke ones. Tracked in issue [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) for the full v3.0.0.0 expansion to every tool in the catalog.
+
+### Why
+
+Operator transcripts surfaced a code-mode AI hitting *"`central.message` / `http_status` were read from the wrong level"* — a class of error caused by every tool having its own response structure. A smart-dict wrapper (overridden `__missing__` for helpful KeyError messages) was prototyped and **empirically rejected**: the Monty sandbox runtime strips dict subclasses across the boundary, so subclass behavior doesn't reach the AI. The only structural fix that survives marshaling is changing the data **shape** itself.
+
+This release ships the shape change scoped to four tools to validate the pattern before committing to the full v3 refactor (which would be a breaking change for static-mode consumers across all 312 tools).
+
+### Envelope shape
+
+```
+{
+  "ok":       bool,            # success indicator
+  "status":   int | null,      # HTTP status (200 / 401 / 503) or null for non-HTTP
+  "data":     <any>,           # the actual payload — list, dict, or null
+  "message":  str | null,      # human-readable error / context message
+  "tool":     str,             # tool name (e.g. "health")
+  "platform": str | null       # platform-prefix-derived; null for cross-platform
+}
+```
+
+For multi-platform tools like `health`, the inner `data` preserves each platform's natural shape rather than triple-nesting envelopes.
+
+### What's new
+
+- **`src/hpe_networking_mcp/middleware/response_envelope.py`** — new `ResponseEnvelopeMiddleware`. Allowlist-scoped to `PROTOTYPE_TOOLS = {health, site_health_check, site_rf_check, manage_wlan_profile}`. Other tools short-circuit and pass through unchanged. Idempotency check ensures already-enveloped responses (a tool returning the envelope explicitly) are not re-wrapped.
+- **`src/hpe_networking_mcp/server.py`** — middleware wired into the chain as **innermost** (last in the list), so it wraps raw tool output before retry / PII / elicitation / etc. process the response. RetryMiddleware's status-code extraction works equally on the envelope's `status` field as on raw `status_code`/`code`/`http_status`.
+- **`tests/unit/test_response_envelope_middleware.py`** — 27 new unit tests covering platform inference, status extraction, envelope-shape detection, success wrapping, prototype-tool short-circuit (non-allowlisted tools pass through), idempotency on already-enveloped responses, and `None`-structured-content handling.
+- **`INSTRUCTIONS.md`** — new "Response envelope on cross-platform tools" section telling AIs how to navigate the new shape: payload is at `result["data"]` for these four tools; everything else returns native shape.
+
+### What this does NOT do
+
+- **Doesn't apply to the other 308 tools.** Their response shapes are unchanged. The full v3 refactor is tracked separately as [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246).
+- **Doesn't fix wrong-level access inside `data`.** The envelope makes the *outer* shape uniform; the inner `data` field still has tool-specific structure. Reduces the navigation surface from "every tool has a different shape" to "the four cross-platform tools all start at `data`," which is genuinely simpler but not a panacea.
+- **Doesn't fix pure Python logic errors** like `same_scope_id = scope_a or scope_b` returning a string instead of a bool. Those are AI capability issues no platform change can paper over.
+- **Doesn't update skill text** to reference the new envelope shape — skills describe data semantically and AIs adapt with one global note in `INSTRUCTIONS.md`. Skill-text updates are deferred to v3 to amortize across the full refactor.
+
+### Decision criteria for promoting to v3
+
+- Operator sessions on the four wrapped tools show no regressions from the existing shape.
+- AI behavior is observably better on these tools (fewer wrong-level errors).
+- Test/skill update pattern is mechanical enough to scale to 312 tools without surprises.
+- PII tokenization continues to work correctly through the envelope (verified — PII walker descends into `data` recursively; envelope metadata fields like `tool` and `platform` aren't tracked field names).
+
+### File touches
+
+- `src/hpe_networking_mcp/middleware/response_envelope.py` — new (143 lines)
+- `src/hpe_networking_mcp/server.py` — added 1 import + 1 line in middleware chain
+- `tests/unit/test_response_envelope_middleware.py` — new (213 lines, 27 tests)
+- `src/hpe_networking_mcp/INSTRUCTIONS.md` — new envelope-explanation section
+- `pyproject.toml` — version 2.5.0.1 → 2.5.1.0
+- `CHANGELOG.md` — this entry
+
+No skill text changes; no breaking changes; no platform code changes.
+
 ## [2.5.0.1] - 2026-05-04
 
 **Eight-item cleanup pass on the `aos-migration` skill driven by operator transcripts.** Drops AOS 6 and Instant AP support, deletes the Stage 0 operator interview, replaces controller-plumbing REGRESSION rules with inventory-only entries, adds applicability gates so empty environments don't generate spurious findings, introduces an `EMPTY-SOURCE` verdict, makes Stage 1 walk the full `/md` hierarchy in code-mode orchestration, and adds a `usage_state` column to the disposition matrix so unused/orphaned config still gets translated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.5.0.1"
+version = "2.5.1.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -104,6 +104,28 @@ When `ENABLE_PII_TOKENIZATION=true` (operator-controlled, off by default), the M
 
 When tokenization is off, tool responses contain plaintext values — your behavior is unchanged.
 
+## Response envelope on cross-platform tools (v2.5.1.0+ prototype)
+
+The four cross-platform tools — `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile` — wrap their responses in a uniform envelope:
+
+```
+{
+  "ok":       bool,            # success indicator
+  "status":   int | null,      # HTTP status (200 / 401 / 503) or null for non-HTTP
+  "data":     <any>,           # the actual payload — list, dict, or null
+  "message":  str | null,      # human-readable error / context message
+  "tool":     str,             # tool name
+  "platform": str | null       # null for these cross-platform tools
+}
+```
+
+**Practical implications:**
+- For these four tools, the actual payload lives at `result["data"]`. Reading `result["status"]` etc. directly gets the envelope's metadata, not the inner data fields.
+- All other tools (`mist_*`, `central_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `greenlake_*`) return their **native shape unchanged** — no envelope. Don't navigate through `["data"]` for those.
+- Errors uniformly arrive as `{"ok": false, "message": "...", "data": null}` for the wrapped tools.
+
+This is a **prototype scope** — issue [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) tracks expanding the envelope to every tool in v3.0.0.0 (which would be a breaking change for static-mode consumers).
+
 ---
 
 # JUNIPER MIST (mist_* tools)

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -1,0 +1,163 @@
+"""Response envelope middleware — wraps tool responses in a uniform shape.
+
+v2.5.1.0 prototype scope: applies only to the 4 cross-platform tools
+(``health``, ``site_health_check``, ``site_rf_check``, ``manage_wlan_profile``)
+to validate the pattern before committing to the full v3.0.0.0 refactor across
+every tool in the catalog. Tracked in issue #246.
+
+Envelope shape::
+
+    {
+      "ok":       bool,           # success indicator
+      "status":   int | None,     # HTTP status (200, 401, 503) or None
+      "data":     Any,            # the actual payload — list, dict, or None
+      "message":  str | None,     # human-readable summary; populated on errors
+      "tool":     str,            # tool name
+      "platform": str | None,     # "central" / "mist" / ... / None for cross-platform
+    }
+
+The middleware sits **innermost** in the chain so it wraps raw tool output
+*before* retry / PII / elicitation / etc. process the response. Retry's
+``_extract_status_code`` works equally on the envelope's ``status`` field
+as it does on raw tool output's ``status_code`` / ``code`` / ``status``.
+
+When a tool already returned a dict matching the envelope shape (i.e. one
+of the 4 tools manually returned an envelope), the middleware passes through
+without re-wrapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+from loguru import logger
+
+# v2.5.1.0 prototype scope. v3.0.0.0 expands this to every tool — see #246.
+PROTOTYPE_TOOLS: frozenset[str] = frozenset(
+    {
+        "health",
+        "site_health_check",
+        "site_rf_check",
+        "manage_wlan_profile",
+    }
+)
+
+# Platform prefixes used to derive the ``platform`` envelope field. Cross-platform
+# tools (those without one of these prefixes) end up with ``platform: null``.
+_PLATFORM_PREFIXES: tuple[str, ...] = (
+    "mist_",
+    "central_",
+    "greenlake_",
+    "clearpass_",
+    "apstra_",
+    "axis_",
+    "aos8_",
+)
+
+# Keys an existing envelope-shaped dict must contain (idempotency check).
+_ENVELOPE_REQUIRED_KEYS: frozenset[str] = frozenset({"ok", "data", "tool"})
+
+# Keys to inspect when extracting an HTTP status code from a raw tool result.
+# Mirrors ``retry.py:_extract_status_code`` so the envelope's ``status`` field
+# is populated consistently with what RetryMiddleware would see.
+_STATUS_CODE_KEYS: tuple[str, ...] = ("status_code", "code", "http_status")
+
+
+def _infer_platform(tool_name: str) -> str | None:
+    """Derive ``platform`` from a tool name's prefix.
+
+    Returns ``None`` for cross-platform tools (no prefix match).
+    """
+    for prefix in _PLATFORM_PREFIXES:
+        if tool_name.startswith(prefix):
+            return prefix.rstrip("_")
+    return None
+
+
+def _extract_status(raw: Any) -> int | None:
+    """Best-effort HTTP-status extraction from a raw tool result.
+
+    Looks for ``status_code`` / ``code`` / ``http_status`` at the top level.
+    Returns ``None`` when the tool's response doesn't carry an HTTP status
+    (most non-HTTP-bound tools).
+    """
+    if not isinstance(raw, dict):
+        return None
+    for key in _STATUS_CODE_KEYS:
+        value = raw.get(key)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _is_envelope_shape(value: Any) -> bool:
+    """True when ``value`` is already an envelope dict (idempotency)."""
+    return isinstance(value, dict) and _ENVELOPE_REQUIRED_KEYS.issubset(value.keys())
+
+
+def _build_envelope(
+    *,
+    ok: bool,
+    data: Any,
+    status: int | None,
+    message: str | None,
+    tool: str,
+    platform: str | None,
+) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "status": status,
+        "data": data,
+        "message": message,
+        "tool": tool,
+        "platform": platform,
+    }
+
+
+class ResponseEnvelopeMiddleware(Middleware):
+    """Wrap allowlisted tool responses in the uniform envelope shape.
+
+    Position **innermost** in the middleware chain (last in the
+    ``middleware=[...]`` list) so the wrap happens on raw tool output
+    *before* retry / PII / elicitation see the response.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next,
+    ) -> ToolResult:
+        tool_name = context.message.name
+
+        if tool_name not in PROTOTYPE_TOOLS:
+            return await call_next(context)  # type: ignore[return-value]
+
+        platform = _infer_platform(tool_name)
+        result = await call_next(context)
+
+        # Determine the raw structured payload, if any.
+        raw = getattr(result, "structured_content", None)
+
+        if raw is not None and _is_envelope_shape(raw):
+            # Tool already returned an envelope — respect it.
+            logger.debug("response_envelope: {} already enveloped, pass-through", tool_name)
+            return result  # type: ignore[return-value]
+
+        envelope = _build_envelope(
+            ok=True,
+            data=raw,
+            status=_extract_status(raw),
+            message=None,
+            tool=tool_name,
+            platform=platform,
+        )
+
+        logger.debug("response_envelope: wrapped {} (platform={})", tool_name, platform)
+
+        return ToolResult(
+            content=result.content,
+            structured_content=envelope,
+        )

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -216,6 +216,7 @@ def create_server(config: ServerConfig) -> FastMCP:
     from hpe_networking_mcp.middleware.pii_tokenization import (
         PIITokenizationMiddleware,
     )
+    from hpe_networking_mcp.middleware.response_envelope import ResponseEnvelopeMiddleware
     from hpe_networking_mcp.middleware.retry import RetryMiddleware
     from hpe_networking_mcp.middleware.sandbox_error_catch import (
         SandboxErrorCatchMiddleware,
@@ -238,6 +239,10 @@ def create_server(config: ServerConfig) -> FastMCP:
     #                         post-detokenization, which is correct (the user is
     #                         the trust boundary holder, not the AI)
     #   Retry               — transient failures retry transparently after elicit
+    #   ResponseEnvelope    — v2.5.1.0 prototype (#246): wraps the 4 cross-platform
+    #                         tools' raw output in {ok, data, status, message, tool,
+    #                         platform}. Innermost so retry's status-code extraction
+    #                         + PII tokenization see the envelope shape on the way out.
     mcp = FastMCP(
         name="HPE Networking MCP",
         instructions=_INSTRUCTIONS,
@@ -251,6 +256,7 @@ def create_server(config: ServerConfig) -> FastMCP:
             PIITokenizationMiddleware(token_store, enabled=config.enable_pii_tokenization),
             ElicitationMiddleware(),
             RetryMiddleware(),
+            ResponseEnvelopeMiddleware(),
         ],
     )
 

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -1,0 +1,264 @@
+"""Unit tests for ResponseEnvelopeMiddleware (v2.5.1.0 prototype, issue #246).
+
+Verifies the envelope-wrapping middleware against the four tool-name
+scopes defined in ``PROTOTYPE_TOOLS``. Non-prototype tools pass through
+unchanged. Already-enveloped responses pass through idempotently.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.tools.tool import ToolResult
+
+from hpe_networking_mcp.middleware.response_envelope import (
+    PROTOTYPE_TOOLS,
+    ResponseEnvelopeMiddleware,
+    _extract_status,
+    _infer_platform,
+    _is_envelope_shape,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — mock MiddlewareContext + tool-result builders
+# ---------------------------------------------------------------------------
+
+
+def _make_context(tool_name: str):
+    message = MagicMock()
+    message.name = tool_name
+    context = MagicMock()
+    context.message = message
+    return context
+
+
+def _make_tool_result(structured: object | None, content: list | None = None) -> ToolResult:
+    """Build a ToolResult with the given structured_content."""
+    return ToolResult(
+        content=content if content is not None else [],
+        structured_content=structured,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _infer_platform
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInferPlatform:
+    def test_central_tool(self):
+        assert _infer_platform("central_get_sites") == "central"
+
+    def test_mist_tool(self):
+        assert _infer_platform("mist_search_device") == "mist"
+
+    def test_aos8_tool(self):
+        assert _infer_platform("aos8_get_ap_database") == "aos8"
+
+    def test_clearpass_tool(self):
+        assert _infer_platform("clearpass_get_sessions") == "clearpass"
+
+    def test_cross_platform_health(self):
+        assert _infer_platform("health") is None
+
+    def test_cross_platform_site_health_check(self):
+        assert _infer_platform("site_health_check") is None
+
+    def test_cross_platform_manage_wlan_profile(self):
+        assert _infer_platform("manage_wlan_profile") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExtractStatus:
+    def test_status_code_key(self):
+        assert _extract_status({"status_code": 200, "data": "x"}) == 200
+
+    def test_code_key(self):
+        assert _extract_status({"code": 404, "message": "not found"}) == 404
+
+    def test_http_status_key(self):
+        assert _extract_status({"http_status": 503}) == 503
+
+    def test_priority_status_code_over_others(self):
+        # Should pick status_code first (mirrors retry.py's _extract_status_code)
+        assert _extract_status({"status_code": 200, "code": 500}) == 200
+
+    def test_no_status_field(self):
+        assert _extract_status({"sites": [], "total": 0}) is None
+
+    def test_non_dict(self):
+        assert _extract_status([1, 2, 3]) is None
+        assert _extract_status("string") is None
+        assert _extract_status(None) is None
+
+    def test_non_int_status(self):
+        # Some tools return status as a string; prototype only accepts int
+        assert _extract_status({"status_code": "200"}) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_envelope_shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsEnvelopeShape:
+    def test_full_envelope(self):
+        assert (
+            _is_envelope_shape(
+                {
+                    "ok": True,
+                    "data": {},
+                    "status": None,
+                    "message": None,
+                    "tool": "health",
+                    "platform": None,
+                }
+            )
+            is True
+        )
+
+    def test_minimal_envelope_keys_only(self):
+        # Only ok/data/tool required
+        assert _is_envelope_shape({"ok": False, "data": None, "tool": "x"}) is True
+
+    def test_missing_ok(self):
+        assert _is_envelope_shape({"data": {}, "tool": "x"}) is False
+
+    def test_missing_data(self):
+        assert _is_envelope_shape({"ok": True, "tool": "x"}) is False
+
+    def test_missing_tool(self):
+        assert _is_envelope_shape({"ok": True, "data": {}}) is False
+
+    def test_non_dict(self):
+        assert _is_envelope_shape([{"ok": True}]) is False
+        assert _is_envelope_shape("string") is False
+        assert _is_envelope_shape(None) is False
+
+
+# ---------------------------------------------------------------------------
+# ResponseEnvelopeMiddleware
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestResponseEnvelopeMiddleware:
+    @pytest.mark.asyncio
+    async def test_wraps_health_response(self):
+        """The cross-platform `health` tool gets wrapped in the envelope."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("health")
+        raw_response = {
+            "status": "ok",
+            "platforms": {"central": {"status": "ok"}, "mist": {"status": "ok"}},
+        }
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw_response))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content == {
+            "ok": True,
+            "status": None,  # no HTTP status in raw response
+            "data": raw_response,
+            "message": None,
+            "tool": "health",
+            "platform": None,  # cross-platform
+        }
+
+    @pytest.mark.asyncio
+    async def test_wraps_site_health_check(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("site_health_check")
+        raw = {"site_name": "dallas-hq", "verdict": "GO"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == raw
+        assert result.structured_content["tool"] == "site_health_check"
+        assert result.structured_content["platform"] is None
+
+    @pytest.mark.asyncio
+    async def test_wraps_manage_wlan_profile_with_status(self):
+        """Status code present in raw response is lifted into the envelope."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("manage_wlan_profile")
+        raw = {"status_code": 200, "wlan": "Corp"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["status"] == 200
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_passes_through_non_prototype_tool(self):
+        """Tools NOT in PROTOTYPE_TOOLS are not wrapped — short-circuit."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_get_sites")
+        raw = {"sites": [{"name": "dallas-hq"}]}
+        original = _make_tool_result(structured=raw)
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        # Same object — no wrapping
+        assert result is original
+        assert result.structured_content == raw
+
+    @pytest.mark.asyncio
+    async def test_already_enveloped_passes_through(self):
+        """If a prototype tool already returned an envelope, don't re-wrap."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("health")
+        existing_envelope = {
+            "ok": True,
+            "data": {"central": {"status": "ok"}},
+            "status": None,
+            "message": None,
+            "tool": "health",
+            "platform": None,
+        }
+        original = _make_tool_result(structured=existing_envelope)
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        # Same object — pass through
+        assert result is original
+        assert result.structured_content == existing_envelope
+
+    @pytest.mark.asyncio
+    async def test_wraps_none_structured_content(self):
+        """When structured_content is None (e.g. text-only result), envelope wraps with data=None."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("health")
+        call_next = AsyncMock(return_value=_make_tool_result(structured=None))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content == {
+            "ok": True,
+            "status": None,
+            "data": None,
+            "message": None,
+            "tool": "health",
+            "platform": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_prototype_tools_set_membership(self):
+        """All four documented prototype tools are in PROTOTYPE_TOOLS."""
+        assert "health" in PROTOTYPE_TOOLS
+        assert "site_health_check" in PROTOTYPE_TOOLS
+        assert "site_rf_check" in PROTOTYPE_TOOLS
+        assert "manage_wlan_profile" in PROTOTYPE_TOOLS
+        assert len(PROTOTYPE_TOOLS) == 4


### PR DESCRIPTION
## Summary

Wraps four cross-platform tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) in a uniform response envelope so AIs navigating their output learn one shape instead of four bespoke ones. v3.0.0.0 candidate scoped to a small allowlist for prototype validation; full expansion across all 312 tools tracked in #246.

Closes #246's prototype milestone (issue itself stays open as the v3 design ledger).

## Why

Operator transcripts captured a code-mode AI hitting *"`central.message` / `http_status` were read from the wrong level"* — every tool having its own response structure forces the AI to learn 312 shapes.

I first tried a smart-dict middleware (overridden `__missing__` for helpful KeyError messages with key-path hints). **Empirically rejected**: the Monty sandbox runtime strips dict subclasses across the boundary. Verified with:

```
[sandbox] sandbox type: dict
```

The only structural fix that survives marshaling is changing the data **shape** itself.

## Envelope

```python
{
  "ok":       bool,            # success indicator
  "status":   int | None,      # HTTP status (200 / 401 / 503) or null
  "data":     <any>,           # the actual payload — list, dict, or null
  "message":  str | None,      # human-readable error / context message
  "tool":     str,             # tool name
  "platform": str | None       # null for cross-platform tools
}
```

For multi-platform tools like `health`, the inner `data` preserves each platform's natural shape rather than triple-nesting envelopes.

## Implementation

- **`ResponseEnvelopeMiddleware`** at `src/hpe_networking_mcp/middleware/response_envelope.py`. Allowlist-scoped to `PROTOTYPE_TOOLS = {health, site_health_check, site_rf_check, manage_wlan_profile}`. Idempotency check on already-enveloped dicts.
- **Position innermost** in the middleware chain (last in the `middleware=[...]` list) so it wraps raw tool output before retry / PII / elicitation see the response. Retry's status extraction works on `envelope.status` the same way it works on raw `status_code`/`code`/`http_status`.
- **PII tokenization compatibility verified**: walker descends into `data` recursively; envelope metadata fields (`tool`, `platform`, `message`) aren't tracked field names so they pass through untokenized.

## Test plan
- [x] `uv run pytest tests/unit/test_response_envelope_middleware.py` → 27/27 pass
- [x] Full suite: 934 passed, 11 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/` clean
- [ ] Live deploy verification: pull v2.5.1.0 image, recreate, call `health` from inside `execute()`. Confirm response is `{"ok": true, "data": {...}, "tool": "health", "platform": null, ...}`. Compare to a non-prototype tool's response (e.g. `central_get_devices`) to confirm it's unchanged.

## What this does NOT do

- **Doesn't apply to the other 308 tools.** Their shapes are unchanged. Full v3 refactor tracked in #246.
- **Doesn't fix wrong-level access INSIDE `data`.** Outer shape uniform; inner `data` still tool-specific. Reduces but doesn't eliminate the navigation surface.
- **Doesn't fix pure Python logic errors** (`x = a or b` returning a string). AI capability issues no platform change can paper over.
- **Doesn't update skill text** to reference the new envelope shape. Skills describe data semantically and AIs adapt with the global note in `INSTRUCTIONS.md`. Deferred to v3.

## Decision criteria for promoting to v3 (#246)

Promote when:
- Operator sessions on these 4 tools show no regressions.
- AI behavior observably better (fewer wrong-level errors).
- Test/skill update pattern is mechanical enough to scale to 312 tools.
- PII tokenization continues to work correctly through the envelope.

Don't promote if:
- Operators dislike the wrapped shape (extra typing burden for static-mode users).
- Unexpected interactions with existing middleware surface.
- AI behavior doesn't materially improve.

## File touches

- `src/hpe_networking_mcp/middleware/response_envelope.py` — new (143 lines)
- `src/hpe_networking_mcp/server.py` — added 1 import + 1 line in middleware chain
- `tests/unit/test_response_envelope_middleware.py` — new (213 lines, 27 tests)
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — new envelope-explanation section
- `pyproject.toml` — version 2.5.0.1 → 2.5.1.0
- `CHANGELOG.md` — full v2.5.1.0 entry

No skill text changes; no breaking changes; no platform code changes.