### PR TITLE
chore(gitignore): exclude Zach's OpenClaw test-report PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ docs/central/vsg/
 # for skill authoring; do not redistribute via the repo.
 docs/mist/vsg/
 docs/mist/
+
+# Test reports shared by external collaborators (kept local — may contain
+# operator-environment data we don't want in public repo)
+docs/Qwen3_4B_OpenClaw_HPE_MCP_Test_Report.pdf


### PR DESCRIPTION
Adds \`docs/Qwen3_4B_OpenClaw_HPE_MCP_Test_Report.pdf\` to .gitignore so the local-only artifact doesn't accidentally get tracked + pushed.

## Why gitignored, not committed

The PDF contains:
- Personal path identifiers (Zach's WSL/Linux home directories in command examples)
- Operator-environment site/scope IDs (Owls Nest collection + site, real persona/device/resource counts)

Per [feedback_generic_example_names](.. nothing — local memory) we don't push real environment data to the public repo. Same hygiene rule applied in #260 (personal-name scrub) extends to other people's identifiers that show up in tracked files.

## Findings already captured publicly

- **#246** — reassessment comment with the v3 envelope prototype validation results from Zach's testing
- **#265** — sandbox \`isError: false\` bug filed + fixed in v2.5.2.1 / PR #264

Nothing in the PDF needs to be committed for the work to be tracked — the issue comments + closed bug report are the canonical record.

## Pre-push checklist

Single-line .gitignore append. No code change. No version bump (gitignore-only).