### PR TITLE
v3.0.1.2: central:role translation + engine empty-dict drop + role transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.2] - 2026-05-07
+
+**Patch release — third translation (`central:role`) + engine empty-dict drop + role-specific transforms.**
+
+Adds the third shipped translation, `central:role`, covering AOS 8 user-role REST object → Central role profile. Live-verified the source shape across 37 user-customized roles in the operator's tenant (top-level fields: `rname`, `role__acl[]`, `role__cp.cp_profile_name`, `role__cp_acc._present`, `role__max_sess.max_sess`, `role__openflow._present`, `role__pool_l2tp.poolname`, `role__reauth.reauthperiod`, `role__vlan.vlanstr`). Twelve additional role sub-properties are mapped from the AOS 8 → CNX LLD reference and marked LLD-INFERRED in their `key_mappings.notes` (none were configured in the sample tenant). Bandwidth contracts (5 sub-shapes) are explicitly deferred to a v2 in `unmapped_fields`.
+
+### Changes
+
+1. **New translation `central:role`.** Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Body has the role at the root plus three nested groups: `session-parameters`, `miscellaneous-parameters`, `classification-parameters`. AOS 8's combined VLAN field (`role__vlan.vlanstr` carries either ID or name) is disambiguated into Central's two distinct fields (`access-vlan-id` int / `access-vlan-name` string) plus a `vlan-type` discriminator via three companion `key_mappings` that all source from the same path. ACL filtering: the `aos8_role_acl_to_central_policies` transform drops AOS 8 system / default / readonly entries so only operator-customized ACLs land in the Central role's `policies[]` array.
+
+2. **Engine: `_drop_none_keys` now drops empty nested dicts.** When every member of a nested body group (e.g. `session-parameters.pool`) is an optional field whose source value was missing, the post-render pass now drops the now-empty parent key entirely. Top-level empty dicts pass through unchanged. Critical for the role translation since most roles configure only a small subset of the ~20 mappable fields.
+
+3. **Five new transforms in `translations/transforms.py`:**
+   - `aos8_role_acl_to_central_policies` — filters system / default / readonly entries; renames `pname` → `name`; returns `None` for empty / all-filtered input so the engine drops the body key.
+   - `vlanstr_to_id_if_numeric` — int VLAN ID when source is numeric string, else `None`.
+   - `vlanstr_to_name_if_nonnumeric` — string VLAN name when source is non-numeric, else `None`.
+   - `vlanstr_to_vlan_type` — `"VLAN_ID"` / `"VLAN_NAME"` discriminator paired with the two above.
+   - `aos8_present_flag_to_bool` — Python bool wrapper for AOS 8 `{_present: ...}` style flag sub-objects.
+
+### Files
+
+- **New: `src/hpe_networking_mcp/translations/targets/central/role_v1.json`** — third shipped translation
+- **`src/hpe_networking_mcp/translations/transforms.py`** — five new transforms + registry entries
+- **`src/hpe_networking_mcp/translations/engine.py`** — `_drop_none_keys` enhanced to drop empty nested dicts
+- **New: `tests/unit/test_translations_transforms.py`** — 25 tests covering the role-specific transforms + the registry
+- **`tests/unit/test_translations_engine.py`** — 12 new role tests (bare record, ACL filtering, VLAN disambiguation, captive portal, pool, full rich record, empty-dict drop in nested groups)
+- **`tests/unit/test_translations_loader.py`** — 1 new role schema-validation test
+- **`pyproject.toml`** — bump 3.0.1.1 → 3.0.1.2
+
+### Notes
+
+- 1086 tests pass (was 1037; +49 from new transforms + role tests).
+- Consumer responsibility documented: pre-filter `_flags.default=true` sub-objects from source records before passing to `emit_calls`. Otherwise every role POST will explicitly carry AOS 8's system defaults (e.g. `max-sessions: 65535`, `check-for-accounting: true`) which may overwrite Central's own defaults at the role profile.
+- LLD-INFERRED fields (12) are marked clearly in `key_mappings.notes` — verify the AOS 8 source-side field name against a configured tenant before treating as authoritative for that field. The `optional: true` flag means an unconfigured field simply drops, but a wrong source-side name would silently lose data.
+- Bandwidth contracts deferred: the AOS 8 → CNX LLD describes 5 distinct CNX sub-shapes (basic, app, appcategory, web-cc-category, web-cc-reputation) plus exclude variants; without configured live samples the source-side AOS 8 shapes are too speculative to author. Captured in `unmapped_fields` with a `todo` to re-author once samples exist.
+
 ## [3.0.1.1] - 2026-05-07
 
 **Patch release — second translation (`central:vlan_id`) + engine optional-field support + iteration rename.**

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (1037+ unit tests)
+├── tests/                       # Unit and integration tests (1086+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.1"
+version = "3.0.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/translations/engine.py
+++ b/src/hpe_networking_mcp/translations/engine.py
@@ -337,15 +337,34 @@ def _render_body(
 
 
 def _drop_none_keys(value: Any) -> Any:
-    """Recursively drop dict keys whose value is ``None``.
+    """Recursively drop dict keys whose value is ``None`` or an empty dict.
 
-    Used for optional body fields: when a key_mapping is ``optional=True`` and
-    the source record lacks that field, the engine substitutes ``None`` and
-    this pass strips the key from the wire payload entirely (rather than
-    sending ``"description": null``).
+    Two-pass behavior, applied during dict descent:
+
+    1. Drop keys whose direct value is ``None`` (optional fields whose source
+       was missing).
+    2. After cleaning a nested dict value, drop the parent key if the cleaned
+       dict is now empty — keeps the wire payload free of orphaned ``{}``
+       sub-objects when every member of a nested group (e.g. ``"pool": {...}``)
+       came from optional fields that were all missing.
+
+    Empty *top-level* dicts pass through unchanged — the caller can decide
+    whether an empty body is meaningful for a given target API.
+
+    Lists are traversed but list elements are kept even when they cleaned
+    down to an empty dict; translation authors needing list filtering should
+    do it inside a transform.
     """
     if isinstance(value, dict):
-        return {k: _drop_none_keys(v) for k, v in value.items() if v is not None}
+        result: dict[str, Any] = {}
+        for k, v in value.items():
+            if v is None:
+                continue
+            cleaned = _drop_none_keys(v)
+            if isinstance(cleaned, dict) and not cleaned:
+                continue
+            result[k] = cleaned
+        return result
     if isinstance(value, list):
         return [_drop_none_keys(item) for item in value]
     return value

--- a/src/hpe_networking_mcp/translations/targets/central/role_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/role_v1.json
@@ -1,0 +1,304 @@
+{
+  "version": 1,
+  "target_platform": "central",
+  "target_id": "role",
+  "target_emits": [
+    {
+      "step":     1,
+      "name":     "create_role_shared",
+      "purpose":  "Create the user-role profile in the Library. Single POST carries the full role body — name + policies + VLAN binding + nested session-parameters / miscellaneous-parameters / classification-parameters groups. Optional sub-properties drop out when the source record lacks them; empty nested groups also drop entirely (e.g. 'pool: {}' won't appear when no pool is configured).",
+      "endpoint": "/network-config/v1alpha1/roles/{name}",
+      "method":   "POST",
+      "query_params": {},
+      "body": {
+        "name":                    "{name}",
+        "policies":                "{policies}",
+        "access-vlan-id":          "{access_vlan_id}",
+        "access-vlan-name":        "{access_vlan_name}",
+        "vlan-type":               "{vlan_type}",
+        "via-connection-profile":  "{via_connection_profile}",
+        "session-parameters": {
+          "captive-portal":                    "{captive_portal}",
+          "check-for-accounting":              "{check_for_accounting}",
+          "max-sessions":                      "{max_sessions}",
+          "reauthentication-interval":         "{reauthentication_interval}",
+          "reauthentication-interval-seconds": "{reauthentication_interval_seconds}",
+          "pool": {
+            "l2tp":     "{pool_l2tp}",
+            "pptp":     "{pool_pptp}",
+            "via-dhcp": "{pool_via_dhcp}"
+          }
+        },
+        "miscellaneous-parameters": {
+          "enforce-dhcp":      "{enforce_dhcp}",
+          "robust-age-out":    "{robust_age_out}",
+          "registration-role": "{registration_role}",
+          "openflow-enable":   "{openflow_enable}"
+        },
+        "classification-parameters": {
+          "ip-classification":    "{ip_classification}",
+          "dpi-classification":   "{dpi_classification}",
+          "dpi-youtube-education":"{dpi_youtubeedu}",
+          "web-cc":               "{web_cc}"
+        }
+      },
+      "iteration": "once",
+      "iteration_notes": "Optional fields drop out of the body when the source record lacks them. Empty nested groups (session-parameters / miscellaneous-parameters / classification-parameters) drop entirely if every member is missing.",
+      "depends_on": []
+    },
+    {
+      "step":     2,
+      "name":     "assign_role",
+      "purpose":  "Assign the role profile to the target scope. Multi-device-function array packed into a single POST.",
+      "endpoint": "/network-config/v1alpha1/config-assignments",
+      "method":   "POST",
+      "query_params": {},
+      "body_template": {
+        "config-assignment": [
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='role', profile-instance='{name}' }}"
+        ]
+      },
+      "iteration": "once",
+      "iteration_notes": "One POST; all device-functions share the array.",
+      "depends_on": [1]
+    }
+  ],
+  "target_meta": {
+    "device_functions": ["MOBILITY_GW", "CAMPUS_AP"],
+    "device_function_filtering_rule": "Step 1 is SHARED with no device-function param. Step 2 packs all device-functions into a single config-assignments array. Operator can override device_functions in runtime_values. Many role fields are GW-only per the AOS 8 reference (option-82, bw-contract, pool, dpi, web-cc, enforce-dhcp, etc.); for AP-only target scopes the consumer should drop these from the source record before passing to emit_calls."
+  },
+  "target_scope_id_resolution": {
+    "rule":   "Central scope_id is supplied by the consuming skill at runtime, derived from the AOS 8 role record's scope path.",
+    "input":  "Source binding scope (string path / identifier); skill-specific",
+    "output": "Central scope_id (string), supplied via runtime_values['central_scope_id']"
+  },
+  "required_runtime_values": ["central_scope_id"],
+  "derived": {},
+  "dependencies": [
+    {
+      "depends_on":  "central:acl_sess (one or more entries in policies[] are session ACL names that must exist before the role POST)",
+      "depended_by": [
+        {
+          "target_id": "ssid_prof / virtual_ap",
+          "field":     "aaa.role",
+          "relation":  "role-by-name reference (string)",
+          "notes":     "Wireless WLAN translations reference roles for default-role / aaa-server roles. Sequence: roles before WLANs."
+        }
+      ]
+    }
+  ],
+  "tokenize_kind_per_field": {},
+  "sources": {
+    "aos8": {
+      "kind":         "rest",
+      "mapping_kind": "simple",
+      "objects": [
+        {
+          "object":      "role",
+          "object_path": "/v1/configuration/object/role",
+          "role":        "user_role_profile",
+          "docs": {
+            "get":  "https://developer.arubanetworks.com/aos8/reference/get_object-role",
+            "post": "https://developer.arubanetworks.com/aos8/reference/post_object-role"
+          },
+          "live_shape_example": "[{\"rname\": \"camera_role_ubt\", \"role__acl\": [{\"acl_type\": \"session\", \"pname\": \"camera_role_ubt\"}], \"role__vlan\": {\"vlanstr\": \"internal\"}, \"role__cp_acc\": {\"_present\": true, \"_flags\": {\"default\": true}}, \"role__openflow\": {\"_present\": true, \"_flags\": {\"default\": true}}, \"role__reauth\": {\"_flags\": {\"default\": true}, \"reauthperiod\": 0}, \"role__max_sess\": {\"_flags\": {\"default\": true}, \"max_sess\": 65535}}, {\"rname\": \"onguard-role\", \"role__cp\": {\"cp_profile_name\": \"onguard-captive-portal\"}, \"role__pool_l2tp\": {\"poolname\": \"via-pool\"}}]",
+          "notes": "Live-verified across 37 user-customized roles in the operator's tenant. Top-level fields seen: rname, role__acl[], role__cp, role__cp_acc, role__max_sess, role__openflow, role__pool_l2tp, role__reauth, role__vlan. Sub-objects use the AOS 8 double-underscore convention. ACL entries carry _flags metadata distinguishing user-customized ACLs from system / inherited / default / readonly entries — the aos8_role_acl_to_central_policies transform filters those system entries out. Many AOS 8 role sub-properties (bw-contract, via, dpi, web-cc, enforce-dhcp, etc.) are not represented in this tenant's data; their source-side field names are inferred from the AOS 8 -> CNX LLD reference (CLI form) plus the verified naming convention. Consumer must filter _flags.default=true sub-objects before passing to emit_calls (system defaults do not need to migrate; sending them would overwrite Central's own defaults at the role profile)."
+        }
+      ],
+      "key_mappings": {
+        "name": {
+          "from":      "rname",
+          "to":        "role name (Central path param + body 'name', profile-instance on step 2)",
+          "transform": "direct_str",
+          "notes":     "Required. AOS 8 'rname' → Central role 'name'."
+        },
+        "policies": {
+          "from":      "role__acl",
+          "to":        "Central role body 'policies' (array of {name})",
+          "transform": "aos8_role_acl_to_central_policies",
+          "optional":  true,
+          "notes":     "Filters _flags.system / _flags.default / _flags.readonly entries (system ACLs that operators didn't add) and renames 'pname' to 'name'. eth/mac ACL types are kept alongside session — Central's role.policies array doesn't carry the type discriminator; the actual ACL profiles themselves live in sibling translations (central:acl_sess, central:acl_eth, central:acl_mac, future v2)."
+        },
+        "access_vlan_id": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'access-vlan-id' (integer; only when source value is numeric)",
+          "transform": "vlanstr_to_id_if_numeric",
+          "optional":  true,
+          "notes":     "AOS 8 stores both VLAN IDs and VLAN names as a single 'vlanstr' string. This mapping returns int-or-None; the access-vlan-name and vlan-type mappings handle the disambiguation. Only one of (access-vlan-id, access-vlan-name) ends up in the wire payload because the other resolves to None and gets dropped."
+        },
+        "access_vlan_name": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'access-vlan-name' (string; only when source value is non-numeric)",
+          "transform": "vlanstr_to_name_if_nonnumeric",
+          "optional":  true,
+          "notes":     "Companion to access_vlan_id. Live example: vlanstr='internal' → access-vlan-name='internal' + vlan-type='VLAN_NAME'."
+        },
+        "vlan_type": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'vlan-type' (enum: 'VLAN_ID' or 'VLAN_NAME')",
+          "transform": "vlanstr_to_vlan_type",
+          "optional":  true,
+          "notes":     "Discriminator that pairs with whichever access-vlan-* field was emitted."
+        },
+        "via_connection_profile": {
+          "from":      "role__via.profile_name",
+          "to":        "Central role body 'via-connection-profile' (string, GW-only)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. The AOS 8 'via $profile' CLI maps to a sub-object on the role; field name is the projection from the convention (role__<feature>.<field>). Verify against a configured tenant before treating as authoritative."
+        },
+        "captive_portal": {
+          "from":      "role__cp.cp_profile_name",
+          "to":        "Central role body 'session-parameters.captive-portal' (string)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "Live-verified: 'guest-logon' has role__cp.cp_profile_name='default'. References a captive-portal profile that must exist in Central before this role is created."
+        },
+        "check_for_accounting": {
+          "from":      "role__cp_acc._present",
+          "to":        "Central role body 'session-parameters.check-for-accounting' (bool)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "Live-verified shape: role__cp_acc = {_present: true, _flags: {default: true}}. Consumer should filter _flags.default=true sub-objects before passing to emit_calls; if not filtered, every role gets check-for-accounting=true on the wire (matching AOS 8's default but possibly overwriting Central's own default)."
+        },
+        "max_sessions": {
+          "from":      "role__max_sess.max_sess",
+          "to":        "Central role body 'session-parameters.max-sessions' (int, range 1-65535, default 64000)",
+          "transform": "direct_int",
+          "optional":  true,
+          "notes":     "Live-verified: every role has max_sess=65535 with _flags.default=true. Consumer should filter."
+        },
+        "reauthentication_interval": {
+          "from":      "role__reauth.reauthperiod",
+          "to":        "Central role body 'session-parameters.reauthentication-interval' (int, minutes; range 0-4096; mutually exclusive with reauthentication-interval-seconds)",
+          "transform": "direct_int",
+          "optional":  true,
+          "notes":     "Live-verified: every role has reauthperiod=0 with _flags.default=true. AOS 8 stores in minutes. Consumer should filter."
+        },
+        "reauthentication_interval_seconds": {
+          "from":      "role__reauth_seconds.reauth_seconds",
+          "to":        "Central role body 'session-parameters.reauthentication-interval-seconds' (int, seconds; range 0-245760; mutually exclusive with reauthentication-interval)",
+          "transform": "direct_int",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. AOS 8 has both 'reauthentication-interval <minutes>' and '... <seconds> seconds' CLI forms; the seconds variant likely surfaces in a separate sub-object (this tenant uses the minutes variant only). Verify before treating as authoritative."
+        },
+        "pool_l2tp": {
+          "from":      "role__pool_l2tp.poolname",
+          "to":        "Central role body 'session-parameters.pool.l2tp' (string)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "Live-verified: faculty-* roles have role__pool_l2tp.poolname='via-pool'. L2TP and DHCP pools are mutually exclusive."
+        },
+        "pool_pptp": {
+          "from":      "role__pool_pptp.poolname",
+          "to":        "Central role body 'session-parameters.pool.pptp' (string)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name (mirrors role__pool_l2tp shape). Verify before treating as authoritative."
+        },
+        "pool_via_dhcp": {
+          "from":      "role__pool_via_dhcp.dhcp_server",
+          "to":        "Central role body 'session-parameters.pool.via-dhcp' (string)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. AOS 8 CLI 'pool via-dhcp <ip> [<subnet> <netmask>]' likely surfaces in a sub-object with the proxy server address. Verify before treating as authoritative."
+        },
+        "enforce_dhcp": {
+          "from":      "role__enforce_dhcp._present",
+          "to":        "Central role body 'miscellaneous-parameters.enforce-dhcp' (bool, GW-only)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name (mirrors role__cp_acc / role__openflow shape). Verify before treating as authoritative."
+        },
+        "robust_age_out": {
+          "from":      "role__robust_age_out._present",
+          "to":        "Central role body 'miscellaneous-parameters.robust-age-out' (bool, GW-only)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. Verify before treating as authoritative."
+        },
+        "registration_role": {
+          "from":      "role__registration_role._present",
+          "to":        "Central role body 'miscellaneous-parameters.registration-role' (bool, GW-only)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. Verify before treating as authoritative."
+        },
+        "openflow_enable": {
+          "from":      "role__openflow._present",
+          "to":        "Central role body 'miscellaneous-parameters.openflow-enable' (bool, GW-only)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "Live-verified: every role has role__openflow={_present: true, _flags: {default: true}}. Consumer should filter."
+        },
+        "ip_classification": {
+          "from":      "role__ip_classification._present",
+          "to":        "Central role body 'classification-parameters.ip-classification' (bool, GW-only; true means DISABLED per the LLD inverse-flag note)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. Caveat: AOS 8 CLI 'ip-classification disable' inverts semantics — _present=true on the source means the operator DISABLED ip-classification. Central's flag matches that inverted semantic per the LLD ('true means disabled'). Pass through unchanged. Verify the source field name before treating as authoritative."
+        },
+        "dpi_classification": {
+          "from":      "role__dpi_classification._present",
+          "to":        "Central role body 'classification-parameters.dpi-classification' (bool, GW-only; true means DISABLED)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED. Same inverted-flag semantic as ip_classification (CLI 'dpi disable')."
+        },
+        "dpi_youtubeedu": {
+          "from":      "role__dpi_youtubeedu._present",
+          "to":        "Central role body 'classification-parameters.dpi-youtube-education' (bool, GW-only)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED source field name. Standard (non-inverted) flag. Verify."
+        },
+        "web_cc": {
+          "from":      "role__web_cc._present",
+          "to":        "Central role body 'classification-parameters.web-cc' (bool, GW-only; true means DISABLED)",
+          "transform": "aos8_present_flag_to_bool",
+          "optional":  true,
+          "notes":     "LLD-INFERRED. Same inverted-flag semantic as ip_classification (CLI 'web-cc disable')."
+        }
+      },
+      "unmapped_fields": [
+        {
+          "from":            "role__bw_contract (and per-app / per-appcategory / per-web-cc-category / per-web-cc-reputation / exclude variants)",
+          "reason":          "AAA bandwidth contracts surface through 5 distinct Central CNX schemas (ArubaAaaBandwidthContract_AaaBwc / AppBasedAaaBwc / AppCatBasedAaaBwc / WebCatBasedAaaBwc / WebRepBasedAaaBwc / ExcludeAppBwc). The AOS 8 source-side shape for each is unknown without configured live samples — this tenant has no bw-contract roles. Deferred to a v2 of this translation once we have verified samples; until then a role with bw-contract configured will silently drop the bw-contract fields when migrated.",
+          "severity_rule":   "always_operator_map",
+          "todo":            "Capture configured AOS 8 role with bw-contract and re-author key_mappings + body for each of the 5 sub-shapes."
+        },
+        {
+          "from":            "role__dialer",
+          "reason":          "VPN dialer configuration. Per the AOS 8 -> CNX LLD reference, no direct CNX RESTful API mapping found in the role schema. Skipping is safe.",
+          "severity_rule":   "non_empty_regression"
+        },
+        {
+          "from":            "role__qos_profile",
+          "reason":          "QoS profile applied to the role. CNX qos-parameters group is SW_PVOS only (not GW/AP per the LLD). Skipping is the right behavior for GW/AP migration.",
+          "severity_rule":   "non_empty_regression"
+        },
+        {
+          "from":            "role__sso, role__stateful_kerberos, role__stateful_ntlm, role__voip_profile, role__wispr",
+          "reason":          "Per the AOS 8 -> CNX LLD reference, no CNX RESTful API mapping found in the role schema. These features are not represented on the Central side.",
+          "severity_rule":   "non_empty_regression"
+        }
+      ],
+      "ignored_variants": [
+        {
+          "form":   "role with _flags.default=true at the top level",
+          "reason": "AOS 8 system / built-in roles (logon, guest, ap-role, etc.) appear with _flags.default=true on the role record itself. Migrating these would create user-role profiles in Central that duplicate Central's own built-ins. Consumer must filter top-level _flags.default=true roles before passing to emit_calls."
+        }
+      ]
+    }
+  },
+  "draft_notes": [
+    "v1 translation. Two-step Central CNX flow (role SHARED create + multi-DF config-assignments), structurally similar to central:vlan_id but with a much richer body — roles have ~20 mappable sub-properties spread across the root object plus three nested groups (session-parameters, miscellaneous-parameters, classification-parameters).",
+    "Live-verified source fields (9): rname, role__acl[], role__cp.cp_profile_name, role__cp_acc._present, role__max_sess.max_sess, role__openflow._present, role__pool_l2tp.poolname, role__reauth.reauthperiod, role__vlan.vlanstr. Sample taken across 37 user-customized roles in the operator's tenant.",
+    "LLD-INFERRED source fields (12): via, reauthentication_interval_seconds, pool_pptp, pool_via_dhcp, enforce_dhcp, robust_age_out, registration_role, ip_classification, dpi_classification, dpi_youtubeedu, web_cc. Each carries a 'LLD-INFERRED' note in its key_mapping. None of these were configured in the sample tenant; source field naming is the projection from AOS 8 conventions and may need adjustment when first encountered.",
+    "DEFERRED to v2: bandwidth contracts (5 sub-shapes: aaa, app, appcategory, web-cc-category, web-cc-reputation) and exclude variants. Captured in unmapped_fields. Need verified samples before authoring.",
+    "Consumer responsibility: pre-filter source records to drop _flags.default=true sub-objects before passing to emit_calls — otherwise every role POST will explicitly set system-default values that might overwrite Central's own defaults. Same for top-level _flags.default=true roles (system / built-in roles).",
+    "VLAN binding disambiguation: AOS 8 stores both ID and name in a single role__vlan.vlanstr string. The translation has three companion key_mappings (access_vlan_id / access_vlan_name / vlan_type) all sourcing from the same path with disambiguating transforms — only one access-vlan-* field reaches the wire payload.",
+    "Idempotency: if a role profile with the same name already exists, the SHARED POST returns HTTP 409. Consumer must handle 409 idempotently.",
+    "Role policies reference ACL session profile names that must exist in Central before the role POST. Sequence: central:acl_sess (and central:acl_eth / central:acl_mac when those translations exist) first, then central:role, then any WLAN translation that references the role."
+  ]
+}

--- a/src/hpe_networking_mcp/translations/transforms.py
+++ b/src/hpe_networking_mcp/translations/transforms.py
@@ -11,6 +11,7 @@ Transforms must stay pure (no I/O) so they can be unit-tested in isolation.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -112,6 +113,109 @@ def expand_vlan_id_csv(value: Any) -> list[int]:
     return out
 
 
+_VLAN_NUMERIC_RE = re.compile(r"^\d+$")
+
+
+def aos8_role_acl_to_central_policies(value: Any) -> list[dict[str, str]] | None:
+    """Convert AOS 8 ``role__acl`` array to Central role ``policies`` array.
+
+    Source shape (per live AOS 8 capture)::
+
+        [
+          {"acl_type": "session", "pname": "global-sacl",
+           "_flags": {"default": true, "readonly": true, "system": true}},
+          {"acl_type": "session", "pname": "camera_role_ubt"}  # user-customized
+        ]
+
+    Target shape (Central role schema, ``policies[]``)::
+
+        [{"name": "camera_role_ubt"}]
+
+    Filtering: drop entries flagged ``system``, ``default``, or ``readonly`` —
+    those are AOS 8 defaults the operator did not customize, and migrating
+    them would overwrite Central's own defaults at the role profile.
+
+    Returns ``None`` for empty input (so the engine drops the body key); a
+    non-empty filtered list otherwise.
+    """
+    if not value:
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        flags = entry.get("_flags", {})
+        if isinstance(flags, dict) and (flags.get("system") or flags.get("default") or flags.get("readonly")):
+            continue
+        pname = entry.get("pname")
+        if pname:
+            out.append({"name": str(pname)})
+    return out if out else None
+
+
+def vlanstr_to_id_if_numeric(value: Any) -> int | None:
+    """Return int VLAN ID if ``value`` is a numeric string, else ``None``.
+
+    AOS 8 stores both VLAN IDs and VLAN names as a single string in
+    ``role__vlan.vlanstr``. Central splits these into ``access-vlan-id``
+    (int) and ``access-vlan-name`` (string) with a ``vlan-type``
+    discriminator. This transform extracts the ID variant; pair with
+    ``vlanstr_to_name_if_nonnumeric`` and ``vlanstr_to_vlan_type``.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if _VLAN_NUMERIC_RE.fullmatch(s):
+        return int(s)
+    return None
+
+
+def vlanstr_to_name_if_nonnumeric(value: Any) -> str | None:
+    """Return string VLAN name if ``value`` is a non-numeric string, else ``None``."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    if _VLAN_NUMERIC_RE.fullmatch(s) or not s:
+        return None
+    return s
+
+
+def vlanstr_to_vlan_type(value: Any) -> str | None:
+    """Return ``"VLAN_ID"`` or ``"VLAN_NAME"`` based on whether ``value`` is numeric.
+
+    Central's role schema uses ``vlan-type`` as a discriminator alongside
+    ``access-vlan-id`` / ``access-vlan-name``. This transform sources from
+    the same AOS 8 ``role__vlan.vlanstr`` field as the two ID/name transforms.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    return "VLAN_ID" if _VLAN_NUMERIC_RE.fullmatch(s) else "VLAN_NAME"
+
+
+def aos8_present_flag_to_bool(value: Any) -> bool | None:
+    """Map AOS 8 ``{_present: true}`` style sub-objects to a Python bool.
+
+    AOS 8 surfaces several boolean role sub-properties (e.g. ``role__cp_acc``,
+    ``role__openflow``, ``role__enforce_dhcp``) as small objects with a
+    ``_present`` discriminator. The engine's ``_path_lookup`` reaches the
+    inner ``_present`` value directly, so this transform is mostly a thin
+    wrapper that tolerates both bool inputs and missing values.
+
+    Returns ``None`` for missing input so the engine's optional-field path
+    drops the corresponding body key; otherwise returns the boolean.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "yes", "1", "enabled")
+    return bool(value)
+
+
 _REGISTRY: dict[str, TransformFn] = {
     "direct": direct,
     "direct_str": direct_str,
@@ -119,4 +223,9 @@ _REGISTRY: dict[str, TransformFn] = {
     "flag_to_bool": flag_to_bool,
     "split_csv_to_string_array": split_csv_to_string_array,
     "expand_vlan_id_csv": expand_vlan_id_csv,
+    "aos8_role_acl_to_central_policies": aos8_role_acl_to_central_policies,
+    "vlanstr_to_id_if_numeric": vlanstr_to_id_if_numeric,
+    "vlanstr_to_name_if_nonnumeric": vlanstr_to_name_if_nonnumeric,
+    "vlanstr_to_vlan_type": vlanstr_to_vlan_type,
+    "aos8_present_flag_to_bool": aos8_present_flag_to_bool,
 }

--- a/tests/unit/test_translations_engine.py
+++ b/tests/unit/test_translations_engine.py
@@ -31,6 +31,11 @@ def vlan_id(translations: dict):
     return translations["central:vlan_id"]
 
 
+@pytest.fixture
+def role(translations: dict):
+    return translations["central:role"]
+
+
 def _runtime(scope_id: str = "SCOPE", device_functions: list[str] | None = None) -> dict:
     """Helper: build Central-shaped runtime_values for the named-VLAN translation."""
     rv: dict = {"central_scope_id": scope_id}
@@ -323,3 +328,183 @@ def test_vlan_id_missing_required_id_raises(vlan_id) -> None:
     """Without 'id' the engine can't build the path — surface clear error."""
     with pytest.raises(EngineError, match="vlan_id"):
         emit_calls(vlan_id, {}, "aos8", runtime_values=_runtime())
+
+
+# --------------------------------------------------------------------------- #
+# central:role — bare and rich AOS 8 role records
+# --------------------------------------------------------------------------- #
+
+
+def test_role_minimum_record_emits_two_calls(role) -> None:
+    """Source with just rname: step 1 body has only 'name'; nested groups drop entirely."""
+    source = {"rname": "minimal-role"}
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime("SCOPE-A"))
+    assert len(calls) == 2
+    assert [c.step for c in calls] == [1, 2]
+
+    step1 = calls[0]
+    assert step1.method == "POST"
+    assert step1.endpoint == "/network-config/v1alpha1/roles/minimal-role"
+    # No optional fields → only required 'name' survives; all nested groups drop
+    assert step1.body == {"name": "minimal-role"}
+
+
+def test_role_with_user_acls_only_filters_system_defaults(role) -> None:
+    """Mix of system + user ACLs: only the user-customized ones land in policies[]."""
+    source = {
+        "rname": "guest-postauth-role",
+        "role__acl": [
+            {
+                "acl_type": "session",
+                "pname": "global-sacl",
+                "_flags": {"system": True, "readonly": True, "default": True},
+            },
+            {"acl_type": "session", "pname": "ra-guard"},
+            {"acl_type": "session", "pname": "guest-postauth"},
+        ],
+    }
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime())
+    step1 = calls[0]
+    assert step1.body == {
+        "name": "guest-postauth-role",
+        "policies": [{"name": "ra-guard"}, {"name": "guest-postauth"}],
+    }
+
+
+def test_role_with_named_vlan_emits_access_vlan_name_and_type(role) -> None:
+    """vlanstr='internal' → access-vlan-name + vlan-type=VLAN_NAME; access-vlan-id absent."""
+    source = {
+        "rname": "camera_role_ubt",
+        "role__vlan": {"vlanstr": "internal"},
+    }
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime())
+    body = calls[0].body or {}
+    assert body == {
+        "name": "camera_role_ubt",
+        "access-vlan-name": "internal",
+        "vlan-type": "VLAN_NAME",
+    }
+
+
+def test_role_with_numeric_vlan_emits_access_vlan_id_and_type(role) -> None:
+    """vlanstr='100' → access-vlan-id (int) + vlan-type=VLAN_ID; access-vlan-name absent."""
+    source = {
+        "rname": "data-role",
+        "role__vlan": {"vlanstr": "100"},
+    }
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime())
+    body = calls[0].body or {}
+    assert body == {
+        "name": "data-role",
+        "access-vlan-id": 100,
+        "vlan-type": "VLAN_ID",
+    }
+
+
+def test_role_with_captive_portal_lands_in_session_parameters(role) -> None:
+    source = {
+        "rname": "onguard-role",
+        "role__cp": {"cp_profile_name": "onguard-captive-portal"},
+    }
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime())
+    body = calls[0].body or {}
+    assert body == {
+        "name": "onguard-role",
+        "session-parameters": {"captive-portal": "onguard-captive-portal"},
+    }
+
+
+def test_role_with_pool_l2tp_lands_in_session_parameters_pool(role) -> None:
+    """pool group is nested inside session-parameters; only the configured sub-key appears."""
+    source = {
+        "rname": "faculty-windows",
+        "role__pool_l2tp": {"poolname": "via-pool"},
+    }
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime())
+    body = calls[0].body or {}
+    assert body == {
+        "name": "faculty-windows",
+        "session-parameters": {"pool": {"l2tp": "via-pool"}},
+    }
+
+
+def test_role_step2_assigns_role_profile_to_all_device_functions(role) -> None:
+    source = {"rname": "demo"}
+    calls = emit_calls(role, source, "aos8", runtime_values=_runtime("SCOPE-A"))
+    step2 = calls[1]
+    assert step2.endpoint == "/network-config/v1alpha1/config-assignments"
+    items = (step2.body or {})["config-assignment"]
+    assert len(items) == 2
+    assert {item["device-function"] for item in items} == {"MOBILITY_GW", "CAMPUS_AP"}
+    assert all(item["profile-type"] == "role" for item in items)
+    assert all(item["profile-instance"] == "demo" for item in items)
+    assert all(item["scope-id"] == "SCOPE-A" for item in items)
+
+
+def test_role_full_rich_record_renders_all_three_nested_groups(role) -> None:
+    """Source with fields in every group: session, miscellaneous, classification all present."""
+    source = {
+        "rname": "rich-role",
+        "role__acl": [{"acl_type": "session", "pname": "allowall"}],
+        "role__vlan": {"vlanstr": "200"},
+        "role__cp": {"cp_profile_name": "guest-cp"},
+        "role__cp_acc": {"_present": True},
+        "role__max_sess": {"max_sess": 1024},
+        "role__reauth": {"reauthperiod": 30},
+        "role__pool_l2tp": {"poolname": "vpn-pool"},
+        "role__openflow": {"_present": True},
+        "role__enforce_dhcp": {"_present": True},
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_runtime())[0].body or {}
+    assert body == {
+        "name": "rich-role",
+        "policies": [{"name": "allowall"}],
+        "access-vlan-id": 200,
+        "vlan-type": "VLAN_ID",
+        "session-parameters": {
+            "captive-portal": "guest-cp",
+            "check-for-accounting": True,
+            "max-sessions": 1024,
+            "reauthentication-interval": 30,
+            "pool": {"l2tp": "vpn-pool"},
+        },
+        "miscellaneous-parameters": {
+            "openflow-enable": True,
+            "enforce-dhcp": True,
+        },
+    }
+
+
+def test_role_missing_required_rname_raises(role) -> None:
+    with pytest.raises(EngineError, match="name"):
+        emit_calls(role, {}, "aos8", runtime_values=_runtime())
+
+
+# --------------------------------------------------------------------------- #
+# _drop_none_keys — empty-dict elimination
+# --------------------------------------------------------------------------- #
+
+
+def test_role_empty_pool_dict_is_dropped_from_session_parameters(role) -> None:
+    """All pool sub-fields missing → pool dict is empty → drops; session-parameters keeps the others."""
+    source = {
+        "rname": "no-pool-role",
+        "role__cp_acc": {"_present": True},
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_runtime())[0].body or {}
+    # session-parameters only carries the one populated field; pool isn't there at all
+    assert body == {
+        "name": "no-pool-role",
+        "session-parameters": {"check-for-accounting": True},
+    }
+    # Explicitly confirm the empty pool dict didn't sneak through
+    assert "pool" not in body["session-parameters"]
+
+
+def test_role_all_nested_groups_drop_when_empty(role) -> None:
+    """Source with only required fields → nested groups all drop entirely."""
+    source = {"rname": "bare", "role__acl": [{"acl_type": "session", "pname": "x"}]}
+    body = emit_calls(role, source, "aos8", runtime_values=_runtime())[0].body or {}
+    assert "session-parameters" not in body
+    assert "miscellaneous-parameters" not in body
+    assert "classification-parameters" not in body

--- a/tests/unit/test_translations_loader.py
+++ b/tests/unit/test_translations_loader.py
@@ -52,6 +52,49 @@ def test_loads_shipped_vlan_id_translation_cleanly() -> None:
     assert src.key_mappings["wired_aaa_profile"].optional is True
 
 
+def test_loads_shipped_role_translation_cleanly() -> None:
+    """The shipped Central role translation has 2 emits + ~20 key_mappings."""
+    translations = load_translations()
+    assert "central:role" in translations
+    r = translations["central:role"]
+    assert r.target_platform == "central"
+    assert r.target_id == "role"
+    assert len(r.target_emits) == 2
+    src = r.sources["aos8"]
+    assert src.mapping_kind == "simple"
+    # Required: name (from rname)
+    assert src.key_mappings["name"].optional is False
+    # All sub-properties optional
+    optional_keys = {
+        "policies",
+        "access_vlan_id",
+        "access_vlan_name",
+        "vlan_type",
+        "via_connection_profile",
+        "captive_portal",
+        "check_for_accounting",
+        "max_sessions",
+        "reauthentication_interval",
+        "reauthentication_interval_seconds",
+        "pool_l2tp",
+        "pool_pptp",
+        "pool_via_dhcp",
+        "enforce_dhcp",
+        "robust_age_out",
+        "registration_role",
+        "openflow_enable",
+        "ip_classification",
+        "dpi_classification",
+        "dpi_youtubeedu",
+        "web_cc",
+    }
+    for key in optional_keys:
+        assert src.key_mappings[key].optional is True, f"{key} should be optional"
+    # Bandwidth contracts deferred to v2 — listed in unmapped_fields
+    bw_unmapped = [u for u in src.unmapped_fields if "bw_contract" in u.from_]
+    assert len(bw_unmapped) == 1
+
+
 def test_loader_key_is_composite_platform_and_id(tmp_path: Path) -> None:
     """Loader key is '<target_platform>:<target_id>'; same target_id under
     different platforms doesn't collide."""

--- a/tests/unit/test_translations_transforms.py
+++ b/tests/unit/test_translations_transforms.py
@@ -1,0 +1,168 @@
+"""Unit tests for translation transforms.
+
+Coverage focuses on the role-specific transforms added in v3.0.1.2 — the
+older shared transforms (direct, direct_int, flag_to_bool,
+split_csv_to_string_array, expand_vlan_id_csv) are exercised end-to-end via
+the engine tests; we don't double up here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.translations.transforms import (
+    aos8_present_flag_to_bool,
+    aos8_role_acl_to_central_policies,
+    get_transform,
+    vlanstr_to_id_if_numeric,
+    vlanstr_to_name_if_nonnumeric,
+    vlanstr_to_vlan_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# aos8_role_acl_to_central_policies
+# --------------------------------------------------------------------------- #
+
+
+class TestAclToPolicies:
+    def test_user_customized_acls_pass_through_with_renamed_field(self) -> None:
+        source = [
+            {"acl_type": "session", "pname": "camera_role_ubt"},
+            {"acl_type": "session", "pname": "allowall"},
+        ]
+        assert aos8_role_acl_to_central_policies(source) == [
+            {"name": "camera_role_ubt"},
+            {"name": "allowall"},
+        ]
+
+    def test_system_default_inherited_readonly_entries_filtered(self) -> None:
+        source = [
+            {
+                "acl_type": "session",
+                "pname": "global-sacl",
+                "_flags": {"system": True, "readonly": True, "default": True},
+            },
+            {"acl_type": "session", "pname": "user-customized"},
+            {"acl_type": "session", "pname": "another-default", "_flags": {"default": True, "inherited": True}},
+        ]
+        assert aos8_role_acl_to_central_policies(source) == [{"name": "user-customized"}]
+
+    def test_eth_and_mac_acl_types_pass_through(self) -> None:
+        source = [
+            {"acl_type": "session", "pname": "session-acl"},
+            {"acl_type": "eth", "pname": "eth-acl"},
+            {"acl_type": "mac", "pname": "mac-acl"},
+        ]
+        assert aos8_role_acl_to_central_policies(source) == [
+            {"name": "session-acl"},
+            {"name": "eth-acl"},
+            {"name": "mac-acl"},
+        ]
+
+    def test_empty_input_returns_none(self) -> None:
+        """None return lets the engine drop the body 'policies' key entirely."""
+        assert aos8_role_acl_to_central_policies(None) is None
+        assert aos8_role_acl_to_central_policies([]) is None
+
+    def test_all_filtered_returns_none(self) -> None:
+        """When every entry is system / default, return None so the key drops."""
+        source = [
+            {"acl_type": "session", "pname": "global-sacl", "_flags": {"system": True}},
+            {"acl_type": "session", "pname": "default-acl", "_flags": {"default": True}},
+        ]
+        assert aos8_role_acl_to_central_policies(source) is None
+
+    def test_entries_without_pname_skipped(self) -> None:
+        source = [{"acl_type": "session"}, {"acl_type": "session", "pname": "real"}]
+        assert aos8_role_acl_to_central_policies(source) == [{"name": "real"}]
+
+
+# --------------------------------------------------------------------------- #
+# VLAN-string disambiguation transforms
+# --------------------------------------------------------------------------- #
+
+
+class TestVlanstrTransforms:
+    @pytest.mark.parametrize(
+        ("source", "id_out", "name_out", "type_out"),
+        [
+            ("100", 100, None, "VLAN_ID"),
+            ("4094", 4094, None, "VLAN_ID"),
+            ("internal", None, "internal", "VLAN_NAME"),
+            ("user-vlan", None, "user-vlan", "VLAN_NAME"),
+            ("0007", 7, None, "VLAN_ID"),  # leading zeros still parse as int
+            (None, None, None, None),
+            ("", None, None, None),
+            ("  ", None, None, None),
+        ],
+    )
+    def test_vlanstr_disambiguation(
+        self, source: str | None, id_out: int | None, name_out: str | None, type_out: str | None
+    ) -> None:
+        assert vlanstr_to_id_if_numeric(source) == id_out
+        assert vlanstr_to_name_if_nonnumeric(source) == name_out
+        assert vlanstr_to_vlan_type(source) == type_out
+
+    def test_whitespace_stripped(self) -> None:
+        assert vlanstr_to_id_if_numeric("  42  ") == 42
+        assert vlanstr_to_name_if_nonnumeric("  guest  ") == "guest"
+        assert vlanstr_to_vlan_type("  100  ") == "VLAN_ID"
+
+
+# --------------------------------------------------------------------------- #
+# aos8_present_flag_to_bool
+# --------------------------------------------------------------------------- #
+
+
+class TestPresentFlagToBool:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("yes", True),
+            ("1", True),
+            ("enabled", True),
+            ("false", False),
+            ("no", False),
+            ("disabled", False),
+            (None, None),  # None propagates so optional drops the key
+        ],
+    )
+    def test_aos8_present_flag_to_bool(self, source, expected) -> None:  # noqa: ANN001
+        assert aos8_present_flag_to_bool(source) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+
+class TestRegistry:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "direct",
+            "direct_str",
+            "direct_int",
+            "flag_to_bool",
+            "split_csv_to_string_array",
+            "expand_vlan_id_csv",
+            "aos8_role_acl_to_central_policies",
+            "vlanstr_to_id_if_numeric",
+            "vlanstr_to_name_if_nonnumeric",
+            "vlanstr_to_vlan_type",
+            "aos8_present_flag_to_bool",
+        ],
+    )
+    def test_all_transforms_resolve(self, name: str) -> None:
+        fn = get_transform(name)
+        assert callable(fn)
+
+    def test_unknown_transform_raises_with_known_list(self) -> None:
+        with pytest.raises(KeyError, match="Unknown transform"):
+            get_transform("does_not_exist")


### PR DESCRIPTION
## Summary
- New translation `central:role` (AOS 8 user-role REST object → Central role profile). Two-step Central CNX flow: role SHARED create + multi-DF config-assignments. Body has the role at root plus three nested groups (`session-parameters`, `miscellaneous-parameters`, `classification-parameters`).
- Engine: `_drop_none_keys` now drops empty nested dicts so `pool: {}` (and similar empty-after-cleanup groups) doesn't appear when every member is an absent optional field. Top-level empty dicts pass through unchanged.
- Five new transforms registered: `aos8_role_acl_to_central_policies`, `vlanstr_to_id_if_numeric`, `vlanstr_to_name_if_nonnumeric`, `vlanstr_to_vlan_type`, `aos8_present_flag_to_bool`.

## What's mapped
**Live-verified source fields (9):** `rname`, `role__acl[]`, `role__cp.cp_profile_name`, `role__cp_acc._present`, `role__max_sess.max_sess`, `role__openflow._present`, `role__pool_l2tp.poolname`, `role__reauth.reauthperiod`, `role__vlan.vlanstr`. Sample taken across 37 user-customized roles in the operator's tenant.

**LLD-INFERRED source fields (12):** `via`, `reauthentication_interval_seconds`, `pool_pptp`, `pool_via_dhcp`, `enforce_dhcp`, `robust_age_out`, `registration_role`, `ip_classification`, `dpi_classification`, `dpi_youtubeedu`, `web_cc`. None configured in the sample tenant; source field naming is the projection from AOS 8 conventions and may need adjustment when first encountered. Each carries a `LLD-INFERRED` note in its key_mapping.

**Deferred to v2 (in unmapped_fields):** all 5 bandwidth-contract sub-shapes (`aaa`, `app`, `appcategory`, `web-cc-category`, `web-cc-reputation`) plus exclude variants. Need verified samples before authoring.

## Notable design choices
- **VLAN binding disambiguation:** AOS 8 stores both ID and name in a single `role__vlan.vlanstr` string. Three companion key_mappings (`access_vlan_id` / `access_vlan_name` / `vlan_type`) all source from the same path; only one access-vlan-* field reaches the wire payload via the engine's optional-field drop behavior.
- **ACL filtering:** `aos8_role_acl_to_central_policies` drops AOS 8 system / default / readonly entries so only operator-customized ACLs land in the Central role's `policies[]`.
- **Consumer responsibility documented:** pre-filter `_flags.default=true` sub-objects from source records before passing to `emit_calls`. Otherwise every role POST will explicitly carry AOS 8's system defaults (e.g. `max-sessions: 65535`) which may overwrite Central's own role-profile defaults.

## Files
- **New:** `src/hpe_networking_mcp/translations/targets/central/role_v1.json`
- **New:** `tests/unit/test_translations_transforms.py` (25 tests)
- `transforms.py` — 5 new transforms + registry entries
- `engine.py` — `_drop_none_keys` enhanced for empty nested dicts
- `tests/unit/test_translations_engine.py` — 12 new role tests
- `tests/unit/test_translations_loader.py` — 1 new role schema test
- `CHANGELOG.md`, `README.md`, `pyproject.toml`

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src/ --ignore-missing-imports` clean
- [x] `uv run pytest tests/ -q` — 1086 passed (was 1037; +49 new tests)
- [x] Source shape live-verified across 37 user-customized roles in tenant
- [ ] LLD-INFERRED fields need verification when first encountered in a configured role

## Notes
- Tracked in #279 (translations engine design ledger). Does not close it.
- No consumer wired yet; engine is still pure-data per the v3.0.1.0 design.
- The earlier draft `docs/mappings/8toCNX/user_role_v1.json` is unchanged (separate working artifact, not the shipped translation).