### PR TITLE
v3.0.0.3: extract ClearPass build_query_string to shared utils.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0.3] - 2026-05-06
+
+**Patch release — ClearPass `build_query_string` consolidation (refactor only).**
+
+Ten ClearPass tool files each carried a private byte-identical copy of `_build_query_string()` (52 grep hits across the platform). Extracted to a single `platforms/clearpass/utils.py` shared helper, dropped the leading underscore (it's now a real shared module-public helper, not module-private), and updated all 42 call sites. Net **−245 lines** across the ClearPass tool layer with no behavior change.
+
+The new helper follows the same pattern as `central/utils.py:normalize_site_name_filter` — a small platform-scoped utility module for cross-tool helpers.
+
+Closes [#125](https://github.com/nowireless4u/hpe-networking-mcp/issues/125).
+
+### Files
+
+- **`src/hpe_networking_mcp/platforms/clearpass/utils.py`** — new module; defines `build_query_string(filter, sort, offset, limit, calculate_count)`. Same body as the previous file-local copies.
+- **`src/hpe_networking_mcp/platforms/clearpass/tools/`** (10 files: `audit.py`, `certificate_authority.py`, `certificates.py`, `endpoint_visibility.py`, `guest_config.py`, `identities.py`, `integrations.py`, `network_devices.py`, `policy_elements.py`, `server_config.py`) — removed the local `_build_query_string` definition; added `from hpe_networking_mcp.platforms.clearpass.utils import build_query_string`; renamed all call sites.
+- **`tests/unit/test_clearpass_utils.py`** — new file pinning the helper's contract (defaults, filter/sort omission when None, calculate_count true/false casing, full-string ordering).
+- **`pyproject.toml`** — bump 3.0.0.2 → 3.0.0.3.
+
+### Notes
+
+- 976 tests pass (was 968; +8 from the new test file).
+- Pure refactor — no runtime behavior change. Every existing call site produces the exact same query string as before.
+
 ## [3.0.0.2] - 2026-05-06
 
 **Patch release — `central_get_aps` empty-list contract fix.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.0.2"
+version = "3.0.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -7,35 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-        calculate_count: When true, response includes total item count.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -85,7 +57,7 @@ async def clearpass_get_system_events(
         from pyclearpass.api_logs import ApiLogs
 
         client = await get_clearpass_session(ApiLogs)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/system-event" + query, "get")
     except Exception as e:
         return f"Error fetching system events: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -19,24 +19,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints."""
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -77,7 +60,7 @@ async def clearpass_get_certificates(
             return client._send_request(f"/certificate/{certificate_id}/chain", "get")
         if certificate_id:
             return client._send_request(f"/certificate/{certificate_id}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/certificate" + query, "get")
     except Exception as e:
         return f"Error fetching CA certificates: {e}"
@@ -122,7 +105,7 @@ async def clearpass_get_onboard_devices(
         client = await get_clearpass_session(ApiCertificateAuthority)
         if onboard_device_id:
             return client._send_request(f"/onboard/device/{onboard_device_id}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/onboard/device" + query, "get")
     except Exception as e:
         return f"Error fetching onboard devices: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -7,35 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-        calculate_count: When true, response includes total item count.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -75,7 +47,7 @@ async def clearpass_get_trust_list(
             return client.get_cert_trust_list_by_cert_trust_list_id(
                 cert_trust_list_id=cert_trust_list_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/cert-trust-list" + query, "get")
     except Exception as e:
         return f"Error fetching trust list: {e}"
@@ -109,7 +81,7 @@ async def clearpass_get_client_certificates(
         client = await get_clearpass_session(ApiPlatformCertificates)
         if client_cert_id:
             return client.get_client_cert_by_client_cert_id(client_cert_id=client_cert_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/client-cert" + query, "get")
     except Exception as e:
         return f"Error fetching client certificates: {e}"
@@ -177,7 +149,7 @@ async def clearpass_get_service_certificates(
         client = await get_clearpass_session(ApiPlatformCertificates)
         if service_cert_id:
             return client.get_service_cert_by_service_cert_id(service_cert_id=service_cert_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/service-cert" + query, "get")
     except Exception as e:
         return f"Error fetching service certificates: {e}"
@@ -217,7 +189,7 @@ async def clearpass_get_revocation_list(
         client = await get_clearpass_session(ApiPlatformCertificates)
         if revocation_list_id:
             return client._send_request(f"/revocation-list/{revocation_list_id}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/revocation-list" + query, "get")
     except Exception as e:
         return f"Error fetching revocation lists: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -14,24 +14,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints."""
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -69,7 +52,7 @@ async def clearpass_get_onguard_activity(
             return client._send_request(f"/onguard-activity/{activity_id}", "get")
         if mac:
             return client._send_request(f"/onguard-activity/mac/{mac}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/onguard-activity" + query, "get")
     except Exception as e:
         return f"Error fetching OnGuard activity: {e}"
@@ -110,7 +93,7 @@ async def clearpass_get_fingerprint_dictionary(
         client = await get_clearpass_session(ApiEndpointVisibility)
         if fingerprint_id:
             return client._send_request(f"/fingerprint/{fingerprint_id}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/fingerprint" + query, "get")
     except Exception as e:
         return f"Error fetching fingerprint dictionary: {e}"
@@ -151,7 +134,7 @@ async def clearpass_get_network_scan(
         client = await get_clearpass_session(ApiEndpointVisibility)
         if scan_id:
             return client._send_request(f"/config/network-scan/{scan_id}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/config/network-scan" + query, "get")
     except Exception as e:
         return f"Error fetching network scans: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -7,24 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints."""
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -55,7 +38,7 @@ async def clearpass_get_pass_templates(
         client = await get_clearpass_session(ApiGuestConfiguration)
         if template_id:
             return client.get_template_pass_by_id(id=template_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/template/pass" + query, "get")
     except Exception as e:
         return f"Error fetching pass templates: {e}"
@@ -89,7 +72,7 @@ async def clearpass_get_print_templates(
         client = await get_clearpass_session(ApiGuestConfiguration)
         if template_id:
             return client.get_template_print_by_id(id=template_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/template/print" + query, "get")
     except Exception as e:
         return f"Error fetching print templates: {e}"
@@ -127,7 +110,7 @@ async def clearpass_get_weblogin_pages(
             return client.get_weblogin_by_id(id=page_id)
         if page_name:
             return client.get_weblogin_page_name_by_page_name(page_name=page_name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/weblogin" + query, "get")
     except Exception as e:
         return f"Error fetching web login pages: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -7,34 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -65,7 +38,7 @@ async def clearpass_get_api_clients(
         client = await get_clearpass_session(ApiIdentities)
         if client_id:
             return client.get_api_client_by_client_id(client_id=client_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/api-client" + query, "get")
     except Exception as e:
         return f"Error fetching API clients: {e}"
@@ -104,7 +77,7 @@ async def clearpass_get_local_users(
             return client.get_local_user_by_local_user_id(local_user_id=local_user_id)
         if user_id:
             return client.get_local_user_user_id_by_user_id(user_id=user_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/local-user" + query, "get")
     except Exception as e:
         return f"Error fetching local users: {e}"
@@ -144,7 +117,7 @@ async def clearpass_get_static_host_lists(
             )
         if name:
             return client.get_static_host_list_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/static-host-list" + query, "get")
     except Exception as e:
         return f"Error fetching static host lists: {e}"
@@ -182,7 +155,7 @@ async def clearpass_get_devices(
             return client.get_device_by_device_id(device_id=device_id)
         if macaddr:
             return client.get_device_mac_by_macaddr(macaddr=macaddr)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/device" + query, "get")
     except Exception as e:
         return f"Error fetching devices: {e}"
@@ -218,7 +191,7 @@ async def clearpass_get_deny_listed_users(
             return client.get_deny_listed_users_by_deny_listed_users_id(
                 deny_listed_users_id=deny_listed_users_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/deny-listed-users" + query, "get")
     except Exception as e:
         return f"Error fetching deny-listed users: {e}"
@@ -264,7 +237,7 @@ async def clearpass_get_external_accounts(
             return client._send_request(f"/external-account/{external_account_id}", "get")
         if name:
             return client._send_request(f"/external-account/name/{name}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/external-account" + query, "get")
     except Exception as e:
         return f"Error fetching external accounts: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -7,34 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -70,7 +43,7 @@ async def clearpass_get_extensions(
             return client.get_extension_instance_by_id_config(id=extension_id)
         if extension_id:
             return client.get_extension_instance_by_id(id=extension_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/extension/instance" + query, "get")
     except Exception as e:
         return f"Error fetching extensions: {e}"
@@ -104,7 +77,7 @@ async def clearpass_get_syslog_targets(
         client = await get_clearpass_session(ApiIntegrations)
         if syslog_target_id:
             return client.get_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/syslog-target" + query, "get")
     except Exception as e:
         return f"Error fetching syslog targets: {e}"
@@ -140,7 +113,7 @@ async def clearpass_get_syslog_export_filters(
             return client.get_syslog_export_filter_by_syslog_export_filter_id(
                 syslog_export_filter_id=syslog_export_filter_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/syslog-export-filter" + query, "get")
     except Exception as e:
         return f"Error fetching syslog export filters: {e}"
@@ -174,7 +147,7 @@ async def clearpass_get_event_sources(
         client = await get_clearpass_session(ApiIntegrations)
         if event_sources_id:
             return client.get_event_sources_by_event_sources_id(event_sources_id=event_sources_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/event-sources" + query, "get")
     except Exception as e:
         return f"Error fetching event sources: {e}"
@@ -210,7 +183,7 @@ async def clearpass_get_context_servers(
             return client.get_context_server_action_by_context_server_action_id(
                 context_server_action_id=context_server_action_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/context-server-action" + query, "get")
     except Exception as e:
         return f"Error fetching context server actions: {e}"
@@ -246,7 +219,7 @@ async def clearpass_get_endpoint_context_servers(
             return client.get_endpoint_context_server_by_endpoint_context_server_id(
                 endpoint_context_server_id=endpoint_context_server_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/endpoint-context-server" + query, "get")
     except Exception as e:
         return f"Error fetching endpoint context servers: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -7,35 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-        calculate_count: When true, response includes total item count.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -70,7 +42,7 @@ async def clearpass_get_network_devices(
             return client.get_network_device_by_network_device_id(network_device_id=device_id)
         if name:
             return client.get_network_device_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/network-device" + query, "get")
     except Exception as e:
         return f"Error fetching network devices: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -7,34 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -69,7 +42,7 @@ async def clearpass_get_services(
             return client.get_config_service_by_config_service_id(config_service_id=config_service_id)
         if name:
             return client.get_config_service_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/config/service" + query, "get")
     except Exception as e:
         return f"Error fetching services: {e}"
@@ -107,7 +80,7 @@ async def clearpass_get_posture_policies(
             return client.get_posture_policy_by_posture_policy_id(posture_policy_id=posture_policy_id)
         if name:
             return client.get_posture_policy_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/posture-policy" + query, "get")
     except Exception as e:
         return f"Error fetching posture policies: {e}"
@@ -147,7 +120,7 @@ async def clearpass_get_device_groups(
             )
         if name:
             return client.get_network_device_group_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/network-device-group" + query, "get")
     except Exception as e:
         return f"Error fetching device groups: {e}"
@@ -185,7 +158,7 @@ async def clearpass_get_proxy_targets(
             return client.get_proxy_target_by_proxy_target_id(proxy_target_id=proxy_target_id)
         if name:
             return client.get_proxy_target_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/proxy-target" + query, "get")
     except Exception as e:
         return f"Error fetching proxy targets: {e}"
@@ -225,7 +198,7 @@ async def clearpass_get_radius_dictionaries(
             )
         if name:
             return client.get_radius_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/radius-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching RADIUS dictionaries: {e}"
@@ -265,7 +238,7 @@ async def clearpass_get_tacacs_dictionaries(
             )
         if name:
             return client.get_tacacs_service_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/tacacs-service-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching TACACS+ dictionaries: {e}"
@@ -305,7 +278,7 @@ async def clearpass_get_application_dictionaries(
             )
         if name:
             return client.get_application_dictionary_name_by_name(name=name)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/application-dictionary" + query, "get")
     except Exception as e:
         return f"Error fetching application dictionaries: {e}"
@@ -350,7 +323,7 @@ async def clearpass_get_radius_dynamic_authorization_template(
             return client._send_request(f"/radius-dynamic-authorization-template/{template_id}", "get")
         if name:
             return client._send_request(f"/radius-dynamic-authorization-template/name/{name}", "get")
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/radius-dynamic-authorization-template" + query, "get")
     except Exception as e:
         return f"Error fetching RADIUS dynamic authorization templates: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -7,34 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-
-
-def _build_query_string(
-    filter: str | None = None,
-    sort: str | None = None,
-    offset: int = 0,
-    limit: int = 25,
-    calculate_count: bool = False,
-) -> str:
-    """Build ClearPass REST API query string for list endpoints.
-
-    Args:
-        filter: JSON filter expression (ClearPass REST API syntax).
-        sort: Sort order (e.g. "+name" or "-id").
-        offset: Pagination offset.
-        limit: Max results per page.
-
-    Returns:
-        Query string starting with '?' for appending to a path.
-    """
-    params = [
-        f"filter={filter}" if filter else "",
-        f"sort={sort}" if sort else "",
-        f"offset={offset}",
-        f"limit={limit}",
-        f"calculate_count={'true' if calculate_count else 'false'}",
-    ]
-    return "?" + "&".join(p for p in params if p)
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
 
 
 @tool(annotations=READ_ONLY)
@@ -65,7 +38,7 @@ async def clearpass_get_admin_users(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if admin_user_id:
             return client.get_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/admin-user" + query, "get")
     except Exception as e:
         return f"Error fetching admin users: {e}"
@@ -101,7 +74,7 @@ async def clearpass_get_admin_privileges(
             return client.get_admin_privilege_by_admin_privilege_id(
                 admin_privilege_id=admin_privilege_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/admin-privilege" + query, "get")
     except Exception as e:
         return f"Error fetching admin privileges: {e}"
@@ -130,7 +103,7 @@ async def clearpass_get_operator_profiles(
         from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/operator-profile" + query, "get")
     except Exception as e:
         return f"Error fetching operator profiles: {e}"
@@ -228,7 +201,7 @@ async def clearpass_get_attributes(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if attribute_id:
             return client.get_attribute_by_attribute_id(attribute_id=attribute_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/attribute" + query, "get")
     except Exception as e:
         return f"Error fetching attributes: {e}"
@@ -262,7 +235,7 @@ async def clearpass_get_data_filters(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         if data_filter_id:
             return client.get_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/data-filter" + query, "get")
     except Exception as e:
         return f"Error fetching data filters: {e}"
@@ -298,7 +271,7 @@ async def clearpass_get_file_backup_servers(
             return client.get_file_backup_server_by_file_backup_server_id(
                 file_backup_server_id=file_backup_server_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/file-backup-server" + query, "get")
     except Exception as e:
         return f"Error fetching file backup servers: {e}"
@@ -352,7 +325,7 @@ async def clearpass_get_snmp_trap_receivers(
             return client.get_snmp_trap_receiver_by_snmp_trap_receiver_id(
                 snmp_trap_receiver_id=snmp_trap_receiver_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/snmp-trap-receiver" + query, "get")
     except Exception as e:
         return f"Error fetching SNMP trap receivers: {e}"
@@ -388,7 +361,7 @@ async def clearpass_get_policy_manager_zones(
             return client.get_server_policy_manager_zones_by_policy_manager_zones_id(
                 policy_manager_zones_id=policy_manager_zones_id,
             )
-        query = _build_query_string(filter, sort, offset, limit, calculate_count)
+        query = build_query_string(filter, sort, offset, limit, calculate_count)
         return client._send_request("/server/policy-manager-zones" + query, "get")
     except Exception as e:
         return f"Error fetching Policy Manager zones: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/utils.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/utils.py
@@ -1,0 +1,39 @@
+"""Shared utilities for the ClearPass platform tool layer.
+
+Currently exposes the ClearPass REST API list-endpoint query-string builder.
+Each ClearPass list operation supports the same five pagination/filter
+parameters (filter, sort, offset, limit, calculate_count); this helper
+formats them into a query string consistently across all 10+ tool files
+that previously inlined an identical local copy.
+"""
+
+from __future__ import annotations
+
+
+def build_query_string(
+    filter: str | None = None,
+    sort: str | None = None,
+    offset: int = 0,
+    limit: int = 25,
+    calculate_count: bool = False,
+) -> str:
+    """Build a ClearPass REST API query string for list endpoints.
+
+    Args:
+        filter: JSON filter expression (ClearPass REST API syntax).
+        sort: Sort order (e.g. ``"+name"`` or ``"-id"``).
+        offset: Pagination offset.
+        limit: Max results per page.
+        calculate_count: When true, response includes the total item count.
+
+    Returns:
+        Query string starting with ``"?"`` for appending to a path.
+    """
+    params = [
+        f"filter={filter}" if filter else "",
+        f"sort={sort}" if sort else "",
+        f"offset={offset}",
+        f"limit={limit}",
+        f"calculate_count={'true' if calculate_count else 'false'}",
+    ]
+    return "?" + "&".join(p for p in params if p)

--- a/tests/unit/test_clearpass_utils.py
+++ b/tests/unit/test_clearpass_utils.py
@@ -1,0 +1,45 @@
+"""Unit tests for the shared ClearPass utility helpers.
+
+Pins the contract for ``build_query_string`` after consolidating ten
+file-local copies into ``platforms/clearpass/utils.py`` (issue #125).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildQueryString:
+    def test_defaults_emit_offset_limit_and_calculate_count(self):
+        assert build_query_string() == "?offset=0&limit=25&calculate_count=false"
+
+    def test_filter_included_when_provided(self):
+        result = build_query_string(filter='{"name":"foo"}')
+        assert 'filter={"name":"foo"}' in result
+        assert result.startswith("?filter=")
+
+    def test_filter_omitted_when_none(self):
+        assert "filter=" not in build_query_string()
+
+    def test_sort_included_when_provided(self):
+        result = build_query_string(sort="+name")
+        assert "sort=+name" in result
+
+    def test_calculate_count_true_lowercases_to_true(self):
+        assert "calculate_count=true" in build_query_string(calculate_count=True)
+
+    def test_calculate_count_false_lowercases_to_false(self):
+        assert "calculate_count=false" in build_query_string(calculate_count=False)
+
+    def test_offset_and_limit_respect_provided_values(self):
+        result = build_query_string(offset=50, limit=100)
+        assert "offset=50" in result
+        assert "limit=100" in result
+
+    def test_full_query_string_orders_filter_sort_offset_limit_count(self):
+        result = build_query_string(filter='{"x":1}', sort="-id", offset=10, limit=5, calculate_count=True)
+        assert result == '?filter={"x":1}&sort=-id&offset=10&limit=5&calculate_count=true'


### PR DESCRIPTION
## Summary

Pure refactor — ten ClearPass tool files each carried a byte-identical copy of \`_build_query_string()\`. Consolidated into \`platforms/clearpass/utils.py\` (mirrors the existing \`central/utils.py\` pattern). Net **−245 lines** across the ClearPass tool layer, **no behavior change**.

Dropped the leading underscore: the helper is now imported across module boundaries, so the \`_\` prefix (which signals module-private) is misleading. The new exported name is \`build_query_string\`.

Closes #125.

## What changed

- **New file**: \`src/hpe_networking_mcp/platforms/clearpass/utils.py\` — \`build_query_string(filter, sort, offset, limit, calculate_count)\`. Same body as the previous file-local copies.
- **10 tool files** lost their local \`_build_query_string\` definitions, gained a single import line, and have their 42 call sites renamed: \`audit.py\`, \`certificate_authority.py\`, \`certificates.py\`, \`endpoint_visibility.py\`, \`guest_config.py\`, \`identities.py\`, \`integrations.py\`, \`network_devices.py\`, \`policy_elements.py\`, \`server_config.py\`.
- **New file**: \`tests/unit/test_clearpass_utils.py\` — 8 tests pinning the contract (defaults, filter/sort omission when None, \`calculate_count\` casing, full-string ordering).

## Test plan

- [x] \`uv run ruff check .\` (in Docker, dev compose)
- [x] \`uv run ruff format --check .\`
- [x] \`uv run mypy src/ --ignore-missing-imports\`
- [x] \`uv run pytest tests/ -q\` — 976 passed (was 968; +8 new)
- [ ] Operator calls any ClearPass list tool (\`clearpass_get_network_devices\`, \`clearpass_get_endpoints\`, etc.) and confirms the resulting query string is unchanged from prior behavior.