### PR TITLE
v2.5.1.2: aos8 run_show graceful + entry_type filter + skill OBJECT_TYPES fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1.2] - 2026-05-04
+
+**Comprehensive AOS 8 audit fallout — restores 8 broken read tools, adds `entry_type` filter for ~93% smaller migration audits, fixes 11 wrong object names in `aos-migration` skill.** Surfaced by a live audit of all 35 aos8 tools against an ArubaMM-VA Conductor (AOS 8.12.0.5).
+
+### Why
+
+After v2.5.1.1 fixed `aos8_get_md_hierarchy` (#248) and improved decode-error diagnostics (#249), an audit of every aos8 tool against the live Conductor showed **9 more tools** were silently broken and **11 of 20** object names in the `aos-migration` skill's COLLECT-01 list were wrong. Three discoveries:
+
+1. **`run_show()` crashed on valid commands with empty / text bodies.** Tools like `aos8_get_alarms`, `aos8_get_clients`, `aos8_get_events`, `aos8_get_audit_trail`, `aos8_get_logs`, etc. were all returning the cryptic *"Expecting value: line 1 column 1 (char 0)"* error — but the underlying commands were valid. The AOS 8 `showcommand` REST endpoint just returns an empty body when there's no data (no clients, no alarms) or a plain-text body for log/audit dumps. `run_show()` called `response.json()` and crashed. Issue [#252](https://github.com/nowireless4u/hpe-networking-mcp/issues/252).
+2. **`/v1/configuration/object/<name>` accepts a `type=user` filter** that strips factory defaults and returns only customer-defined entries. Live A/B testing across 20 object types × 5 hierarchy scopes: response payload shrinks ~93% (~145 KB → ~10 KB per scope). For migration audits, defaults are pure noise — the AI should only see customer config. Issue [#253](https://github.com/nowireless4u/hpe-networking-mcp/issues/253).
+3. **The `aos-migration` skill's hard-coded `OBJECT_TYPES` list was authored against AOS 8 CLI command nouns**, not REST schema names. 11 of 20 names silently returned `{"ERROR": "Invalid Object"}` — meaning critical config (RBAC roles, ACLs, ARM, auth profiles, cluster) was being dropped from every migration plan against every Conductor. Operator-facing translation was materially incomplete and the failure mode was invisible. Issue [#250](https://github.com/nowireless4u/hpe-networking-mcp/issues/250).
+
+### What's new
+
+- **`src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py`**:
+  - `run_show()` now mirrors `aos8_show_command`'s passthrough contract on non-JSON bodies: empty body → `{}` (success, no data); text body → `{"output": <text>}`. Restores 8 tools to working state without changing their tool surfaces.
+  - `get_object()` adds an optional `entry_type` parameter that maps to AOS 8's `type` query filter (`"user"`, `"local"`, `"default"`, `"inherited"`). `get_object()` remains strict on JSON parsing — the object endpoint always returns JSON or an `Invalid Object` envelope, so non-JSON bodies there indicate a real protocol problem (AOS8DecodeError from v2.5.1.1).
+- **`src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py`** — `aos8_get_effective_config` exposes `entry_type` to AI callers with documentation pointing at migration audits as the primary use case.
+- **`src/hpe_networking_mcp/skills/aos-migration.md`** — COLLECT-01 `OBJECT_TYPES` list rewritten with 11 corrected REST schema names: `aaa_server_group` → `server_group_prof`; `wlan_ssid_profile` dropped (duplicate of `ssid_prof`); `reg_domain_profile` → `reg_domain_prof`; `arm_profile` → `arm_prof`; `dot11a_radio_prof` + `dot11g_radio_prof` → `ht_radio_prof` (combined since AOS 8.4); `user_role` → `role`; `ip_access_list` → 3-way split into `acl_sess` / `acl_eth` / `acl_mac`; `captive_portal_auth_profile` → `cp_auth_profile`; `dot1x_authentication_profile` → `dot1x_auth_profile`; `mac_authentication_profile` → `mac_auth_profile`; `lc_cluster_profile` → `cluster_prof` + `group_membership` (paired); `internal_db_server` dropped (Central replaces internal-DB auth entirely). COLLECT-01 loop now defaults to `entry_type="user"` and surfaces `Invalid Object` responses as `_collection_error` so future schema drift fails loudly instead of silently dropping rows.
+- **`tests/unit/test_aos8_read_differentiators.py`** — replaces the v2.5.1.1 strict-decode test on `aos8_get_md_hierarchy` (now graceful) with two new tests for the empty/text body shapes; adds a strict-decode test on `aos8_get_effective_config` to pin the `get_object()` contract; adds two tests for `entry_type` (passes through as `type` query param when set; omitted from query when `None`).
+
+### What this does NOT do
+
+Air-monitor coverage (`aos8_get_air_monitors` sends `show ap monitor active-laser-beams`, which is a WIDS feature, not the AM AP list) is **not fixed in this release**. Dropped from scope: the `aos-migration` skill doesn't use it, AP mode is already accessible from `aos8_get_ap_database`, and dedicated air-monitor APs are largely deprecated in AOS 10. Tool stays broken-but-harmless until a future skill needs it.
+
+The hierarchy-mapping rules engine for the `aos-migration` skill (translating AOS 8 `/md/<path>` nodes to AOS 10 site collection / site / device group / device persona) is **deferred** — design discussion in progress; needs live cluster data before rules can be locked in.
+
+### Notes
+
+- This is the third instance ([#237](https://github.com/nowireless4u/hpe-networking-mcp/issues/237), [#248](https://github.com/nowireless4u/hpe-networking-mcp/issues/248), now [#250](https://github.com/nowireless4u/hpe-networking-mcp/issues/250)) of mistakes that would have been caught by live verification against a real device. Future schema-touching changes should be live-verified before merge — not just unit-tested against fixtures.
+- Verified live against a `developer.arubanetworks.com/aos8/reference`-documented schema. The reference site is the authoritative source for REST object names; CLI nouns are not a reliable mapping.
+
 ## [2.5.1.1] - 2026-05-04
 
 **`aos8_get_md_hierarchy` was sending an unrecognized CLI command — fixed; AOS 8 helpers now diagnose decode failures.** Two related bugs surfaced from an `aos-migration` operator transcript:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.5.1.1"
+version = "2.5.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -638,6 +638,16 @@ Authentication is automatic — the client logs in to `/v1/api/login` with `aos8
 
 For AOS 8 reachability call `health(platform="aos8")`.
 
+## Filtering object responses with `entry_type`
+`aos8_get_effective_config` accepts an optional `entry_type` parameter that maps to AOS 8's `type` query filter on `/v1/configuration/object/<name>`:
+- `entry_type="user"` — returns only customer-defined entries (no factory defaults, no inherited). **Use this for migration audits and config-drift analysis** — typical response shrinks ~93% across a hierarchy walk and the AI doesn't have to filter `_flags.default: true` entries.
+- `entry_type="local"` — entries defined at THIS scope only (no inherited resolution).
+- `entry_type="default"` — factory defaults only.
+- `entry_type="inherited"` — only entries resolved from parent scopes.
+- (omitted) — returns everything (defaults + user + inherited).
+
+The canonical REST schema names (e.g. `role` not `user_role`, `cluster_prof` not `lc_cluster_profile`, `acl_sess` / `acl_eth` / `acl_mac` not `ip_access_list`) are documented at https://developer.arubanetworks.com/aos8/reference. CLI command nouns are NOT a reliable mapping to REST object names.
+
 ## Pending-Changes Workflow
 AOS 8 buffers configuration writes on MM until they are committed and pushed to MDs.
 

--- a/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
@@ -86,6 +86,19 @@ async def run_show(
 ) -> Any:
     """Execute an AOS8 show command and return the cleaned JSON body.
 
+    The AOS 8 ``showcommand`` endpoint responds in three shapes:
+
+    * **JSON body** — for structured ``show`` output (most ``show`` commands).
+      Returned with ``_meta`` and ``_global_result`` stripped.
+    * **Empty body** — for valid commands that have no data to return on this
+      controller (e.g. ``show alarms`` with no active alarms, ``show user-table``
+      with no clients). Returned as ``{}`` so callers see "success, no data"
+      rather than a parse error.
+    * **Plain text body** — for commands whose output is a text dump
+      (e.g. ``show log system``, ``show audit-trail``, ``show running-config``).
+      Wrapped as ``{"output": <text>}`` to match ``aos8_show_command``'s
+      passthrough contract.
+
     Args:
         client: ``AOS8Client`` from ``ctx.lifespan_context["aos8_client"]``.
         command: Full show command string (e.g. ``"show ap database"``).
@@ -93,13 +106,18 @@ async def run_show(
             query params only when not ``None``.
 
     Returns:
-        Parsed JSON body with ``_meta`` and ``_global_result`` stripped.
+        Parsed JSON body with envelope keys stripped, or one of the
+        empty/text shapes described above.
     """
     params: dict[str, Any] = {"command": command}
     if config_path is not None:
         params["config_path"] = config_path
     response = await client.request("GET", "/v1/configuration/showcommand", params=params)
-    return strip_meta(_decode_json_or_raise(response, f"show command {command!r}"))
+    try:
+        return strip_meta(response.json())
+    except ValueError:
+        body = response.text or ""
+        return {"output": body} if body else {}
 
 
 async def get_object(
@@ -107,6 +125,7 @@ async def get_object(
     object_path: str,
     *,
     config_path: str = "/md",
+    entry_type: str | None = None,
 ) -> Any:
     """Fetch a configuration object via ``/v1/configuration/object/<path>``.
 
@@ -114,14 +133,22 @@ async def get_object(
         client: ``AOS8Client`` instance.
         object_path: Object name (e.g. ``"ssid_prof"``, ``"ap_group"``).
         config_path: Hierarchy node; defaults to ``"/md"``.
+        entry_type: Optional ``type`` filter (``"user"``, ``"local"``,
+            ``"default"``, ``"inherited"``). When set, AOS 8 returns only
+            entries matching the filter — most useful is ``"user"`` which
+            strips factory defaults and returns only customer-defined
+            configuration.
 
     Returns:
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped.
     """
+    params: dict[str, Any] = {"config_path": config_path}
+    if entry_type is not None:
+        params["type"] = entry_type
     response = await client.request(
         "GET",
         f"/v1/configuration/object/{object_path}",
-        params={"config_path": config_path},
+        params=params,
     )
     return strip_meta(_decode_json_or_raise(response, f"object {object_path!r}"))
 

--- a/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
@@ -73,6 +73,7 @@ async def aos8_get_effective_config(
     ctx: Context,
     object_name: str,
     config_path: str = "/md",
+    entry_type: str | None = None,
 ) -> dict[str, Any] | str:
     """Return the effective resolved config for ``object_name`` at ``config_path``.
 
@@ -83,13 +84,22 @@ async def aos8_get_effective_config(
         ctx: FastMCP request context.
         object_name: AOS8 object name (e.g. ``ssid_prof``, ``virtual_ap``).
         config_path: Hierarchy scope; defaults to ``/md``.
+        entry_type: Optional ``type`` filter (``"user"``, ``"local"``,
+            ``"default"``, ``"inherited"``). Pass ``"user"`` to strip
+            factory defaults and return only customer-defined entries —
+            useful for migration audits where defaults are noise.
 
     Returns:
         Parsed JSON body on success; error string on failure.
     """
     client = ctx.lifespan_context["aos8_client"]
     try:
-        return await get_object(client, object_name, config_path=config_path)
+        return await get_object(
+            client,
+            object_name,
+            config_path=config_path,
+            entry_type=entry_type,
+        )
     except Exception as exc:  # noqa: BLE001
         return format_aos8_error(exc, f"fetch effective config for {object_name}")
 

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -155,14 +155,23 @@ The biggest historical bug in this skill was Stage 1 collecting only at `/md` ro
 # Goal: produce config_by_scope = {scope: {object_type: response, ...}, ...}
 # covering EVERY node in the /md tree.
 
+# Object names are the AOS 8 REST schema names (NOT the CLI nouns).
+# Live-verified against an AOS 8.12 Mobility Conductor — earlier versions
+# of this list mixed CLI nouns with REST names and 13 of 20 silently
+# returned {"ERROR": "Invalid Object"}. See issue #250 for the audit.
 OBJECT_TYPES = [
-    "ap_sys_prof", "virtual_ap", "ssid_prof", "aaa_prof",
-    "aaa_server_group", "wlan_ssid_profile", "reg_domain_profile",
-    "arm_profile", "dot11a_radio_prof", "dot11g_radio_prof",
-    "lc_cluster_profile", "user_role", "ip_access_list",
-    "captive_portal_auth_profile", "dot1x_authentication_profile",
-    "mac_authentication_profile", "rad_server", "tacacs_server",
-    "ldap_server", "internal_db_server",
+    # WLAN / radio
+    "ssid_prof", "virtual_ap", "ht_radio_prof", "reg_domain_prof",
+    "arm_prof", "ap_sys_prof",
+    # Authentication / AAA
+    "aaa_prof", "rad_server", "tacacs_server", "ldap_server",
+    "server_group_prof", "dot1x_auth_profile", "mac_auth_profile",
+    "cp_auth_profile",
+    # RBAC / ACLs
+    "role", "acl_sess", "acl_eth", "acl_mac",
+    # Cluster (paired — cluster_prof defines the profile, group_membership
+    # binds devices to it)
+    "cluster_prof", "group_membership",
 ]
 
 hierarchy = await call_tool("aos8_get_md_hierarchy", {})
@@ -176,10 +185,28 @@ for scope in scopes:
     config_by_scope[scope] = {}
     for obj_type in OBJECT_TYPES:
         try:
-            config_by_scope[scope][obj_type] = await call_tool(
+            # entry_type="user" strips factory defaults and inherited
+            # entries — for migration audits, defaults are noise. Reduces
+            # response size by ~93% on this Conductor; the AI sees only
+            # customer-defined config.
+            response = await call_tool(
                 "aos8_get_effective_config",
-                {"object_name": obj_type, "config_path": scope},
+                {
+                    "object_name": obj_type,
+                    "config_path": scope,
+                    "entry_type": "user",
+                },
             )
+            # Surface "Invalid Object" loudly — the AOS 8 REST schema may
+            # drift between versions, and a silently-dropped object means
+            # the migration plan is materially incomplete.
+            inner = response.get("result") if isinstance(response, dict) and "result" in response else response
+            if isinstance(inner, dict) and inner.get("ERROR") == "Invalid Object":
+                config_by_scope[scope][obj_type] = {
+                    "_collection_error": f"Invalid Object — REST schema may have renamed {obj_type!r} on this AOS build"
+                }
+            else:
+                config_by_scope[scope][obj_type] = response
         except Exception as exc:
             config_by_scope[scope][obj_type] = {"_collection_error": str(exc)}
 ```

--- a/tests/unit/test_aos8_read_differentiators.py
+++ b/tests/unit/test_aos8_read_differentiators.py
@@ -63,19 +63,19 @@ async def test_get_md_hierarchy():
     assert any(r["Type"] == "Device" and r["Name"] for r in rows)
 
 
-async def test_get_md_hierarchy_non_json_body_diagnoses_decode_error():
-    """Empty / non-JSON 2xx bodies must surface a diagnostic — not a bare
-    json-module ValueError. Regression test for issue #248 / #249.
+async def test_run_show_empty_body_returns_empty_dict():
+    """run_show() must treat empty 2xx bodies as success-with-no-data (return
+    {}), not raise. Many AOS 8 commands legitimately return empty bodies on
+    Conductors with no matching state — e.g. ``show alarms`` with no active
+    alarms, ``show user-table`` with no clients. Regression for issue #252.
     """
     from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_md_hierarchy
 
-    # Simulate an empty body returned with HTTP 200 + text/html (CLI parser
-    # silently rejected an unrecognized command).
     r = MagicMock()
     r.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
     r.text = ""
     r.status_code = 200
-    r.headers = {"content-type": "text/html"}
+    r.headers = {"content-type": "text/plain"}
 
     client = MagicMock()
     client.request = AsyncMock(return_value=r)
@@ -84,12 +84,60 @@ async def test_get_md_hierarchy_non_json_body_diagnoses_decode_error():
 
     result = await aos8_get_md_hierarchy(ctx)
 
+    assert result == {}
+
+
+async def test_run_show_text_body_wraps_as_output():
+    """run_show() must wrap plain text 2xx bodies as {"output": <text>} —
+    matches aos8_show_command's passthrough contract. Some commands like
+    ``show log system`` and ``show audit-trail`` return text dumps, not
+    JSON. Regression for issue #252.
+    """
+    from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_md_hierarchy
+
+    text_body = "<my_xml_tag3xxx>\nMay 4 22:10:46 2026 :354028: log line\n"
+    r = MagicMock()
+    r.json.side_effect = json.JSONDecodeError("Expecting value", text_body, 0)
+    r.text = text_body
+    r.status_code = 200
+    r.headers = {"content-type": "text/plain"}
+
+    client = MagicMock()
+    client.request = AsyncMock(return_value=r)
+    ctx = MagicMock()
+    ctx.lifespan_context = {"aos8_client": client}
+
+    result = await aos8_get_md_hierarchy(ctx)
+
+    assert result == {"output": text_body}
+
+
+async def test_get_object_still_diagnoses_decode_errors():
+    """get_object() (used by aos8_get_effective_config) must REMAIN strict —
+    the /v1/configuration/object endpoint always returns JSON or an
+    Invalid-Object envelope, so any non-JSON body indicates a real protocol
+    problem. Surface the diagnostic introduced in v2.5.1.1 / issue #249.
+    """
+    from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_effective_config
+
+    r = MagicMock()
+    r.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+    r.text = "<html>session expired</html>"
+    r.status_code = 200
+    r.headers = {"content-type": "text/html"}
+
+    client = MagicMock()
+    client.request = AsyncMock(return_value=r)
+    ctx = MagicMock()
+    ctx.lifespan_context = {"aos8_client": client}
+
+    result = await aos8_get_effective_config(ctx, object_name="ssid_prof")
+
     assert isinstance(result, str)
     assert "decode error" in result.lower()
     assert "HTTP 200" in result
     assert "text/html" in result
-    assert "0 bytes" in result
-    # The bare json-module error must NOT leak through
+    # Bare json-module error must not leak
     assert "Expecting value: line 1 column 1" not in result
 
 
@@ -127,6 +175,49 @@ async def test_get_effective_config_defaults_config_path():
         "/v1/configuration/object/ssid_prof",
         params={"config_path": "/md"},
     )
+
+
+async def test_get_effective_config_entry_type_user():
+    """When entry_type is set, it MUST be passed to the API as the ``type``
+    query param. AOS 8 uses this to filter out factory defaults / inherited
+    entries. Verified live: type=user reduces response size ~93% across
+    typical migration audits. Issue #253.
+    """
+    from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_effective_config
+
+    body = {"_global_result": {"status": "0"}, "_data": {"role": []}}
+    ctx, client = _make_ctx(body)
+
+    await aos8_get_effective_config(
+        ctx,
+        object_name="role",
+        config_path="/md/Campus/East",
+        entry_type="user",
+    )
+
+    client.request.assert_awaited_once_with(
+        "GET",
+        "/v1/configuration/object/role",
+        params={"config_path": "/md/Campus/East", "type": "user"},
+    )
+
+
+async def test_get_effective_config_no_entry_type_omits_type_param():
+    """When entry_type is omitted (default None), the ``type`` query param
+    MUST NOT be sent — preserves pre-#253 behavior for callers that haven't
+    opted into filtering.
+    """
+    from hpe_networking_mcp.platforms.aos8.tools.differentiators import aos8_get_effective_config
+
+    body = {"_global_result": {"status": "0"}, "_data": {"role": []}}
+    ctx, client = _make_ctx(body)
+
+    await aos8_get_effective_config(ctx, object_name="role", config_path="/md")
+
+    # type must not appear in params at all
+    call_kwargs = client.request.await_args.kwargs
+    assert "type" not in call_kwargs["params"]
+    assert call_kwargs["params"] == {"config_path": "/md"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #250
Closes #252
Closes #253

Comprehensive AOS 8 audit fallout — restores 8 broken read tools, adds `entry_type` filter for ~93% smaller migration audits, and fixes 11 wrong object names in the `aos-migration` skill. Surfaced by an audit of all 35 aos8 tools against an ArubaMM-VA Conductor (AOS 8.12.0.5).

## Summary

- **#252 — `run_show()` crashed on valid commands with empty / text bodies.** 8 tools (`aos8_get_clients`, `aos8_get_alarms`, `aos8_get_events`, `aos8_get_audit_trail`, `aos8_get_logs`, `aos8_get_arm_history`, `aos8_get_rf_monitor`, `aos8_get_cluster_state`) all returned the cryptic *"Expecting value: line 1 column 1 (char 0)"* — but the underlying CLI commands were valid. The AOS 8 `showcommand` REST endpoint just returns empty bodies when there's no data and text bodies for log/audit dumps. `run_show()` now mirrors `aos8_show_command`'s passthrough: empty → `{}`, text → `{"output": <text>}`. `get_object()` stays strict.
- **#253 — `type=user` query filter wired in.** Live A/B test across 20 objects × 5 scopes shows ~93% payload reduction (~145 KB → ~10 KB per scope). The migration skill defaults to `entry_type="user"` so the AI no longer wades through factory defaults during translation analysis.
- **#250 — `aos-migration` `OBJECT_TYPES` list corrected.** 11 of 20 names were AOS 8 CLI nouns (e.g. `user_role`, `wlan_ssid_profile`, `lc_cluster_profile`) instead of REST schema names (`role`, `ssid_prof`, `cluster_prof` + `group_membership`). Every previous run silently dropped roles, ACLs, ARM, auth profiles, and cluster data from the migration plan. Now uses correct names + surfaces `Invalid Object` responses as `_collection_error` so future schema drift fails loudly.

## Verification

| Test | Result |
|---|---|
| `aos8_get_md_hierarchy` (live, post-fix from PR #251) | Returns `/md` tree (16 nodes spanning System / Group / Device) |
| `aos8_get_effective_config(role, /md/Campus/East, entry_type=user)` | 42 customer-defined roles (vs 56 with defaults — 14 stripped) |
| `aos8_get_effective_config(acl_sess, /md, entry_type=user)` | 0 entries / 28 B (vs 65 entries / 56 KB — all 65 were defaults) |
| `aos8_get_alarms()` | Returns `{}` on a Conductor with no active alarms (was: crash) |
| `aos8_get_logs()` | Returns `{"output": "<14 KB syslog text>"}` (was: crash) |

Cross-validated all 20 corrected object names at `/md`, `/md/ACX`, `/md/Branch`, `/md/Campus/East`, `/md/Campus/West`. Every name × every scope returned data without `Invalid Object` errors.

## Files changed

- `src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py` — `run_show()` graceful empty/text handling, `get_object()` `entry_type` parameter
- `src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py` — `aos8_get_effective_config` exposes `entry_type`
- `src/hpe_networking_mcp/skills/aos-migration.md` — corrected `OBJECT_TYPES`, default `entry_type="user"`, Invalid-Object surfacing
- `tests/unit/test_aos8_read_differentiators.py` — flips strict-decode test on `aos8_get_md_hierarchy` to graceful empty/text shapes; new strict-decode test on `aos8_get_effective_config`; two new `entry_type` tests
- `CHANGELOG.md` + `pyproject.toml` — v2.5.1.2
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — `entry_type` documentation + REST schema source pointer

## Pre-push checklist

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 271 files already formatted
- [x] `uv run mypy src/ --ignore-missing-imports` — Success: no issues found in 212 source files
- [x] `uv run pytest tests/ -q` — 950 passed (was 946; +4 new tests)

## Test plan

- [ ] After merge + image rebuild, re-run `aos-migration` against the live Conductor — verify COLLECT-01 returns customer config for all 20 corrected types at every scope, and that the response payload is ~10x smaller than pre-`entry_type` runs.
- [ ] Verify the previously broken tools (`aos8_get_alarms`, `aos8_get_clients`, etc.) return clean empty/text shapes on a Conductor with no matching state.
- [ ] Verify `aos8_get_audit_trail` and `aos8_get_logs` return `{"output": <text>}` rather than erroring.
- [ ] Run a hierarchy-aware audit and confirm `Invalid Object` warnings appear in `_collection_error` if any future AOS build renames an object — should NOT silently drop rows.

## Out of scope (deferred)

- Air-monitor coverage (`aos8_get_air_monitors` sends a wrong CLI command). Dropped from scope per discussion — no skill uses it, AP mode is accessible from `aos8_get_ap_database`, and dedicated AMs are largely deprecated in AOS 10. Will revisit when a future skill needs it.
- Hierarchy-mapping rules engine for the `aos-migration` skill (translating AOS 8 `/md/<path>` nodes to AOS 10 site collection / site / device group / device persona). Design discussion in progress; needs live cluster data before rules can be locked in.