### PR TITLE
v2.5.1.1: fix aos8_get_md_hierarchy command + diagnose decode failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1.1] - 2026-05-04
+
+**`aos8_get_md_hierarchy` was sending an unrecognized CLI command — fixed; AOS 8 helpers now diagnose decode failures.** Two related bugs surfaced from an `aos-migration` operator transcript:
+
+- The differentiator tool was issuing `show switch hierarchy` (singular), which is not a real AOS 8 CLI command. The Conductor's CLI parser silently rejected it and returned an empty body, which `run_show()` couldn't parse → bare `JSONDecodeError` → cryptic *"Expecting value: line 1 column 1 (char 0)"* error reaching the AI. The hand-built fixture invented both the command name and the response shape, so the unit test was passing against a fiction. Verified live against an ArubaMM-VA conductor (AOS 8.12.0.5): the correct command is `show configuration node-hierarchy`, returning a `Configuration node hierarchy` table with `Config Node` / `Name` / `Type` columns. Issue [#248](https://github.com/nowireless4u/hpe-networking-mcp/issues/248).
+- More generally, every AOS 8 read tool that goes through `run_show()` or `get_object()` was leaking raw `json.JSONDecodeError` messages on any 2xx-with-non-JSON response (empty body, HTML login redirect, plaintext error). The bare error gave the AI no hint about *what* failed. Helpers now raise `AOS8DecodeError` with HTTP status, content-type, body length, and a body preview, which `format_aos8_error()` renders as an actionable diagnostic. Issue [#249](https://github.com/nowireless4u/hpe-networking-mcp/issues/249).
+
+A follow-up issue [#250](https://github.com/nowireless4u/hpe-networking-mcp/issues/250) tracks the related `aos-migration` skill bug — 13 of 20 names in the COLLECT-01 `OBJECT_TYPES` list are not valid AOS 8 REST schema names; that fix lands separately.
+
+### What's new
+
+- **`src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py`** — `aos8_get_md_hierarchy` now sends `show configuration node-hierarchy`. Docstring updated to reflect the real top-level response key.
+- **`src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py`** — new `AOS8DecodeError` class + `_decode_json_or_raise()` helper. `run_show()` and `get_object()` route their `response.json()` calls through it. `format_aos8_error()` gains a branch for `AOS8DecodeError` so the diagnostic surfaces verbatim instead of falling into the generic *"Unexpected error"* path.
+- **`tests/unit/fixtures/aos8/show_configuration_node_hierarchy.json`** — replaces hand-built `show_switch_hierarchy.json` with a real-shape capture (16 rows: System / Group / Device entries spanning `/md/ACX`, `/md/Branch`, `/md/Campus/East`, `/md/Campus/West`, `/mm/mynode`).
+- **`tests/unit/test_aos8_read_differentiators.py`** — `test_get_md_hierarchy` updated to the new command + shape; new `test_get_md_hierarchy_non_json_body_diagnoses_decode_error` regression test ensures decode failures surface a structured diagnostic with HTTP status, content-type, and body length, and that the bare json-module error never leaks to callers.
+
+### Notes
+
+- This is the second instance (after [#237](https://github.com/nowireless4u/hpe-networking-mcp/issues/237)) of a hand-fabricated fixture masking a real-world bug. Live-capture-only fixtures remain mandatory for new code paths.
+
 ## [2.5.1.0] - 2026-05-04
 
 **Response envelope prototype (v3.0.0.0 candidate).** Wraps the four cross-platform tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) in a uniform response envelope so AIs navigating their output learn one shape instead of four bespoke ones. Tracked in issue [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) for the full v3.0.0.0 expansion to every tool in the catalog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.5.1.0"
+version = "2.5.1.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -625,7 +625,7 @@ Authentication is automatic — the client logs in to `/v1/api/login` with `aos8
 ## Mobility Conductor (MM) vs Managed Device (MD) Context
 - **MM** is the configuration/policy plane — cluster state, AP database, AP groups, SSID profiles, virtual APs, user roles, AAA all live here.
 - **MD** is the data plane — clients terminate on MDs; runtime state (active APs per MD, RF radios, IPsec tunnels) is queried per-MD.
-- Several tools accept an explicit MD context argument; when omitted they query MM. `aos8_get_md_hierarchy` lists MDs under MM.
+- Several tools accept an explicit MD context argument; when omitted they query MM. `aos8_get_md_hierarchy` returns the full configuration node tree (`/`, `/md`, `/md/<group>`, `/md/<group>/<device-mac>`, `/mm/...`) with `Type` of `System`, `Group`, or `Device`.
 
 ## Tool Categories
 - **Health/inventory**: `aos8_get_controllers`, `aos8_get_ap_database`, `aos8_get_active_aps`, `aos8_get_ap_detail`, `aos8_get_bss_table`, `aos8_get_radio_summary`, `aos8_get_version`, `aos8_get_licenses`.

--- a/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
@@ -20,7 +20,23 @@ from hpe_networking_mcp.platforms.aos8.client import (
     AOS8Client,
 )
 
-__all__ = ["strip_meta", "run_show", "get_object", "post_object", "format_aos8_error"]
+__all__ = [
+    "strip_meta",
+    "run_show",
+    "get_object",
+    "post_object",
+    "format_aos8_error",
+    "AOS8DecodeError",
+]
+
+
+class AOS8DecodeError(RuntimeError):
+    """Raised when an AOS 8 endpoint returns a 2xx body that isn't valid JSON.
+
+    Common triggers: an unrecognized show-command (CLI parser silently
+    rejects, returns empty body), an HTML login redirect, or a plaintext
+    error from a misrouted request.
+    """
 
 
 def strip_meta(body: Any) -> Any:
@@ -36,6 +52,30 @@ def strip_meta(body: Any) -> Any:
     if not isinstance(body, dict):
         return body
     return {k: v for k, v in body.items() if k not in ("_meta", "_global_result")}
+
+
+def _decode_json_or_raise(response: httpx.Response, what: str) -> Any:
+    """Return ``response.json()`` or raise AOS8DecodeError with diagnostics.
+
+    AOS 8 may return a 2xx response with an empty body, an HTML login page,
+    or a plaintext error when the CLI parser silently rejects a command or
+    a session cookie has gone stale. Surface enough metadata for the AI
+    caller to act on (status, content-type, body length, body preview)
+    instead of leaking the raw json-module ValueError.
+    """
+    try:
+        return response.json()
+    except ValueError as exc:
+        body = response.text or ""
+        preview = body[:120].replace("\n", " ").strip()
+        content_type = response.headers.get("content-type", "<missing>")
+        raise AOS8DecodeError(
+            f"AOS 8 returned non-JSON body for {what} "
+            f"(HTTP {response.status_code}, content-type={content_type}, {len(body)} bytes)"
+            + (f": {preview!r}" if preview else " — body was empty")
+            + ". Likely causes: command not recognized by the controller's"
+            " CLI parser, an HTML login redirect, or a misrouted endpoint."
+        ) from exc
 
 
 async def run_show(
@@ -59,7 +99,7 @@ async def run_show(
     if config_path is not None:
         params["config_path"] = config_path
     response = await client.request("GET", "/v1/configuration/showcommand", params=params)
-    return strip_meta(response.json())
+    return strip_meta(_decode_json_or_raise(response, f"show command {command!r}"))
 
 
 async def get_object(
@@ -83,7 +123,7 @@ async def get_object(
         f"/v1/configuration/object/{object_path}",
         params={"config_path": config_path},
     )
-    return strip_meta(response.json())
+    return strip_meta(_decode_json_or_raise(response, f"object {object_path!r}"))
 
 
 async def post_object(
@@ -139,6 +179,8 @@ def format_aos8_error(exc: BaseException, action: str) -> str:
         return f"AOS8 authentication failed while attempting to {action}: {exc}"
     if isinstance(exc, AOS8APIError):
         return f"AOS8 API error while attempting to {action}: {exc}"
+    if isinstance(exc, AOS8DecodeError):
+        return f"AOS8 decode error while attempting to {action}: {exc}"
     if isinstance(exc, httpx.HTTPStatusError):
         return f"AOS8 HTTP {exc.response.status_code} while attempting to {action}: {exc}"
     if isinstance(exc, httpx.HTTPError):

--- a/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
@@ -53,12 +53,12 @@ async def aos8_get_md_hierarchy(ctx: Context) -> dict[str, Any] | str:
         ctx: FastMCP request context (provides ``aos8_client``).
 
     Returns:
-        Dict with the AOS8 ``Switch Hierarchy`` table on success; error
-        string on failure.
+        Dict with the AOS8 ``Configuration node hierarchy`` table on success;
+        error string on failure.
     """
     client = ctx.lifespan_context["aos8_client"]
     try:
-        return await run_show(client, "show switch hierarchy")
+        return await run_show(client, "show configuration node-hierarchy")
     except Exception as exc:  # noqa: BLE001
         return format_aos8_error(exc, "fetch MD hierarchy")
 

--- a/tests/unit/fixtures/aos8/show_configuration_node_hierarchy.json
+++ b/tests/unit/fixtures/aos8/show_configuration_node_hierarchy.json
@@ -1,0 +1,23 @@
+{
+  "_meta": ["Config Node", "Name", "Type"],
+  "_data": ["Default-node is not configured. Autopark is disabled."],
+  "Configuration node hierarchy": [
+    {"Config Node": "/", "Name": null, "Type": "System"},
+    {"Config Node": "/md", "Name": null, "Type": "System"},
+    {"Config Node": "/md/ACX", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/ACX/00:0c:29:3b:0e:6d", "Name": "ACX-VMC02", "Type": "Device"},
+    {"Config Node": "/md/ACX/00:0c:29:41:37:35", "Name": "ACX-VMC01", "Type": "Device"},
+    {"Config Node": "/md/Branch", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Branch/Branch_Sites", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Branch/Branch_Sites_Static", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Branch/Branch_VPNC", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Campus", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Campus/East", "Name": null, "Type": "Group"},
+    {"Config Node": "/md/Campus/East/00:0c:29:41:a2:5a", "Name": "MJG-EAST-02", "Type": "Device"},
+    {"Config Node": "/md/Campus/East/00:0c:29:a1:08:18", "Name": "MJG-EAST-01", "Type": "Device"},
+    {"Config Node": "/md/Campus/West", "Name": null, "Type": "Group"},
+    {"Config Node": "/mm", "Name": null, "Type": "System"},
+    {"Config Node": "/mm/mynode", "Name": null, "Type": "System"}
+  ],
+  "_global_result": {"status": "0", "status_str": "Success"}
+}

--- a/tests/unit/fixtures/aos8/show_switch_hierarchy.json
+++ b/tests/unit/fixtures/aos8/show_switch_hierarchy.json
@@ -1,7 +1,0 @@
-{
-  "_global_result": {"status": "0", "status_str": "Success"},
-  "Switch Hierarchy": [
-    {"Name": "MC-01", "IP Address": "10.0.0.1", "Role": "master", "config_path": "/mm/mynode"},
-    {"Name": "MD-01", "IP Address": "10.0.0.2", "Role": "local", "config_path": "/md/branch1"}
-  ]
-}

--- a/tests/unit/test_aos8_read_differentiators.py
+++ b/tests/unit/test_aos8_read_differentiators.py
@@ -45,7 +45,7 @@ def _make_ctx(body: dict):
 async def test_get_md_hierarchy():
     from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_md_hierarchy
 
-    body = _load("show_switch_hierarchy.json")
+    body = _load("show_configuration_node_hierarchy.json")
     ctx, client = _make_ctx(body)
 
     result = await aos8_get_md_hierarchy(ctx)
@@ -53,11 +53,44 @@ async def test_get_md_hierarchy():
     client.request.assert_awaited_once_with(
         "GET",
         "/v1/configuration/showcommand",
-        params={"command": "show switch hierarchy"},
+        params={"command": "show configuration node-hierarchy"},
     )
     assert "_meta" not in result
     assert "_global_result" not in result
-    assert result["Switch Hierarchy"][0]["Name"] == "MC-01"
+    rows = result["Configuration node hierarchy"]
+    assert {r["Type"] for r in rows} >= {"System", "Group", "Device"}
+    assert any(r["Config Node"] == "/md" for r in rows)
+    assert any(r["Type"] == "Device" and r["Name"] for r in rows)
+
+
+async def test_get_md_hierarchy_non_json_body_diagnoses_decode_error():
+    """Empty / non-JSON 2xx bodies must surface a diagnostic — not a bare
+    json-module ValueError. Regression test for issue #248 / #249.
+    """
+    from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_md_hierarchy
+
+    # Simulate an empty body returned with HTTP 200 + text/html (CLI parser
+    # silently rejected an unrecognized command).
+    r = MagicMock()
+    r.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+    r.text = ""
+    r.status_code = 200
+    r.headers = {"content-type": "text/html"}
+
+    client = MagicMock()
+    client.request = AsyncMock(return_value=r)
+    ctx = MagicMock()
+    ctx.lifespan_context = {"aos8_client": client}
+
+    result = await aos8_get_md_hierarchy(ctx)
+
+    assert isinstance(result, str)
+    assert "decode error" in result.lower()
+    assert "HTTP 200" in result
+    assert "text/html" in result
+    assert "0 bytes" in result
+    # The bare json-module error must NOT leak through
+    assert "Expecting value: line 1 column 1" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #248
Closes #249

Two bugs surfaced from an `aos-migration` operator transcript against a real Mobility Conductor (ArubaMM-VA, AOS 8.12.0.5):

## Summary

- **`aos8_get_md_hierarchy` was sending an unrecognized CLI command.** The tool issued `show switch hierarchy` (singular), which the Conductor's CLI parser silently rejects → 200 OK with empty body → bare `JSONDecodeError` reaching the AI as *"Expecting value: line 1 column 1 (char 0)"*. The fix replaces the command with `show configuration node-hierarchy` (live-verified) and replaces the hand-fabricated fixture with a real-shape capture. (#248)
- **`run_show`/`get_object` swallowed JSON-decode diagnostics.** Every AOS 8 read tool routed `response.json()` calls without catching `ValueError`, so any non-JSON 2xx body (empty / HTML / plaintext) leaked the json-module exception with no status code, content-type, or body length. New `AOS8DecodeError` + `_decode_json_or_raise()` helper surface a structured diagnostic; `format_aos8_error()` renders it. (#249)

## Verification (live, before fix)

| Call | Live result |
|---|---|
| `aos8_get_md_hierarchy` | `"Expecting value: line 1 column 1 (char 0)"` (original symptom) |
| `aos8_show_command "show switch hierarchy"` | `{"output": ""}` (CLI rejects, empty body) |
| `aos8_show_command "show configuration node-hierarchy"` | Real `/md` tree: 16 nodes spanning System / Group / Device |

## Why the test never caught this

The original `show_switch_hierarchy.json` fixture was hand-fabricated — invented top-level key, invented columns, synthetic data. Same failure pattern as #237. New fixture is a real-shape capture with 16 representative rows across `/md/ACX`, `/md/Branch`, `/md/Campus/East`, `/md/Campus/West`, and `/mm/mynode` (device hostnames preserved from the captured response with original MAC IDs).

## Files changed

- `src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py` — command string fix + docstring
- `src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py` — `AOS8DecodeError`, `_decode_json_or_raise()`, route both helpers through it, `format_aos8_error` branch
- `tests/unit/fixtures/aos8/show_configuration_node_hierarchy.json` — new (replaces hand-built one)
- `tests/unit/fixtures/aos8/show_switch_hierarchy.json` — removed
- `tests/unit/test_aos8_read_differentiators.py` — DIFF-01 test updated to new shape; new regression test for decode-error diagnostics
- `CHANGELOG.md` + `pyproject.toml` — v2.5.1.1
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — MM/MD context note reflects new tree shape

## Pre-push checklist

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 271 files already formatted
- [x] `uv run mypy src/ --ignore-missing-imports` — Success: no issues found in 212 source files
- [x] `uv run pytest tests/ -q` — 946 passed (was 945; +1 new regression test)

## Test plan

- [ ] After merge + image rebuild, re-run COLLECT-01 from `aos-migration` against the live Conductor — verify `aos8_get_md_hierarchy` now returns the `/md` tree successfully and the skill's hierarchy walk proceeds without the fallback path.
- [ ] Verify a deliberately bogus command via `aos8_show_command` (e.g. `show no-such-thing`) still routes through the wrapper as `{"output": ""}` (no regression to the passthrough).
- [ ] Spot-check that other AOS 8 read tools still return correctly (e.g. `aos8_get_ap_database`, `aos8_get_cluster_state`) — the new helper is a strict superset of the old behavior on valid JSON responses.

## Follow-up (not in this PR)

#250 — `aos-migration` skill's COLLECT-01 `OBJECT_TYPES` list has 13 of 20 invalid AOS 8 REST schema names. Tracked separately so the platform-layer fixes can ship now; the skill change is a separate diff.