### PR TITLE
docs: scrub personal identifiers from public files (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1731,8 +1731,8 @@ The empty-list and zero-counts symptoms reproduced in both `dynamic` and `code` 
 
 | Tool | Before | After |
 |---|---|---|
-| `central_get_site_health` | `[]` | 13 sites; HOME = 38 clients / 17 devices, with full per-type breakdown |
-| `central_get_site_name_id_mapping` (HOME) | `health: 0, total_devices: 0, total_clients: 0, total_alerts: 0` | `health: 81, total_devices: 17, total_clients: 38, total_alerts: 3` |
+| `central_get_site_health` | `[]` | 13 sites; HQ = 38 clients / 17 devices, with full per-type breakdown |
+| `central_get_site_name_id_mapping` (HQ) | `health: 0, total_devices: 0, total_clients: 0, total_alerts: 0` | `health: 81, total_devices: 17, total_clients: 38, total_alerts: 3` |
 
 ### Tests
 
@@ -1824,7 +1824,7 @@ This lets `tags(detail=brief)` surface useful platform buckets and `search(query
 - `tags(brief)` returns platform buckets (`mist (31 tools)`, `central (73)`, `axis (0)`, etc.) plus module categories.
 - `search(query="disconnected", tags=["mist"])` returns 7 of 173 tools, BM25-ranked and platform-scoped.
 - `execute` with `return await call_tool("health", {})` returns the live health report.
-- Cross-platform join (mist_get_self → mist_search_device → central_get_aps) runs in ONE execute call, returning `{"mist_aps_count": 5, "central_aps_count": 3, "sample_mist_ap": "KNAPP-BASEMENT", "sample_central_ap": "HOME-GARAGE-AP", "cross_platform_match": True}`.
+- Cross-platform join (mist_get_self → mist_search_device → central_get_aps) runs in ONE execute call, returning `{"mist_aps_count": 5, "central_aps_count": 3, "sample_mist_ap": "BRANCH-1-AP-1", "sample_central_ap": "HQ-AP-1", "cross_platform_match": True}`.
 - `call_tool("site_health_check", ...)` correctly raises `Unknown tool: site_health_check` — gating verified.
 - `MCP_TOOL_MODE=dynamic` (default) — unchanged. Still 18 tools advertised (15 meta + health + site_health_check + site_rf_check).
 
@@ -1915,7 +1915,7 @@ Channel notation differs across platforms: Central uses bonded-channel suffixes 
 
 ### Verified live
 
-3 Aruba AP-755s at site HOME (Central) — full report rendered with 2.4G/5G/6G channel bars, noise floors, utilization meters, per-AP table. Picker mode tested across 19 sites with accurate online counts. Mist-side picker uses `connected: bool` from `/orgs/{id}/inventory` (not the `status` field — that endpoint doesn't carry it).
+3 Aruba AP-755s at site HQ (Central) — full report rendered with 2.4G/5G/6G channel bars, noise floors, utilization meters, per-AP table. Picker mode tested across 19 sites with accurate online counts. Mist-side picker uses `connected: bool` from `/orgs/{id}/inventory` (not the `status` field — that endpoint doesn't carry it).
 
 ### Test additions
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -46,7 +46,7 @@ me = await call_tool("mist_get_self", {"action_type": "account_info"})
 org_id = me["result"]["privileges"][0]["org_id"]
 
 mist_aps = await call_tool("mist_search_device", {"org_id": org_id, "device_type": "ap", "limit": 5})
-central_aps = await call_tool("central_get_aps", {"site_name": "HOME", "status": "ONLINE"})
+central_aps = await call_tool("central_get_aps", {"site_name": "HQ", "status": "ONLINE"})
 
 return {
     "mist_count": len(mist_aps["result"]["results"]),

--- a/docs/mappings/WLAN.md
+++ b/docs/mappings/WLAN.md
@@ -10,9 +10,9 @@ Fields marked **[NEEDS REVIEW]** may have a mapping but need confirmation.
 
 Central and Mist have fundamentally different naming models:
 
-- **Central**: WLAN profile name ≠ SSID name. The profile has a name (e.g. "ADAMS-WIFI2")
-  and an optional SSID alias (e.g. "AdamsLAB") that resolves to the broadcasted SSID name
-  (e.g. "ADAMS-WIFI"). When `essid.use-alias` is true, the alias must be resolved via
+- **Central**: WLAN profile name ≠ SSID name. The profile has a name (e.g. "CORP-WIFI-2")
+  and an optional SSID alias (e.g. "CORP-LAB") that resolves to the broadcasted SSID name
+  (e.g. "CORP-WIFI"). When `essid.use-alias` is true, the alias must be resolved via
   `GET /network-config/v1alpha1/aliases/{alias_name}` to get the actual SSID.
 - **Mist**: WLAN template name is the container. The WLAN `ssid` field IS the broadcasted name.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dependencies = [
 hpe-networking-mcp = "hpe_networking_mcp.__main__:main"
 
 [project.urls]
-Repository = "https://github.com/jonadams/hpe-networking-mcp"
-Issues = "https://github.com/jonadams/hpe-networking-mcp/issues"
+Repository = "https://github.com/nowireless4u/hpe-networking-mcp"
+Issues = "https://github.com/nowireless4u/hpe-networking-mcp/issues"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -31,7 +31,7 @@ Every per-platform tool listed below this section is reachable through the meta-
 ```
 central_list_tools(filter="sites")
 → [{"name":"central_get_site_health","params":{"site_name":"string","platform":"string?",...}}, ...]
-central_invoke_tool(name="central_get_site_health", params={"site_name":"HOME"})
+central_invoke_tool(name="central_get_site_health", params={"site_name":"HQ"})
 → <tool result>
 ```
 
@@ -348,11 +348,11 @@ The same cross-platform behavior applies to **sites** — when asked generically
 
 | User says | Call |
 |---|---|
-| "how is site HOME doing" (no platform named) | `site_health_check(site_name="HOME")` — queries every enabled platform (default) |
-| "how is site HOME doing **in Central**" | `site_health_check(site_name="HOME", platform="central")` |
-| "how is site HOME doing **on Mist**" | `site_health_check(site_name="HOME", platform="mist")` |
-| "how is site HOME doing **in ClearPass**" | `site_health_check(site_name="HOME", platform="clearpass")` |
-| "how is HOME doing in Central and Mist" | `site_health_check(site_name="HOME", platform=["central", "mist"])` |
+| "how is site HQ doing" (no platform named) | `site_health_check(site_name="HQ")` — queries every enabled platform (default) |
+| "how is site HQ doing **in Central**" | `site_health_check(site_name="HQ", platform="central")` |
+| "how is site HQ doing **on Mist**" | `site_health_check(site_name="HQ", platform="mist")` |
+| "how is site HQ doing **in ClearPass**" | `site_health_check(site_name="HQ", platform="clearpass")` |
+| "how is HQ doing in Central and Mist" | `site_health_check(site_name="HQ", platform=["central", "mist"])` |
 
 Valid `platform` values are `"mist"`, `"central"`, `"clearpass"` (or a list). Apstra and GreenLake don't have site-scoped telemetry and aren't accepted. Omit `platform` entirely (null/None) for the full cross-platform view — that's the right default when the user asks generically.
 

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -153,7 +153,7 @@ async def central_manage_config_assignment(
         Field(
             description=(
                 "Name of the specific profile to assign. For WLAN SSIDs "
-                "this is the SSID name (e.g. 'ADAMS-TEST'). For roles "
+                "this is the SSID name (e.g. 'TEST-SSID'). For roles "
                 "this is the role name, etc."
             ),
         ),
@@ -175,7 +175,7 @@ async def central_manage_config_assignment(
     - scope_id = the site's scope ID (from central_get_scope_tree)
     - device_function = "CAMPUS_AP"
     - profile_type = "wlan-ssids"
-    - profile_instance = "ADAMS-TEST"
+    - profile_instance = "TEST-SSID"
 
     To find the scope_id, call central_get_scope_tree and look up the
     target scope (Global, site collection, or site) by name.

--- a/src/hpe_networking_mcp/skills/TEMPLATE.md
+++ b/src/hpe_networking_mcp/skills/TEMPLATE.md
@@ -66,4 +66,4 @@ so different skill runs produce comparable output.
 A 1-2 line example query that should trigger this skill, e.g.:
 
 > "give me the daily infra health snapshot"
-> "is everything healthy at site HOME?"
+> "is everything healthy at site HQ?"

--- a/src/hpe_networking_mcp/skills/change-post-check.md
+++ b/src/hpe_networking_mcp/skills/change-post-check.md
@@ -139,8 +139,8 @@ active session count by service).
 
 | Metric | Baseline | Now | Delta % |
 |---|---|---|---|
-| Clients (HOME) | 38 | 35 | -7.9% |
-| APs up (HOME) | 17 | 17 | 0% |
+| Clients (HQ) | 38 | 35 | -7.9% |
+| APs up (HQ) | 17 | 17 | 0% |
 | Active NAC sessions | 1240 | 1198 | -3.4% |
 
 **Verdict contribution by delta magnitude:**
@@ -169,7 +169,7 @@ Format the report as shown below.
 | Condition | Action |
 |---|---|
 | No baseline available in chat or paste | STOP. Ask user for the pre-check snapshot. Don't run blind. |
-| Baseline target ≠ current scope | STOP. Pre-check covered site `HOME`, post-check shouldn't run against site `OFFICE`. Confirm with user. |
+| Baseline target ≠ current scope | STOP. Pre-check covered site `HQ`, post-check shouldn't run against site `OFFICE`. Confirm with user. |
 | Change landed less than 5 minutes ago + Wi-Fi affected | Note that client/RF metrics may still be settling; consider a follow-up post-check in 10 minutes |
 | Verdict is REGRESSION | Lead the report with the regression specifics. Suggest the operator consider rollback. |
 | Audit log shows unplanned admin actions | Surface the actor + timestamp explicitly so the operator can investigate |
@@ -206,8 +206,8 @@ verdicts, lead with the specifics under "Verdict reasoning."
 ### Impact metrics
 | Metric | Baseline | Now | Delta |
 |---|---|---|---|
-| Clients (HOME) | 38 | 35 | -7.9% (within normal churn) |
-| APs up (HOME) | 17 | 17 | 0% |
+| Clients (HQ) | 38 | 35 | -7.9% (within normal churn) |
+| APs up (HQ) | 17 | 17 | 0% |
 
 ### Verdict reasoning
 - Reachability unchanged

--- a/src/hpe_networking_mcp/skills/change-pre-check.md
+++ b/src/hpe_networking_mcp/skills/change-pre-check.md
@@ -165,8 +165,8 @@ sections; if you have observations, put them under "Notes."
 <paste of relevant config block(s) — typically 5-30 lines>
 
 ### Active impact metrics (snapshot for post-change diff)
-- Mist site `HOME`: 38 clients, 17 APs up, 0 disconnected
-- Central site `HOME`: 24 switches, 0 alerts
+- Mist site `HQ`: 38 clients, 17 APs up, 0 disconnected
+- Central site `HQ`: 24 switches, 0 alerts
 
 ### Notes
 - Pre-existing minor alarm on AP-12 — NOT my change.
@@ -185,6 +185,6 @@ End the response by reminding the operator:
 
 ## Example queries that should trigger this skill
 
-> "I'm about to push a config change to the HOME WLAN — give me a baseline"
+> "I'm about to push a config change to the HQ WLAN — give me a baseline"
 > "running pre-change checks for the AP firmware push tonight"
 > "before I touch the NAC policy can you snapshot the current state"

--- a/src/hpe_networking_mcp/skills/mist-scope-audit.md
+++ b/src/hpe_networking_mcp/skills/mist-scope-audit.md
@@ -518,7 +518,7 @@ Use the EXACT structure below. Every section must be present even if its content
 
 ### REGRESSION findings (lead with these)
 - **Bare site-level WLANs**: <N> findings.
-  - Site `HOME`: 2 bare site-level WLANs (`legacy-corp`, `guest-test`) — created without a template. Recommendation: move into an org-level WLAN template + delete site-level copies.
+  - Site `HQ`: 2 bare site-level WLANs (`legacy-corp`, `guest-test`) — created without a template. Recommendation: move into an org-level WLAN template + delete site-level copies.
 - **Switch managed via CLI** (Mist Wired explicitly forbids): <N> findings.
   - Switch `<name>`: CLI changes detected outside Mist management. Recommendation: re-import config into a template + revert CLI.
 - **Hardcoded RADIUS IPs**: <N> findings.

--- a/src/hpe_networking_mcp/skills/morning-coffee-report.md
+++ b/src/hpe_networking_mcp/skills/morning-coffee-report.md
@@ -278,7 +278,7 @@ rules in order; the first match wins.
 Show the rubric color at the very top of the report on its own line,
 followed by a single sentence summarizing why that color was chosen
 (*"all SLEs above 90%, no critical alerts overnight, only routine
-audit activity"* for green; *"5 critical alerts at HOME-KNAPP, MTU
+audit activity"* for green; *"5 critical alerts at BRANCH-1, MTU
 mismatch on aggregation link"* for red).
 
 ## Decision matrix
@@ -317,8 +317,8 @@ comparable output. Use Markdown headings; render in the AI client.
 One sentence describing why this color was chosen. Examples:
 
 - 🟢 GREEN — all SLEs above 90%, 0 critical alerts, only routine audit activity
-- 🟡 YELLOW — 2 major alerts at HOME-KNAPP (PoE budget warning), all SLEs healthy
-- 🔴 RED — 5 critical alerts at HOME-KNAPP (MTU mismatch + VSX keepalive), Time-to-Connect SLE at 72%
+- 🟡 YELLOW — 2 major alerts at BRANCH-1 (PoE budget warning), all SLEs healthy
+- 🔴 RED — 5 critical alerts at BRANCH-1 (MTU mismatch + VSX keepalive), Time-to-Connect SLE at 72%
 
 ## Headline
 
@@ -326,14 +326,14 @@ One sentence describing why this color was chosen. Examples:
 
 - "All quiet overnight — no critical alerts, 2 admin logins, top talker
   is a single client at 8.2 GB."
-- "5 critical alerts at HOME-KNAPP — MTU mismatch on aggregation
+- "5 critical alerts at BRANCH-1 — MTU mismatch on aggregation
   link is the priority. 1 admin made 14 config changes overnight."
 
 ## Activity
 
 **Central** (N total events, M write actions):
 - alice@corp.com — 12 events: 3 logins, 9 reads, 0 writes
-- bob@corp.com — 4 events: 1 login, 1 write (`Update Site` at HOME)
+- bob@corp.com — 4 events: 1 login, 1 write (`Update Site` at HQ)
 - system — 23 events: routine (skip detail)
 
 **Mist** (N total events, M write actions):
@@ -342,8 +342,8 @@ One sentence describing why this color was chosen. Examples:
 ## What's broken right now
 
 **Central** (severity counts: X critical / Y major / Z minor):
-- 🔴 [CRITICAL] MTU mismatch — HOME-AGG-SW1-1 1/1/4 ↔ 6100 1/1/15 (9198 vs 1500)
-- [MAJOR] VSX keepalive failed — HOME-AGG-SW1-1 loopback0
+- 🔴 [CRITICAL] MTU mismatch — HQ-AGG-SW1-1 1/1/4 ↔ 6100 1/1/15 (9198 vs 1500)
+- [MAJOR] VSX keepalive failed — HQ-AGG-SW1-1 loopback0
 - ... (top 5)
 
 **Mist** (N alarm types, M total events):
@@ -355,13 +355,13 @@ One sentence describing why this color was chosen. Examples:
 **Central — top clients:**
 | Client | SSID | Site | Traffic (24h) |
 |---|---|---|---|
-| johns-laptop | Corp-Wifi | HOME | 8.2 GB |
+| user-laptop-1 | Corp-Wifi | HQ | 8.2 GB |
 | ... |
 
 **Central — top APs:**
 | AP | Site | Clients | Load |
 |---|---|---|---|
-| AP-Floor-3 | HOME | 47 | 78% |
+| AP-Floor-3 | HQ | 47 | 78% |
 | ... |
 
 **Mist — top clients / top APs:**
@@ -371,7 +371,7 @@ One sentence describing why this color was chosen. Examples:
 
 **Mist SLE:**
 - Worst category: Time-to-Connect at 87% (org-wide)
-- Worst site: HOME-KNAPP at 78% aggregate
+- Worst site: BRANCH-1 at 78% aggregate
 
 **Central:**
 - Alert category trending up: "Client" alerts +40% vs the 7-day average
@@ -379,8 +379,8 @@ One sentence describing why this color was chosen. Examples:
 ## Suggested next steps
 
 1–3 bullets, each pointing at a tool/skill to drill in:
-- Run `central-scope-audit` on HOME-KNAPP to investigate the MTU and VSX issues
-- Run `mist_get_site_sle(site_id=<HOME-KNAPP id>)` for the SLE breakdown
+- Run `central-scope-audit` on BRANCH-1 to investigate the MTU and VSX issues
+- Run `mist_get_site_sle(site_id=<BRANCH-1 id>)` for the SLE breakdown
 ```
 
 ### Executive-mode template
@@ -424,11 +424,11 @@ When producing the executive output, the AI MUST:
 - **Drop all technical jargon.** No tool names (`central_get_alerts`),
   no platform names (`Mist` / `Central`), no IPs / MACs / port numbers
   / VLAN IDs / SSID names / device serial numbers. If the engineer
-  template would say *"5 critical alerts at HOME-KNAPP — MTU mismatch
+  template would say *"5 critical alerts at BRANCH-1 — MTU mismatch
   on aggregation link"*, the exec template says *"a site has a network
   reliability issue affecting wireless connectivity."*
 - **Round counts.** *"Approximately 15% of clients"*, not *"47 clients"*.
-  *"A site"* not *"HOME-KNAPP"* unless naming the site is needed for
+  *"A site"* not *"BRANCH-1"* unless naming the site is needed for
   clarity (e.g. multi-site orgs where the leader actually knows site
   names).
 - **Use business-impact framing.** *"Affecting users in the building"*,

--- a/src/hpe_networking_mcp/skills/wlan-sync-validation.md
+++ b/src/hpe_networking_mcp/skills/wlan-sync-validation.md
@@ -140,5 +140,5 @@ keep going. Always group by bucket so "everything is fine" is one glance.
 
 > "are our WLANs in sync between Mist and Central?"
 > "did the WLAN sync run cleanly?"
-> "audit WLAN drift for site HOME"
+> "audit WLAN drift for site HQ"
 > "compare WLANs across platforms"

--- a/tests/unit/test_central_utils.py
+++ b/tests/unit/test_central_utils.py
@@ -161,7 +161,7 @@ def _sample_sites_health_response() -> list[dict]:
     """Single-site fragment matching the live ``/sites-health`` response shape."""
     return [
         {
-            "siteName": "HOME",
+            "siteName": "HQ",
             "id": "18413656377",
             "address": {"city": "Anytown", "country": "US"},
             "location": {"latitude": "39.0", "longitude": "-77.0"},
@@ -204,7 +204,7 @@ def _sample_sites_device_health_response() -> list[dict]:
     """Single-site fragment matching the live ``/sites-device-health`` response shape."""
     return [
         {
-            "siteName": "HOME",
+            "siteName": "HQ",
             "id": "18413656377",
             "type": "v1",
             "deviceTypes": [
@@ -227,7 +227,7 @@ def _sample_sites_client_health_response() -> list[dict]:
     """Single-site fragment matching the live ``/sites-client-health`` response shape."""
     return [
         {
-            "siteName": "HOME",
+            "siteName": "HQ",
             "id": "18413656377",
             "type": "v1",
             "clientTypes": [
@@ -269,7 +269,7 @@ class TestProcessSiteHealthData:
             _sample_sites_device_health_response(),
             _sample_sites_client_health_response(),
         )
-        assert "HOME" in result, (
+        assert "HQ" in result, (
             "process_site_health_data must key on the 'siteName' field — "
             "if this fails, the API response shape changed or the field-rename regressed"
         )
@@ -282,7 +282,7 @@ class TestProcessSiteHealthData:
             _sample_sites_device_health_response(),
             _sample_sites_client_health_response(),
         )
-        details = result["HOME"].metrics.devices.get("Details")
+        details = result["HQ"].metrics.devices.get("Details")
         assert details is not None, "deviceTypes details missing — siteName merge regression"
         assert "Access Points" in details
 
@@ -293,7 +293,7 @@ class TestProcessSiteHealthData:
             _sample_sites_device_health_response(),
             _sample_sites_client_health_response(),
         )
-        details = result["HOME"].metrics.clients.get("Details")
+        details = result["HQ"].metrics.clients.get("Details")
         assert details is not None, "clientTypes details missing — siteName merge regression"
         assert "Wired" in details and "Wireless" in details
 
@@ -307,7 +307,7 @@ class TestTransformToSiteData:
         exist in the real response — yielding empty-string names everywhere.
         """
         site = transform_to_site_data(_sample_sites_health_response()[0])
-        assert site.name == "HOME", f"Expected 'HOME', got '{site.name}' — siteName mapping regressed"
+        assert site.name == "HQ", f"Expected 'HQ', got '{site.name}' — siteName mapping regressed"
 
     def test_summary_total_derived_from_groups_when_count_present(self):
         """Per-site totals come from summing the health.groups[] values via

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -606,10 +606,10 @@ class TestTokenizeResponse:
         # Mist's MPSK pattern uses the user's email as the PSK display
         # name — which would have leaked pre-v2.3.1.2.
         result = tokenize_response(
-            {"name": "travis.knapp@burninlab.com", "ssid": "MPSK", "vlan_id": 1},
+            {"name": "taylor.morgan@example.com", "ssid": "MPSK", "vlan_id": 1},
             tokenizer,
         )
-        assert "travis.knapp@burninlab.com" not in str(result)
+        assert "taylor.morgan@example.com" not in str(result)
         assert "[[EMAIL:" in result["name"]
         assert result["ssid"] == "MPSK"  # SSID still passes through
         assert result["vlan_id"] == 1

--- a/tests/unit/test_site_rf_check.py
+++ b/tests/unit/test_site_rf_check.py
@@ -304,10 +304,10 @@ class TestSynthesize:
 class TestRenderReport:
     def test_smoke(self):
         report = SiteRFReport(
-            site_name="HOME",
+            site_name="HQ",
             platforms_queried=["mist", "central"],
             platforms_matched=["mist", "central"],
-            headline="Site 'HOME': all good",
+            headline="Site 'HQ': all good",
             bands={
                 "2.4": BandSummary(band="2.4", ap_count=2, radios_active=2, channel_distribution={"1": 2}),
                 "5": BandSummary(band="5", ap_count=0, radios_active=0, channel_distribution={}),
@@ -321,8 +321,8 @@ class TestRenderReport:
         )
         out = _render_report(report)
         # Headline + bands header + AP table + recommendations all present
-        assert "# RF Check — HOME" in out
-        assert "Site 'HOME'" in out
+        assert "# RF Check — HQ" in out
+        assert "Site 'HQ'" in out
         assert "### 2.4 GHz — 2 radio(s)" in out
         assert "ch   1" in out  # channel occupancy line
         assert "## Per-AP radio snapshot" in out
@@ -399,11 +399,11 @@ class TestRenderSiteOptions:
 
     def test_with_options(self):
         opts = [
-            SiteOption(name="HOME", platform="central", ap_count=3, online_ap_count=3),
-            SiteOption(name="HOME", platform="mist", ap_count=5, online_ap_count=0),
+            SiteOption(name="HQ", platform="central", ap_count=3, online_ap_count=3),
+            SiteOption(name="HQ", platform="mist", ap_count=5, online_ap_count=0),
         ]
         out = _render_site_options(opts)
-        assert "HOME" in out
+        assert "HQ" in out
         assert "central" in out and "mist" in out
         assert "site_rf_check" in out
         # Header columns rendered
@@ -422,7 +422,7 @@ class TestRenderSiteOptions:
 class TestModels:
     def test_site_rf_report_serializes_with_rendered_field(self):
         report = SiteRFReport(
-            site_name="HOME",
+            site_name="HQ",
             platforms_queried=["mist"],
             platforms_matched=["mist"],
             headline="ok",
@@ -430,7 +430,7 @@ class TestModels:
         )
         dumped = report.model_dump()
         assert dumped["rendered_report"] == "# test"
-        assert dumped["site_name"] == "HOME"
+        assert dumped["site_name"] == "HQ"
 
     def test_mist_central_summaries_default_missing(self):
         # A report with no platforms found should still serialize cleanly.


### PR DESCRIPTION
Closes #259

Scrubs personal/customer-looking identifiers from files pushed to GitHub. All examples now use generic industry-standard placeholders.

## Summary

| Old | New | Where |
|---|---|---|
| \`HOME\` | \`HQ\` | CHANGELOG, INSTRUCTIONS, TOOLS.md, 6 skills, 2 test files |
| \`HOME-KNAPP\` | \`BRANCH-1\` | morning-coffee-report skill |
| \`HOME-GARAGE-AP\` | \`HQ-AP-1\` | CHANGELOG |
| \`KNAPP-BASEMENT\` | \`BRANCH-1-AP-1\` | CHANGELOG |
| \`HOME-AGG-SW1-1\` | \`HQ-AGG-SW1-1\` | morning-coffee-report skill |
| \`ADAMS-WIFI\` / \`ADAMS-WIFI2\` | \`CORP-WIFI\` / \`CORP-WIFI-2\` | docs/mappings/WLAN.md |
| \`ADAMS-TEST\` | \`TEST-SSID\` | config_assignments.py docstring |
| \`AdamsLAB\` | \`CORP-LAB\` | docs/mappings/WLAN.md |
| \`johns-laptop\` | \`user-laptop-1\` | morning-coffee-report skill |
| \`travis.knapp@burninlab.com\` | \`taylor.morgan@example.com\` | test_pii_redaction.py (MPSK fixture) |

Also fixes \`pyproject.toml\` repository URLs that pointed to a non-existent \`github.com/jonadams/hpe-networking-mcp\` — corrected to the actual \`nowireless4u/hpe-networking-mcp\`.

## What was preserved

- \`Jon Adams\` author attribution in \`pyproject.toml\` \`authors\` field — appropriate public attribution.
- \`Author: Jon Adams\` byline in \`docs/PRP.md\` — author attribution.
- \`home realms\` term in Mist's RADIUS schema — generic IT terminology, not a personal identifier.

## Why

These were Jon's personal home-network site names + family names that had leaked into illustrative examples across the public repo. Since this is an open-source project on GitHub, anyone reading the skills, tests, or CHANGELOG could see Jon's actual home network setup and what looked like a real personal email. Generic placeholders preserve example readability without exposing real identifiers.

## Test integrity

The MPSK email tokenization test (\`test_email_in_psk_name_field_tokenized\` in \`tests/unit/test_pii_redaction.py\`) keeps the same \`firstname.lastname@domain\` shape with \`taylor.morgan@example.com\` (RFC 2606 reserved domain). The test continues to validate the v2.3.1.2 universal email-scan behavior — it just no longer uses a real-looking PII string as the fixture.

## Pre-push checklist

- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run ruff format --check .\` — 271 files already formatted
- [x] \`uv run mypy src/ --ignore-missing-imports\` — Success: no issues found
- [x] \`uv run pytest tests/ -q\` — 950 passed (no test count change; only fixture VALUES changed)

## No version bump

Per project rule: docs/sanitization changes don't get version bumps or release tags. This PR is a content-only change with no behavior or API impact.

## Test plan

- [ ] After merge, verify the GitHub release notes for past versions still render correctly (since some past CHANGELOG entries were sanitized in place — release notes auto-pull from CHANGELOG, so the historical releases will show the sanitized examples).
- [ ] Operator can spot-check that the morning-coffee-report skill still produces sensible example output with the new generic naming.