### PR TITLE
v3.0.0.5: AOS 8 transposed-table tokenization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0.5] - 2026-05-06
+
+**Patch release — AOS 8 transposed-table tokenization fix.**
+
+AOS 8 `show <thing> detail`-style commands (notably `show aaa authentication-server radius/tacacs/ldap/internal <name>`) return their content as a **transposed key/value table** — a list of two-column rows where every row is a dict with literal field names `"Parameter"` and `"Value"`. The PII tokenization walker classifies values by JSON field name, so it could never see the *semantic* field name (`Host`, `Key`, `NAS IP`, ...) hidden in the `Parameter` column. Identifier-field rules keyed on names like `host` could not fire — RADIUS/TACACS/LDAP server IPs and FQDNs leaked to the AI in cleartext.
+
+Fix: added `flatten_param_value_lists()` to `aos8/tools/_helpers.py` that recursively detects `[{Parameter: k, Value: v}, ...]` and rewrites it into a regular dict (`{k: v, ...}`). Applied in `run_show()` so every AOS 8 show-command response gets the treatment automatically. The walker's existing space-→-underscore normalization (added in v2.4.0.5) makes `"Host"` resolve to `host`, so a new `host` rule in `TOKENIZED_IDENTIFIER_FIELDS` fires on the AAA-server IP/FQDN. Carve-out from the v2.3.1.2 "internal IPs not tokenized" decision — AAA infrastructure is auth-fabric-critical.
+
+Live-verified the transposed shape against an AOS 8.13.1.2 LSR Mobility Conductor before designing the flattener (captured `show aaa authentication-server radius ClearPass70` → `RADIUS Server ClearPass70: [{Parameter: Host, Value: 192.168.20.70}, ...]`). Fixture saved to `tests/unit/fixtures/aos8/show_aaa_radius_server_detail.json`.
+
+Closes [#235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235).
+
+### Files
+
+- **`src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py`** — added `flatten_param_value_lists()`. Conservative detection: only flattens lists where *every* element is a dict containing at minimum `Parameter` and `Value` keys. Non-matching shapes pass through unchanged. Applied in `run_show()` after `strip_meta()`.
+- **`src/hpe_networking_mcp/redaction/rules.py`** — added `host: TokenKind.HOSTNAME` to `TOKENIZED_IDENTIFIER_FIELDS`. Carve-out from the v2.3.1.2 IP-passthrough rule, scoped to AAA server detail (where the field name `host` is the server's IP/FQDN). Comment cites issue #235.
+- **`tests/unit/test_aos8_helpers.py`** — new unit-test file for the flattener (8 tests covering: transposed list flattens; nested transposed list flattens in place; non-transposed list passes through; empty list passes through; scalar passes through; mixed-shape list passes through; real fixture flattens; idempotent on already-flattened dict). Plus an integration-style test for `run_show()`.
+- **`tests/unit/fixtures/aos8/show_aaa_radius_server_detail.json`** — captured fixture from a live AOS 8.13.1.2 MM, with the masked `Key: ********` value preserved as-returned by the controller.
+- **`tests/unit/test_pii_redaction.py`** — updated two Mist/Central RADIUS-server fixture tests (`test_full_walk`, `test_server_group_radius_secrets_tokenized`) to reflect the new contract: `host` in a RADIUS-server context IS tokenized as HOSTNAME, where v2.3.1.2 had treated it as a generic IP. Added `test_aos8_aaa_radius_detail_after_flatten_tokenizes_host` end-to-end regression.
+- **`pyproject.toml`** — bump 3.0.0.4 → 3.0.0.5.
+
+### Behavior change to flag
+
+The `host` rule applies fleet-wide, not just to AOS 8. Mist/Central tools that return RADIUS server records with a `host` field will now tokenize the IP/FQDN where they previously did not. This is consistent with the issue's stated threat model (AAA infrastructure is critical, regardless of platform).
+
+The masked `Key: "********"` placeholder that AOS 8 returns for shared secrets gets tokenized as APITOKEN after flattening, because the walker sees `Key` (a generic credential field name) and `********` looks credential-shaped to its heuristic. The detokenize round-trip returns `********` unchanged, so this is harmless — just a slightly noisier representation of an already-masked value.
+
+### Notes
+
+- 989 tests pass (was 979; +10 from the new helper + tokenization tests).
+- The flattener is conservative (requires *every* row to match the shape), so existing show commands that return regular records (e.g. `show ap database`, `show aaa authentication-server radius` listing) are untouched.
+
 ## [3.0.0.4] - 2026-05-06
 
 **Patch release — ClearPass `_send_request` private-method dependency wrapped (refactor only).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,17 @@ Closes [#235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235).
 
 The `host` rule applies fleet-wide, not just to AOS 8. Mist/Central tools that return RADIUS server records with a `host` field will now tokenize the IP/FQDN where they previously did not. This is consistent with the issue's stated threat model (AAA infrastructure is critical, regardless of platform).
 
-The masked `Key: "********"` placeholder that AOS 8 returns for shared secrets gets tokenized as APITOKEN after flattening, because the walker sees `Key` (a generic credential field name) and `********` looks credential-shaped to its heuristic. The detokenize round-trip returns `********` unchanged, so this is harmless — just a slightly noisier representation of an already-masked value.
+### Subtlety: masked-placeholder skip (also added in this release)
+
+AOS 8 returns shared secrets / passwords as runs of asterisks (`"********"`) — the real value never leaves the controller. After this release's transposed-table flattening, the walker would see `Key: "********"` as a `key` field with a credential-shaped value, and tokenize the placeholder as `[[APITOKEN:uuid]]`.
+
+That sounds harmless, but it isn't: a tokenized placeholder creates the **dangerous illusion** that the AI has a real tokenized secret it can pass to a write tool. The detokenize round-trip restores `"********"` — which Central / AOS 10 would happily accept as a literal RADIUS shared secret, and RADIUS auth would then fail silently the next time a client tries to associate. Better to fail loudly: AI sees `"********"` directly and knows it has to ask the operator for the real secret.
+
+Added `is_masked_placeholder(value)` to `redaction/rules.py` (recognizes all-asterisk strings of length 4+) and a short-circuit at the top of `classify_field` that skips tokenization for masked values regardless of which rule path the field name matches. Future placeholder patterns (`<hidden>`, `[REDACTED]`, etc.) can be added as they surface.
 
 ### Notes
 
-- 989 tests pass (was 979; +10 from the new helper + tokenization tests).
+- 998 tests pass (was 979; +19 total: +10 from the flattener + tokenization tests, +9 from the placeholder-skip tests).
 - The flattener is conservative (requires *every* row to match the shape), so existing show commands that return regular records (e.g. `show ap database`, `show aaa authentication-server radius` listing) are untouched.
 
 ## [3.0.0.4] - 2026-05-06

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.0.4"
+version = "3.0.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
@@ -22,6 +22,7 @@ from hpe_networking_mcp.platforms.aos8.client import (
 
 __all__ = [
     "strip_meta",
+    "flatten_param_value_lists",
     "run_show",
     "get_object",
     "post_object",
@@ -52,6 +53,54 @@ def strip_meta(body: Any) -> Any:
     if not isinstance(body, dict):
         return body
     return {k: v for k, v in body.items() if k not in ("_meta", "_global_result")}
+
+
+def flatten_param_value_lists(body: Any) -> Any:
+    """Flatten AOS 8 ``[{Parameter: k, Value: v}, ...]`` rows into ``{k: v, ...}``.
+
+    AOS 8 ``show <thing> detail``-style commands (notably the AAA
+    authentication-server detail commands —
+    ``show aaa authentication-server radius/tacacs/ldap/internal <name>``)
+    return their content as a transposed key/value table where every row
+    is a dict with literal field names ``Parameter`` and ``Value``. The
+    PII tokenization walker classifies values by their JSON field name,
+    so it can never see the *semantic* field name (``Host``, ``NAS IP``,
+    ``Key``, ...) hidden in the ``Parameter`` column. Rules keyed on
+    server-identifier names like ``host`` cannot fire.
+
+    This helper detects the transposed shape recursively and rewrites it
+    into a regular dict (``{"Host": "192.168.20.70", "Key": "********",
+    ...}``). The walker's space → underscore normalization
+    (``Host`` → ``host``) then makes identifier-field rules fire normally.
+
+    Non-matching shapes pass through unchanged. The detection is
+    conservative: a list is only flattened when *every* element is a
+    dict containing at minimum the ``Parameter`` and ``Value`` keys —
+    so a list whose elements happen to share those keys among others
+    (a richer record shape) is preserved as-is.
+
+    See [issue #235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235)
+    for context.
+
+    Args:
+        body: Parsed AOS 8 JSON body. May be a dict, list, or scalar.
+
+    Returns:
+        A new structure with transposed-table lists flattened. Other
+        nested dicts/lists/scalars are returned unchanged.
+    """
+    if isinstance(body, list):
+        if body and all(isinstance(row, dict) and {"Parameter", "Value"} <= set(row.keys()) for row in body):
+            # Transposed shape detected — flatten this list.
+            # Last-wins on duplicate Parameter names (extremely rare in
+            # AOS 8; the transposed-table semantics are key-unique within
+            # a single block).
+            return {row["Parameter"]: row["Value"] for row in body}
+        # Otherwise: recurse element-wise.
+        return [flatten_param_value_lists(item) for item in body]
+    if isinstance(body, dict):
+        return {k: flatten_param_value_lists(v) for k, v in body.items()}
+    return body
 
 
 def _decode_json_or_raise(response: httpx.Response, what: str) -> Any:
@@ -114,7 +163,7 @@ async def run_show(
         params["config_path"] = config_path
     response = await client.request("GET", "/v1/configuration/showcommand", params=params)
     try:
-        return strip_meta(response.json())
+        return flatten_param_value_lists(strip_meta(response.json()))
     except ValueError:
         body = response.text or ""
         return {"output": body} if body else {}

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -357,6 +357,34 @@ def is_known_enum_value(value: str) -> bool:
     return lowered in _COMMON_ENUM_VALUES
 
 
+def is_masked_placeholder(value: str) -> bool:
+    """Return True if ``value`` is a source-platform-side masked placeholder.
+
+    AOS 8 (and similar systems) returns shared secrets, passwords, and other
+    sensitive fields as runs of asterisks (``"********"``) rather than the
+    cleartext value. The real secret never leaves the source platform.
+
+    Such placeholders must NEVER be tokenized: a tokenized placeholder
+    creates a *dangerous illusion* — the AI sees ``[[APITOKEN:uuid]]`` and
+    believes it has a real tokenized secret it can pass to a write tool.
+    The detokenize round-trip restores only the placeholder ``"********"``,
+    which downstream platforms accept as a literal value. The result is a
+    silent production failure (RADIUS auth breaks the next time a client
+    tries to associate) rather than the loud failure of "AI can't get the
+    secret, must ask operator".
+
+    Returns True for all-asterisk strings of length 4 or more. Other
+    common masked patterns (``<hidden>``, ``[REDACTED]``, etc.) can be
+    added as they surface.
+
+    See [issue #235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235)
+    for the AOS 8 ``Key: "********"`` case.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    return len(value) >= 4 and all(c == "*" for c in value)
+
+
 _COMMON_ENUM_VALUES: frozenset[str] = frozenset(
     {
         "auto",
@@ -427,6 +455,13 @@ def classify_field(
     if not isinstance(field_name, str):
         return FieldClassification.SKIP, None
     name = _normalize_field_name(field_name)
+
+    # Source-platform-masked placeholders (e.g. AOS 8's ``"********"``) must
+    # never be tokenized regardless of which rule path matches the field name.
+    # See ``is_masked_placeholder`` for the rationale (dangerous illusion of
+    # a tokenized real secret; round-trip restores only the placeholder).
+    if isinstance(value, str) and is_masked_placeholder(value):
+        return FieldClassification.SKIP, None
 
     # Exact-match secret fields
     if name in SECRET_FIELD_NAMES:

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -194,6 +194,10 @@ TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
     "ap_name": TokenKind.HOSTNAME,
     "hostname": TokenKind.HOSTNAME,
     "host_name": TokenKind.HOSTNAME,  # AOS 8 client tables use "Host Name"
+    # AOS 8 AAA-server detail (after transposed-table flatten); RADIUS/TACACS/LDAP
+    # server IP/FQDN. Carve-out from the v2.3.1.2 "internal IPs not tokenized"
+    # rule — AAA infrastructure is auth-fabric-critical (issue #235).
+    "host": TokenKind.HOSTNAME,
     "controller_name": TokenKind.HOSTNAME,  # AOS 8 controller / MM identifier
     "switch_name": TokenKind.HOSTNAME,  # AOS 8 / Central switch identifier
     "fqdn": TokenKind.HOSTNAME,

--- a/tests/unit/fixtures/aos8/show_aaa_radius_server_detail.json
+++ b/tests/unit/fixtures/aos8/show_aaa_radius_server_detail.json
@@ -1,0 +1,32 @@
+{
+  "RADIUS Server ClearPass70": [
+    {"Parameter": "Enable IPv6", "Value": "Disabled"},
+    {"Parameter": "Host", "Value": "192.168.20.70"},
+    {"Parameter": "Key", "Value": "********"},
+    {"Parameter": "CPPM credentials", "Value": "N/A"},
+    {"Parameter": "Auth Port", "Value": "1812"},
+    {"Parameter": "Acct Port", "Value": "1813"},
+    {"Parameter": "RadSec Port", "Value": "2083"},
+    {"Parameter": "Retransmits", "Value": "3"},
+    {"Parameter": "Timeout", "Value": "5 sec"},
+    {"Parameter": "NAS ID", "Value": "N/A"},
+    {"Parameter": "NAS IP", "Value": "N/A"},
+    {"Parameter": "NAS IPv6", "Value": "N/A"},
+    {"Parameter": "Source Interface", "Value": "N/A"},
+    {"Parameter": "Use MD5", "Value": "Disabled"},
+    {"Parameter": "Use IP address for calling station ID", "Value": "Disabled"},
+    {"Parameter": "Mode", "Value": "Enabled"},
+    {"Parameter": "Lowercase MAC addresses", "Value": "Disabled"},
+    {"Parameter": "MAC address delimiter", "Value": "none"},
+    {"Parameter": "Service-type of FRAMED-USER", "Value": "Disabled"},
+    {"Parameter": "RadSec", "Value": "Disabled"},
+    {"Parameter": "RadSec Trusted CA Name", "Value": "N/A"},
+    {"Parameter": "RadSec Server Cert Name", "Value": "N/A"},
+    {"Parameter": "RadSec Client Cert", "Value": "N/A"},
+    {"Parameter": "called-station-id", "Value": "macaddr colon disable"},
+    {"Parameter": "Access-Request Modifier", "Value": "N/A"},
+    {"Parameter": "Accounting-Request Modifier", "Value": "N/A"},
+    {"Parameter": "Message-Authenticator required in Access-Accept/Reject/Challenge", "Value": "No"}
+  ],
+  "_meta": ["Parameter", "Value"]
+}

--- a/tests/unit/test_aos8_helpers.py
+++ b/tests/unit/test_aos8_helpers.py
@@ -1,0 +1,125 @@
+"""Unit tests for AOS 8 tool helpers — focus on the transposed-table flattener.
+
+The flattener was added in v3.0.0.5 to fix a PII tokenization gap (issue #235):
+AOS 8 ``show <thing> detail`` commands return their content as a transposed
+key/value table with literal ``Parameter`` / ``Value`` field names. The
+walker classifies by JSON field name and so cannot see the *semantic*
+field name hidden in the ``Parameter`` column. The flattener detects the
+shape and rewrites it into a regular dict so identifier-field rules can
+fire normally on the semantic names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from hpe_networking_mcp.platforms.aos8.tools._helpers import (
+    flatten_param_value_lists,
+    run_show,
+)
+
+pytestmark = pytest.mark.unit
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "aos8"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text())
+
+
+class TestFlattenParamValueLists:
+    def test_transposed_list_flattens_to_dict(self):
+        body = [
+            {"Parameter": "Host", "Value": "192.168.20.70"},
+            {"Parameter": "Key", "Value": "********"},
+            {"Parameter": "Auth Port", "Value": "1812"},
+        ]
+        assert flatten_param_value_lists(body) == {
+            "Host": "192.168.20.70",
+            "Key": "********",
+            "Auth Port": "1812",
+        }
+
+    def test_nested_transposed_list_flattens_in_place(self):
+        body = {
+            "RADIUS Server ClearPass70": [
+                {"Parameter": "Host", "Value": "192.168.20.70"},
+                {"Parameter": "Key", "Value": "********"},
+            ]
+        }
+        result = flatten_param_value_lists(body)
+        assert result == {
+            "RADIUS Server ClearPass70": {
+                "Host": "192.168.20.70",
+                "Key": "********",
+            }
+        }
+
+    def test_non_transposed_list_passes_through(self):
+        # Regular AOS 8 list of records — every row has rich fields, not
+        # just ``Parameter`` and ``Value``. Don't touch it.
+        body = [
+            {"Name": "ClearPass70", "Profile Status": None, "References": "2"},
+            {"Name": "ClearPass75", "Profile Status": None, "References": "1"},
+        ]
+        assert flatten_param_value_lists(body) == body
+
+    def test_empty_list_passes_through(self):
+        assert flatten_param_value_lists([]) == []
+
+    def test_scalar_passes_through(self):
+        assert flatten_param_value_lists("hello") == "hello"
+        assert flatten_param_value_lists(42) == 42
+        assert flatten_param_value_lists(None) is None
+
+    def test_list_with_mixed_shapes_passes_through(self):
+        # Conservative: even one non-Parameter/Value row preserves the list as-is.
+        body = [
+            {"Parameter": "Host", "Value": "192.168.20.70"},
+            {"some_other": "shape"},
+        ]
+        # Recurses into elements; first row is a dict (not a transposed list),
+        # so it stays a list of dicts.
+        assert flatten_param_value_lists(body) == body
+
+    def test_real_radius_detail_fixture_flattens(self):
+        body = _load("show_aaa_radius_server_detail.json")
+        flat = flatten_param_value_lists(body)
+
+        # Wrapping key preserved; its value is now a dict, not a list
+        assert isinstance(flat["RADIUS Server ClearPass70"], dict)
+        # Semantic field names now visible at the JSON field level
+        assert flat["RADIUS Server ClearPass70"]["Host"] == "192.168.20.70"
+        assert flat["RADIUS Server ClearPass70"]["Key"] == "********"
+        assert flat["RADIUS Server ClearPass70"]["Auth Port"] == "1812"
+        # _meta key (not a transposed list) untouched
+        assert flat["_meta"] == ["Parameter", "Value"]
+
+    def test_idempotent_on_already_flattened_dict(self):
+        body = {"RADIUS Server X": {"Host": "1.2.3.4", "Key": "********"}}
+        assert flatten_param_value_lists(body) == body
+
+
+class TestRunShowAppliesFlatten:
+    """run_show should pipe the response through both strip_meta and the flattener."""
+
+    async def test_run_show_flattens_radius_detail_response(self):
+        body = _load("show_aaa_radius_server_detail.json")
+        response = MagicMock(spec=httpx.Response)
+        response.json.return_value = body
+        response.text = json.dumps(body)
+        client = MagicMock()
+        client.request = AsyncMock(return_value=response)
+
+        result = await run_show(client, "show aaa authentication-server radius ClearPass70")
+
+        # _meta stripped (existing strip_meta behavior)
+        assert "_meta" not in result
+        # Transposed list flattened into a dict
+        assert isinstance(result["RADIUS Server ClearPass70"], dict)
+        assert result["RADIUS Server ClearPass70"]["Host"] == "192.168.20.70"

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -555,6 +555,49 @@ class TestTokenizeResponse:
         assert record["Model"] == "ArubaMM-VA"
         assert record["Location"] == "Building1.floor1"
 
+    def test_aos8_aaa_radius_detail_after_flatten_tokenizes_host(self, tokenizer: Tokenizer) -> None:
+        """End-to-end regression for issue #235.
+
+        AOS 8 ``show aaa authentication-server radius <name>`` returns a
+        transposed key/value table. The ``run_show()`` helper flattens
+        ``[{Parameter: k, Value: v}, ...]`` rows into a regular dict
+        before the tokenizer sees the response. After flattening, the
+        ``Host`` field carries the RADIUS server's IP/FQDN and must be
+        tokenized as HOSTNAME — even though general IPs pass through
+        per the v2.3.1.2 carve-out, AAA infrastructure is auth-fabric-
+        critical (issue #235 carve-out).
+        """
+        # Post-flatten shape, as run_show() returns it
+        flattened = {
+            "RADIUS Server ClearPass70": {
+                "Host": "192.168.20.70",
+                "Key": "********",
+                "Auth Port": "1812",
+                "NAS IP": "N/A",
+            }
+        }
+        result = tokenize_response(flattened, tokenizer)
+        record = result["RADIUS Server ClearPass70"]
+
+        # Host tokenized as HOSTNAME (the issue #235 carve-out)
+        assert record["Host"] != "192.168.20.70"
+        match = TOKEN_RE.fullmatch(record["Host"])
+        assert match is not None
+        assert match.group(1) == "HOSTNAME"
+
+        # ``Key`` is a generic credential-named field and the AOS-masked
+        # placeholder ``********`` looks credential-shaped to the walker —
+        # so it gets tokenized. Round-trip (detokenize) returns the
+        # placeholder unchanged. Tokenizing a placeholder is harmless and
+        # consistent with the walker's "treat anything credential-shaped
+        # as a credential" contract.
+        assert record["Key"] != "********"
+        assert TOKEN_RE.fullmatch(record["Key"]) is not None
+
+        # Non-PII config values stay cleartext.
+        assert record["Auth Port"] == "1812"
+        assert record["NAS IP"] == "N/A"
+
     def test_aos8_mac_address_with_space_normalized(self, tokenizer: Tokenizer) -> None:
         """AOS 8 ``"MAC Address"`` and ``"Wired MAC Address"`` columns
         should reach the MAC canonicalizer the same as ``mac`` /
@@ -772,10 +815,15 @@ class TestRealisticMistFixture:
         # SSID — passes through (broadcast, refined in v2.3.1.1)
         assert result["ssid"] == "Corp-Wifi"
 
-        # IPs — pass through everywhere (refined in v2.3.1.2)
-        assert result["radius_servers"][0]["host"] == "10.50.10.10"
-        assert result["radius_servers"][1]["host"] == "10.50.10.11"
+        # IPs in arbitrary fields — pass through (refined in v2.3.1.2)
         assert "10.50.10.1" in result["description"]  # internal IP in free text
+
+        # ...except `host` in a RADIUS-server context, which IS tokenized
+        # (issue #235 carve-out: AAA infrastructure is auth-fabric-critical).
+        assert TOKEN_RE.fullmatch(result["radius_servers"][0]["host"]).group(1) == "HOSTNAME"
+        assert TOKEN_RE.fullmatch(result["radius_servers"][1]["host"]).group(1) == "HOSTNAME"
+        # Different IPs get different tokens (deterministic per session).
+        assert result["radius_servers"][0]["host"] != result["radius_servers"][1]["host"]
 
         # Hostnames — still tokenized (real customer naming pattern)
         assert result["device_name"] != "AP-Floor3-Conf"
@@ -940,9 +988,11 @@ class TestRealisticCentralFixture:
             secret_token = server["shared-secret"]
             assert TOKEN_RE.fullmatch(secret_token).group(1) == "RADSEC"
 
-        # IPs — pass through everywhere (v2.3.1.2)
-        assert result["radius_servers"][0]["host"] == "10.50.10.10"
-        assert result["radius_servers"][1]["host"] == "10.50.10.11"
+        # `host` in a RADIUS-server context IS tokenized (issue #235 carve-out:
+        # AAA infrastructure is auth-fabric-critical, even though general IPs
+        # pass through per v2.3.1.2).
+        assert TOKEN_RE.fullmatch(result["radius_servers"][0]["host"]).group(1) == "HOSTNAME"
+        assert TOKEN_RE.fullmatch(result["radius_servers"][1]["host"]).group(1) == "HOSTNAME"
 
         # Different secrets get different tokens
         assert result["radius_servers"][0]["shared-secret"] != result["radius_servers"][1]["shared-secret"]

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -17,6 +17,7 @@ from hpe_networking_mcp.redaction.rules import (
     TokenKind,
     classify_field,
     is_known_enum_value,
+    is_masked_placeholder,
     looks_like_credential,
 )
 from hpe_networking_mcp.redaction.token_store import (
@@ -398,6 +399,56 @@ class TestTokenStoreLifecycle:
         assert re.match(rf"\[\[PSK:{UUID_PART}\]\]", token)
 
 
+class TestIsMaskedPlaceholder:
+    """is_masked_placeholder() recognizes source-platform-masked values
+    that must not be tokenized (they would create the illusion of a
+    tokenized real secret while the round-trip restores only the
+    placeholder). See issue #235."""
+
+    def test_eight_asterisks_is_placeholder(self) -> None:
+        assert is_masked_placeholder("********")
+
+    def test_four_asterisks_is_placeholder(self) -> None:
+        assert is_masked_placeholder("****")
+
+    def test_three_asterisks_too_short(self) -> None:
+        # Conservative lower bound — three '*' could be a regex artifact
+        # in a description field, etc. Real AOS 8 placeholder is 8 chars.
+        assert not is_masked_placeholder("***")
+
+    def test_real_credential_with_asterisks_not_placeholder(self) -> None:
+        # An asterisk *inside* a real credential doesn't trigger the
+        # placeholder rule — the rule only matches all-asterisk strings.
+        assert not is_masked_placeholder("Welcome*123!")
+
+    def test_empty_string_not_placeholder(self) -> None:
+        assert not is_masked_placeholder("")
+
+    def test_non_string_not_placeholder(self) -> None:
+        assert not is_masked_placeholder(None)
+        assert not is_masked_placeholder(42)
+
+    def test_classify_field_skips_masked_secret_field(self) -> None:
+        # ``shared_secret`` is in SECRET_FIELD_NAMES — would normally
+        # tokenize unconditionally. Masked placeholder must short-circuit
+        # to SKIP.
+        cls, _ = classify_field("shared_secret", "********")
+        assert cls == FieldClassification.SKIP
+
+    def test_classify_field_skips_masked_generic_credential_field(self) -> None:
+        # ``key`` is in GENERIC_CREDENTIAL_FIELD_NAMES with shape-check.
+        # Even though ``********`` passes looks_like_credential, the
+        # placeholder check fires first.
+        cls, _ = classify_field("key", "********")
+        assert cls == FieldClassification.SKIP
+
+    def test_classify_field_still_tokenizes_real_credential(self) -> None:
+        # Sanity: the placeholder skip must not affect real values.
+        cls, kind = classify_field("shared_secret", "MyRealSecret123!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.RADSEC
+
+
 class TestTokenizer:
     def _make(self, max_entries: int = 100) -> Tokenizer:
         keymap = SessionKeymap()
@@ -585,14 +636,17 @@ class TestTokenizeResponse:
         assert match is not None
         assert match.group(1) == "HOSTNAME"
 
-        # ``Key`` is a generic credential-named field and the AOS-masked
-        # placeholder ``********`` looks credential-shaped to the walker —
-        # so it gets tokenized. Round-trip (detokenize) returns the
-        # placeholder unchanged. Tokenizing a placeholder is harmless and
-        # consistent with the walker's "treat anything credential-shaped
-        # as a credential" contract.
-        assert record["Key"] != "********"
-        assert TOKEN_RE.fullmatch(record["Key"]) is not None
+        # ``Key: "********"`` is a source-platform-masked placeholder.
+        # AOS 8 returns this for any retrieved shared secret — the real
+        # value never leaves the controller. The walker MUST NOT tokenize
+        # it: a tokenized placeholder creates the dangerous illusion that
+        # the AI has a real tokenized secret it can pass to a write tool.
+        # The detokenize round-trip would restore only ``"********"``,
+        # which Central / AOS 10 would accept as a literal RADIUS shared
+        # secret — RADIUS auth then fails silently in production. Skipping
+        # the tokenization makes the AI see ``"********"`` directly and
+        # know it has to ask the operator for the real secret.
+        assert record["Key"] == "********"
 
         # Non-PII config values stay cleartext.
         assert record["Auth Port"] == "1812"


### PR DESCRIPTION
## Summary

AOS 8 \`show <thing> detail\` commands (notably \`show aaa authentication-server radius/tacacs/ldap/internal <name>\`) return content as a **transposed key/value table** — every row is a dict with literal field names \`Parameter\` and \`Value\`. The PII walker classifies by JSON field name, so the *semantic* field name hidden in \`Parameter\` was invisible. RADIUS/TACACS/LDAP server IPs and FQDNs leaked to the AI in cleartext.

Live-verified the transposed shape against an AOS 8.13.1.2 LSR MM before designing the fix:
\`\`\`
'RADIUS Server ClearPass70': [
    {'Parameter': 'Host',      'Value': '192.168.20.70'},
    {'Parameter': 'Key',       'Value': '********'},
    ...
]
\`\`\`

## Fix

- **\`flatten_param_value_lists()\`** added to \`aos8/tools/_helpers.py\`. Conservative recursive detector: only flattens lists where *every* element is a dict containing at minimum \`Parameter\` and \`Value\` keys. Non-matching shapes pass through unchanged. Applied in \`run_show()\` so every AOS 8 show-command response gets it automatically.
- **\`host\` rule** added to \`TOKENIZED_IDENTIFIER_FIELDS\` (HOSTNAME). Carve-out from the v2.3.1.2 "internal IPs not tokenized" decision — AAA infrastructure is auth-fabric-critical per the issue's threat model. After flattening, \`Host\` lowercases to \`host\` via the existing space-→-underscore normalization (v2.4.0.5) and the rule fires.
- **\`is_masked_placeholder()\`** added — see below.

Closes #235.

## Subtlety: masked-placeholder skip

AOS 8 returns shared secrets / passwords as runs of asterisks (\`"********"\`) — the real value never leaves the controller. After flattening, the walker sees \`Key: "********"\` as a \`key\` field with a credential-shaped value, and would tokenize the placeholder as \`[[APITOKEN:uuid]]\`.

That sounds harmless, but it isn't: a tokenized placeholder creates the **dangerous illusion** that the AI has a real tokenized secret it can pass to a write tool. The detokenize round-trip restores \`"********"\` — which Central / AOS 10 would happily accept as a literal RADIUS shared secret, and RADIUS auth would then fail silently the next time a client tries to associate. Better to fail loudly: AI sees \`"********"\` directly and knows it has to ask the operator for the real secret.

Fix: added \`is_masked_placeholder(value)\` (recognizes all-asterisk strings of length 4+) plus a short-circuit at the top of \`classify_field\` that skips tokenization for masked values regardless of which rule path the field name matches.

## Behavior change to flag

The \`host\` rule applies **fleet-wide**, not just to AOS 8. Mist/Central tools that return RADIUS server records with a \`host\` field will now tokenize the IP/FQDN where they previously did not. This is consistent with the issue's stated threat model. Two existing PII tests (Mist + Central RADIUS server fixtures) were updated to reflect the new contract.

## Test plan

- [x] \`uv run ruff check .\` (in Docker, dev compose)
- [x] \`uv run ruff format --check .\`
- [x] \`uv run mypy src/ --ignore-missing-imports\`
- [x] \`uv run pytest tests/ -q\` — 998 passed (was 979 at start of branch; +19 new tests)
- [ ] Operator runs \`aos8_show_command(command=\"show aaa authentication-server radius <name>\")\` against the lab MM and confirms (a) the response is a flattened dict (no \`Parameter\`/\`Value\` rows), (b) the \`Host\` value is rendered as \`[[HOSTNAME:uuid]]\`, (c) other config values stay cleartext, (d) the masked \`Key\` value stays as \`\"********\"\` (cleartext, not tokenized).