### PR TITLE
v3.0.0.2: central_get_aps empty-list contract — return [] not string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0.2] - 2026-05-06
+
+**Patch release — `central_get_aps` empty-list contract fix.**
+
+`central_get_aps()` returned the human-string `"No access points found matching the specified criteria."` when the AP list was empty, which broke caller patterns like `len(result)` (returned 38, the string length) and `for ap in result` (iterates over characters). Fix: return `[]` instead so callers can iterate without `None`/`str` guards.
+
+Live-verified the broken behavior against the maintainer's Central workspace before fixing (issue #244 also reported `None` as a possible value, but the actual current behavior was the string — both fixed by the same change).
+
+Closes [#244](https://github.com/nowireless4u/hpe-networking-mcp/issues/244).
+
+### Files
+
+- **`src/hpe_networking_mcp/platforms/central/tools/monitoring.py`** — replaced the empty-result string fallback with `return aps or []`. Single-line change. Type signature `-> list[dict] | str` unchanged (str now reserved for actual error paths).
+- **`tests/unit/test_central_monitoring.py`** — new unit-test file pinning the empty-list contract (covers `None` → `[]`, `[]` → `[]`, populated → passthrough, SDK exception → error string).
+- **`pyproject.toml`** — bump 3.0.0.1 → 3.0.0.2.
+
+### Side housekeeping (not in this release; closed during review)
+
+- **#243** (GreenLake `state` field shows `?`) — closed; verified live the GreenLake API field is `subscriptionStatus`, not `state`. Tool wrapper passes the raw response through unchanged. The `?` rendering was the AI's own placeholder for a missing field name. No code change needed.
+- **#165** (Phase 7 v2.0 cleanup) — closed as no-longer-applicable; verified GreenLake aliases gone, `greenlake_tool_mode` config alias gone, dynamic-mode benchmarking implicitly answered by v3.0.0.0's default flip to code mode.
+
 ## [3.0.0.1] - 2026-05-06
 
 **Patch release — aos-migration skill robustness pass from operator transcript.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.0.1"
+version = "3.0.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -89,9 +89,7 @@ async def central_get_aps(
     except Exception as e:
         return f"Error fetching access points: {e}"
 
-    if not aps:
-        return "No access points found matching the specified criteria."
-    return aps
+    return aps or []
 
 
 @tool(annotations=READ_ONLY)

--- a/tests/unit/test_central_monitoring.py
+++ b/tests/unit/test_central_monitoring.py
@@ -1,0 +1,56 @@
+"""Unit tests for central_get_aps empty-list contract.
+
+Pin the contract for issue #244: when ``MonitoringAPs.get_all_aps()`` returns
+an empty result (None or []), ``central_get_aps`` must return ``[]`` so callers
+can iterate without ``None``-guards. Earlier behavior returned the human-string
+``"No access points found matching the specified criteria."``, which broke
+``len(result)`` and ``for ap in result`` patterns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    ctx.get_state = AsyncMock(return_value="prompt")
+    return ctx
+
+
+class TestCentralGetApsEmptyContract:
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    async def test_none_normalizes_to_empty_list(self, mock_get_all):
+        from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
+
+        mock_get_all.return_value = None
+        assert await central_get_aps(_ctx()) == []
+
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    async def test_empty_list_passes_through_as_empty_list(self, mock_get_all):
+        from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
+
+        mock_get_all.return_value = []
+        assert await central_get_aps(_ctx()) == []
+
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    async def test_populated_list_passes_through(self, mock_get_all):
+        from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
+
+        sample = [{"name": "AP-1", "serial": "ABC123"}, {"name": "AP-2", "serial": "DEF456"}]
+        mock_get_all.return_value = sample
+        assert await central_get_aps(_ctx()) == sample
+
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    async def test_sdk_exception_returns_error_string(self, mock_get_all):
+        from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
+
+        mock_get_all.side_effect = RuntimeError("auth failed")
+        result = await central_get_aps(_ctx())
+        assert isinstance(result, str)
+        assert "auth failed" in result


### PR DESCRIPTION
## Summary

\`central_get_aps()\` returned the human-string \`\"No access points found matching the specified criteria.\"\` for empty results — broke caller patterns (\`len()\` returns 38, iteration walks characters). Fix: \`return aps or []\` so callers can iterate without \`None\` / \`str\` guards.

Live-verified the broken behavior against the maintainer's Central workspace before fixing — both fake-site-name filter and \`status=OFFLINE\` filter returned the literal string. v3 envelope wraps the string at \`data\`, so it survives all the way to the AI.

Closes #244.

## Test plan

- [x] \`uv run ruff check .\` (in Docker, dev compose)
- [x] \`uv run ruff format --check .\`
- [x] \`uv run mypy src/ --ignore-missing-imports\`
- [x] \`uv run pytest tests/ -q\` — 968 passed (was 964; +4 from the new test file)
- [ ] Operator calls \`central_get_aps\` with a filter that returns no APs and confirms \`result[\"data\"]\` is \`[]\`, not the human string

## Side housekeeping (closed during this review)

- **#243** (GreenLake \`state\` field shows \`?\`) — verified live: API field is \`subscriptionStatus\`, not \`state\`. Tool wrapper passes raw response through unchanged. The \`?\` was the AI's own missing-field placeholder. No code change.
- **#165** (Phase 7 v2.0 cleanup) — verified each item: GreenLake aliases gone, \`greenlake_tool_mode\` config alias gone, dynamic-mode benchmarking implicitly answered by v3.0.0.0's default flip. Closed as no-longer-applicable.