### PR TITLE
v3.0.0.0: drop static mode + code mode default + envelope full-fleet expansion + pydantic_monty required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0.0] - 2026-05-06
+
+**Major release.** Three breaking changes bundled into one:
+
+1. **`MCP_TOOL_MODE=static` REMOVED** — at 367 tools / ~64K tokens of schema, static mode was no longer practical. Setting it now raises `ValueError` at startup with a migration message.
+2. **Default tool mode flipped from `dynamic` → `code`** — code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 367 underlying tools are reachable via `await call_tool(name, params)` inside the sandboxed Python `execute()` block. Smallest initial token cost; best for orchestrators driving small / local LLMs.
+3. **Response envelope universal** — every tool's response is wrapped in `{ok, status, data, message, tool, platform}`. v2.5.1.0 prototyped this on 4 cross-platform tools; v3.0.0.0 expanded to every tool after Zach's OpenClaw + Qwen3 4B test confirmed the envelope worked for the small-local-model use case (#246 reassessment). The actual API payload always lives at `result["data"]`.
+
+Closes [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246), [#267](https://github.com/nowireless4u/hpe-networking-mcp/issues/267).
+
+### Why this is one release, not three
+
+The three changes are tightly coupled:
+- Removing static mode removes the breaking-change concern from the original [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) envelope expansion (which had cited static-mode consumers as the load-bearing reason it had to be a major bump).
+- Flipping the default to code mode fully realizes the envelope's value (uniform shape across every `call_tool()` return inside `execute()`).
+- Doing all three together gives operators ONE breaking-change story to learn instead of three separate releases close together.
+
+The original effort estimate was ~3 days per [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246); actual work was a fraction of that because the test rewrite was much smaller than expected (unit tests call tool functions directly and bypass middleware, so envelope expansion didn't break them).
+
+### Migration paths
+
+| If you were running... | After v3.0.0.0... | Action |
+|---|---|---|
+| `MCP_TOOL_MODE=static` (explicit) | Hard error at startup with migration message | Switch to `dynamic` (per-platform meta-tools, ~3,700 tokens) or `code` (sandboxed `execute`, ~minimal tokens) |
+| `MCP_TOOL_MODE=dynamic` (explicit) | Continues to work as before | Nothing required |
+| `MCP_TOOL_MODE=code` (explicit) | Continues to work as before | Nothing required |
+| No `MCP_TOOL_MODE` set (implicit default) | Now defaults to `code` mode (was `dynamic` in v2.x); startup log warns once | Set `MCP_TOOL_MODE=dynamic` in your compose to keep prior behavior |
+| AI client checking `result["foo"]` directly on tool calls | Now needs `result["data"]["foo"]` (envelope wraps everything) | Update client code to navigate through the envelope |
+| Static-mode `tools/call` usage | No longer supported | Use code mode (`execute` + `call_tool`) or dynamic mode (`<platform>_invoke_tool`) |
+| `pydantic_monty` was previously installed via `fastmcp[code-mode]` extra | Now a hard requirement (code mode is default) | The extra is still on the dependency line; nothing to do for fresh installs |
+
+### What's new
+
+- **`src/hpe_networking_mcp/config.py`** — drop `static` from valid `MCP_TOOL_MODE` values; raise `ValueError` with migration message. Flip application default from `dynamic` → `code`. Log a startup migration message when env var unset.
+- **Per-platform `__init__.py`** (Mist, Central, GreenLake, ClearPass, Apstra, Axis, AOS 8, `_template`) — drop the static-mode log branch; only dynamic / code remain.
+- **`src/hpe_networking_mcp/server.py`** — cleanup `dynamic / static modes` comment to just `dynamic mode`.
+- **`src/hpe_networking_mcp/middleware/response_envelope.py`** — drop `PROTOTYPE_TOOLS` allowlist; envelope wraps every tool universally. Already-enveloped responses still pass through idempotently.
+- **`pyproject.toml`** — bump 2.5.2.1 → 3.0.0.0; updated `fastmcp[code-mode]` dependency comment to reflect code-mode-as-default (the extra is still required as a hard dep).
+- **`docker-compose.yml`** (committed template) — comment out `MCP_TOOL_MODE=${MCP_TOOL_MODE:-dynamic}` so the application default takes effect for fresh installs. Explanatory comment for opting back into dynamic.
+- **`tests/unit/test_code_mode.py`** — test contract updates: default is `code`, unknown values fall back to `code`, `static` raises ValueError. Removed `test_static_mode_registers_all_aggregators` (premise no longer applies).
+- **`tests/unit/test_response_envelope_middleware.py`** — drop `PROTOTYPE_TOOLS` import; flipped `test_passes_through_non_prototype_tool` → `test_wraps_platform_prefixed_tool` (asserts `central_get_sites` IS wrapped now); replaced `test_prototype_tools_set_membership` with `test_wraps_aos8_tool` (verifies AOS 8 tools added after v2.5.1.0 are also wrapped).
+- **`src/hpe_networking_mcp/skills/aos-migration.md`** — `response.get("result")` envelope unwrap → `response.get("data", response)` for v3 envelope shape; same for ap_database access in COLLECT-04.
+- **`src/hpe_networking_mcp/INSTRUCTIONS.md`** — rewrote tool-discovery preamble for code-default + dynamic-opt-in; expanded "Response envelope" section to universal scope; flagged static-mode removal.
+- **`README.md`** — comparison table heading + default-tool-surface callout + startup-log examples + architecture-diagram ASCII art + env-var table + troubleshooting section all updated for v3.0.0.0 reality.
+- **`docs/TOOLS.md`** — code mode documented first (as default); dynamic mode follows (opt-in); static mode removal documented.
+
+### Notes
+
+- 964 tests still pass throughout. The unit-test suite calls tool functions directly (bypassing middleware) so the envelope expansion didn't break them. AI clients / orchestrators that previously checked `result["foo"]` directly on the wire will need to navigate through `result["data"]["foo"]` post-v3.0.0.0.
+- `pydantic_monty` was already pulled in via `fastmcp[code-mode]` — no new dependency.
+- Code mode's premise (LLM composes per-platform tools via `call_tool` inside the sandbox) explicitly does NOT include the cross-platform aggregators (`site_health_check`, `site_rf_check`, `manage_wlan_profile`) — those are workarounds for dynamic mode's "AI picks one platform and stops" problem. They remain registered only in dynamic mode.
+
 ## [2.5.2.1] - 2026-05-05
 
 **`SandboxErrorCatchMiddleware` now signals `isError: true` on the wire for code-mode sandbox failures.** Reported by Zach during OpenClaw MCP execute testing — sandbox parse/runtime errors were reaching MCP clients as `isError: false` tool results, making it impossible for orchestrators to distinguish failed execution from successful JSON output that happened to contain error-shaped strings.

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools (static mode)** | **35 + 2 prompts** | **87 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
-| **Exposed meta-tools (dynamic mode, default)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
+| **Underlying tools** | **35 + 2 prompts** | **87 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
-> **Default tool surface**: v2.0+ ships with `MCP_TOOL_MODE=dynamic` by default. Each platform exposes three meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), plus four cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) and two skills tools (`skills_list`, `skills_load`). **27 tools total** for the seven-platform configuration (7 × 3 meta-tools + 4 cross-platform + 2 skills) — down from 275+ tools / ~64,000 tokens in v1.x. Set `MCP_TOOL_MODE=static` to restore the full per-tool surface (every underlying tool is still here; it just defaults to hidden behind the meta-tools). v2.1.0.0 also ships `MCP_TOOL_MODE=code` as an experimental opt-in — FastMCP's `CodeMode` transform with a sandboxed Python `execute` for multi-step workflows; see [docs/TOOLS.md#code-mode](docs/TOOLS.md). v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -196,7 +196,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 tools registered`, `ClearPass: 140 tools registered`, `Axis: 25 underlying tools registered`, `AOS8: 47 underlying tools + 3 meta-tools (dynamic mode)`, `Tool mode: dynamic`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default dynamic mode, only 27 tools are exposed to the AI when all seven platforms are enabled — the underlying platform tools are discoverable via each platform's `list_tools` / `get_tool_schema` / `invoke_tool` meta-tools. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 35 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -233,7 +233,7 @@ Central: disabled (missing secrets: central_client_id, central_client_secret)
 GreenLake: disabled (missing secrets: greenlake_client_id)
 AOS8: disabled (missing secrets: aos8_host)
 Enabled platforms: mist
-Tool mode: dynamic
+Tool mode: code
 ```
 
 > **Heads up:** auto-disable triggers on **empty or absent secret content**, not on placeholder/example values. If you copy `apstra_server.example` → `apstra_server` and leave the contents as `apstra.example.com`, the server thinks Apstra is configured and tries to authenticate against the fake host — your logs fill with login errors. Either empty those files, drop the platform via `docker-compose.override.yml`, or fill in real values.
@@ -441,14 +441,12 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
                                         │ Streamable HTTP
                                         ▼
 ┌─────────────────────────────────────────────────────────────────────────────────────────┐
-│                  HPE Networking MCP Server (:8000)  —  MCP_TOOL_MODE=dynamic            │
+│      HPE Networking MCP Server (:8000)  —  MCP_TOOL_MODE=code (default since v3.0.0.0) │
 │                                                                                         │
-│   Exposed to the AI  (27 tools total when all 7 platforms enabled):                     │
-│     • 4 cross-platform static tools: health, site_health_check,                         │
-│       site_rf_check, manage_wlan_profile                                                │
-│     • 7 × 3 per-platform meta-tools: <platform>_list_tools,                             │
-│       <platform>_get_tool_schema, <platform>_invoke_tool                                │
-│     • 2 skills tools: skills_list, skills_load (multi-step runbooks)                    │
+│   Exposed to the AI  (6 tools in code mode):                                            │
+│     • execute (sandboxed Python; await call_tool(name, params) inside)                  │
+│     • 5 discovery tools: tags, search, get_schema, skills_list, skills_load             │
+│   Set MCP_TOOL_MODE=dynamic to use the v2.x meta-tool surface (24 tools).               │
 │                                                                                         │
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
@@ -456,7 +454,8 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
-│  Hidden behind meta-tools in dynamic mode;  fully exposed in static mode.               │
+│  All 367 underlying tools reachable via call_tool() in code mode or via                 │
+│  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘           │
 │     │          │          │          │          │          │          │                 │
 └─────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼─────────────────┘
@@ -470,7 +469,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Dynamic tool mode by default** — each platform exposes 3 meta-tools; the AI discovers the 300+ underlying tools on demand. Keeps the tool-schema payload small enough to fit in a 32K-context local LLM.
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 367 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -532,7 +531,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `dynamic` | Tool exposure: `dynamic` (22 exposed, rest discoverable via meta-tools) or `static` (every tool registers individually — 300+ visible) |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 367 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -727,25 +726,27 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (24 tools vs. 312)
+### Tool Surface Looks Wrong (6 tools vs. 367)
 
-Since v2.0.0.0, every platform runs in dynamic mode by default: each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) and the underlying tools are discoverable through them. A correctly configured server with all 7 platforms enabled will advertise **27 tools** to the AI client — 21 meta-tools + 4 cross-platform static tools (`health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`) + 2 skills tools.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: dynamic"   → default (27 exposed tools with all 7 platforms)
-# "Tool mode: static"    → every underlying tool visible (300+)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 367 underlying via call_tool)
+# "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
-To restore v1.x-style surface (every tool registered individually), set `MCP_TOOL_MODE=static` in `docker-compose.yml` under `environment`:
+To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
-- MCP_TOOL_MODE=static    # every tool individually exposed
-- MCP_TOOL_MODE=dynamic   # meta-tool discovery pattern (default)
+- MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 367 (default since v3.0.0.0)
 ```
 
-See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for why this changed.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+
+See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 
 ### Write Tools Not Visible
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       - ENABLE_AXIS_WRITE_TOOLS=${ENABLE_AXIS_WRITE_TOOLS:-false}
       - ENABLE_AOS8_WRITE_TOOLS=${ENABLE_AOS8_WRITE_TOOLS:-false}
       - DISABLE_ELICITATION=${DISABLE_ELICITATION:-false}
-      - MCP_TOOL_MODE=${MCP_TOOL_MODE:-dynamic}
+      # Tool exposure mode (since v3.0.0.0 the application default is "code").
+      # Uncomment + set to "dynamic" to opt back into the per-platform meta-tool
+      # surface (the v2.x default). The "static" value was REMOVED in v3.0.0.0.
+      # - MCP_TOOL_MODE=${MCP_TOOL_MODE:-code}
     secrets:
       # Mist (remove lines for platforms you don't use)
       - mist_api_token

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -5,16 +5,33 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 `greenlake_*` (HPE GreenLake), `clearpass_*` (Aruba ClearPass), `apstra_*`
 (Juniper Apstra), and `axis_*` (Axis Atmos Cloud).
 
-## Dynamic mode (default since v2.0.0.0)
+## Code mode (default since v3.0.0.0)
 
-The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the AI sees **24 tools**:
+The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
+
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 367 underlying tools
+- **`tags(detail="brief")`** — browse the catalog by platform / module
+- **`search(query, tags=[...], detail)`** — BM25 search the catalog
+- **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
+- **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
+- **`skills_load(name=...)`** — load a runbook to execute
+
+All 367 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+
+**Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
+
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical.
+
+## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
+
+With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
 
 - **4 cross-platform static tools**
   - `health(platform=...)`
   - `site_health_check(site_name=...)`
   - `site_rf_check(site_name=...)`
   - `manage_wlan_profile(...)`
-- **3 meta-tools per platform** (× 6 platforms = 18)
+- **3 meta-tools per platform** (× 7 platforms = 21)
   - `<platform>_list_tools(filter=...)` — list candidates
   - `<platform>_get_tool_schema(name=...)` — fetch parameter schema
   - `<platform>_invoke_tool(name=..., arguments={...})` — invoke by name
@@ -22,11 +39,9 @@ The server ships with `MCP_TOOL_MODE=dynamic` by default. At session start the A
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-All 312 per-platform tools documented below still exist and are discoverable through the meta-tools. Their names, parameters, and return shapes are unchanged from v1.x. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the meta-tools.
+The 367 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
-Set `MCP_TOOL_MODE=static` to restore the v1.x surface where every per-platform tool registers individually (312 visible). Set `MCP_TOOL_MODE=code` for an experimental four-tier discovery + sandboxed Python execution surface — see the next section.
-
-## Code mode (experimental, opt-in since v2.1.0.0)
+## Code mode details (the default — see above for surface summary)
 
 With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool surface: `tags`, `search`, `get_schema`, and `execute`. The LLM writes async Python inside `execute`; `call_tool(tool_name, params)` dispatches through the real FastMCP call_tool so every middleware (NullStrip, Elicitation, Pydantic coercion) keeps working. Multi-step workflows collapse from N MCP round-trips to one.
 
@@ -78,11 +93,10 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 
 ### When to use which mode
 
-- **`dynamic` (default)** — stable, production-tested, best for lookup-style questions
-- **`static`** — v1.x behavior, every tool visible, only useful for agents that hardcode tool names
-- **`code`** — experimental; best for multi-step aggregations, cross-platform joins, filter/map/reduce workflows
+- **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
+- **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-If you're not sure, stay on `dynamic`. Code mode is meant for measurement + evaluation right now.
+The `static` mode was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -99,7 +113,7 @@ If you're not sure, stay on `dynamic`. Code mode is meant for measurement + eval
 
 Write tools are disabled by default per platform. Enable them with environment variables:
 `ENABLE_MIST_WRITE_TOOLS=true`, `ENABLE_CENTRAL_WRITE_TOOLS=true`,
-`ENABLE_CLEARPASS_WRITE_TOOLS=true`, `ENABLE_APSTRA_WRITE_TOOLS=true`, or `ENABLE_AXIS_WRITE_TOOLS=true`. Elicitation applies in both tool modes — the AI still gets a confirmation prompt before a destructive call, whether it invoked the tool directly (static mode) or through `<platform>_invoke_tool` (dynamic mode).
+`ENABLE_CLEARPASS_WRITE_TOOLS=true`, `ENABLE_APSTRA_WRITE_TOOLS=true`, or `ENABLE_AXIS_WRITE_TOOLS=true`. Elicitation applies in both tool modes — the AI still gets a confirmation prompt before a destructive call, whether it invoked the tool inside `execute()` (code mode, default) or via `<platform>_invoke_tool` (dynamic mode).
 
 ## Cross-platform static tools
 
@@ -2061,9 +2075,7 @@ in `platforms/axis/__init__.py` if Axis ever flips them on.
 
 ## Aruba OS 8 / Mobility Conductor (47 tools + 9 prompts)
 
-Tools are exposed in dynamic mode by default via 3 meta-tools (`aos8_list_tools`,
-`aos8_get_tool_schema`, `aos8_invoke_tool`). Set `MCP_TOOL_MODE=static` to expose
-each underlying tool individually. Write tools require `ENABLE_AOS8_WRITE_TOOLS=true`.
+Tools are reachable via `await call_tool("aos8_<tool>", {...})` inside `execute()` in code mode (default since v3.0.0.0), or via the per-platform meta-tools (`aos8_list_tools`, `aos8_get_tool_schema`, `aos8_invoke_tool`) in dynamic mode. Write tools require `ENABLE_AOS8_WRITE_TOOLS=true`.
 
 ### Health & Inventory (8)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "2.5.2.1"
+version = "3.0.0.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
@@ -13,7 +13,9 @@ keywords = ["mcp", "networking", "mist", "aruba", "central", "greenlake", "clear
 authors = [{ name = "Jon Adams" }]
 
 dependencies = [
-    # MCP framework — Central requires code-mode, Mist requires >=3.1.0
+    # MCP framework — code-mode is the default tool mode since v3.0.0.0
+    # (was opt-in via the fastmcp[code-mode] extra in v2.x); the extra is
+    # now a hard requirement.
     "fastmcp[code-mode]>=3.1.1",
     # MCP protocol — GreenLake requires >=1.20.0, Mist requires >=1.9.2
     "mcp[cli]>=1.20.0",

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -129,6 +129,15 @@ When tokenization is off, tool responses contain plaintext values — your behav
 - Errors uniformly arrive as `{"ok": false, "message": "...", "data": null}` regardless of which platform / tool failed.
 - The `platform` field is inferred from the tool-name prefix (`central_*` → `"central"`, `aos8_*` → `"aos8"`, etc.); cross-platform tools (`health`, `site_health_check`, etc.) get `null`.
 - A small number of tools that explicitly return an envelope shape are passed through without re-wrapping (idempotent behavior).
+- **Some tools additionally wrap their return in an inner `{"result": ...}` shape** (a pre-v3 convention from when their backing API client returned that shape). The envelope wraps that wrapper — so for those tools the actual data lives at `result["data"]["result"]`. To handle both shapes uniformly inside `execute()`, use a fallback:
+
+  ```python
+  envelope_data = response.get("data", response)
+  payload = envelope_data.get("result", envelope_data) if isinstance(envelope_data, dict) and "result" in envelope_data else envelope_data
+  # `payload` is the actual API response regardless of which wrapping convention the tool used
+  ```
+
+  Tools known to use the inner wrapper as of v3.0.0.0: most `central_*` and `aos8_*` reads (e.g. `central_get_sites`, `aos8_get_ap_database`, `aos8_get_effective_config`). Tools that return the payload directly (no inner wrapper): `health`, the 4 cross-platform tools, most `mist_*` reads. When in doubt, use the fallback pattern above — it's safe for both shapes.
 
 ---
 

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -12,12 +12,17 @@ Tools are namespaced by platform:
 - `axis_*` — Axis Atmos Cloud (SASE / cloud-edge, connectors, tunnels)
 - `aos8_*` — Aruba OS 8 / Mobility Conductor (legacy controller-based wireless, AOS 8.x)
 
-# TOOL DISCOVERY (dynamic mode — default since v2.0)
+# TOOL DISCOVERY
 
-Only 27 tools are directly visible at session start:
-- **4 cross-platform static tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
-- **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
-- **2 skills tools** (since v2.3.0.0): `skills_list`, `skills_load`
+Two modes are supported (the `static` mode was removed in v3.0.0.0):
+
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
+    - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
+    - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
+    - **2 skills tools** (since v2.3.0.0): `skills_list`, `skills_load`
+
+The discovery patterns below describe **dynamic mode** (the v2.x default). In code mode, the AI calls `await call_tool("<platform>_list_tools", {"filter": "..."})` (or any other tool name) inside `execute()`, gets back the wrapped envelope `{"ok": ..., "data": [...], ...}`, and acts on `result["data"]`.
 
 Every per-platform tool listed below this section is reachable through the meta-tools. **Use this discovery pattern:**
 
@@ -61,7 +66,7 @@ Use the cross-platform tools directly when they apply — they replace several p
 - `site_rf_check(site_name=...)` — unified per-AP, per-band RF state (channels, power, utilization, noise floor) across Mist + Central; includes a pre-rendered ASCII RF dashboard. **Use for any channel-planning / spectrum / RF-health / "how are my 5/6 GHz channels" question** — do NOT fall back to Mist-only or Central-only RF tools without a reason.
 - `manage_wlan_profile(...)` — the mandatory entry point for any WLAN create/copy/sync request
 
-If `MCP_TOOL_MODE=static` is set, every per-platform tool is visible up front without needing the meta-tool round-trip. The names and behaviors are identical either way — only the discovery mechanism differs.
+**Static mode was removed in v3.0.0.0.** Setting `MCP_TOOL_MODE=static` now raises `ValueError` at startup; switch to `dynamic` (per-platform meta-tools) or `code` (sandboxed Python `execute`) per the discovery section above.
 
 # CRITICAL RULES
 1. **Never assume IDs or MAC addresses.** Always retrieve them with the appropriate tools before using them. This especially applies to org_id — ALWAYS call `mist_get_self(action_type=account_info)` first to get the correct org_id. Do NOT use an org_id from memory, a previous conversation, or any other source.
@@ -104,9 +109,9 @@ When `ENABLE_PII_TOKENIZATION=true` (operator-controlled, off by default), the M
 
 When tokenization is off, tool responses contain plaintext values — your behavior is unchanged.
 
-## Response envelope on cross-platform tools (v2.5.1.0+ prototype)
+## Response envelope (universal since v3.0.0.0)
 
-The four cross-platform tools — `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile` — wrap their responses in a uniform envelope:
+**Every tool's response is wrapped in a uniform envelope.** v2.5.1.0 prototyped this on 4 cross-platform tools; v3.0.0.0 expanded it to every tool in the catalog after Zach's OpenClaw + Qwen3 4B test confirmed it worked for the small-local-model use case.
 
 ```
 {
@@ -115,16 +120,15 @@ The four cross-platform tools — `health`, `site_health_check`, `site_rf_check`
   "data":     <any>,           # the actual payload — list, dict, or null
   "message":  str | null,      # human-readable error / context message
   "tool":     str,             # tool name
-  "platform": str | null       # null for these cross-platform tools
+  "platform": str | null       # "central" / "mist" / etc. — null for cross-platform
 }
 ```
 
 **Practical implications:**
-- For these four tools, the actual payload lives at `result["data"]`. Reading `result["status"]` etc. directly gets the envelope's metadata, not the inner data fields.
-- All other tools (`mist_*`, `central_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `greenlake_*`) return their **native shape unchanged** — no envelope. Don't navigate through `["data"]` for those.
-- Errors uniformly arrive as `{"ok": false, "message": "...", "data": null}` for the wrapped tools.
-
-This is a **prototype scope** — issue [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) tracks expanding the envelope to every tool in v3.0.0.0 (which would be a breaking change for static-mode consumers).
+- The actual API payload always lives at `result["data"]`. Reading `result["status"]` etc. directly gets the envelope's metadata, not the inner data fields.
+- Errors uniformly arrive as `{"ok": false, "message": "...", "data": null}` regardless of which platform / tool failed.
+- The `platform` field is inferred from the tool-name prefix (`central_*` → `"central"`, `aos8_*` → `"aos8"`, etc.); cross-platform tools (`health`, `site_health_check`, etc.) get `null`.
+- A small number of tools that explicitly return an envelope shape are passed through without re-wrapping (idempotent behavior).
 
 ---
 

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -128,12 +128,19 @@ class ServerConfig:
     allowed_origins: list[str] = field(default_factory=lambda: ["http://localhost:8000", "http://127.0.0.1:8000"])
 
     # Tool exposure mode (generalized from GreenLake's original setting, #151).
-    # "static"  — every tool registers with FastMCP individually; all visible.
+    # "code"    — only ``execute`` + 5 discovery tools (``tags``, ``search``,
+    #             ``get_schema``, ``skills_list``, ``skills_load``) are exposed
+    #             at the top level; every underlying tool is reachable via
+    #             ``call_tool(name, args)`` inside a sandboxed Python
+    #             ``execute()`` call. Default since v3.0.0.0.
     # "dynamic" — the per-platform 3 meta-tools (list / schema / invoke) are
     #             exposed; the underlying tools are hidden via a Visibility
-    #             transform. Default since v2.0.0.0; set MCP_TOOL_MODE=static
-    #             to opt out.
-    tool_mode: str = "dynamic"
+    #             transform. Set MCP_TOOL_MODE=dynamic to opt back in to the
+    #             v2.x default behavior.
+    # "static" was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no
+    # longer practical. Setting MCP_TOOL_MODE=static now raises ValueError
+    # at startup with a migration message.
+    tool_mode: str = "code"
 
     # PII tokenization (v2.3.1.0). When enabled, sensitive fields (PSKs,
     # RADIUS secrets, certificates) and identifiers (UUIDs, hostnames,
@@ -452,14 +459,30 @@ def load_config() -> ServerConfig:
     debug = os.getenv("DEBUG", "false").lower() in ("true", "1", "yes")
     log_file = os.getenv("LOG_FILE") or None
 
-    # Tool exposure mode — MCP_TOOL_MODE env var. Same env-var name as the
-    # old GreenLake-specific setting; the internal config field is now just
-    # ``tool_mode`` because every platform honors it in v2.0. Default flipped
-    # from "static" → "dynamic" in v2.0.0.0.
-    tool_mode = os.getenv("MCP_TOOL_MODE", "dynamic").lower().strip()
-    if tool_mode not in ("static", "dynamic", "code"):
-        logger.warning("Ignoring unknown MCP_TOOL_MODE={!r}, defaulting to 'dynamic'", tool_mode)
-        tool_mode = "dynamic"
+    # Tool exposure mode — MCP_TOOL_MODE env var. Default flipped from
+    # "static" → "dynamic" in v2.0.0.0; flipped again from "dynamic" → "code"
+    # in v3.0.0.0. The "static" value was REMOVED in v3.0.0.0 — at 367 tools
+    # / ~64K tokens it was no longer practical.
+    tool_mode_raw = os.getenv("MCP_TOOL_MODE")
+    if tool_mode_raw is None:
+        tool_mode = "code"
+        logger.info(
+            "MCP_TOOL_MODE not set — defaulting to 'code' (changed in v3.0.0.0 from 'dynamic'). "
+            "Set MCP_TOOL_MODE=dynamic in your environment to keep the v2.x default behavior."
+        )
+    else:
+        tool_mode = tool_mode_raw.lower().strip()
+        if tool_mode == "static":
+            raise ValueError(
+                "MCP_TOOL_MODE=static was REMOVED in v3.0.0.0. "
+                "At 367 tools / ~64K tokens of schema, static mode was no longer practical. "
+                "Switch to MCP_TOOL_MODE=dynamic (per-platform meta-tools, ~3,700 tokens) or "
+                "MCP_TOOL_MODE=code (sandboxed Python execute, ~minimal tokens). "
+                "See the v3.0.0.0 CHANGELOG entry for migration guidance."
+            )
+        if tool_mode not in ("dynamic", "code"):
+            logger.warning("Ignoring unknown MCP_TOOL_MODE={!r}, defaulting to 'code'", tool_mode)
+            tool_mode = "code"
 
     # ALLOWED_ORIGINS — comma-separated. Empty value falls back to the
     # localhost defaults (most users). ``*`` disables the check.

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -1,9 +1,11 @@
 """Response envelope middleware — wraps tool responses in a uniform shape.
 
-v2.5.1.0 prototype scope: applies only to the 4 cross-platform tools
-(``health``, ``site_health_check``, ``site_rf_check``, ``manage_wlan_profile``)
-to validate the pattern before committing to the full v3.0.0.0 refactor across
-every tool in the catalog. Tracked in issue #246.
+v3.0.0.0 scope: applies to **every tool** in the catalog. The v2.5.1.0
+prototype was scoped to the 4 cross-platform tools (``health``,
+``site_health_check``, ``site_rf_check``, ``manage_wlan_profile``) to
+validate the pattern; Zach's OpenClaw + Qwen3 4B test (#246 reassessment
+comment) confirmed the envelope worked for the small-local-model use case
+that motivated v3 in the first place. Allowlist removed in v3.0.0.0.
 
 Envelope shape::
 
@@ -21,9 +23,9 @@ The middleware sits **innermost** in the chain so it wraps raw tool output
 ``_extract_status_code`` works equally on the envelope's ``status`` field
 as it does on raw tool output's ``status_code`` / ``code`` / ``status``.
 
-When a tool already returned a dict matching the envelope shape (i.e. one
-of the 4 tools manually returned an envelope), the middleware passes through
-without re-wrapping.
+When a tool already returned a dict matching the envelope shape (e.g. a
+tool that explicitly constructed and returned an envelope), the middleware
+passes through without re-wrapping (idempotency check via ``_is_envelope_shape``).
 """
 
 from __future__ import annotations
@@ -34,16 +36,6 @@ import mcp.types
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from loguru import logger
-
-# v2.5.1.0 prototype scope. v3.0.0.0 expands this to every tool — see #246.
-PROTOTYPE_TOOLS: frozenset[str] = frozenset(
-    {
-        "health",
-        "site_health_check",
-        "site_rf_check",
-        "manage_wlan_profile",
-    }
-)
 
 # Platform prefixes used to derive the ``platform`` envelope field. Cross-platform
 # tools (those without one of these prefixes) end up with ``platform: null``.
@@ -118,11 +110,15 @@ def _build_envelope(
 
 
 class ResponseEnvelopeMiddleware(Middleware):
-    """Wrap allowlisted tool responses in the uniform envelope shape.
+    """Wrap every tool response in the uniform envelope shape.
 
     Position **innermost** in the middleware chain (last in the
     ``middleware=[...]`` list) so the wrap happens on raw tool output
     *before* retry / PII / elicitation see the response.
+
+    v2.5.1.0 had an allowlist (``PROTOTYPE_TOOLS``); v3.0.0.0 removes it
+    and the envelope applies fleet-wide. Tools that explicitly returned an
+    envelope shape are still passed through via the idempotency check.
     """
 
     async def on_call_tool(
@@ -131,10 +127,6 @@ class ResponseEnvelopeMiddleware(Middleware):
         call_next,
     ) -> ToolResult:
         tool_name = context.message.name
-
-        if tool_name not in PROTOTYPE_TOOLS:
-            return await call_next(context)  # type: ignore[return-value]
-
         platform = _infer_platform(tool_name)
         result = await call_next(context)
 

--- a/src/hpe_networking_mcp/platforms/_template/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_template/__init__.py
@@ -60,6 +60,6 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             len(loaded),
         )
     else:
-        logger.info("Template: {} tools registered (static mode)", len(loaded))
+        logger.info("Template: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/aos8/__init__.py
+++ b/src/hpe_networking_mcp/platforms/aos8/__init__.py
@@ -107,12 +107,9 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     except Exception as e:
         logger.warning("AOS8: failed to load prompts -- {}", e)
 
-    mode = config.tool_mode
-    if mode == "dynamic":
+    if config.tool_mode == "dynamic":
         build_meta_tools("aos8", mcp)
         logger.info("AOS8: registered {} underlying tools + 3 meta-tools (dynamic mode)", total)
-    elif mode == "code":
-        logger.info("AOS8: registered {} tools (code mode)", total)
     else:
-        logger.info("AOS8: registered {} tools (static mode)", total)
+        logger.info("AOS8: registered {} underlying tools (code mode)", total)
     return total

--- a/src/hpe_networking_mcp/platforms/apstra/__init__.py
+++ b/src/hpe_networking_mcp/platforms/apstra/__init__.py
@@ -78,9 +78,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Apstra: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("Apstra: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("Apstra: {} tools registered (static mode)", len(loaded))
+        logger.info("Apstra: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -90,9 +90,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Axis: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("Axis: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("Axis: {} tools registered (static mode)", len(loaded))
+        logger.info("Axis: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -160,9 +160,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Central: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("Central: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("Central: {} tools registered (static mode)", len(loaded))
+        logger.info("Central: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/clearpass/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/__init__.py
@@ -246,9 +246,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "ClearPass: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("ClearPass: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("ClearPass: {} tools registered (static mode)", len(loaded))
+        logger.info("ClearPass: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/greenlake/__init__.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/__init__.py
@@ -47,9 +47,7 @@ def register_tools(mcp_instance: FastMCP, config: ServerConfig) -> int:
             "GreenLake: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("GreenLake: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("GreenLake: {} tools registered (static mode)", len(loaded))
+        logger.info("GreenLake: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -104,9 +104,7 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
             "Mist: {} underlying tools + 3 meta-tools registered (dynamic mode)",
             len(loaded),
         )
-    elif config.tool_mode == "code":
-        logger.info("Mist: {} underlying tools registered (code mode)", len(loaded))
     else:
-        logger.info("Mist: {} tools registered (static mode)", len(loaded))
+        logger.info("Mist: {} underlying tools registered (code mode)", len(loaded))
 
     return len(loaded)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -307,12 +307,12 @@ def create_server(config: ServerConfig) -> FastMCP:
     _register_health(mcp)
 
     # --- Skills (markdown-defined multi-step procedures, always visible) ---
-    # In dynamic / static modes, register via @mcp.tool — they appear at the
-    # top level via the standard catalog. In CODE mode, we deliberately skip
-    # this path and instead pass discovery-tool factories to CodeMode below
-    # (see _register_code_mode); CodeMode's transform_tools replaces the
-    # visible catalog with [discovery_tools, execute] only, which would
-    # otherwise hide @mcp.tool registrations.
+    # In dynamic mode, register via @mcp.tool — they appear at the top level
+    # via the standard catalog. In CODE mode (default since v3.0.0.0), we
+    # deliberately skip this path and instead pass discovery-tool factories
+    # to CodeMode below (see _register_code_mode); CodeMode's transform_tools
+    # replaces the visible catalog with [discovery_tools, execute] only,
+    # which would otherwise hide @mcp.tool registrations.
     if config.tool_mode != "code":
         from hpe_networking_mcp.skills import register as _register_skills
 

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -202,9 +202,15 @@ for scope in scopes:
             # the migration plan is materially incomplete.
             #
             # v3.0.0.0+: every tool response is wrapped in the envelope
-            # {ok, status, data, message, tool, platform}. The actual API
-            # payload lives at response["data"].
-            inner = response.get("data", response)  # envelope unwrap; fall back to raw if shape changes
+            # {ok, status, data, message, tool, platform}. The API payload
+            # lives at response["data"]. Some tools additionally wrap their
+            # return in {"result": ...} — handle both shapes via fallback.
+            envelope_data = response.get("data", response)
+            inner = (
+                envelope_data["result"]
+                if isinstance(envelope_data, dict) and "result" in envelope_data
+                else envelope_data
+            )
             if isinstance(inner, dict) and inner.get("ERROR") == "Invalid Object":
                 config_by_scope[scope][obj_type] = {
                     "_collection_error": f"Invalid Object — REST schema may have renamed {obj_type!r} on this AOS build"
@@ -247,8 +253,11 @@ clients = await call_tool("aos8_get_clients", {})
 bss_table = await call_tool("aos8_get_bss_table", {})
 active_aps = await call_tool("aos8_get_active_aps", {})
 
-ap_db_data = ap_database.get("data", ap_database)  # v3.0.0.0+: envelope unwrap
-ap_names = [ap["ap_name"] for ap in ap_db_data.get("AP Database", [])]
+# v3.0.0.0+: envelope unwrap, then handle the inner {"result": ...} wrapper
+# that some tools return (aos8_get_ap_database does).
+_envelope_data = ap_database.get("data", ap_database)
+_payload = _envelope_data.get("result", _envelope_data) if isinstance(_envelope_data, dict) else _envelope_data
+ap_names = [ap["ap_name"] for ap in _payload.get("AP Database", [])]
 ap_wired_ports = {}
 for ap_name in ap_names:
     ap_wired_ports[ap_name] = await call_tool(

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -200,7 +200,11 @@ for scope in scopes:
             # Surface "Invalid Object" loudly — the AOS 8 REST schema may
             # drift between versions, and a silently-dropped object means
             # the migration plan is materially incomplete.
-            inner = response.get("result") if isinstance(response, dict) and "result" in response else response
+            #
+            # v3.0.0.0+: every tool response is wrapped in the envelope
+            # {ok, status, data, message, tool, platform}. The actual API
+            # payload lives at response["data"].
+            inner = response.get("data", response)  # envelope unwrap; fall back to raw if shape changes
             if isinstance(inner, dict) and inner.get("ERROR") == "Invalid Object":
                 config_by_scope[scope][obj_type] = {
                     "_collection_error": f"Invalid Object — REST schema may have renamed {obj_type!r} on this AOS build"
@@ -243,7 +247,8 @@ clients = await call_tool("aos8_get_clients", {})
 bss_table = await call_tool("aos8_get_bss_table", {})
 active_aps = await call_tool("aos8_get_active_aps", {})
 
-ap_names = [ap["ap_name"] for ap in ap_database.get("AP Database", [])]
+ap_db_data = ap_database.get("data", ap_database)  # v3.0.0.0+: envelope unwrap
+ap_names = [ap["ap_name"] for ap in ap_db_data.get("AP Database", [])]
 ap_wired_ports = {}
 for ap_name in ap_names:
     ap_wired_ports[ap_name] = await call_tool(

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -163,9 +163,10 @@ class TestCreateServer:
     def test_no_visibility_transform_when_write_tools_enabled(self, mist_secrets):
         """create_server() does NOT add per-platform write-tool Visibility transforms when every write flag is enabled.
 
-        Scoped to static mode so the `dynamic_managed` Visibility transform — always present
-        in dynamic mode (the v2.0 default) — doesn't pollute the assertion. The intent of
-        this test is the write-tool gating logic, not the tool-mode visibility logic.
+        Scoped to code mode (the v3.0.0.0 default) — the catalog is replaced
+        by CodeMode and no `dynamic_managed` Visibility transform is added,
+        so the test isolates the write-tool gating logic. The intent of this
+        test is the write-tool gating logic, not the tool-mode visibility logic.
         """
         config = ServerConfig(
             mist=mist_secrets,
@@ -175,7 +176,7 @@ class TestCreateServer:
             enable_apstra_write_tools=True,
             enable_axis_write_tools=True,
             enable_aos8_write_tools=True,
-            tool_mode="static",
+            tool_mode="code",
         )
 
         with patch("hpe_networking_mcp.server._register_mist_tools"):
@@ -188,6 +189,6 @@ class TestCreateServer:
 
         visibility_found = any(isinstance(t, Visibility) for t in transforms)
         assert not visibility_found, (
-            f"Visibility transform should NOT be present when all write tools are enabled in static mode. "
+            f"Visibility transform should NOT be present when all write tools are enabled in code mode. "
             f"Found transforms: {transforms}"
         )

--- a/tests/unit/test_aos8_init.py
+++ b/tests/unit/test_aos8_init.py
@@ -117,14 +117,18 @@ def test_register_tools_dynamic_mode():
     assert len(REGISTRIES.get("aos8", {})) == EXPECTED_TOTAL
 
 
-def test_register_tools_static_mode():
+def test_register_tools_code_mode():
+    """v3.0.0.0: code mode is the default. Static mode was REMOVED. This
+    test verifies code mode registers all underlying tools (the meta-tools
+    aren't built; tools are reachable via call_tool() inside execute()).
+    """
     from fastmcp import FastMCP
 
     from hpe_networking_mcp.platforms.aos8 import register_tools
 
-    mcp = FastMCP("test-aos8-static", on_duplicate="replace")
+    mcp = FastMCP("test-aos8-code", on_duplicate="replace")
     config = MagicMock()
-    config.tool_mode = "static"
+    config.tool_mode = "code"
 
     count = register_tools(mcp, config)
 

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -47,20 +47,28 @@ class TestCodeModeConfig:
         cfg = self._load_with_mode("code")
         assert cfg.tool_mode == "code"
 
-    def test_unknown_value_falls_back_to_dynamic(self):
+    def test_unknown_value_falls_back_to_code(self):
+        # Default fell back to "dynamic" pre-v3.0.0.0; now falls back to "code".
         cfg = self._load_with_mode("codee")
-        assert cfg.tool_mode == "dynamic"
+        assert cfg.tool_mode == "code"
 
-    def test_static_still_accepted(self):
-        cfg = self._load_with_mode("static")
-        assert cfg.tool_mode == "static"
+    def test_static_raises_value_error(self):
+        # MCP_TOOL_MODE=static was REMOVED in v3.0.0.0 — at 367 tools / ~64K
+        # tokens it was no longer practical. Setting it now raises with a
+        # migration message pointing at dynamic / code.
+        import pytest
+
+        with pytest.raises(ValueError, match="REMOVED in v3.0.0.0"):
+            self._load_with_mode("static")
 
     def test_dynamic_still_accepted(self):
         cfg = self._load_with_mode("dynamic")
         assert cfg.tool_mode == "dynamic"
 
-    def test_default_is_dynamic(self):
-        # No MCP_TOOL_MODE env var set.
+    def test_default_is_code(self):
+        # No MCP_TOOL_MODE env var set. Default flipped from "dynamic" → "code"
+        # in v3.0.0.0; the server logs a migration message at startup when this
+        # happens.
         from hpe_networking_mcp.config import MistSecrets, load_config
 
         with (
@@ -76,7 +84,7 @@ class TestCodeModeConfig:
             patch("hpe_networking_mcp.config._load_axis", return_value=None),
         ):
             cfg = load_config()
-        assert cfg.tool_mode == "dynamic"
+        assert cfg.tool_mode == "code"
 
 
 @pytest.mark.unit
@@ -132,17 +140,6 @@ class TestCodeModeCrossPlatformGating:
         assert mocks["code_mode"].call_count == 0
         assert mocks["skills_register"].call_count == 1, (
             "skills.register must be called in dynamic mode (skills via @mcp.tool)"
-        )
-
-    def test_static_mode_registers_all_aggregators(self):
-        mocks = self._run_create_server("static")
-        assert mocks["health"].call_count == 1
-        assert mocks["rf"].call_count == 1
-        assert mocks["sync_tools"].call_count == 1
-        assert mocks["sync_prompts"].call_count == 1
-        assert mocks["code_mode"].call_count == 0
-        assert mocks["skills_register"].call_count == 1, (
-            "skills.register must be called in static mode (skills via @mcp.tool)"
         )
 
     def test_code_mode_skips_every_aggregator_and_invokes_code_mode_hook(self):

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -1,8 +1,11 @@
-"""Unit tests for ResponseEnvelopeMiddleware (v2.5.1.0 prototype, issue #246).
+"""Unit tests for ResponseEnvelopeMiddleware.
 
-Verifies the envelope-wrapping middleware against the four tool-name
-scopes defined in ``PROTOTYPE_TOOLS``. Non-prototype tools pass through
-unchanged. Already-enveloped responses pass through idempotently.
+v2.5.1.0 prototype scoped wrapping to 4 cross-platform tools via
+``PROTOTYPE_TOOLS``. v3.0.0.0 expanded to every tool — the allowlist is
+gone. These tests verify the universal-wrapping contract: every tool
+gets enveloped, already-enveloped responses pass through idempotently,
+and edge cases (None structured content, status-code extraction, platform
+inference) all behave correctly.
 """
 
 from __future__ import annotations
@@ -13,7 +16,6 @@ import pytest
 from fastmcp.tools.tool import ToolResult
 
 from hpe_networking_mcp.middleware.response_envelope import (
-    PROTOTYPE_TOOLS,
     ResponseEnvelopeMiddleware,
     _extract_status,
     _infer_platform,
@@ -200,8 +202,11 @@ class TestResponseEnvelopeMiddleware:
         assert result.structured_content["ok"] is True
 
     @pytest.mark.asyncio
-    async def test_passes_through_non_prototype_tool(self):
-        """Tools NOT in PROTOTYPE_TOOLS are not wrapped — short-circuit."""
+    async def test_wraps_platform_prefixed_tool(self):
+        """v3.0.0.0: every tool gets wrapped — including platform-prefixed ones.
+        v2.5.1.0 prototype passed these through unchanged; v3 wraps them in
+        the envelope with platform field inferred from the prefix.
+        """
         middleware = ResponseEnvelopeMiddleware()
         ctx = _make_context("central_get_sites")
         raw = {"sites": [{"name": "dallas-hq"}]}
@@ -210,13 +215,20 @@ class TestResponseEnvelopeMiddleware:
 
         result = await middleware.on_call_tool(ctx, call_next)
 
-        # Same object — no wrapping
-        assert result is original
-        assert result.structured_content == raw
+        # Wrapped now
+        assert result is not original
+        assert result.structured_content == {
+            "ok": True,
+            "status": None,
+            "data": raw,
+            "message": None,
+            "tool": "central_get_sites",
+            "platform": "central",
+        }
 
     @pytest.mark.asyncio
     async def test_already_enveloped_passes_through(self):
-        """If a prototype tool already returned an envelope, don't re-wrap."""
+        """If a tool already returned an envelope, don't re-wrap."""
         middleware = ResponseEnvelopeMiddleware()
         ctx = _make_context("health")
         existing_envelope = {
@@ -255,10 +267,20 @@ class TestResponseEnvelopeMiddleware:
         }
 
     @pytest.mark.asyncio
-    async def test_prototype_tools_set_membership(self):
-        """All four documented prototype tools are in PROTOTYPE_TOOLS."""
-        assert "health" in PROTOTYPE_TOOLS
-        assert "site_health_check" in PROTOTYPE_TOOLS
-        assert "site_rf_check" in PROTOTYPE_TOOLS
-        assert "manage_wlan_profile" in PROTOTYPE_TOOLS
-        assert len(PROTOTYPE_TOOLS) == 4
+    async def test_wraps_aos8_tool(self):
+        """v3.0.0.0: AOS 8 tools (added after the v2.5.1.0 prototype) are
+        wrapped just like every other tool. Pin a sample so future regressions
+        in the platform-prefix list are caught.
+        """
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("aos8_get_md_hierarchy")
+        raw = {"Configuration node hierarchy": [{"Config Node": "/md", "Type": "System"}]}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        envelope = result.structured_content
+        assert envelope["tool"] == "aos8_get_md_hierarchy"
+        assert envelope["platform"] == "aos8"
+        assert envelope["data"] == raw
+        assert envelope["ok"] is True


### PR DESCRIPTION
**Ready for review.** Closes #246, #267.

Three breaking changes bundled into one v3.0.0.0 release:

1. **`MCP_TOOL_MODE=static` REMOVED** — at 367 tools / ~64K tokens it was no longer practical. Setting it now raises ValueError at startup.
2. **Default flipped `dynamic` → `code`** — code mode exposes only `execute` + 5 discovery tools; all 367 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs.
3. **Response envelope universal** — every tool's response wrapped in `{ok, status, data, message, tool, platform}`. The actual API payload lives at `result["data"]`.

Validated by Zach's OpenClaw + Qwen3 4B test (#246 reassessment) — small local model successfully drove the prototype envelope. v3.0.0.0 expands the prototype fleet-wide.

## Commits on this branch

- **`7e6e076`** — drop static mode + flip default to code mode (config + per-platform inits + server.py + pyproject + compose template + test contract updates)
- **`d07f0c2`** — expand response envelope to every tool (allowlist removed; idempotency check preserved)
- **`2bbe470`** — docs + skill content for code-mode default + universal envelope (INSTRUCTIONS, README, TOOLS.md, aos-migration skill)
- **`202c096`** — CHANGELOG.md v3.0.0.0 entry with full migration table
- **`c5f5e20`** — audit follow-up: 2 missed test files (`test_aos8_init`, `test_server`) + skill double-unwrap fix from live verification + INSTRUCTIONS inner-wrapper documentation

## Live verification

End-to-end tested in dev container after rebuild:

- Startup log confirms `Tool mode: code` (default since v3.0.0.0)
- `call_tool("health", {})` inside `execute()` returned the universal envelope correctly through both layers
- aos-migration skill exercised end-to-end against the live Conductor — initial single-unwrap failed for `aos8_get_ap_database` because that tool wraps its return in an inner `{"result": ...}` shape. Fixed in `c5f5e20` with a double-unwrap pattern (envelope first, then `result` fallback) and documented the inner-wrapper inconsistency in INSTRUCTIONS.md so future skill / AI authors handle both shapes uniformly.

## Migration paths (operator-facing — full table in CHANGELOG)

| Was running... | After v3.0.0.0... | Action |
|---|---|---|
| `MCP_TOOL_MODE=static` (explicit) | Hard error at startup | Switch to `dynamic` or `code` |
| `MCP_TOOL_MODE=dynamic` (explicit) | Continues to work | Nothing required |
| `MCP_TOOL_MODE=code` (explicit) | Continues to work | Nothing required |
| No `MCP_TOOL_MODE` set (implicit default) | Now defaults to `code` (was `dynamic`); startup log warns once | Set `MCP_TOOL_MODE=dynamic` to keep prior behavior |
| AI client checking `result["foo"]` directly | Now needs `result["data"]["foo"]` | Update client code |

## Pre-push checklist

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — already formatted
- [x] `uv run mypy src/ --ignore-missing-imports` — Success: no issues found
- [x] `uv run pytest tests/ -q` — 964 passed
- [x] Live verified: code mode default + envelope wraps real tool calls + aos-migration skill against live Conductor
- [x] CI green on latest commit (`c5f5e20`) — 7/7 checks passing

## Test plan post-merge

- [ ] After image rebuild, anyone running with no `MCP_TOOL_MODE` set will see the startup migration log message (one-line, INFO level)
- [ ] Anyone with `MCP_TOOL_MODE=static` in their compose will get a hard ValueError at startup with the migration message
- [ ] Confirm Zach can re-run OpenClaw + Qwen3 4B tests against v3.0.0.0 image and the prompts that previously worked still work