### PR TITLE
v2.5.2.1: SandboxErrorCatchMiddleware now signals isError on the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2.1] - 2026-05-05
+
+**`SandboxErrorCatchMiddleware` now signals `isError: true` on the wire for code-mode sandbox failures.** Reported by Zach during OpenClaw MCP execute testing — sandbox parse/runtime errors were reaching MCP clients as `isError: false` tool results, making it impossible for orchestrators to distinguish failed execution from successful JSON output that happened to contain error-shaped strings.
+
+### Why
+
+`SandboxErrorCatchMiddleware` (added in v2.x as the fix for [#208](https://github.com/nowireless4u/hpe-networking-mcp/issues/208) so the LLM can read sandbox error messages and self-correct) was returning the unwrapped error text via `ToolResult(content=...)`. FastMCP's `ToolResult` doesn't expose `isError` — that flag is set on the wire only when a tool raises an exception. Returning a `ToolResult` always gets `isError: false`.
+
+The trade-off had been: LLM gets readable error message ✓ / orchestrator sees error flag ✗. After Zach's bug report we have evidence both halves are needed: the agent self-corrected through 5+ retries (the message is reaching it correctly), but the orchestrator's trace recorded every failed iteration as a successful tool call.
+
+### Fix
+
+`SandboxErrorCatchMiddleware` now **re-raises a fresh `ToolError`** carrying the unwrapped sandbox error text, instead of returning a `ToolResult`. Verified empirically against FastMCP's masking logic (`server.py:1241-1243`): the `except FastMCPError` branch re-raises `ToolError` instances unchanged before the generic `except Exception` masking branch can wrap them. So a middleware-raised `ToolError` propagates to the wire with `isError: true` AND our enriched message intact.
+
+Live verification in the dev container with intentionally bad indentation (` return 1` — the same shape as the model-generated code that triggered Zach's report):
+
+```
+Sandbox error: Unexpected indentation at byte range 1..2
+```
+
+The MCP client received the response wrapped in error-marker tags (proving `isError: true` on the wire) AND the readable cause text in the content. Successful execute calls continue to work unchanged.
+
+### What's new
+
+- **`src/hpe_networking_mcp/middleware/sandbox_error_catch.py`** — middleware now raises `ToolError(error_text) from cause` instead of returning `ToolResult(content=error_text)`. Module docstring updated with the call-chain reasoning (middleware sits outside the masking layer; `ToolError` from middleware bypasses `mask_error_details`). Removed the unused `ToolResult` import.
+- **`tests/unit/test_middleware.py`** — `test_catches_monty_runtime_error_on_execute` renamed to `test_catches_monty_runtime_error_on_execute_and_re_raises`, asserts `pytest.raises(ToolError)` instead of `result.content`. New regression test `test_catches_monty_syntax_error_and_re_raises` pins the OpenClaw-reported syntax-error path specifically (built via real `MontySyntaxError` from ` return 1`). Both tests verify the original cause is preserved on `ToolError.__cause__` for telemetry.
+
+### Validates / closes
+
+- Closes the OpenClaw-reported isError signaling bug (no GitHub issue filed; reported via maintainer's session).
+- Re-validates [#208](https://github.com/nowireless4u/hpe-networking-mcp/issues/208) — message readability is preserved (the LLM still sees the actual error cause, just now via the standard error-response path instead of via content of a successful response).
+
+### Notes
+
+- Patch (`x.x.x.X`) bump — bug fix, no API surface change. Behavior change: clients that previously checked `result.content` for error-shaped text on a successful response now need to check `isError` per the MCP spec. This matches what the spec says clients should do anyway.
+- Docs-only files (README, INSTRUCTIONS, TOOLS.md) unchanged — no tool surface change, no operator-visible workflow change.
+
 ## [2.5.2.0] - 2026-05-05
 
 **Central Gateway Cluster Intent (GCIS) tools + `aos-migration` Stage 7 cluster-mode derivation.** Closes [#261](https://github.com/nowireless4u/hpe-networking-mcp/issues/261). Adds 4 new Central tools for managing AOS 10's gateway cluster orchestration plane — the migration target for AOS 8 `cluster_prof` + `group_membership`.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **83 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools (static mode)** | **35 + 2 prompts** | **87 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
@@ -453,7 +453,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │35 tools│ │83 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
 │  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.               │
@@ -599,7 +599,7 @@ hpe-networking-mcp/
 │       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
 │       ├── health.py            # Cross-platform health probe tool
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
-│       ├── central/             # 73 Central tools + 12 prompts + API client
+│       ├── central/             # 87 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
 │       ├── clearpass/           # 140 ClearPass tools + pyclearpass SDK client
 │       ├── apstra/              # 19 Apstra tools + async httpx client
@@ -609,7 +609,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (767+ unit tests)
+├── tests/                       # Unit and integration tests (964+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -34,7 +34,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (83)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (87)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.5.2.0"
+version = "2.5.2.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -10,17 +10,23 @@ LLM with nothing to self-correct from.
 
 The original ``MontyError`` is preserved on ``ToolError.__cause__``, so this
 middleware catches ``ToolError`` for the ``execute`` tool, inspects the
-cause, and if it's a ``MontyError`` returns the actual error text as a
-string ``ToolResult`` so the LLM can read the real cause.
+cause, and if it's a ``MontyError`` re-raises a fresh ``ToolError`` carrying
+the actual error text. Middleware sits *outside* the masking layer in the
+call chain, so this fresh exception propagates to the MCP request handler
+unmasked — the wire response gets ``isError: true`` AND the readable error
+text in ``content``. The LLM sees the message; the orchestrator sees the
+failure flag.
 
 (Aside on why this differs from ``ValidationCatchMiddleware``: FastMCP
 special-cases ``ValidationError`` to re-raise unchanged — so that catch can
 match the original type. ``MontyError`` falls through to the generic
 ``Exception`` branch which applies the masking wrapper.)
 
-Closes #208. The "Unknown tool: search" masking case is the most common
-trigger — LLMs frequently try to call discovery tools from inside
+Closes #208 (LLM self-correction) and #(this PR) (orchestrator-visible
+``isError`` flag). The "Unknown tool: search" masking case is the most
+common trigger — LLMs frequently try to call discovery tools from inside
 ``execute()`` even though those only exist at the outer MCP surface.
+Syntax errors from stray indentation in model-generated code are another.
 """
 
 from __future__ import annotations
@@ -30,7 +36,6 @@ from typing import Any
 import mcp.types
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
-from fastmcp.tools.tool import ToolResult
 from loguru import logger
 
 # pydantic_monty ships in the fastmcp[code-mode] extra. If it's missing,
@@ -47,7 +52,15 @@ except ImportError:
 
 class SandboxErrorCatchMiddleware(Middleware):
     """Convert sandbox ``MontyError`` (wrapped in ``ToolError`` by FastMCP's
-    masking layer) into a readable string ``ToolResult``.
+    masking layer) into a fresh ``ToolError`` with the readable cause text.
+
+    Re-raising (rather than returning a ``ToolResult``) is deliberate: the
+    fresh ``ToolError`` propagates to the MCP request handler unmasked, so
+    the wire response gets ``isError: true`` AND the readable error text in
+    ``content``. Returning a ``ToolResult`` instead would suppress
+    ``isError`` (the wire flag would be ``false`` since no exception was
+    raised) — orchestrators can't distinguish failed tool calls from
+    successful ones that returned an error-shaped string.
 
     Only acts on the code-mode ``execute`` tool. All other tools pass through
     untouched — sandbox errors are a code-mode-specific failure mode.
@@ -59,16 +72,16 @@ class SandboxErrorCatchMiddleware(Middleware):
         self,
         context: MiddlewareContext[mcp.types.CallToolRequestParams],
         call_next: Any,
-    ) -> ToolResult:
+    ) -> Any:
         if not _HAS_MONTY:
-            return await call_next(context)  # type: ignore[no-any-return]
+            return await call_next(context)
 
         tool_name = getattr(context.message, "name", "")
         if tool_name != self.EXECUTE_TOOL_NAME:
-            return await call_next(context)  # type: ignore[no-any-return]
+            return await call_next(context)
 
         try:
-            return await call_next(context)  # type: ignore[no-any-return]
+            return await call_next(context)
         except ToolError as e:
             # FastMCP wraps the original sandbox exception in ToolError when
             # mask_error_details=True is set. The original is on __cause__.
@@ -78,4 +91,8 @@ class SandboxErrorCatchMiddleware(Middleware):
                 raise
             error_text = f"Sandbox error: {cause}"
             logger.debug("SandboxErrorCatch: caught on {} → {}", tool_name, error_text)
-            return ToolResult(content=error_text)
+            # Re-raise so the wire response sets isError=true. Middleware
+            # sits outside the masking layer, so this propagates with the
+            # message intact — fixing both LLM-readability (#208) and
+            # orchestrator-visible isError flag.
+            raise ToolError(error_text) from cause

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -277,6 +277,23 @@ async def _make_monty_error(message: str):
     raise AssertionError("expected MontyError")  # pragma: no cover
 
 
+async def _make_monty_error_via_syntax_error():
+    """Build a real ``MontySyntaxError`` (Rust-backed; only obtainable by
+    feeding malformed code to ``Monty(...)``). Note that syntax errors
+    raise at construction time, not at ``run_async()`` — different from
+    runtime errors which raise during execution.
+    """
+    import pydantic_monty
+
+    # Stray leading space on a top-level line — same shape as the model-
+    # generated code that triggered the OpenClaw bug report.
+    try:
+        pydantic_monty.Monty(" return 1\n")
+    except pydantic_monty.MontyError as e:
+        return e
+    raise AssertionError("expected MontyError at construction")  # pragma: no cover
+
+
 def _wrap_in_tool_error(cause: BaseException) -> ToolError:
     """Mirror what FastMCP's ``server.call_tool`` does with
     ``mask_error_details=True``: wrap the original exception in a generic
@@ -291,9 +308,10 @@ def _wrap_in_tool_error(cause: BaseException) -> ToolError:
 class TestSandboxErrorCatchMiddleware:
     """The middleware must intercept the ``ToolError`` that FastMCP wraps
     around a sandbox ``MontyError`` (caused by the masking layer) and
-    return the underlying error's text as a structured ToolResult, so the
-    AI can read the actual cause and self-correct instead of seeing a
-    generic "Error calling tool 'execute'". Closes #208.
+    re-raise a fresh ``ToolError`` carrying the unwrapped error text. This
+    propagates to the wire as ``isError: true`` AND keeps the readable
+    message in ``content`` — fixing both LLM self-correction (#208) and
+    orchestrator-visible error signaling.
 
     We synthesize the wrap-in-ToolError shape in tests because that's
     exactly what FastMCP's ``server.call_tool`` produces when
@@ -301,11 +319,13 @@ class TestSandboxErrorCatchMiddleware:
     """
 
     @pytest.mark.asyncio
-    async def test_catches_monty_runtime_error_on_execute(self):
+    async def test_catches_monty_runtime_error_on_execute_and_re_raises(self):
         """The originally-bug-inducing case: LLM calls `search` from inside
         execute() → sandbox raises MontyError("Unknown tool: search")
-        → FastMCP wraps as ToolError → middleware unwraps → ToolResult
-        content carries the readable text.
+        → FastMCP wraps as ToolError with masked message
+        → middleware unwraps, re-raises fresh ToolError with readable text.
+        Re-raising (not returning ToolResult) is what gives the wire
+        response ``isError: true``.
         """
         cause = await _make_monty_error("Unknown tool: search")
         wrapped = _wrap_in_tool_error(cause)
@@ -316,12 +336,42 @@ class TestSandboxErrorCatchMiddleware:
         async def _raise(_ctx):
             raise wrapped
 
-        result = await middleware.on_call_tool(ctx, _raise)
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
 
-        assert hasattr(result, "content"), "must return a ToolResult-like object"
-        text = result.content[0].text if result.content else ""
+        text = str(exc_info.value)
         assert "sandbox error" in text.lower()
         assert "Unknown tool: search" in text
+        # Generic FastMCP-masked text must NOT survive — only our enriched message
+        assert text != "Error calling tool 'execute'"
+        # Original cause is preserved on __cause__ for telemetry
+        assert exc_info.value.__cause__ is cause
+
+    @pytest.mark.asyncio
+    async def test_catches_monty_syntax_error_and_re_raises(self):
+        """Regression test for the OpenClaw-reported case: model-generated code
+        with stray indentation triggers MontySyntaxError. Same code path as
+        the runtime-error case, but pinned separately because syntax errors
+        are the most user-visible failure mode (LLMs generate them often).
+        """
+        cause = await _make_monty_error_via_syntax_error()
+        wrapped = _wrap_in_tool_error(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise wrapped
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        text = str(exc_info.value)
+        assert "sandbox error" in text.lower()
+        # The Monty error text mentions "Unexpected indentation" or similar;
+        # we don't pin the exact string (Monty/Rust may rewrap it) but we DO
+        # pin that something descriptive made it through, not the masked text
+        assert text != "Error calling tool 'execute'"
 
     @pytest.mark.asyncio
     async def test_does_not_catch_on_non_execute_tools(self):
@@ -387,8 +437,9 @@ class TestSandboxErrorCatchMiddleware:
 
     @pytest.mark.asyncio
     async def test_error_text_carries_actionable_detail(self):
-        """The wrapped error's str() form must be preserved in the returned
-        text — that's what the LLM reads to fix its code.
+        """The wrapped error's str() form must be preserved in the raised
+        ToolError's message — that's what the LLM reads to fix its code,
+        carried via the wire response's content alongside isError: true.
         """
         cause = await _make_monty_error("division by zero at line 4")
         wrapped = _wrap_in_tool_error(cause)
@@ -399,9 +450,10 @@ class TestSandboxErrorCatchMiddleware:
         async def _raise(_ctx):
             raise wrapped
 
-        result = await middleware.on_call_tool(ctx, _raise)
-        text = result.content[0].text
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
 
+        text = str(exc_info.value)
         assert "division by zero" in text
         assert "line 4" in text
 


### PR DESCRIPTION
Reported by Zach during OpenClaw MCP execute testing.

## Symptom

Code-mode sandbox parse/runtime errors were reaching MCP clients as \`isError: false\` tool results — orchestrators couldn't distinguish failed execution from successful JSON output containing error-shaped strings. OpenClaw's recorded trace marked every failed retry as a successful tool call.

## Root cause

\`SandboxErrorCatchMiddleware\` (added for [#208](https://github.com/nowireless4u/hpe-networking-mcp/issues/208) so the LLM can read sandbox error messages and self-correct) was returning the unwrapped error text via \`ToolResult(content=...)\`. FastMCP's \`ToolResult\` doesn't expose \`isError\` — that flag is set on the wire only when a tool raises an exception. The original fix traded message readability ✓ for orchestrator-visible error flag ✗. The trade was deliberate but wasn't noticed because no orchestrator was building on \`isError\` until OpenClaw.

## Fix

\`raise ToolError(error_text) from cause\` instead of \`return ToolResult(content=error_text)\`. Verified against FastMCP's masking logic (\`server.py:1241-1243\`): the \`except FastMCPError: raise\` branch re-raises \`ToolError\` instances unchanged before the generic \`except Exception\` masking branch can wrap them. So a middleware-raised \`ToolError\` propagates to the wire with \`isError: true\` AND our enriched message intact.

## Empirical verification

Dev container test with bad indentation (\` return 1\` — same shape as the model-generated code Zach hit):

```
<error>Sandbox error: Unexpected indentation at byte range 1..2</error>
```

MCP client received the response wrapped in error-marker tags (proving \`isError: true\` on the wire) AND the readable cause text. Successful execute calls (\`return {"sanity": "ok"}\`) continue to work unchanged.

## Why this is the BEST OF BOTH WORLDS

| | isError on wire | LLM sees error text |
|---|---|---|
| Pre-#208 (FastMCP default masking) | ✓ true | ✗ generic "Error calling tool 'execute'" |
| Post-#208 (returns ToolResult) | ✗ false | ✓ unwrapped sandbox text |
| **v2.5.2.1 (raises ToolError)** | ✓ true | ✓ unwrapped sandbox text |

Re-validates [#208](https://github.com/nowireless4u/hpe-networking-mcp/issues/208) — message readability preserved. Closes the OpenClaw-reported isError signaling bug.

## Files changed

- \`src/hpe_networking_mcp/middleware/sandbox_error_catch.py\` — middleware raises \`ToolError\` instead of returning \`ToolResult\`. Module docstring updated. Removed unused \`ToolResult\` import.
- \`tests/unit/test_middleware.py\` — updated existing tests to assert \`pytest.raises(ToolError)\` per new contract; new regression test for the OpenClaw syntax-error case via a real \`MontySyntaxError\`.
- \`CHANGELOG.md\` + \`pyproject.toml\` — v2.5.2.1.

## Pre-push checklist

- [x] \`uv run ruff check .\` — All checks passed
- [x] \`uv run ruff format --check .\` — already formatted
- [x] \`uv run mypy src/ --ignore-missing-imports\` — Success: no issues found
- [x] \`uv run pytest tests/ -q\` — 965 passed (was 964; +1 new regression test)

## Test plan

- [ ] After merge + image rebuild, re-run Zach's exact OpenClaw scenario — confirm the orchestrator now records failed iterations as failed (\`isError: true\`).
- [ ] Verify the agent still self-corrects through syntax errors (LLM-readable message preserved).
- [ ] Spot-check that successful \`execute\` calls return native shape with \`isError: false\` (no regression on the success path).

## Notes

- Patch bump (\`x.x.x.X\`) — bug fix, no API surface change. Behavior change for clients: those that previously checked \`result.content\` for error-shaped text on a successful response now need to check \`isError\` per the MCP spec. This matches what the spec says clients should do anyway.
- No README / TOOLS / INSTRUCTIONS changes — no tool surface or operator workflow change.