### PR TITLE
docs: refresh tool + test counts post-v2.5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **83 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools (static mode)** | **35 + 2 prompts** | **87 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
@@ -453,7 +453,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │35 tools│ │83 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
 │  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.               │
@@ -599,7 +599,7 @@ hpe-networking-mcp/
 │       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
 │       ├── health.py            # Cross-platform health probe tool
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
-│       ├── central/             # 73 Central tools + 12 prompts + API client
+│       ├── central/             # 87 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
 │       ├── clearpass/           # 140 ClearPass tools + pyclearpass SDK client
 │       ├── apstra/              # 19 Apstra tools + async httpx client
@@ -609,7 +609,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (767+ unit tests)
+├── tests/                       # Unit and integration tests (964+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -34,7 +34,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (83)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (87)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |


### PR DESCRIPTION
PR #262 (v2.5.2.0) updated INSTRUCTIONS.md, CHANGELOG.md, and the relevant sections of docs/TOOLS.md but missed several other count references that needed the Central 83 → 87 (+4 GCIS tools) refresh and a stale test count.

## Changes

**README.md:**
- Comparison table (line 55): Central column \`83 + 12 prompts\` → \`87 + 12 prompts\`
- Architecture diagram (line 456): Central box \`83 tools\` → \`87 tools\`
- Project structure (line 602): \`73 Central tools\` → \`87 Central tools\` (was already stale before v2.5.2.0)
- Test count (line 612): \`767+ unit tests\` → \`964+ unit tests\`

**docs/TOOLS.md:**
- Code-mode tags-brief example (line 37): \`central (83)\` → \`central (87)\`

## What's NOT changed

Historical CHANGELOG entries reference older counts (73, 83, etc.) at the time of those past releases — those are correct history and intentionally left alone.

## Pre-push checklist

Docs-only change. No code touched. No version bump (per project rule: docs-only PRs don't get version bumps or release tags).

CI will still run (Lint & Format, Tests, etc.) but no behavior change.