### PR TITLE
v3.0.0.4: wrap pyclearpass _send_request GET dependency in clearpass_get helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0.4] - 2026-05-06
+
+**Patch release — ClearPass `_send_request` private-method dependency wrapped (refactor only).**
+
+ClearPass GET reads have to use `pyclearpass.ClearPassAPILogin._send_request(path, "get")` because the SDK doesn't expose a public list method for most resource types. That direct dependency on a private SDK method (the leading underscore) was scattered across 69 call sites in 16 tool files — if a future pyclearpass release renames or removes `_send_request`, all 69 sites break.
+
+Wrapped the dependency in a single `clearpass_get(client, path)` helper in `platforms/clearpass/utils.py`, alongside the `build_query_string` helper added in v3.0.0.3. Now there's exactly one place to update if pyclearpass changes its transport layer.
+
+Pure refactor. No behavior change — every call site produces the same HTTP request as before.
+
+Closes [#126](https://github.com/nowireless4u/hpe-networking-mcp/issues/126).
+
+### Files
+
+- **`src/hpe_networking_mcp/platforms/clearpass/utils.py`** — added `clearpass_get(client, path)` helper. Single line of meaningful code (`return client._send_request(path, "get")`); the rest is a docstring explaining why the wrapper exists.
+- **16 ClearPass tool files** (`audit.py`, `auth.py`, `certificate_authority.py`, `certificates.py`, `endpoint_visibility.py`, `endpoints.py`, `enforcement.py`, `guest_config.py`, `guests.py`, `identities.py`, `integrations.py`, `network_devices.py`, `policy_elements.py`, `roles.py`, `server_config.py`, `sessions.py`) — replaced 69 \`client._send_request(path, "get")\` calls with `clearpass_get(client, path)`. 10 files extended their existing `build_query_string` import; 6 files added a fresh import.
+- **`tests/unit/test_clearpass_utils.py`** — added 3 new tests covering `clearpass_get` (delegation contract, path passthrough, return-value passthrough). 11 tests total in the file.
+- **`pyproject.toml`** — bump 3.0.0.3 → 3.0.0.4.
+
+### Notes
+
+- 979 tests pass (was 976; +3 from the new helper tests).
+- Scope deliberately limited to GET reads (the issue's stated target). The 139 remaining `_send_request` write-method call sites (POST / PATCH / DELETE) are unchanged. If a future pyclearpass change breaks them too, a follow-up PR can extend the wrapper to method-agnostic.
+
 ## [3.0.0.3] - 2026-05-06
 
 **Patch release — ClearPass `build_query_string` consolidation (refactor only).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.0.3"
+version = "3.0.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -58,7 +58,7 @@ async def clearpass_get_system_events(
 
         client = await get_clearpass_session(ApiLogs)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/system-event" + query, "get")
+        return clearpass_get(client, "/system-event" + query)
     except Exception as e:
         return f"Error fetching system events: {e}"
 
@@ -97,7 +97,7 @@ async def clearpass_get_insight_alerts(
         if name:
             return client.get_alert_by_name(name=name)
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
-        return client._send_request("/alert" + query, "get")
+        return clearpass_get(client, "/alert" + query)
     except Exception as e:
         return f"Error fetching insight alerts: {e}"
 
@@ -136,7 +136,7 @@ async def clearpass_get_insight_reports(
         if name:
             return client.get_report_by_name(name=name)
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
-        return client._send_request("/report" + query, "get")
+        return clearpass_get(client, "/report" + query)
     except Exception as e:
         return f"Error fetching insight reports: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -49,7 +50,7 @@ async def clearpass_get_auth_sources(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/auth-source" + query, "get")
+        return clearpass_get(client, "/auth-source" + query)
     except Exception as e:
         return f"Error fetching auth sources: {e}"
 
@@ -144,6 +145,6 @@ async def clearpass_get_auth_methods(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/auth-method" + query, "get")
+        return clearpass_get(client, "/auth-method" + query)
     except Exception as e:
         return f"Error fetching auth methods: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -19,7 +19,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -57,11 +57,11 @@ async def clearpass_get_certificates(
 
         client = await get_clearpass_session(ApiCertificateAuthority)
         if certificate_id and chain:
-            return client._send_request(f"/certificate/{certificate_id}/chain", "get")
+            return clearpass_get(client, f"/certificate/{certificate_id}/chain")
         if certificate_id:
-            return client._send_request(f"/certificate/{certificate_id}", "get")
+            return clearpass_get(client, f"/certificate/{certificate_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/certificate" + query, "get")
+        return clearpass_get(client, "/certificate" + query)
     except Exception as e:
         return f"Error fetching CA certificates: {e}"
 
@@ -104,8 +104,8 @@ async def clearpass_get_onboard_devices(
 
         client = await get_clearpass_session(ApiCertificateAuthority)
         if onboard_device_id:
-            return client._send_request(f"/onboard/device/{onboard_device_id}", "get")
+            return clearpass_get(client, f"/onboard/device/{onboard_device_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/onboard/device" + query, "get")
+        return clearpass_get(client, "/onboard/device" + query)
     except Exception as e:
         return f"Error fetching onboard devices: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -48,7 +48,7 @@ async def clearpass_get_trust_list(
                 cert_trust_list_id=cert_trust_list_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/cert-trust-list" + query, "get")
+        return clearpass_get(client, "/cert-trust-list" + query)
     except Exception as e:
         return f"Error fetching trust list: {e}"
 
@@ -82,7 +82,7 @@ async def clearpass_get_client_certificates(
         if client_cert_id:
             return client.get_client_cert_by_client_cert_id(client_cert_id=client_cert_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/client-cert" + query, "get")
+        return clearpass_get(client, "/client-cert" + query)
     except Exception as e:
         return f"Error fetching client certificates: {e}"
 
@@ -116,7 +116,7 @@ async def clearpass_get_server_certificates(
                 server_uuid=server_uuid,
                 service_name=service_name,
             )
-        return client._send_request("/server-cert", "get")
+        return clearpass_get(client, "/server-cert")
     except Exception as e:
         return f"Error fetching server certificates: {e}"
 
@@ -150,7 +150,7 @@ async def clearpass_get_service_certificates(
         if service_cert_id:
             return client.get_service_cert_by_service_cert_id(service_cert_id=service_cert_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/service-cert" + query, "get")
+        return clearpass_get(client, "/service-cert" + query)
     except Exception as e:
         return f"Error fetching service certificates: {e}"
 
@@ -188,8 +188,8 @@ async def clearpass_get_revocation_list(
 
         client = await get_clearpass_session(ApiPlatformCertificates)
         if revocation_list_id:
-            return client._send_request(f"/revocation-list/{revocation_list_id}", "get")
+            return clearpass_get(client, f"/revocation-list/{revocation_list_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/revocation-list" + query, "get")
+        return clearpass_get(client, "/revocation-list" + query)
     except Exception as e:
         return f"Error fetching revocation lists: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -14,7 +14,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -49,11 +49,11 @@ async def clearpass_get_onguard_activity(
 
         client = await get_clearpass_session(ApiEndpointVisibility)
         if activity_id:
-            return client._send_request(f"/onguard-activity/{activity_id}", "get")
+            return clearpass_get(client, f"/onguard-activity/{activity_id}")
         if mac:
-            return client._send_request(f"/onguard-activity/mac/{mac}", "get")
+            return clearpass_get(client, f"/onguard-activity/mac/{mac}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/onguard-activity" + query, "get")
+        return clearpass_get(client, "/onguard-activity" + query)
     except Exception as e:
         return f"Error fetching OnGuard activity: {e}"
 
@@ -92,9 +92,9 @@ async def clearpass_get_fingerprint_dictionary(
 
         client = await get_clearpass_session(ApiEndpointVisibility)
         if fingerprint_id:
-            return client._send_request(f"/fingerprint/{fingerprint_id}", "get")
+            return clearpass_get(client, f"/fingerprint/{fingerprint_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/fingerprint" + query, "get")
+        return clearpass_get(client, "/fingerprint" + query)
     except Exception as e:
         return f"Error fetching fingerprint dictionary: {e}"
 
@@ -133,9 +133,9 @@ async def clearpass_get_network_scan(
 
         client = await get_clearpass_session(ApiEndpointVisibility)
         if scan_id:
-            return client._send_request(f"/config/network-scan/{scan_id}", "get")
+            return clearpass_get(client, f"/config/network-scan/{scan_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/config/network-scan" + query, "get")
+        return clearpass_get(client, "/config/network-scan" + query)
     except Exception as e:
         return f"Error fetching network scans: {e}"
 
@@ -163,6 +163,6 @@ async def clearpass_get_onguard_settings(
 
         client = await get_clearpass_session(ApiEndpointVisibility)
         path = "/onguard/global-settings" if global_settings else "/onguard/settings"
-        return client._send_request(path, "get")
+        return clearpass_get(client, path)
     except Exception as e:
         return f"Error fetching OnGuard settings: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -57,7 +58,7 @@ async def clearpass_get_endpoints(
             f"profile_details={'true' if profile_details else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/endpoint" + query, "get")
+        return clearpass_get(client, "/endpoint" + query)
     except Exception as e:
         return f"Error fetching endpoints: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -52,7 +53,7 @@ async def clearpass_get_enforcement_policies(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/enforcement-policy" + query, "get")
+        return clearpass_get(client, "/enforcement-policy" + query)
     except Exception as e:
         return f"Error fetching enforcement policies: {e}"
 
@@ -100,7 +101,7 @@ async def clearpass_get_enforcement_profiles(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/enforcement-profile" + query, "get")
+        return clearpass_get(client, "/enforcement-profile" + query)
     except Exception as e:
         return f"Error fetching enforcement profiles: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -39,7 +39,7 @@ async def clearpass_get_pass_templates(
         if template_id:
             return client.get_template_pass_by_id(id=template_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/template/pass" + query, "get")
+        return clearpass_get(client, "/template/pass" + query)
     except Exception as e:
         return f"Error fetching pass templates: {e}"
 
@@ -73,7 +73,7 @@ async def clearpass_get_print_templates(
         if template_id:
             return client.get_template_print_by_id(id=template_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/template/print" + query, "get")
+        return clearpass_get(client, "/template/print" + query)
     except Exception as e:
         return f"Error fetching print templates: {e}"
 
@@ -111,7 +111,7 @@ async def clearpass_get_weblogin_pages(
         if page_name:
             return client.get_weblogin_page_name_by_page_name(page_name=page_name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/weblogin" + query, "get")
+        return clearpass_get(client, "/weblogin" + query)
     except Exception as e:
         return f"Error fetching web login pages: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -49,6 +50,6 @@ async def clearpass_get_guest_users(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/guest" + query, "get")
+        return clearpass_get(client, "/guest" + query)
     except Exception as e:
         return f"Error fetching guest users: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -39,7 +39,7 @@ async def clearpass_get_api_clients(
         if client_id:
             return client.get_api_client_by_client_id(client_id=client_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/api-client" + query, "get")
+        return clearpass_get(client, "/api-client" + query)
     except Exception as e:
         return f"Error fetching API clients: {e}"
 
@@ -78,7 +78,7 @@ async def clearpass_get_local_users(
         if user_id:
             return client.get_local_user_user_id_by_user_id(user_id=user_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/local-user" + query, "get")
+        return clearpass_get(client, "/local-user" + query)
     except Exception as e:
         return f"Error fetching local users: {e}"
 
@@ -118,7 +118,7 @@ async def clearpass_get_static_host_lists(
         if name:
             return client.get_static_host_list_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/static-host-list" + query, "get")
+        return clearpass_get(client, "/static-host-list" + query)
     except Exception as e:
         return f"Error fetching static host lists: {e}"
 
@@ -156,7 +156,7 @@ async def clearpass_get_devices(
         if macaddr:
             return client.get_device_mac_by_macaddr(macaddr=macaddr)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/device" + query, "get")
+        return clearpass_get(client, "/device" + query)
     except Exception as e:
         return f"Error fetching devices: {e}"
 
@@ -192,7 +192,7 @@ async def clearpass_get_deny_listed_users(
                 deny_listed_users_id=deny_listed_users_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/deny-listed-users" + query, "get")
+        return clearpass_get(client, "/deny-listed-users" + query)
     except Exception as e:
         return f"Error fetching deny-listed users: {e}"
 
@@ -234,10 +234,10 @@ async def clearpass_get_external_accounts(
 
         client = await get_clearpass_session(ApiIdentities)
         if external_account_id:
-            return client._send_request(f"/external-account/{external_account_id}", "get")
+            return clearpass_get(client, f"/external-account/{external_account_id}")
         if name:
-            return client._send_request(f"/external-account/name/{name}", "get")
+            return clearpass_get(client, f"/external-account/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/external-account" + query, "get")
+        return clearpass_get(client, "/external-account" + query)
     except Exception as e:
         return f"Error fetching external accounts: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -44,7 +44,7 @@ async def clearpass_get_extensions(
         if extension_id:
             return client.get_extension_instance_by_id(id=extension_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/extension/instance" + query, "get")
+        return clearpass_get(client, "/extension/instance" + query)
     except Exception as e:
         return f"Error fetching extensions: {e}"
 
@@ -78,7 +78,7 @@ async def clearpass_get_syslog_targets(
         if syslog_target_id:
             return client.get_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/syslog-target" + query, "get")
+        return clearpass_get(client, "/syslog-target" + query)
     except Exception as e:
         return f"Error fetching syslog targets: {e}"
 
@@ -114,7 +114,7 @@ async def clearpass_get_syslog_export_filters(
                 syslog_export_filter_id=syslog_export_filter_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/syslog-export-filter" + query, "get")
+        return clearpass_get(client, "/syslog-export-filter" + query)
     except Exception as e:
         return f"Error fetching syslog export filters: {e}"
 
@@ -148,7 +148,7 @@ async def clearpass_get_event_sources(
         if event_sources_id:
             return client.get_event_sources_by_event_sources_id(event_sources_id=event_sources_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/event-sources" + query, "get")
+        return clearpass_get(client, "/event-sources" + query)
     except Exception as e:
         return f"Error fetching event sources: {e}"
 
@@ -184,7 +184,7 @@ async def clearpass_get_context_servers(
                 context_server_action_id=context_server_action_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/context-server-action" + query, "get")
+        return clearpass_get(client, "/context-server-action" + query)
     except Exception as e:
         return f"Error fetching context server actions: {e}"
 
@@ -220,7 +220,7 @@ async def clearpass_get_endpoint_context_servers(
                 endpoint_context_server_id=endpoint_context_server_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/endpoint-context-server" + query, "get")
+        return clearpass_get(client, "/endpoint-context-server" + query)
     except Exception as e:
         return f"Error fetching endpoint context servers: {e}"
 
@@ -249,6 +249,6 @@ async def clearpass_get_extension_log(
         path = f"/extension-instance/{extension_id}/log"
         if tail is not None:
             path += f"?tail={tail}"
-        return client._send_request(path, "get")
+        return clearpass_get(client, path)
     except Exception as e:
         return f"Error fetching extension log: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -43,7 +43,7 @@ async def clearpass_get_network_devices(
         if name:
             return client.get_network_device_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/network-device" + query, "get")
+        return clearpass_get(client, "/network-device" + query)
     except Exception as e:
         return f"Error fetching network devices: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -43,7 +43,7 @@ async def clearpass_get_services(
         if name:
             return client.get_config_service_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/config/service" + query, "get")
+        return clearpass_get(client, "/config/service" + query)
     except Exception as e:
         return f"Error fetching services: {e}"
 
@@ -81,7 +81,7 @@ async def clearpass_get_posture_policies(
         if name:
             return client.get_posture_policy_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/posture-policy" + query, "get")
+        return clearpass_get(client, "/posture-policy" + query)
     except Exception as e:
         return f"Error fetching posture policies: {e}"
 
@@ -121,7 +121,7 @@ async def clearpass_get_device_groups(
         if name:
             return client.get_network_device_group_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/network-device-group" + query, "get")
+        return clearpass_get(client, "/network-device-group" + query)
     except Exception as e:
         return f"Error fetching device groups: {e}"
 
@@ -159,7 +159,7 @@ async def clearpass_get_proxy_targets(
         if name:
             return client.get_proxy_target_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/proxy-target" + query, "get")
+        return clearpass_get(client, "/proxy-target" + query)
     except Exception as e:
         return f"Error fetching proxy targets: {e}"
 
@@ -199,7 +199,7 @@ async def clearpass_get_radius_dictionaries(
         if name:
             return client.get_radius_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/radius-dictionary" + query, "get")
+        return clearpass_get(client, "/radius-dictionary" + query)
     except Exception as e:
         return f"Error fetching RADIUS dictionaries: {e}"
 
@@ -239,7 +239,7 @@ async def clearpass_get_tacacs_dictionaries(
         if name:
             return client.get_tacacs_service_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/tacacs-service-dictionary" + query, "get")
+        return clearpass_get(client, "/tacacs-service-dictionary" + query)
     except Exception as e:
         return f"Error fetching TACACS+ dictionaries: {e}"
 
@@ -279,7 +279,7 @@ async def clearpass_get_application_dictionaries(
         if name:
             return client.get_application_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/application-dictionary" + query, "get")
+        return clearpass_get(client, "/application-dictionary" + query)
     except Exception as e:
         return f"Error fetching application dictionaries: {e}"
 
@@ -320,10 +320,10 @@ async def clearpass_get_radius_dynamic_authorization_template(
 
         client = await get_clearpass_session(ApiPolicyElements)
         if template_id:
-            return client._send_request(f"/radius-dynamic-authorization-template/{template_id}", "get")
+            return clearpass_get(client, f"/radius-dynamic-authorization-template/{template_id}")
         if name:
-            return client._send_request(f"/radius-dynamic-authorization-template/name/{name}", "get")
+            return clearpass_get(client, f"/radius-dynamic-authorization-template/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/radius-dynamic-authorization-template" + query, "get")
+        return clearpass_get(client, "/radius-dynamic-authorization-template" + query)
     except Exception as e:
         return f"Error fetching RADIUS dynamic authorization templates: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -49,7 +50,7 @@ async def clearpass_get_roles(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/role" + query, "get")
+        return clearpass_get(client, "/role" + query)
     except Exception as e:
         return f"Error fetching roles: {e}"
 
@@ -97,6 +98,6 @@ async def clearpass_get_role_mappings(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/role-mapping" + query, "get")
+        return clearpass_get(client, "/role-mapping" + query)
     except Exception as e:
         return f"Error fetching role mappings: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -7,7 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -39,7 +39,7 @@ async def clearpass_get_admin_users(
         if admin_user_id:
             return client.get_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/admin-user" + query, "get")
+        return clearpass_get(client, "/admin-user" + query)
     except Exception as e:
         return f"Error fetching admin users: {e}"
 
@@ -75,7 +75,7 @@ async def clearpass_get_admin_privileges(
                 admin_privilege_id=admin_privilege_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/admin-privilege" + query, "get")
+        return clearpass_get(client, "/admin-privilege" + query)
     except Exception as e:
         return f"Error fetching admin privileges: {e}"
 
@@ -104,7 +104,7 @@ async def clearpass_get_operator_profiles(
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/operator-profile" + query, "get")
+        return clearpass_get(client, "/operator-profile" + query)
     except Exception as e:
         return f"Error fetching operator profiles: {e}"
 
@@ -202,7 +202,7 @@ async def clearpass_get_attributes(
         if attribute_id:
             return client.get_attribute_by_attribute_id(attribute_id=attribute_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/attribute" + query, "get")
+        return clearpass_get(client, "/attribute" + query)
     except Exception as e:
         return f"Error fetching attributes: {e}"
 
@@ -236,7 +236,7 @@ async def clearpass_get_data_filters(
         if data_filter_id:
             return client.get_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/data-filter" + query, "get")
+        return clearpass_get(client, "/data-filter" + query)
     except Exception as e:
         return f"Error fetching data filters: {e}"
 
@@ -272,7 +272,7 @@ async def clearpass_get_file_backup_servers(
                 file_backup_server_id=file_backup_server_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/file-backup-server" + query, "get")
+        return clearpass_get(client, "/file-backup-server" + query)
     except Exception as e:
         return f"Error fetching file backup servers: {e}"
 
@@ -326,7 +326,7 @@ async def clearpass_get_snmp_trap_receivers(
                 snmp_trap_receiver_id=snmp_trap_receiver_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/snmp-trap-receiver" + query, "get")
+        return clearpass_get(client, "/snmp-trap-receiver" + query)
     except Exception as e:
         return f"Error fetching SNMP trap receivers: {e}"
 
@@ -362,7 +362,7 @@ async def clearpass_get_policy_manager_zones(
                 policy_manager_zones_id=policy_manager_zones_id,
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return client._send_request("/server/policy-manager-zones" + query, "get")
+        return clearpass_get(client, "/server/policy-manager-zones" + query)
     except Exception as e:
         return f"Error fetching Policy Manager zones: {e}"
 
@@ -380,6 +380,6 @@ async def clearpass_get_oauth_privileges(
         from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        return client._send_request("/oauth/all-privileges", "get")
+        return clearpass_get(client, "/oauth/all-privileges")
     except Exception as e:
         return f"Error fetching OAuth privileges: {e}"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
 @tool(annotations=READ_ONLY)
@@ -45,7 +46,7 @@ async def clearpass_get_sessions(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return client._send_request("/session" + query, "get")
+        return clearpass_get(client, "/session" + query)
     except Exception as e:
         return f"Error fetching sessions: {e}"
 

--- a/src/hpe_networking_mcp/platforms/clearpass/utils.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/utils.py
@@ -1,13 +1,39 @@
 """Shared utilities for the ClearPass platform tool layer.
 
-Currently exposes the ClearPass REST API list-endpoint query-string builder.
-Each ClearPass list operation supports the same five pagination/filter
-parameters (filter, sort, offset, limit, calculate_count); this helper
-formats them into a query string consistently across all 10+ tool files
-that previously inlined an identical local copy.
+Exposes:
+- ``build_query_string`` — formats the five list-endpoint pagination /
+  filter parameters (filter, sort, offset, limit, calculate_count) into
+  a query string. Consolidated from 10 file-local copies (issue #125).
+- ``clearpass_get`` — single-purpose wrapper for ``ClearPassAPILogin._send_request(path, "get")``.
+  Centralizes the use of pyclearpass's private transport method so a
+  future SDK change (e.g. addition of a public list method) only needs
+  updating in one place rather than ~70 call sites (issue #126).
 """
 
 from __future__ import annotations
+
+from typing import Any
+
+
+def clearpass_get(client: Any, path: str) -> Any:
+    """Send a GET request via pyclearpass's transport layer.
+
+    pyclearpass does not expose a public list method for most resource
+    types — list and single-item reads have to use the private
+    ``ClearPassAPILogin._send_request(path, "get")`` method. This wrapper
+    isolates the dependency so a future SDK change only requires
+    updating a single call site.
+
+    Args:
+        client: A ``ClearPassAPILogin`` instance returned by
+            ``get_clearpass_session()``.
+        path: API path (including any pre-built query string from
+            ``build_query_string``).
+
+    Returns:
+        The decoded JSON body returned by pyclearpass.
+    """
+    return client._send_request(path, "get")
 
 
 def build_query_string(

--- a/tests/unit/test_clearpass_utils.py
+++ b/tests/unit/test_clearpass_utils.py
@@ -1,16 +1,43 @@
 """Unit tests for the shared ClearPass utility helpers.
 
-Pins the contract for ``build_query_string`` after consolidating ten
-file-local copies into ``platforms/clearpass/utils.py`` (issue #125).
+Pins the contract for ``build_query_string`` (consolidated from 10 file-local
+copies in issue #125) and ``clearpass_get`` (the centralized wrapper around
+pyclearpass's private ``_send_request`` method, issue #126).
 """
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from hpe_networking_mcp.platforms.clearpass.utils import build_query_string
+from hpe_networking_mcp.platforms.clearpass.utils import (
+    build_query_string,
+    clearpass_get,
+)
 
 pytestmark = pytest.mark.unit
+
+
+class TestClearPassGet:
+    def test_delegates_to_send_request_with_get_method(self):
+        client = MagicMock()
+        client._send_request.return_value = {"items": []}
+        result = clearpass_get(client, "/network-device?offset=0&limit=25")
+        client._send_request.assert_called_once_with("/network-device?offset=0&limit=25", "get")
+        assert result == {"items": []}
+
+    def test_passes_path_through_unchanged(self):
+        client = MagicMock()
+        clearpass_get(client, "/cert-trust-list/42")
+        # Single-item lookups (no query string) work the same way.
+        client._send_request.assert_called_once_with("/cert-trust-list/42", "get")
+
+    def test_returns_whatever_the_sdk_returns(self):
+        client = MagicMock()
+        sentinel = object()
+        client._send_request.return_value = sentinel
+        assert clearpass_get(client, "/anything") is sentinel
 
 
 class TestBuildQueryString:


### PR DESCRIPTION
## Summary

ClearPass GET reads have to use \`pyclearpass.ClearPassAPILogin._send_request(path, \"get\")\` because the SDK doesn't expose a public list method for most resource types. The dependency on the private \`_send_request\` method (leading underscore) was scattered across **69 call sites in 16 tool files** — if a future pyclearpass release renames or removes it, all 69 sites break.

Wrapped in a single \`clearpass_get(client, path)\` helper in \`platforms/clearpass/utils.py\`, alongside the \`build_query_string\` helper added in v3.0.0.3. Pure refactor — every call site produces the same HTTP request as before.

Scope deliberately limited to GET reads (the issue's stated target). The 139 remaining \`_send_request\` write-method call sites (POST / PATCH / DELETE) are unchanged. If a future pyclearpass change breaks them too, a follow-up can extend the wrapper to method-agnostic.

Closes #126.

## What changed

- **\`src/hpe_networking_mcp/platforms/clearpass/utils.py\`** — added \`clearpass_get(client, path)\`. Single line of meaningful code; rest is docstring explaining why the wrapper exists.
- **16 tool files**: \`audit.py\`, \`auth.py\`, \`certificate_authority.py\`, \`certificates.py\`, \`endpoint_visibility.py\`, \`endpoints.py\`, \`enforcement.py\`, \`guest_config.py\`, \`guests.py\`, \`identities.py\`, \`integrations.py\`, \`network_devices.py\`, \`policy_elements.py\`, \`roles.py\`, \`server_config.py\`, \`sessions.py\`. 69 call sites rewritten. 10 files extended their existing \`build_query_string\` import; 6 files added a fresh import.
- **\`tests/unit/test_clearpass_utils.py\`** — +3 tests for the helper (delegation contract, path passthrough, return-value passthrough). 11 tests in the file total.

## Test plan

- [x] \`uv run ruff check .\` (in Docker, dev compose)
- [x] \`uv run ruff format --check .\`
- [x] \`uv run mypy src/ --ignore-missing-imports\`
- [x] \`uv run pytest tests/ -q\` — 979 passed (was 976; +3 new)
- [ ] Operator calls any ClearPass list tool (\`clearpass_get_network_devices\`, \`clearpass_get_endpoints\`, \`clearpass_get_sessions\`, etc.) and confirms the response shape is identical to prior behavior.