### PR TITLE
v3.0.1.2: central:role translation (Gateway-targeted, schema-verified) + engine empty-dict drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.2] - 2026-05-07
+
+**Patch release — third translation (`central:role`, Gateway-targeted) + engine empty-dict drop + role-specific transforms (including all five bandwidth-contract sub-shapes).**
+
+Adds `central:role`, the third shipped translation, covering AOS 8 user-role REST object → Central role profile for the Gateway device-function. This is the **second iteration** of the role translation: the first iteration (PR #282, never merged) was caught in operator-led review with several wire-incorrect fields (a `policies[]` body field that doesn't exist on Central's role schema, VLAN binding nested inside `vlan-parameters` when GW puts it at the root, and 5 LLD-INFERRED source field names that turned out wrong). The current version is fully cross-referenced against the live AOS 8 tenant **and** the Central role schema's `x-supportedDeviceType=Gateway` annotations. Bandwidth contracts (originally deferred to v2) shipped after the operator configured the missing variants on the test role.
+
+### Three changes
+
+1. **New translation `central:role`.** Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Body has the role at the root plus three nested groups (`session-parameters`, `miscellaneous-parameters`, `classification-parameters`). Every body field is Gateway-supported per the Central role schema. `target_meta.device_functions` is **`["MOBILITY_GW"]` only** — AP-targeted role definitions use a different schema (`vlan-parameters`, `named-vlan`, etc.) and would need a separate translation.
+
+   Source-side field names verified live, including a purpose-configured `parent` role at `/md/Campus/West` with the full Tier 1 flag set + `reauthentication-interval 3600 seconds`. The single-underscore prefix gotcha (`role_disable_ipclassify`, `role_enable_youtubeedu`) is real and called out in the JSON. The reauth disambiguator (`role__reauth.seconds: true` flag distinguishes the seconds-form from the minutes-form) is handled by paired transforms. Bandwidth contracts (`role__bwc`) deferred to a future v2 — one variant captured live (basic per-role with `dir_type` discriminator) but the 4 other LLD sub-shapes still need samples. VIA + IP pool families excluded from v1 per operator's call (rarely used; alternative products handle that workflow).
+
+   **Inversion call-out (the bug the review caught):** AOS 8 carries the role→ACL binding inside the role record (`role__acl[]`). Central inverts this — policies reference roles via `policy-rule[].condition.source.role`, and Central back-fills `role.policies[]` automatically from those references. This translation does **NOT** send `policies[]` in the role body; ACL/policy binding is owned by the future `central:policy` translation.
+
+2. **Engine: `_drop_none_keys` now drops empty nested dicts.** When every member of a nested body group is an optional field whose source value was missing, the post-render pass now drops the now-empty parent key entirely. Top-level empty dicts pass through unchanged. Critical for the role translation since most roles configure only a small subset of the ~16 mappable fields (and all three nested groups are entirely optional).
+
+3. **Eleven new transforms in `translations/transforms.py`:**
+   - `vlanstr_to_id_if_numeric` / `vlanstr_to_name_if_nonnumeric` / `vlanstr_to_vlan_type` — disambiguate AOS 8's combined `role__vlan.vlanstr` field (Central splits it into separate `access-vlan-id` int / `access-vlan-name` string + `vlan-type` enum).
+   - `aos8_field_present_to_true` — handles both the older Pattern A flag shape (`{_present: true, _flags: {default: true}}` on `role__cp_acc` / `role__openflow`) and the newer Pattern B shape (empty `{}` when configured on `role__enforce_dhcp` / `role__reg_role` / `role__dpi_disable` / etc.). Returns `True` for any non-`None` input — reaching the transform implies the path resolved.
+   - `aos8_reauth_minutes_value` / `aos8_reauth_seconds_value` — paired transforms reading the `role__reauth` dict; one returns the value when `seconds` is falsy/absent (minutes form), the other when `seconds: true` (seconds form). Live-verified on the `parent` role.
+   - **`aos8_role_bwc_basic_to_central`** — basic per-role bandwidth contract: `role__bwc[]` → `aaa-bw-contract.bw-contract[]`. Live shape verified on `blacklisted` role.
+   - **`aos8_role_bwc_app_filter_app`** / **`aos8_role_bwc_app_filter_appcategory`** — paired transforms that fan out the AOS 8 `role__bwc_app[]` array (which mixes per-app + per-appcategory entries discriminated by `app_type`) into Central's two distinct schemas (`app-aaa-contract.app[]` and `app-category-aaa-contract.app-category[]`). Live-verified on `parent` role with `youtube` (app) and `streaming` (appcategory).
+   - **`aos8_role_bwc_web_filter_category`** / **`aos8_role_bwc_web_filter_reputation`** — same fan-out pattern for `role__bwc_web[]` (mixed per-web-cc-category + per-web-cc-reputation discriminated by `web_opt`) → `web-category-aaa-contract.web-category[]` / `web-reputation-aaa-contract.web-reputation[]`. Category names are uppercased + slash-replaced (e.g. `streaming/media` → `STREAMING-MEDIA`); reputations are uppercased + dash-to-underscore-replaced (e.g. `low-risk` → `LOW_RISK`).
+
+### Files
+
+- **New: `src/hpe_networking_mcp/translations/targets/central/role_v1.json`** — third shipped translation
+- **`src/hpe_networking_mcp/translations/transforms.py`** — six new transforms + registry entries
+- **`src/hpe_networking_mcp/translations/engine.py`** — `_drop_none_keys` enhanced to drop empty nested dicts
+- **New: `tests/unit/test_translations_transforms.py`** — 36 tests covering the role-specific transforms + the registry
+- **`tests/unit/test_translations_engine.py`** — 13 new role tests (minimum record, named-VLAN at root, numeric-VLAN at root, Pattern-A flags, Pattern-B flags, reauth-minutes routing, reauth-seconds routing, captive portal, max-sessions, full rich record, no-policies-emitted, MOBILITY_GW-only assignment, missing-rname error, empty-group drop)
+- **`tests/unit/test_translations_loader.py`** — 1 new role schema-validation test (asserts the corrected source field names + that `policies` doesn't appear in the body template + that `role__bwc` and `role__acl` are explicitly captured as deferred)
+- **`pyproject.toml`** — bump 3.0.1.1 → 3.0.1.2
+
+### Notes
+
+- 1107 tests pass (was 1037; +70 from new transforms + role tests including bw-contract coverage).
+- Cross-referenced the operator's live tenant (55 roles at `/md/Campus/West`, including the test `parent` role with all 5 bw-contract sub-shapes configured) against `api-endpoints/central/role.json`'s `x-supportedDeviceType` annotations. The body shape is now the strict intersection of "AOS 8 carries it" + "Central role schema accepts it for Gateway".
+- Consumer responsibility documented: pre-filter `_flags.default=true` sub-objects (and top-level `_flags.default=true` roles) from source records before passing to `emit_calls`. Otherwise every role POST will explicitly carry AOS 8 system defaults (`max-sessions=65535`, `check-for-accounting=true`, etc.) which may overwrite Central's own role-profile defaults.
+- Deferred (now narrower): `role__bwc_excl` (bw-contract exclude variants — AOS 8 source field name not yet sampled), `role__acl` (handled by future `central:policy` translation), VIA + pool fields (operator scoped them out as rarely used / better handled by alternative products), `disable-cp-gw-translation` (Gateway-only Central field; AOS 8 source name unknown).
+- Earlier draft from PR #282 is gone — the rework is a clean replacement, not a patch.
+
 ## [3.0.1.1] - 2026-05-07
 
 **Patch release — second translation (`central:vlan_id`) + engine optional-field support + iteration rename.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,14 @@ Adds `central:role`, the third shipped translation, covering AOS 8 user-role RES
 
 2. **Engine: `_drop_none_keys` now drops empty nested dicts.** When every member of a nested body group is an optional field whose source value was missing, the post-render pass now drops the now-empty parent key entirely. Top-level empty dicts pass through unchanged. Critical for the role translation since most roles configure only a small subset of the ~16 mappable fields (and all three nested groups are entirely optional).
 
-3. **Eleven new transforms in `translations/transforms.py`:**
+3. **Thirteen new transforms in `translations/transforms.py`:**
    - `vlanstr_to_id_if_numeric` / `vlanstr_to_name_if_nonnumeric` / `vlanstr_to_vlan_type` — disambiguate AOS 8's combined `role__vlan.vlanstr` field (Central splits it into separate `access-vlan-id` int / `access-vlan-name` string + `vlan-type` enum).
    - `aos8_field_present_to_true` — handles both the older Pattern A flag shape (`{_present: true, _flags: {default: true}}` on `role__cp_acc` / `role__openflow`) and the newer Pattern B shape (empty `{}` when configured on `role__enforce_dhcp` / `role__reg_role` / `role__dpi_disable` / etc.). Returns `True` for any non-`None` input — reaching the transform implies the path resolved.
    - `aos8_reauth_minutes_value` / `aos8_reauth_seconds_value` — paired transforms reading the `role__reauth` dict; one returns the value when `seconds` is falsy/absent (minutes form), the other when `seconds: true` (seconds form). Live-verified on the `parent` role.
    - **`aos8_role_bwc_basic_to_central`** — basic per-role bandwidth contract: `role__bwc[]` → `aaa-bw-contract.bw-contract[]`. Live shape verified on `blacklisted` role.
    - **`aos8_role_bwc_app_filter_app`** / **`aos8_role_bwc_app_filter_appcategory`** — paired transforms that fan out the AOS 8 `role__bwc_app[]` array (which mixes per-app + per-appcategory entries discriminated by `app_type`) into Central's two distinct schemas (`app-aaa-contract.app[]` and `app-category-aaa-contract.app-category[]`). Live-verified on `parent` role with `youtube` (app) and `streaming` (appcategory).
    - **`aos8_role_bwc_web_filter_category`** / **`aos8_role_bwc_web_filter_reputation`** — same fan-out pattern for `role__bwc_web[]` (mixed per-web-cc-category + per-web-cc-reputation discriminated by `web_opt`) → `web-category-aaa-contract.web-category[]` / `web-reputation-aaa-contract.web-reputation[]`. Category names are uppercased + slash-replaced (e.g. `streaming/media` → `STREAMING-MEDIA`); reputations are uppercased + dash-to-underscore-replaced (e.g. `low-risk` → `LOW_RISK`).
+   - **`aos8_role_bwc_excl_filter_app`** / **`aos8_role_bwc_excl_filter_appcategory`** — same pattern for the bw-contract exclude variants (`role__bwc_ex[]` discriminated by `app_type`) → `exclude-app-contract.exclude-app[]` / `exclude-app-cat-contract.exclude-app-category[]`. The exclude variant carries no traffic direction and no contract reference — listed apps/categories simply bypass bandwidth-contract enforcement.
 
 ### Files
 
@@ -41,10 +42,10 @@ Adds `central:role`, the third shipped translation, covering AOS 8 user-role RES
 
 ### Notes
 
-- 1107 tests pass (was 1037; +70 from new transforms + role tests including bw-contract coverage).
-- Cross-referenced the operator's live tenant (55 roles at `/md/Campus/West`, including the test `parent` role with all 5 bw-contract sub-shapes configured) against `api-endpoints/central/role.json`'s `x-supportedDeviceType` annotations. The body shape is now the strict intersection of "AOS 8 carries it" + "Central role schema accepts it for Gateway".
+- 1114 tests pass (was 1037; +77 from new transforms + role tests including all 7 bw-contract sub-shapes).
+- Cross-referenced the operator's live tenant (55 roles at `/md/Campus/West`, including the test `parent` role with all 7 bw-contract sub-shapes configured — basic + per-app + per-appcategory + per-web-cc-category + per-web-cc-reputation + exclude-app + exclude-appcategory) against `api-endpoints/central/role.json`'s `x-supportedDeviceType` annotations. The body shape is now the strict intersection of "AOS 8 carries it" + "Central role schema accepts it for Gateway".
 - Consumer responsibility documented: pre-filter `_flags.default=true` sub-objects (and top-level `_flags.default=true` roles) from source records before passing to `emit_calls`. Otherwise every role POST will explicitly carry AOS 8 system defaults (`max-sessions=65535`, `check-for-accounting=true`, etc.) which may overwrite Central's own role-profile defaults.
-- Deferred (now narrower): `role__bwc_excl` (bw-contract exclude variants — AOS 8 source field name not yet sampled), `role__acl` (handled by future `central:policy` translation), VIA + pool fields (operator scoped them out as rarely used / better handled by alternative products), `disable-cp-gw-translation` (Gateway-only Central field; AOS 8 source name unknown).
+- Remaining deferrals: `role__acl` (handled by future `central:policy` translation), VIA + pool fields (operator scoped them out as rarely used / better handled by alternative products), `disable-cp-gw-translation` (Gateway-only Central field; AOS 8 source name unknown).
 - Earlier draft from PR #282 is gone — the rework is a clean replacement, not a patch.
 
 ## [3.0.1.1] - 2026-05-07

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (1037+ unit tests)
+├── tests/                       # Unit and integration tests (1107+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (1107+ unit tests)
+├── tests/                       # Unit and integration tests (1114+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.1"
+version = "3.0.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/translations/engine.py
+++ b/src/hpe_networking_mcp/translations/engine.py
@@ -337,15 +337,34 @@ def _render_body(
 
 
 def _drop_none_keys(value: Any) -> Any:
-    """Recursively drop dict keys whose value is ``None``.
+    """Recursively drop dict keys whose value is ``None`` or an empty dict.
 
-    Used for optional body fields: when a key_mapping is ``optional=True`` and
-    the source record lacks that field, the engine substitutes ``None`` and
-    this pass strips the key from the wire payload entirely (rather than
-    sending ``"description": null``).
+    Two-pass behavior, applied during dict descent:
+
+    1. Drop keys whose direct value is ``None`` (optional fields whose source
+       was missing).
+    2. After cleaning a nested dict value, drop the parent key if the cleaned
+       dict is now empty — keeps the wire payload free of orphaned ``{}``
+       sub-objects when every member of a nested group (e.g. ``"pool": {...}``)
+       came from optional fields that were all missing.
+
+    Empty *top-level* dicts pass through unchanged — the caller can decide
+    whether an empty body is meaningful for a given target API.
+
+    Lists are traversed but list elements are kept even when they cleaned
+    down to an empty dict; translation authors needing list filtering should
+    do it inside a transform.
     """
     if isinstance(value, dict):
-        return {k: _drop_none_keys(v) for k, v in value.items() if v is not None}
+        result: dict[str, Any] = {}
+        for k, v in value.items():
+            if v is None:
+                continue
+            cleaned = _drop_none_keys(v)
+            if isinstance(cleaned, dict) and not cleaned:
+                continue
+            result[k] = cleaned
+        return result
     if isinstance(value, list):
         return [_drop_none_keys(item) for item in value]
     return value

--- a/src/hpe_networking_mcp/translations/targets/central/role_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/role_v1.json
@@ -48,6 +48,12 @@
         },
         "web-reputation-aaa-contract": {
           "web-reputation": "{bw_contract_web_reputation}"
+        },
+        "exclude-app-contract": {
+          "exclude-app": "{bw_contract_exclude_app}"
+        },
+        "exclude-app-cat-contract": {
+          "exclude-app-category": "{bw_contract_exclude_appcategory}"
         }
       },
       "iteration": "once",
@@ -266,15 +272,23 @@
           "transform": "aos8_role_bwc_web_filter_reputation",
           "optional":  true,
           "notes":     "Per-WebCC-reputation bandwidth contract. Companion to bw_contract_web_category — sources from the same role__bwc_web array but filters to web_opt=='web-cc-reputation'. Transform uppercases (and dash->underscore) the AOS 8 'web_rep' value to match Central's 5-value enum (TRUSTWORTHY / LOW_RISK / MODERATE_RISK / SUSPICIOUS / HIGH_RISK). Live-verified on 'parent' role with web_rep='trustworthy'."
+        },
+        "bw_contract_exclude_app": {
+          "from":      "role__bwc_ex",
+          "to":        "Central role body 'exclude-app-contract.exclude-app[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_excl_filter_app",
+          "optional":  true,
+          "notes":     "Per-app bw-contract exclusion. AOS 8 stores per-app + per-appcategory exclude entries in a single role__bwc_ex array discriminated by 'app_type'; filters to app_type=='app'. The exclude variant carries no traffic direction and no contract reference — listed apps simply bypass bandwidth-contract enforcement. Live-verified on 'parent' role with appname='netflix'. Source AOS 8 app names pass through verbatim; if Central's DPI catalog rejects an unknown app, operators must remap manually."
+        },
+        "bw_contract_exclude_appcategory": {
+          "from":      "role__bwc_ex",
+          "to":        "Central role body 'exclude-app-cat-contract.exclude-app-category[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_excl_filter_appcategory",
+          "optional":  true,
+          "notes":     "Per-app-category bw-contract exclusion. Companion to bw_contract_exclude_app — sources from the same role__bwc_ex array but filters to app_type=='appcategory'. Transform uppercases the AOS 8 'appname' value (which carries the category name in this variant) to match Central's 24-value enum. Live-verified on 'parent' role with appname='collaboration' (-> 'COLLABORATION')."
         }
       },
       "unmapped_fields": [
-        {
-          "from":            "role__bwc_excl (CLI: 'bw-contract exclude {app|appcategory}')",
-          "reason":          "AOS 8 supports excluding specific apps / app-categories from a bw-contract. Central CNX has matching schemas (ArubaAaaBandwidthContract_ExcludeAppBwc + ExcludeAppCatBwc with body keys 'exclude-app-contract' / 'exclude-app-cat-contract'), but the AOS 8 source-side field name for these exclude variants was not surfaced in the configured 'parent' role samples. Deferred until a configured tenant surfaces the exclude variant.",
-          "severity_rule":   "non_empty_regression",
-          "todo":            "Configure 'bw-contract exclude app <appname>' or 'bw-contract exclude appcategory <category>' on a test role and re-pull to discover the AOS 8 source field name."
-        },
         {
           "from":            "role__via, role__pool_pptp, role__pool_via_dhcp",
           "reason":          "VIA connection profile + PPTP / DHCP-proxy IP pools. Operator ruled VIA + the VIA-only pool variants out of scope for v1 (VIA workflows are increasingly handled by alternative products). role__pool_l2tp is captured below as a confirmed-live unused mapping kept for future enablement.",
@@ -313,8 +327,8 @@
   },
   "draft_notes": [
     "v1 translation, Gateway-targeted. Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Every body field is Gateway-supported per the Central role schema (verified via api-endpoints/central/role.json's x-supportedDeviceType annotations).",
-    "Live-verified source field names across 55 roles in the operator's tenant including a purpose-configured 'parent' role with all Tier 1 flag features + reauthentication-interval-seconds + per-app / per-appcategory / per-web-cc-category / per-web-cc-reputation bandwidth contracts, and the 'blacklisted' role with the basic per-role bandwidth contract. All five core bw-contract sub-shapes are mapped; only the 'exclude app/appcategory' variants remain deferred (their AOS 8 source field name was not surfaced in the available samples).",
-    "Bandwidth-contract source shape: AOS 8 stores per-app + per-appcategory in a single 'role__bwc_app' array discriminated by 'app_type' ('app' or 'appcategory'). Similarly per-web-cc-category + per-web-cc-reputation share a single 'role__bwc_web' array discriminated by 'web_opt'. The Central side has FIVE distinct schemas (one per variant), so each AOS 8 array is fanned out to two Central body fields via paired filter-and-transform key_mappings.",
+    "Live-verified source field names across 55 roles in the operator's tenant including a purpose-configured 'parent' role with all Tier 1 flag features + reauthentication-interval-seconds + per-app / per-appcategory / per-web-cc-category / per-web-cc-reputation bandwidth contracts + bw-contract exclude (app + appcategory), and the 'blacklisted' role with the basic per-role bandwidth contract. All seven bw-contract sub-shapes are mapped (basic per-role + per-app + per-appcategory + per-web-cc-category + per-web-cc-reputation + exclude-app + exclude-appcategory).",
+    "Bandwidth-contract source shape: AOS 8 stores three discriminated source arrays: 'role__bwc_app' carries per-app + per-appcategory entries (discriminator 'app_type'), 'role__bwc_web' carries per-web-cc-category + per-web-cc-reputation entries (discriminator 'web_opt'), and 'role__bwc_ex' carries exclude-app + exclude-appcategory entries (also using 'app_type'). Plus the basic per-role 'role__bwc'. Central has SEVEN distinct body schemas; each AOS 8 array fans out to two Central body fields via paired filter-and-transform key_mappings.",
     "INVERSION CALL-OUT: AOS 8 carries the role->ACL binding inside the role record (role__acl array). Central inverts the relationship — policies reference roles via policy-rule[].condition.source.role, and Central back-fills role.policies[] from those references. This translation does NOT send policies[] in the role body. ACL->role binding is owned by the future central:policy translation.",
     "Idempotency: if a role profile with the same name already exists, the SHARED POST returns HTTP 409. Consumer must handle 409 idempotently.",
     "Two AOS 8 flag SHAPES coexist in the source: Pattern A (role__cp_acc / role__openflow have {_present: true, _flags: {default: true}}) and Pattern B (role__enforce_dhcp / role__reg_role / role__dpi_disable / role__disable_webcc / role_disable_ipclassify / role_enable_youtubeedu surface as empty {} when configured, absent when not). Both are handled by the same aos8_field_present_to_true transform — it returns True for any non-None value, relying on the engine's optional-field path to drop the body key when the source path is missing entirely.",

--- a/src/hpe_networking_mcp/translations/targets/central/role_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/role_v1.json
@@ -1,0 +1,324 @@
+{
+  "version": 1,
+  "target_platform": "central",
+  "target_id": "role",
+  "target_emits": [
+    {
+      "step":     1,
+      "name":     "create_role_shared",
+      "purpose":  "Create the user-role profile in the Library for the Gateway device-function. Body carries the role at the root plus three nested groups (session-parameters, miscellaneous-parameters, classification-parameters). All sub-fields below the root are Gateway-supported per the Central role schema; non-Gateway fields (mtu, auth-mode, poe-*, vlan-parameters, etc.) are intentionally NOT populated by this translation since AOS 8 -> Central is a Gateway path.",
+      "endpoint": "/network-config/v1alpha1/roles/{name}",
+      "method":   "POST",
+      "query_params": {},
+      "body": {
+        "name":             "{name}",
+        "access-vlan-id":   "{access_vlan_id}",
+        "access-vlan-name": "{access_vlan_name}",
+        "vlan-type":        "{vlan_type}",
+        "session-parameters": {
+          "captive-portal":                    "{captive_portal}",
+          "check-for-accounting":              "{check_for_accounting}",
+          "max-sessions":                      "{max_sessions}",
+          "reauthentication-interval":         "{reauthentication_interval}",
+          "reauthentication-interval-seconds": "{reauthentication_interval_seconds}"
+        },
+        "miscellaneous-parameters": {
+          "enforce-dhcp":      "{enforce_dhcp}",
+          "robust-age-out":    "{robust_age_out}",
+          "registration-role": "{registration_role}",
+          "openflow-enable":   "{openflow_enable}"
+        },
+        "classification-parameters": {
+          "ip-classification":     "{ip_classification}",
+          "dpi-classification":    "{dpi_classification}",
+          "dpi-youtube-education": "{dpi_youtube_education}",
+          "web-cc":                "{web_cc}"
+        },
+        "aaa-bw-contract": {
+          "bw-contract": "{bw_contract_basic}"
+        },
+        "app-aaa-contract": {
+          "app": "{bw_contract_app}"
+        },
+        "app-category-aaa-contract": {
+          "app-category": "{bw_contract_appcategory}"
+        },
+        "web-category-aaa-contract": {
+          "web-category": "{bw_contract_web_category}"
+        },
+        "web-reputation-aaa-contract": {
+          "web-reputation": "{bw_contract_web_reputation}"
+        }
+      },
+      "iteration": "once",
+      "iteration_notes": "Optional fields drop out of the body when the source record lacks them. Empty nested groups (session-parameters / miscellaneous-parameters / classification-parameters) drop entirely if every member is missing.",
+      "depends_on": []
+    },
+    {
+      "step":     2,
+      "name":     "assign_role",
+      "purpose":  "Assign the role profile to the target scope. Multi-device-function array packed into a single POST.",
+      "endpoint": "/network-config/v1alpha1/config-assignments",
+      "method":   "POST",
+      "query_params": {},
+      "body_template": {
+        "config-assignment": [
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='role', profile-instance='{name}' }}"
+        ]
+      },
+      "iteration": "once",
+      "iteration_notes": "One POST; all device-functions share the array.",
+      "depends_on": [1]
+    }
+  ],
+  "target_meta": {
+    "device_functions": ["MOBILITY_GW"],
+    "device_function_filtering_rule": "Per the Central role schema, every field in the body is Gateway-supported. AOS 8 user-roles map to Gateway roles in Central — that's the AOS 8 -> AOS 10/Central upgrade path. CAMPUS_AP role definition lives elsewhere (different schema fields). If an operator wants to assign the same name to AP scopes, they author a separate AP-targeted role translation (out of scope here)."
+  },
+  "target_scope_id_resolution": {
+    "rule":   "Central scope_id is supplied by the consuming skill at runtime, derived from the AOS 8 role record's scope path.",
+    "input":  "Source binding scope (string path / identifier); skill-specific",
+    "output": "Central scope_id (string), supplied via runtime_values['central_scope_id']"
+  },
+  "required_runtime_values": ["central_scope_id"],
+  "derived": {},
+  "dependencies": [
+    {
+      "depends_on":  "central:policy (when authored — AOS 8 access-list session profiles map to Central policies, and policies reference roles via policy-rule[].condition.source.role; Central back-fills role.policies[] automatically from those references, so this translation does NOT send policies[] on the role body)",
+      "depended_by": [
+        {
+          "target_id": "ssid_prof / virtual_ap",
+          "field":     "aaa.role",
+          "relation":  "role-by-name reference (string)",
+          "notes":     "Wireless WLAN translations reference roles for default-role / aaa-server roles. Sequence: roles before WLANs."
+        }
+      ]
+    }
+  ],
+  "tokenize_kind_per_field": {},
+  "sources": {
+    "aos8": {
+      "kind":         "rest",
+      "mapping_kind": "simple",
+      "objects": [
+        {
+          "object":      "role",
+          "object_path": "/v1/configuration/object/role",
+          "role":        "user_role_profile",
+          "docs": {
+            "get":  "https://developer.arubanetworks.com/aos8/reference/get_object-role",
+            "post": "https://developer.arubanetworks.com/aos8/reference/post_object-role"
+          },
+          "live_shape_example": "[{\"rname\": \"parent\", \"role__acl\": [{\"acl_type\": \"session\", \"pname\": \"parent\"}], \"role__vlan\": {\"vlanstr\": \"104\"}, \"role__cp_acc\": {\"_present\": true, \"_flags\": {\"default\": true}}, \"role__openflow\": {\"_present\": true, \"_flags\": {\"default\": true}}, \"role__reauth\": {\"seconds\": true, \"reauthperiod\": 3600}, \"role__max_sess\": {\"_flags\": {\"default\": true}, \"max_sess\": 65535}, \"role__enforce_dhcp\": {}, \"role__robust_age_out\": {}, \"role__reg_role\": {}, \"role__dpi_disable\": {}, \"role_enable_youtubeedu\": {}, \"role_disable_ipclassify\": {}, \"role__disable_webcc\": {}}, {\"rname\": \"blacklisted\", \"role__bwc\": [{\"dir_type\": \"downstream\", \"name\": \"...\"}, {\"dir_type\": \"upstream\", \"name\": \"...\"}]}, {\"rname\": \"camera_role_ubt\", \"role__vlan\": {\"vlanstr\": \"internal\"}}, {\"rname\": \"onguard-role\", \"role__cp\": {\"cp_profile_name\": \"onguard-captive-portal\"}}]",
+          "notes": "Live-verified across 55 user-customized + system roles in the operator's tenant including a purpose-configured 'parent' role at /md/Campus/West with the full Tier 1 flag set + reauth-seconds. AOS 8 sub-objects use BOTH double-underscore (role__*) and single-underscore (role_*) prefixes — the classification flags 'role_disable_ipclassify' and 'role_enable_youtubeedu' use the single-underscore form (a quirk of the AOS 8 schema). Two distinct flag SHAPES surface: the older sub-objects like role__cp_acc / role__openflow use {_present: true, _flags: {...}} (Pattern A); the newer sub-objects like role__enforce_dhcp / role__reg_role / role__dpi_disable use empty {} when configured / absent when not (Pattern B). The aos8_field_present_to_true transform handles both by checking parent-path existence rather than a specific value. Inheritance: filter _flags.inherited=true entries from BOTH the role record itself and from its sub-objects before passing to emit_calls."
+        }
+      ],
+      "key_mappings": {
+        "name": {
+          "from":      "rname",
+          "to":        "role name (Central path param + body 'name', profile-instance on step 2)",
+          "transform": "direct_str",
+          "notes":     "Required. AOS 8 'rname' -> Central role 'name'."
+        },
+        "access_vlan_id": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'access-vlan-id' (Gateway-only, integer; only when source is numeric)",
+          "transform": "vlanstr_to_id_if_numeric",
+          "optional":  true,
+          "notes":     "AOS 8 stores both VLAN IDs and names as a single 'vlanstr' string. Three companion key_mappings (this one, access_vlan_name, vlan_type) all source from the same path with disambiguating transforms — only the matching access-vlan-* field survives. Per the Central role schema, access-vlan-id is at the ROOT of the role body (not inside vlan-parameters) for Gateway device-function."
+        },
+        "access_vlan_name": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'access-vlan-name' (Gateway-only, string; only when source is non-numeric)",
+          "transform": "vlanstr_to_name_if_nonnumeric",
+          "optional":  true,
+          "notes":     "Live example: vlanstr='internal' on camera_role_ubt -> access-vlan-name='internal'."
+        },
+        "vlan_type": {
+          "from":      "role__vlan.vlanstr",
+          "to":        "Central role body 'vlan-type' (root, enum: 'VLAN_ID' or 'VLAN_NAME')",
+          "transform": "vlanstr_to_vlan_type",
+          "optional":  true,
+          "notes":     "Discriminator for whichever access-vlan-* field was emitted."
+        },
+        "captive_portal": {
+          "from":      "role__cp.cp_profile_name",
+          "to":        "Central role body 'session-parameters.captive-portal' (Gateway + AP + Switch CX/PVOS, string)",
+          "transform": "direct_str",
+          "optional":  true,
+          "notes":     "Live-verified: 'onguard-role' has role__cp.cp_profile_name='onguard-captive-portal'. References a captive-portal profile that must exist in Central before this role is created."
+        },
+        "check_for_accounting": {
+          "from":      "role__cp_acc",
+          "to":        "Central role body 'session-parameters.check-for-accounting' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-A flag: source carries {_present: true, _flags: {default: true}}. The transform returns True for any non-None input. Consumer should filter _flags.default=true entries before passing to emit_calls."
+        },
+        "max_sessions": {
+          "from":      "role__max_sess.max_sess",
+          "to":        "Central role body 'session-parameters.max-sessions' (Gateway-only, int)",
+          "transform": "direct_int",
+          "optional":  true,
+          "notes":     "Live-verified: every role surfaces with max_sess=65535 _flags.default=true. Consumer should filter."
+        },
+        "reauthentication_interval": {
+          "from":      "role__reauth",
+          "to":        "Central role body 'session-parameters.reauthentication-interval' (Gateway-only, int minutes; mutually exclusive with -seconds form)",
+          "transform": "aos8_reauth_minutes_value",
+          "optional":  true,
+          "notes":     "Source dict: {reauthperiod: N} for minutes form; {seconds: true, reauthperiod: N} for seconds form. This transform returns N only when 'seconds' is falsy/absent; otherwise None so the seconds companion claims it. Live-verified: most roles have {reauthperiod: 0, _flags: {default: true}}. Consumer should filter _flags.default=true before passing to emit_calls."
+        },
+        "reauthentication_interval_seconds": {
+          "from":      "role__reauth",
+          "to":        "Central role body 'session-parameters.reauthentication-interval-seconds' (Gateway-only, int seconds)",
+          "transform": "aos8_reauth_seconds_value",
+          "optional":  true,
+          "notes":     "Companion to reauthentication_interval. Live-verified on the test 'parent' role configured with 'reauthentication-interval 3600 seconds' -> source {seconds: true, reauthperiod: 3600}."
+        },
+        "openflow_enable": {
+          "from":      "role__openflow",
+          "to":        "Central role body 'miscellaneous-parameters.openflow-enable' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-A flag (source has _present + _flags). Live-verified: every role surfaces with _flags.default=true; consumer should filter."
+        },
+        "enforce_dhcp": {
+          "from":      "role__enforce_dhcp",
+          "to":        "Central role body 'miscellaneous-parameters.enforce-dhcp' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified on test 'parent' role): source carries empty {} when configured. Transform returns True for any value; if absent, optional path drops the body key."
+        },
+        "robust_age_out": {
+          "from":      "role__robust_age_out",
+          "to":        "Central role body 'miscellaneous-parameters.robust-age-out' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified)."
+        },
+        "registration_role": {
+          "from":      "role__reg_role",
+          "to":        "Central role body 'miscellaneous-parameters.registration-role' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified). AOS 8 source name is abbreviated to 'reg_role' (not 'registration_role')."
+        },
+        "ip_classification": {
+          "from":      "role_disable_ipclassify",
+          "to":        "Central role body 'classification-parameters.ip-classification' (Gateway-only, bool; true means DISABLED per Central convention for the disable-flag pattern)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified). NOTE the AOS 8 source uses a SINGLE underscore prefix (role_, not role__) for this field — verified live. Inverted semantic: AOS 8 CLI 'ip-classification disable' surfaces as field presence; the resulting True value maps to Central's flag where true also means disabled (per the AOS 8 -> CNX LLD reference)."
+        },
+        "dpi_classification": {
+          "from":      "role__dpi_disable",
+          "to":        "Central role body 'classification-parameters.dpi-classification' (Gateway-only, bool; true means DISABLED)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified). AOS 8 source name reflects the CLI verb 'dpi disable'."
+        },
+        "dpi_youtube_education": {
+          "from":      "role_enable_youtubeedu",
+          "to":        "Central role body 'classification-parameters.dpi-youtube-education' (Gateway-only, bool)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified). NOTE single underscore prefix (role_, not role__). Standard (non-inverted) flag — AOS 8 CLI 'dpi youtubeedu' enables the feature."
+        },
+        "web_cc": {
+          "from":      "role__disable_webcc",
+          "to":        "Central role body 'classification-parameters.web-cc' (Gateway-only, bool; true means DISABLED)",
+          "transform": "aos8_field_present_to_true",
+          "optional":  true,
+          "notes":     "Pattern-B flag (live-verified). AOS 8 source name reflects the CLI verb 'web-cc disable'."
+        },
+        "bw_contract_basic": {
+          "from":      "role__bwc",
+          "to":        "Central role body 'aaa-bw-contract.bw-contract[]' (Gateway + AP)",
+          "transform": "aos8_role_bwc_basic_to_central",
+          "optional":  true,
+          "notes":     "Per-role bandwidth contract. Source shape live-verified on 'blacklisted' role at /md/Campus/West: [{dir_type, name}]. Transform renames dir_type -> direction (uppercase) and name -> bwc-name. AOS 8 doesn't carry the association field (per-user vs per-apgroup); Central applies its default."
+        },
+        "bw_contract_app": {
+          "from":      "role__bwc_app",
+          "to":        "Central role body 'app-aaa-contract.app[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_app_filter_app",
+          "optional":  true,
+          "notes":     "Per-app bandwidth contract. AOS 8 stores per-app AND per-appcategory entries in the same role__bwc_app array, discriminated by 'app_type'. This mapping filters to app_type=='app' and outputs Central's app-aaa-contract.app[] shape. Live-verified on 'parent' role at /md/Campus/West with app_type='app', appname='youtube'. Note: Central's appname is an enum of ~3953 DPI app names; AOS 8 source values pass through as-is and may need manual remapping if the catalogs drift."
+        },
+        "bw_contract_appcategory": {
+          "from":      "role__bwc_app",
+          "to":        "Central role body 'app-category-aaa-contract.app-category[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_app_filter_appcategory",
+          "optional":  true,
+          "notes":     "Per-app-category bandwidth contract. Companion to bw_contract_app — sources from the same role__bwc_app array but filters to app_type=='appcategory'. Transform uppercases the AOS 8 'appname' value (the category name) to match Central's 24-value enum (e.g. 'streaming' -> 'STREAMING'). Live-verified on 'parent' role with appname='streaming'."
+        },
+        "bw_contract_web_category": {
+          "from":      "role__bwc_web",
+          "to":        "Central role body 'web-category-aaa-contract.web-category[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_web_filter_category",
+          "optional":  true,
+          "notes":     "Per-WebCC-category bandwidth contract. AOS 8 stores per-category AND per-reputation entries in the same role__bwc_web array, discriminated by 'web_opt'. Filters to web_opt=='web-cc-category' and uppercases + slash-replaces the category name (AOS 8 'streaming/media' -> Central 'STREAMING-MEDIA'). Live-verified on 'parent' role. Caveat: only the simple slash-and-uppercase mapping is performed; some Central categories carry connective words AOS 8 omits (e.g. AOS 8 'entertainment/arts' would become 'ENTERTAINMENT-ARTS' from this transform but Central's enum is 'ENTERTAINMENT-AND-ARTS'). Operators should spot-check categories with multi-word Central forms after migration."
+        },
+        "bw_contract_web_reputation": {
+          "from":      "role__bwc_web",
+          "to":        "Central role body 'web-reputation-aaa-contract.web-reputation[]' (Gateway-only)",
+          "transform": "aos8_role_bwc_web_filter_reputation",
+          "optional":  true,
+          "notes":     "Per-WebCC-reputation bandwidth contract. Companion to bw_contract_web_category — sources from the same role__bwc_web array but filters to web_opt=='web-cc-reputation'. Transform uppercases (and dash->underscore) the AOS 8 'web_rep' value to match Central's 5-value enum (TRUSTWORTHY / LOW_RISK / MODERATE_RISK / SUSPICIOUS / HIGH_RISK). Live-verified on 'parent' role with web_rep='trustworthy'."
+        }
+      },
+      "unmapped_fields": [
+        {
+          "from":            "role__bwc_excl (CLI: 'bw-contract exclude {app|appcategory}')",
+          "reason":          "AOS 8 supports excluding specific apps / app-categories from a bw-contract. Central CNX has matching schemas (ArubaAaaBandwidthContract_ExcludeAppBwc + ExcludeAppCatBwc with body keys 'exclude-app-contract' / 'exclude-app-cat-contract'), but the AOS 8 source-side field name for these exclude variants was not surfaced in the configured 'parent' role samples. Deferred until a configured tenant surfaces the exclude variant.",
+          "severity_rule":   "non_empty_regression",
+          "todo":            "Configure 'bw-contract exclude app <appname>' or 'bw-contract exclude appcategory <category>' on a test role and re-pull to discover the AOS 8 source field name."
+        },
+        {
+          "from":            "role__via, role__pool_pptp, role__pool_via_dhcp",
+          "reason":          "VIA connection profile + PPTP / DHCP-proxy IP pools. Operator ruled VIA + the VIA-only pool variants out of scope for v1 (VIA workflows are increasingly handled by alternative products). role__pool_l2tp is captured below as a confirmed-live unused mapping kept for future enablement.",
+          "severity_rule":   "non_empty_regression"
+        },
+        {
+          "from":            "role__pool_l2tp.poolname",
+          "reason":          "L2TP IP pool reference. Live-verified shape on faculty-* roles in the source tenant. Maps to Central session-parameters.pool.l2tp (Gateway-only). Not included in v1 because the user explicitly excluded the pool-family fields with the VIA / pool tier of features. If/when re-enabled, the source field is confirmed and the Central target is confirmed in the role schema.",
+          "severity_rule":   "non_empty_regression",
+          "todo":            "Re-enable in v2 if pool migration becomes in-scope."
+        },
+        {
+          "from":            "session-parameters.disable-cp-gw-translation",
+          "reason":          "Gateway-only Central field discovered via schema review (api-endpoints/central/role.json). The corresponding AOS 8 source field name is unknown (not surfaced in any of the 55 sampled roles). Skipped from key_mappings entirely until a configured tenant surfaces the source-side shape.",
+          "severity_rule":   "non_empty_regression",
+          "todo":            "Find AOS 8 source field name (likely role__cp_gw_translation_disable or similar) and add an optional key_mapping."
+        },
+        {
+          "from":            "role__acl",
+          "reason":          "AOS 8 access-list session bindings on the role. Central does NOT carry policies/ACLs as a field on the role profile body — instead, Central policies (separate /policies endpoint) reference roles via policy-rule[].condition.source.role, and Central back-fills role.policies[] automatically from those references. The ACL -> role binding is owned by the future central:policy translation (policy POST body carries the role reference). The role translation deliberately drops role__acl from the body to avoid sending a field Central will reject.",
+          "severity_rule":   "always_operator_map",
+          "todo":            "Author central:policy. Migrate AOS 8 ip access-list session profiles into Central policy POSTs, with the policy's policy-rule.condition.source.role pointed at the role(s) that originally listed the ACL in their role__acl array."
+        }
+      ],
+      "ignored_variants": [
+        {
+          "form":   "role with _flags.default=true at the top level",
+          "reason": "AOS 8 system / built-in roles (logon, guest, ap-role, etc.) appear with _flags.default=true. Migrating them would create duplicate user-role profiles in Central that shadow Central's own built-ins. Consumer must filter top-level _flags.default=true roles before passing to emit_calls."
+        },
+        {
+          "form":   "Switch CX / Switch PVOS / Access Point role-profile fields (mtu, auth-mode, poe-*, vlan-parameters.*, named-vlan, etc.)",
+          "reason": "Per the Central role schema, many session-parameters / vlan-parameters fields are device-function-specific (Switch CX, Switch PVOS, AP). AOS 8 -> Central is a Gateway path, so this translation populates only Gateway-supported fields. A separate translation would be needed for AP-targeted roles (different schema fields, and AOS 8 has no equivalent for most of them)."
+        }
+      ]
+    }
+  },
+  "draft_notes": [
+    "v1 translation, Gateway-targeted. Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Every body field is Gateway-supported per the Central role schema (verified via api-endpoints/central/role.json's x-supportedDeviceType annotations).",
+    "Live-verified source field names across 55 roles in the operator's tenant including a purpose-configured 'parent' role with all Tier 1 flag features + reauthentication-interval-seconds + per-app / per-appcategory / per-web-cc-category / per-web-cc-reputation bandwidth contracts, and the 'blacklisted' role with the basic per-role bandwidth contract. All five core bw-contract sub-shapes are mapped; only the 'exclude app/appcategory' variants remain deferred (their AOS 8 source field name was not surfaced in the available samples).",
+    "Bandwidth-contract source shape: AOS 8 stores per-app + per-appcategory in a single 'role__bwc_app' array discriminated by 'app_type' ('app' or 'appcategory'). Similarly per-web-cc-category + per-web-cc-reputation share a single 'role__bwc_web' array discriminated by 'web_opt'. The Central side has FIVE distinct schemas (one per variant), so each AOS 8 array is fanned out to two Central body fields via paired filter-and-transform key_mappings.",
+    "INVERSION CALL-OUT: AOS 8 carries the role->ACL binding inside the role record (role__acl array). Central inverts the relationship — policies reference roles via policy-rule[].condition.source.role, and Central back-fills role.policies[] from those references. This translation does NOT send policies[] in the role body. ACL->role binding is owned by the future central:policy translation.",
+    "Idempotency: if a role profile with the same name already exists, the SHARED POST returns HTTP 409. Consumer must handle 409 idempotently.",
+    "Two AOS 8 flag SHAPES coexist in the source: Pattern A (role__cp_acc / role__openflow have {_present: true, _flags: {default: true}}) and Pattern B (role__enforce_dhcp / role__reg_role / role__dpi_disable / role__disable_webcc / role_disable_ipclassify / role_enable_youtubeedu surface as empty {} when configured, absent when not). Both are handled by the same aos8_field_present_to_true transform — it returns True for any non-None value, relying on the engine's optional-field path to drop the body key when the source path is missing entirely.",
+    "Single-underscore prefix gotcha: most role sub-objects use 'role__' (double underscore), but two classification flags use 'role_' (single underscore): 'role_disable_ipclassify' and 'role_enable_youtubeedu'. Verified live; not a typo.",
+    "Consumer responsibility documented: pre-filter source records to drop _flags.default=true sub-objects (and top-level default=true roles) before passing to emit_calls. Otherwise every role POST will explicitly carry AOS 8 system defaults (max-sessions=65535, check-for-accounting=true, etc.) which may overwrite Central's own role-profile defaults."
+  ]
+}

--- a/src/hpe_networking_mcp/translations/targets/central/role_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/role_v1.json
@@ -301,12 +301,6 @@
           "todo":            "Re-enable in v2 if pool migration becomes in-scope."
         },
         {
-          "from":            "session-parameters.disable-cp-gw-translation",
-          "reason":          "Gateway-only Central field discovered via schema review (api-endpoints/central/role.json). The corresponding AOS 8 source field name is unknown (not surfaced in any of the 55 sampled roles). Skipped from key_mappings entirely until a configured tenant surfaces the source-side shape.",
-          "severity_rule":   "non_empty_regression",
-          "todo":            "Find AOS 8 source field name (likely role__cp_gw_translation_disable or similar) and add an optional key_mapping."
-        },
-        {
           "from":            "role__acl",
           "reason":          "AOS 8 access-list session bindings on the role. Central does NOT carry policies/ACLs as a field on the role profile body — instead, Central policies (separate /policies endpoint) reference roles via policy-rule[].condition.source.role, and Central back-fills role.policies[] automatically from those references. The ACL -> role binding is owned by the future central:policy translation (policy POST body carries the role reference). The role translation deliberately drops role__acl from the body to avoid sending a field Central will reject.",
           "severity_rule":   "always_operator_map",
@@ -333,6 +327,7 @@
     "Idempotency: if a role profile with the same name already exists, the SHARED POST returns HTTP 409. Consumer must handle 409 idempotently.",
     "Two AOS 8 flag SHAPES coexist in the source: Pattern A (role__cp_acc / role__openflow have {_present: true, _flags: {default: true}}) and Pattern B (role__enforce_dhcp / role__reg_role / role__dpi_disable / role__disable_webcc / role_disable_ipclassify / role_enable_youtubeedu surface as empty {} when configured, absent when not). Both are handled by the same aos8_field_present_to_true transform — it returns True for any non-None value, relying on the engine's optional-field path to drop the body key when the source path is missing entirely.",
     "Single-underscore prefix gotcha: most role sub-objects use 'role__' (double underscore), but two classification flags use 'role_' (single underscore): 'role_disable_ipclassify' and 'role_enable_youtubeedu'. Verified live; not a typo.",
-    "Consumer responsibility documented: pre-filter source records to drop _flags.default=true sub-objects (and top-level default=true roles) before passing to emit_calls. Otherwise every role POST will explicitly carry AOS 8 system defaults (max-sessions=65535, check-for-accounting=true, etc.) which may overwrite Central's own role-profile defaults."
+    "Consumer responsibility documented: pre-filter source records to drop _flags.default=true sub-objects (and top-level default=true roles) before passing to emit_calls. Otherwise every role POST will explicitly carry AOS 8 system defaults (max-sessions=65535, check-for-accounting=true, etc.) which may overwrite Central's own role-profile defaults.",
+    "Central-side fields with no AOS 8 source equivalent (kept visible here for future translation paths, not migration targets in this AOS 8 -> Central GW path): (1) 'airslice-application-list' (root, GW) and 'monitoring-application-list' (root, GW) — Central-native AppRF / AirSlice features without an AOS 8 counterpart; (2) 'dap-application-uuid' (root, GW) — feeds Central's Dynamic App Prioritization service, configured via that service's UI not via role profile in AOS 8; (3) 'vlan-parameters.trunk-allowed-vlan-names' (GW per schema) and the 'ipfix-flow-monitor' separate sub-schema — both anticipated to surface on a future Classic-Central / switching-role translation path (Classic Central switch -> Central CNX), not on this Gateway translation; (4) 'session-parameters.disable-cp-gw-translation' (GW-only) — labelled an 'Internal flag' in the schema for captive-portal translation behavior on the GW agent, not operator-settable from AOS 8. None of these block AOS 8 -> Central GW migration; they're fields that will need a source mapping when the corresponding non-AOS-8 source platform / use case lands."
   ]
 }

--- a/src/hpe_networking_mcp/translations/transforms.py
+++ b/src/hpe_networking_mcp/translations/transforms.py
@@ -11,6 +11,7 @@ Transforms must stay pure (no I/O) so they can be unit-tested in isolation.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -112,6 +113,286 @@ def expand_vlan_id_csv(value: Any) -> list[int]:
     return out
 
 
+_VLAN_NUMERIC_RE = re.compile(r"^\d+$")
+
+
+def vlanstr_to_id_if_numeric(value: Any) -> int | None:
+    """Return int VLAN ID if ``value`` is a numeric string, else ``None``.
+
+    AOS 8 stores both VLAN IDs and VLAN names as a single string in
+    ``role__vlan.vlanstr``. Central splits these into ``access-vlan-id``
+    (int) and ``access-vlan-name`` (string) with a ``vlan-type``
+    discriminator. This transform extracts the ID variant; pair with
+    ``vlanstr_to_name_if_nonnumeric`` and ``vlanstr_to_vlan_type``.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if _VLAN_NUMERIC_RE.fullmatch(s):
+        return int(s)
+    return None
+
+
+def vlanstr_to_name_if_nonnumeric(value: Any) -> str | None:
+    """Return string VLAN name if ``value`` is a non-numeric string, else ``None``."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    if _VLAN_NUMERIC_RE.fullmatch(s) or not s:
+        return None
+    return s
+
+
+def vlanstr_to_vlan_type(value: Any) -> str | None:
+    """Return ``"VLAN_ID"`` or ``"VLAN_NAME"`` based on whether ``value`` is numeric.
+
+    Central's role schema uses ``vlan-type`` as a discriminator alongside
+    ``access-vlan-id`` / ``access-vlan-name``. This transform sources from
+    the same AOS 8 ``role__vlan.vlanstr`` field as the two ID/name transforms.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    return "VLAN_ID" if _VLAN_NUMERIC_RE.fullmatch(s) else "VLAN_NAME"
+
+
+def aos8_field_present_to_true(value: Any) -> bool | None:
+    """Map AOS 8 "field is present in payload" semantics to a Python ``True``.
+
+    AOS 8 surfaces several boolean role sub-properties as empty dicts when
+    configured (e.g. ``role__enforce_dhcp: {}``, ``role__reg_role: {}``,
+    ``role__dpi_disable: {}``). The presence of the parent path means the
+    operator enabled the feature; absence means they did not. Reaching this
+    transform implies the engine's ``_path_lookup`` already succeeded — so
+    the value is "configured" regardless of payload contents (empty dict,
+    ``{_present: true}``, or any other shape).
+
+    Returns ``True`` for any non-``None`` input; ``None`` for ``None``
+    (so the engine's optional-field path drops the body key).
+    """
+    if value is None:
+        return None
+    return True
+
+
+def aos8_reauth_minutes_value(value: Any) -> int | None:
+    """Extract ``reauthperiod`` from ``role__reauth`` only when it's the minutes form.
+
+    Source shape::
+
+        {"reauthperiod": <int>}                       # minutes (default form)
+        {"seconds": true, "reauthperiod": <int>}      # seconds form
+
+    Returns ``reauthperiod`` only when ``seconds`` is absent / falsy;
+    returns ``None`` for the seconds form so the seconds companion mapping
+    can claim the value instead. ``None`` propagates to drop the body key.
+    """
+    if not isinstance(value, dict):
+        return None
+    if value.get("seconds"):
+        return None
+    period = value.get("reauthperiod")
+    return int(period) if period is not None else None
+
+
+def aos8_reauth_seconds_value(value: Any) -> int | None:
+    """Extract ``reauthperiod`` from ``role__reauth`` only when it's the seconds form.
+
+    Companion to ``aos8_reauth_minutes_value``. Returns the value only when
+    ``seconds`` is truthy on the source dict.
+    """
+    if not isinstance(value, dict):
+        return None
+    if not value.get("seconds"):
+        return None
+    period = value.get("reauthperiod")
+    return int(period) if period is not None else None
+
+
+# --------------------------------------------------------------------------- #
+# Bandwidth-contract transforms
+# --------------------------------------------------------------------------- #
+#
+# AOS 8 carries role bandwidth-contract bindings in three source arrays that
+# Central CNX splits into FIVE distinct schemas (plus two exclude variants):
+#
+#   role__bwc            -> aaa-bw-contract.bw-contract[]
+#   role__bwc_app        -> app-aaa-contract.app[]                  (app_type="app")
+#                        -> app-category-aaa-contract.app-category[] (app_type="appcategory")
+#   role__bwc_web        -> web-category-aaa-contract.web-category[] (web_opt="web-cc-category")
+#                        -> web-reputation-aaa-contract.web-reputation[] (web_opt="web-cc-reputation")
+#
+# Each transform filters the relevant source variant, normalises the casing
+# (Central enums use UPPERCASE direction / reputation / category-name),
+# renames the source fields to their Central equivalents, and returns
+# ``None`` for empty-after-filter so the engine drops the body key.
+#
+# Live samples used to author these came from two roles in the operator's
+# tenant: ``blacklisted`` (basic per-role) and ``parent`` at /md/Campus/West
+# (per-app + per-appcategory + per-web-cc-category + per-web-cc-reputation).
+
+
+def _norm_direction(value: Any) -> str:
+    """AOS 8 lowercase 'downstream'/'upstream' -> Central UPPERCASE enum."""
+    return str(value).strip().upper()
+
+
+def aos8_role_bwc_basic_to_central(value: Any) -> list[dict[str, str]] | None:
+    """Map ``role__bwc[]`` to Central's ``aaa-bw-contract.bw-contract[]``.
+
+    Source items: ``{"dir_type": "downstream"|"upstream", "name": "<contract>"}``.
+    Target items: ``{"bwc-name", "direction": "DOWNSTREAM"|"UPSTREAM"}``.
+
+    AOS 8 doesn't carry the ``association`` field (per-user vs per-apgroup);
+    Central will apply its default. Returns ``None`` for empty input so the
+    engine drops the body key.
+    """
+    if not isinstance(value, list) or not value:
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        dir_type = entry.get("dir_type")
+        if name and dir_type:
+            out.append({"bwc-name": str(name), "direction": _norm_direction(dir_type)})
+    return out or None
+
+
+def aos8_role_bwc_app_filter_app(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_app[]`` to ``app_type == "app"``; rename for Central.
+
+    Source items (filtered): ``{"app_type": "app", "dir": "...", "appname": "<dpi-app>", "name": "<contract>"}``.
+    Target items: ``{"appname", "bwc-name", "direction"}``.
+
+    NOTE: Central's ``appname`` is an enum of ~3953 DPI app identifiers. AOS 8
+    source values pass through as-is; if AOS 8 and Central's DPI catalog drift
+    apart, the operator may need to remap unrecognized app names manually.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("app_type") != "app":
+            continue
+        appname = entry.get("appname")
+        name = entry.get("name")
+        direction = entry.get("dir")
+        if appname and name and direction:
+            out.append(
+                {
+                    "appname": str(appname),
+                    "bwc-name": str(name),
+                    "direction": _norm_direction(direction),
+                }
+            )
+    return out or None
+
+
+def aos8_role_bwc_app_filter_appcategory(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_app[]`` to ``app_type == "appcategory"``; rename + uppercase.
+
+    Source (filtered): ``{"app_type": "appcategory", "dir": "...",
+    "appname": "streaming", "name": "<contract>"}``.
+    Target: ``{"category-name": "STREAMING", "bwc-name", "direction"}``.
+
+    Central's ``category-name`` is an enum of 24 UPPERCASE-DASHED app category
+    identifiers; this transform uppercases the AOS 8 source value (``streaming``
+    -> ``STREAMING``) and otherwise passes through verbatim.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("app_type") != "appcategory":
+            continue
+        cat = entry.get("appname")
+        name = entry.get("name")
+        direction = entry.get("dir")
+        if cat and name and direction:
+            out.append(
+                {
+                    "category-name": str(cat).upper(),
+                    "bwc-name": str(name),
+                    "direction": _norm_direction(direction),
+                }
+            )
+    return out or None
+
+
+def aos8_role_bwc_web_filter_category(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_web[]`` to ``web_opt == "web-cc-category"``; rename + normalise.
+
+    Source (filtered): ``{"web_opt": "web-cc-category", "dir": "...",
+    "webcccatgname": "streaming/media", "name": "<contract>"}``.
+    Target: ``{"webcategory-name": "STREAMING-MEDIA", "bwc-name", "direction"}``.
+
+    Central's ``webcategory-name`` is an enum of 85 UPPERCASE-DASHED Web Content
+    Classification category names. The transform uppercases and replaces ``/``
+    with ``-`` to match Central's casing convention. Live example: AOS 8
+    ``streaming/media`` -> Central ``STREAMING-MEDIA`` (slash to dash + uppercase).
+
+    Caveat: only the simplest ``a/b -> A-B`` mapping is performed. Some Central
+    category names include connective words AOS 8 omits (e.g. AOS 8 may store
+    ``entertainment/arts`` while Central wants ``ENTERTAINMENT-AND-ARTS``).
+    Operators should spot-check categories with multi-word Central forms after
+    migration.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("web_opt") != "web-cc-category":
+            continue
+        cat = entry.get("webcccatgname")
+        name = entry.get("name")
+        direction = entry.get("dir")
+        if cat and name and direction:
+            out.append(
+                {
+                    "webcategory-name": str(cat).replace("/", "-").upper(),
+                    "bwc-name": str(name),
+                    "direction": _norm_direction(direction),
+                }
+            )
+    return out or None
+
+
+def aos8_role_bwc_web_filter_reputation(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_web[]`` to ``web_opt == "web-cc-reputation"``; rename + uppercase.
+
+    Source (filtered): ``{"web_opt": "web-cc-reputation", "dir": "...",
+    "web_rep": "trustworthy", "name": "<contract>"}``.
+    Target: ``{"webrepname": "TRUSTWORTHY", "bwc-name", "direction"}``.
+
+    Central's ``webrepname`` is a 5-value enum (TRUSTWORTHY / LOW_RISK /
+    MODERATE_RISK / SUSPICIOUS / HIGH_RISK). AOS 8 stores the lowercase form;
+    this transform uppercases. Underscores in the multi-word forms (``low-risk``
+    vs ``LOW_RISK``) are handled by replacing ``-`` with ``_``.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("web_opt") != "web-cc-reputation":
+            continue
+        rep = entry.get("web_rep")
+        name = entry.get("name")
+        direction = entry.get("dir")
+        if rep and name and direction:
+            out.append(
+                {
+                    "webrepname": str(rep).replace("-", "_").upper(),
+                    "bwc-name": str(name),
+                    "direction": _norm_direction(direction),
+                }
+            )
+    return out or None
+
+
 _REGISTRY: dict[str, TransformFn] = {
     "direct": direct,
     "direct_str": direct_str,
@@ -119,4 +400,15 @@ _REGISTRY: dict[str, TransformFn] = {
     "flag_to_bool": flag_to_bool,
     "split_csv_to_string_array": split_csv_to_string_array,
     "expand_vlan_id_csv": expand_vlan_id_csv,
+    "vlanstr_to_id_if_numeric": vlanstr_to_id_if_numeric,
+    "vlanstr_to_name_if_nonnumeric": vlanstr_to_name_if_nonnumeric,
+    "vlanstr_to_vlan_type": vlanstr_to_vlan_type,
+    "aos8_field_present_to_true": aos8_field_present_to_true,
+    "aos8_reauth_minutes_value": aos8_reauth_minutes_value,
+    "aos8_reauth_seconds_value": aos8_reauth_seconds_value,
+    "aos8_role_bwc_basic_to_central": aos8_role_bwc_basic_to_central,
+    "aos8_role_bwc_app_filter_app": aos8_role_bwc_app_filter_app,
+    "aos8_role_bwc_app_filter_appcategory": aos8_role_bwc_app_filter_appcategory,
+    "aos8_role_bwc_web_filter_category": aos8_role_bwc_web_filter_category,
+    "aos8_role_bwc_web_filter_reputation": aos8_role_bwc_web_filter_reputation,
 }

--- a/src/hpe_networking_mcp/translations/transforms.py
+++ b/src/hpe_networking_mcp/translations/transforms.py
@@ -393,6 +393,50 @@ def aos8_role_bwc_web_filter_reputation(value: Any) -> list[dict[str, str]] | No
     return out or None
 
 
+def aos8_role_bwc_excl_filter_app(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_ex[]`` to ``app_type == "app"``; rename for Central.
+
+    Source (filtered): ``{"app_type": "app", "appname": "<dpi-app>"}``.
+    Target: ``{"exclude-app-name": "<dpi-app>"}``.
+
+    The exclude variant carries no traffic direction and no contract
+    reference — listed apps simply bypass bandwidth-contract enforcement.
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("app_type") != "app":
+            continue
+        appname = entry.get("appname")
+        if appname:
+            out.append({"exclude-app-name": str(appname)})
+    return out or None
+
+
+def aos8_role_bwc_excl_filter_appcategory(value: Any) -> list[dict[str, str]] | None:
+    """Filter ``role__bwc_ex[]`` to ``app_type == "appcategory"``; rename + uppercase.
+
+    Source (filtered): ``{"app_type": "appcategory", "appname": "collaboration"}``.
+    Target: ``{"exclude-app-category-name": "COLLABORATION"}``.
+
+    Companion to ``aos8_role_bwc_excl_filter_app`` — sources from the same
+    ``role__bwc_ex`` array but filters to the appcategory variant. The
+    AOS 8 ``appname`` field carries the category name (a quirk of the
+    source schema reusing the field for both variants).
+    """
+    if not isinstance(value, list):
+        return None
+    out: list[dict[str, str]] = []
+    for entry in value:
+        if not isinstance(entry, dict) or entry.get("app_type") != "appcategory":
+            continue
+        cat = entry.get("appname")
+        if cat:
+            out.append({"exclude-app-category-name": str(cat).upper()})
+    return out or None
+
+
 _REGISTRY: dict[str, TransformFn] = {
     "direct": direct,
     "direct_str": direct_str,
@@ -411,4 +455,6 @@ _REGISTRY: dict[str, TransformFn] = {
     "aos8_role_bwc_app_filter_appcategory": aos8_role_bwc_app_filter_appcategory,
     "aos8_role_bwc_web_filter_category": aos8_role_bwc_web_filter_category,
     "aos8_role_bwc_web_filter_reputation": aos8_role_bwc_web_filter_reputation,
+    "aos8_role_bwc_excl_filter_app": aos8_role_bwc_excl_filter_app,
+    "aos8_role_bwc_excl_filter_appcategory": aos8_role_bwc_excl_filter_appcategory,
 }

--- a/tests/unit/test_translations_engine.py
+++ b/tests/unit/test_translations_engine.py
@@ -672,5 +672,29 @@ def test_role_no_bwc_configured_drops_all_bw_contract_keys(role) -> None:
         "app-category-aaa-contract",
         "web-category-aaa-contract",
         "web-reputation-aaa-contract",
+        "exclude-app-contract",
+        "exclude-app-cat-contract",
     ):
         assert key not in body
+
+
+def test_role_bwc_exclude_array_fans_out_to_app_and_appcategory_groups(role) -> None:
+    """Live shape: role__bwc_ex=[{app_type, appname}] mixes app + appcategory.
+
+    Source from 'parent' role at /md/Campus/West:
+      [{"app_type": "app", "appname": "netflix"},
+       {"app_type": "appcategory", "appname": "collaboration"}]
+    """
+    source = {
+        "rname": "parent",
+        "role__bwc_ex": [
+            {"app_type": "app", "appname": "netflix"},
+            {"app_type": "appcategory", "appname": "collaboration"},
+        ],
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "exclude-app-contract": {"exclude-app": [{"exclude-app-name": "netflix"}]},
+        "exclude-app-cat-contract": {"exclude-app-category": [{"exclude-app-category-name": "COLLABORATION"}]},
+    }

--- a/tests/unit/test_translations_engine.py
+++ b/tests/unit/test_translations_engine.py
@@ -31,6 +31,11 @@ def vlan_id(translations: dict):
     return translations["central:vlan_id"]
 
 
+@pytest.fixture
+def role(translations: dict):
+    return translations["central:role"]
+
+
 def _runtime(scope_id: str = "SCOPE", device_functions: list[str] | None = None) -> dict:
     """Helper: build Central-shaped runtime_values for the named-VLAN translation."""
     rv: dict = {"central_scope_id": scope_id}
@@ -323,3 +328,349 @@ def test_vlan_id_missing_required_id_raises(vlan_id) -> None:
     """Without 'id' the engine can't build the path — surface clear error."""
     with pytest.raises(EngineError, match="vlan_id"):
         emit_calls(vlan_id, {}, "aos8", runtime_values=_runtime())
+
+
+# --------------------------------------------------------------------------- #
+# central:role — Gateway-targeted, sourced from live AOS 8 captures
+# --------------------------------------------------------------------------- #
+
+
+def _role_runtime(scope_id: str = "SCOPE") -> dict:
+    """Helper: role translation defaults to MOBILITY_GW only (no AP)."""
+    return {"central_scope_id": scope_id}
+
+
+def test_role_minimum_record_emits_two_calls(role) -> None:
+    """Source with just rname: step 1 body has only 'name'; nested groups drop entirely."""
+    source = {"rname": "minimal-role"}
+    calls = emit_calls(role, source, "aos8", runtime_values=_role_runtime("SCOPE-A"))
+    assert len(calls) == 2
+    assert [c.step for c in calls] == [1, 2]
+    step1 = calls[0]
+    assert step1.method == "POST"
+    assert step1.endpoint == "/network-config/v1alpha1/roles/minimal-role"
+    assert step1.body == {"name": "minimal-role"}
+
+
+def test_role_with_named_vlan_emits_root_access_vlan_name(role) -> None:
+    """Per Central role schema, GW VLAN binding is at the ROOT (not vlan-parameters)."""
+    source = {"rname": "camera_role_ubt", "role__vlan": {"vlanstr": "internal"}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "camera_role_ubt",
+        "access-vlan-name": "internal",
+        "vlan-type": "VLAN_NAME",
+    }
+
+
+def test_role_with_numeric_vlan_emits_root_access_vlan_id(role) -> None:
+    source = {"rname": "data-role", "role__vlan": {"vlanstr": "104"}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {"name": "data-role", "access-vlan-id": 104, "vlan-type": "VLAN_ID"}
+
+
+def test_role_pattern_b_flags_render_as_true(role) -> None:
+    """Empty-dict source flags (live shape on configured 'parent' role) -> body bool true.
+
+    Source: role__enforce_dhcp/role__robust_age_out/role__reg_role/role__dpi_disable/
+    role__disable_webcc surface as {} when configured. Single-underscore variants
+    (role_disable_ipclassify / role_enable_youtubeedu) too. role__openflow is
+    deliberately omitted to confirm it doesn't appear in the body.
+    """
+    source = {
+        "rname": "parent",
+        "role__enforce_dhcp": {},
+        "role__robust_age_out": {},
+        "role__reg_role": {},
+        "role__dpi_disable": {},
+        "role__disable_webcc": {},
+        "role_disable_ipclassify": {},
+        "role_enable_youtubeedu": {},
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "miscellaneous-parameters": {
+            "enforce-dhcp": True,
+            "robust-age-out": True,
+            "registration-role": True,
+        },
+        "classification-parameters": {
+            "ip-classification": True,
+            "dpi-classification": True,
+            "dpi-youtube-education": True,
+            "web-cc": True,
+        },
+    }
+    assert "openflow-enable" not in body["miscellaneous-parameters"]
+
+
+def test_role_pattern_a_flags_render_as_true(role) -> None:
+    """Pattern-A flags ({_present: true} live shape on system defaults) also -> True."""
+    source = {
+        "rname": "logon-role",
+        "role__cp_acc": {"_present": True, "_flags": {"default": True}},
+        "role__openflow": {"_present": True, "_flags": {"default": True}},
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "logon-role",
+        "session-parameters": {"check-for-accounting": True},
+        "miscellaneous-parameters": {"openflow-enable": True},
+    }
+
+
+def test_role_reauth_minutes_routes_to_minutes_field(role) -> None:
+    source = {"rname": "r1", "role__reauth": {"reauthperiod": 30}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {"name": "r1", "session-parameters": {"reauthentication-interval": 30}}
+
+
+def test_role_reauth_seconds_routes_to_seconds_field(role) -> None:
+    """Live shape from configured 'parent' role: {seconds: true, reauthperiod: 3600}."""
+    source = {"rname": "parent", "role__reauth": {"seconds": True, "reauthperiod": 3600}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "session-parameters": {"reauthentication-interval-seconds": 3600},
+    }
+
+
+def test_role_captive_portal_lands_in_session_parameters(role) -> None:
+    source = {"rname": "onguard-role", "role__cp": {"cp_profile_name": "onguard-captive-portal"}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "onguard-role",
+        "session-parameters": {"captive-portal": "onguard-captive-portal"},
+    }
+
+
+def test_role_max_sessions_lands_in_session_parameters(role) -> None:
+    source = {"rname": "r", "role__max_sess": {"max_sess": 1024}}
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {"name": "r", "session-parameters": {"max-sessions": 1024}}
+
+
+def test_role_full_rich_record_renders_all_three_groups(role) -> None:
+    """Reproduce the live 'parent' role at /md/Campus/West (full Tier 1 + reauth-seconds)."""
+    source = {
+        "rname": "parent",
+        "role__vlan": {"vlanstr": "104"},
+        "role__cp_acc": {"_present": True},
+        "role__openflow": {"_present": True},
+        "role__reauth": {"seconds": True, "reauthperiod": 3600},
+        "role__max_sess": {"max_sess": 65535},
+        "role__enforce_dhcp": {},
+        "role__robust_age_out": {},
+        "role__reg_role": {},
+        "role__dpi_disable": {},
+        "role__disable_webcc": {},
+        "role_disable_ipclassify": {},
+        "role_enable_youtubeedu": {},
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "access-vlan-id": 104,
+        "vlan-type": "VLAN_ID",
+        "session-parameters": {
+            "check-for-accounting": True,
+            "max-sessions": 65535,
+            "reauthentication-interval-seconds": 3600,
+        },
+        "miscellaneous-parameters": {
+            "enforce-dhcp": True,
+            "robust-age-out": True,
+            "registration-role": True,
+            "openflow-enable": True,
+        },
+        "classification-parameters": {
+            "ip-classification": True,
+            "dpi-classification": True,
+            "dpi-youtube-education": True,
+            "web-cc": True,
+        },
+    }
+
+
+def test_role_does_not_emit_policies_field(role) -> None:
+    """Critical inversion: AOS 8 role.role__acl is NOT mapped to body 'policies'.
+
+    Central back-fills role.policies[] from policy-side references; sending
+    policies[] would either be rejected or silently overwritten.
+    """
+    source = {
+        "rname": "guest-postauth-role",
+        "role__acl": [
+            {"acl_type": "session", "pname": "ra-guard"},
+            {"acl_type": "session", "pname": "guest-postauth"},
+        ],
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {"name": "guest-postauth-role"}
+    assert "policies" not in body
+
+
+def test_role_step2_assigns_only_to_mobility_gw_by_default(role) -> None:
+    """target_meta declares MOBILITY_GW only — no CAMPUS_AP."""
+    source = {"rname": "demo"}
+    step2 = emit_calls(role, source, "aos8", runtime_values=_role_runtime("SCOPE-A"))[1]
+    items = (step2.body or {})["config-assignment"]
+    assert len(items) == 1
+    assert items[0]["device-function"] == "MOBILITY_GW"
+    assert items[0]["profile-type"] == "role"
+    assert items[0]["profile-instance"] == "demo"
+
+
+def test_role_missing_required_rname_raises(role) -> None:
+    with pytest.raises(EngineError, match="name"):
+        emit_calls(role, {}, "aos8", runtime_values=_role_runtime())
+
+
+def test_role_empty_nested_groups_drop_when_no_subfields_set(role) -> None:
+    """Confirm session-parameters / miscellaneous-parameters / classification-parameters
+    drop entirely when the source has no fields targeting them.
+    """
+    body = emit_calls(role, {"rname": "bare"}, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert "session-parameters" not in body
+    assert "miscellaneous-parameters" not in body
+    assert "classification-parameters" not in body
+
+
+# --------------------------------------------------------------------------- #
+# central:role — bandwidth-contract sub-shapes
+# --------------------------------------------------------------------------- #
+
+
+def test_role_bwc_basic_lands_in_aaa_bw_contract(role) -> None:
+    """Source from 'blacklisted' role: role__bwc=[{dir_type, name}]."""
+    source = {
+        "rname": "blacklisted",
+        "role__bwc": [
+            {"dir_type": "downstream", "name": "blacklisteddownstreamper-roleui"},
+            {"dir_type": "upstream", "name": "blacklistedupstreamper-roleui"},
+        ],
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "blacklisted",
+        "aaa-bw-contract": {
+            "bw-contract": [
+                {"bwc-name": "blacklisteddownstreamper-roleui", "direction": "DOWNSTREAM"},
+                {"bwc-name": "blacklistedupstreamper-roleui", "direction": "UPSTREAM"},
+            ]
+        },
+    }
+
+
+def test_role_bwc_app_array_fans_out_to_app_and_appcategory_groups(role) -> None:
+    """Live shape: role__bwc_app mixes app + appcategory; the engine fans out
+    via paired filter transforms to two distinct Central body fields.
+    """
+    source = {
+        "rname": "parent",
+        "role__bwc_app": [
+            {"app_type": "app", "dir": "downstream", "appname": "youtube", "name": "parentyoutubedownstream"},
+            {"app_type": "app", "dir": "upstream", "appname": "youtube", "name": "parentyoutubeupstream"},
+            {
+                "app_type": "appcategory",
+                "dir": "downstream",
+                "appname": "streaming",
+                "name": "parentstreamingdownstream",
+            },
+            {
+                "app_type": "appcategory",
+                "dir": "upstream",
+                "appname": "streaming",
+                "name": "parentstreamingupstream",
+            },
+        ],
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "app-aaa-contract": {
+            "app": [
+                {"appname": "youtube", "bwc-name": "parentyoutubedownstream", "direction": "DOWNSTREAM"},
+                {"appname": "youtube", "bwc-name": "parentyoutubeupstream", "direction": "UPSTREAM"},
+            ]
+        },
+        "app-category-aaa-contract": {
+            "app-category": [
+                {"category-name": "STREAMING", "bwc-name": "parentstreamingdownstream", "direction": "DOWNSTREAM"},
+                {"category-name": "STREAMING", "bwc-name": "parentstreamingupstream", "direction": "UPSTREAM"},
+            ]
+        },
+    }
+
+
+def test_role_bwc_web_array_fans_out_to_category_and_reputation_groups(role) -> None:
+    """Live shape: role__bwc_web mixes web-cc-category + web-cc-reputation."""
+    source = {
+        "rname": "parent",
+        "role__bwc_web": [
+            {
+                "webcccatgname": "streaming/media",
+                "web_opt": "web-cc-category",
+                "dir": "downstream",
+                "name": "parent-streaming-down",
+            },
+            {
+                "webcccatgname": "streaming/media",
+                "web_opt": "web-cc-category",
+                "dir": "upstream",
+                "name": "parent-streaming-up",
+            },
+            {
+                "web_rep": "trustworthy",
+                "web_opt": "web-cc-reputation",
+                "dir": "downstream",
+                "name": "parent-trustworthy-down",
+            },
+            {
+                "web_rep": "trustworthy",
+                "web_opt": "web-cc-reputation",
+                "dir": "upstream",
+                "name": "parent-trustworthy-up",
+            },
+        ],
+    }
+    body = emit_calls(role, source, "aos8", runtime_values=_role_runtime())[0].body or {}
+    assert body == {
+        "name": "parent",
+        "web-category-aaa-contract": {
+            "web-category": [
+                {
+                    "webcategory-name": "STREAMING-MEDIA",
+                    "bwc-name": "parent-streaming-down",
+                    "direction": "DOWNSTREAM",
+                },
+                {
+                    "webcategory-name": "STREAMING-MEDIA",
+                    "bwc-name": "parent-streaming-up",
+                    "direction": "UPSTREAM",
+                },
+            ]
+        },
+        "web-reputation-aaa-contract": {
+            "web-reputation": [
+                {"webrepname": "TRUSTWORTHY", "bwc-name": "parent-trustworthy-down", "direction": "DOWNSTREAM"},
+                {"webrepname": "TRUSTWORTHY", "bwc-name": "parent-trustworthy-up", "direction": "UPSTREAM"},
+            ]
+        },
+    }
+
+
+def test_role_no_bwc_configured_drops_all_bw_contract_keys(role) -> None:
+    """Confirm a role without any bw-contract source doesn't produce empty
+    aaa-bw-contract / app-aaa-contract / etc. groups.
+    """
+    body = emit_calls(role, {"rname": "no-bwc"}, "aos8", runtime_values=_role_runtime())[0].body or {}
+    for key in (
+        "aaa-bw-contract",
+        "app-aaa-contract",
+        "app-category-aaa-contract",
+        "web-category-aaa-contract",
+        "web-reputation-aaa-contract",
+    ):
+        assert key not in body

--- a/tests/unit/test_translations_loader.py
+++ b/tests/unit/test_translations_loader.py
@@ -52,6 +52,67 @@ def test_loads_shipped_vlan_id_translation_cleanly() -> None:
     assert src.key_mappings["wired_aaa_profile"].optional is True
 
 
+def test_loads_shipped_role_translation_cleanly() -> None:
+    """The shipped Central role translation targets MOBILITY_GW only.
+
+    Field set is verified against the live AOS 8 source shape (parent role at
+    /md/Campus/West with full Tier 1 + reauth-seconds) and the Central role
+    schema's x-supportedDeviceType=Gateway annotations.
+    """
+    translations = load_translations()
+    assert "central:role" in translations
+    r = translations["central:role"]
+    assert r.target_platform == "central"
+    assert r.target_id == "role"
+    assert len(r.target_emits) == 2
+    # Gateway-only target (AP roles use a different schema)
+    assert r.target_meta.device_functions == ["MOBILITY_GW"]
+
+    src = r.sources["aos8"]
+    assert src.mapping_kind == "simple"
+    # Required: name (from rname)
+    assert src.key_mappings["name"].optional is False
+    # All sub-properties optional
+    optional_keys = {
+        "access_vlan_id",
+        "access_vlan_name",
+        "vlan_type",
+        "captive_portal",
+        "check_for_accounting",
+        "max_sessions",
+        "reauthentication_interval",
+        "reauthentication_interval_seconds",
+        "openflow_enable",
+        "enforce_dhcp",
+        "robust_age_out",
+        "registration_role",
+        "ip_classification",
+        "dpi_classification",
+        "dpi_youtube_education",
+        "web_cc",
+    }
+    for key in optional_keys:
+        assert src.key_mappings[key].optional is True, f"{key} should be optional"
+
+    # Verify the single-underscore source field names that surprised me on review
+    assert src.key_mappings["ip_classification"].from_ == "role_disable_ipclassify"
+    assert src.key_mappings["dpi_youtube_education"].from_ == "role_enable_youtubeedu"
+    # Verify the corrected naming: reg_role not registration_role on the source side
+    assert src.key_mappings["registration_role"].from_ == "role__reg_role"
+    assert src.key_mappings["dpi_classification"].from_ == "role__dpi_disable"
+    assert src.key_mappings["web_cc"].from_ == "role__disable_webcc"
+
+    # Confirm policies dropped: there is no key_mapping that produces a 'policies' body field
+    body = next(e.body for e in r.target_emits if e.step == 1)
+    assert body is not None
+    assert "policies" not in body
+
+    # Confirm bw-contract + acl-binding are explicitly captured as deferred
+    deferred_topics = " ".join(u.from_ for u in src.unmapped_fields)
+    assert "role__bwc" in deferred_topics
+    assert "role__acl" in deferred_topics
+
+
 def test_loader_key_is_composite_platform_and_id(tmp_path: Path) -> None:
     """Loader key is '<target_platform>:<target_id>'; same target_id under
     different platforms doesn't collide."""

--- a/tests/unit/test_translations_loader.py
+++ b/tests/unit/test_translations_loader.py
@@ -90,6 +90,13 @@ def test_loads_shipped_role_translation_cleanly() -> None:
         "dpi_classification",
         "dpi_youtube_education",
         "web_cc",
+        "bw_contract_basic",
+        "bw_contract_app",
+        "bw_contract_appcategory",
+        "bw_contract_web_category",
+        "bw_contract_web_reputation",
+        "bw_contract_exclude_app",
+        "bw_contract_exclude_appcategory",
     }
     for key in optional_keys:
         assert src.key_mappings[key].optional is True, f"{key} should be optional"
@@ -102,14 +109,22 @@ def test_loads_shipped_role_translation_cleanly() -> None:
     assert src.key_mappings["dpi_classification"].from_ == "role__dpi_disable"
     assert src.key_mappings["web_cc"].from_ == "role__disable_webcc"
 
+    # Verify bw-contract source paths route to all 7 Central body fields
+    assert src.key_mappings["bw_contract_basic"].from_ == "role__bwc"
+    assert src.key_mappings["bw_contract_app"].from_ == "role__bwc_app"
+    assert src.key_mappings["bw_contract_appcategory"].from_ == "role__bwc_app"
+    assert src.key_mappings["bw_contract_web_category"].from_ == "role__bwc_web"
+    assert src.key_mappings["bw_contract_web_reputation"].from_ == "role__bwc_web"
+    assert src.key_mappings["bw_contract_exclude_app"].from_ == "role__bwc_ex"
+    assert src.key_mappings["bw_contract_exclude_appcategory"].from_ == "role__bwc_ex"
+
     # Confirm policies dropped: there is no key_mapping that produces a 'policies' body field
     body = next(e.body for e in r.target_emits if e.step == 1)
     assert body is not None
     assert "policies" not in body
 
-    # Confirm bw-contract + acl-binding are explicitly captured as deferred
+    # role__acl still captured as the explicit deferred entry (handled by future central:policy)
     deferred_topics = " ".join(u.from_ for u in src.unmapped_fields)
-    assert "role__bwc" in deferred_topics
     assert "role__acl" in deferred_topics
 
 

--- a/tests/unit/test_translations_transforms.py
+++ b/tests/unit/test_translations_transforms.py
@@ -17,6 +17,8 @@ from hpe_networking_mcp.translations.transforms import (
     aos8_role_bwc_app_filter_app,
     aos8_role_bwc_app_filter_appcategory,
     aos8_role_bwc_basic_to_central,
+    aos8_role_bwc_excl_filter_app,
+    aos8_role_bwc_excl_filter_appcategory,
     aos8_role_bwc_web_filter_category,
     aos8_role_bwc_web_filter_reputation,
     get_transform,
@@ -253,6 +255,38 @@ class TestBwcWebFilters:
         assert aos8_role_bwc_web_filter_reputation(None) is None
 
 
+class TestBwcExcludeFilters:
+    def test_filter_exclude_app_returns_app_only(self) -> None:
+        """Live shape: role__bwc_ex=[{app_type, appname}] (no dir, no name)."""
+        source = [
+            {"app_type": "app", "appname": "netflix"},
+            {"app_type": "appcategory", "appname": "collaboration"},
+        ]
+        assert aos8_role_bwc_excl_filter_app(source) == [{"exclude-app-name": "netflix"}]
+
+    def test_filter_exclude_appcategory_returns_uppercased(self) -> None:
+        source = [
+            {"app_type": "app", "appname": "skip-me"},
+            {"app_type": "appcategory", "appname": "collaboration"},
+            {"app_type": "appcategory", "appname": "streaming"},
+        ]
+        assert aos8_role_bwc_excl_filter_appcategory(source) == [
+            {"exclude-app-category-name": "COLLABORATION"},
+            {"exclude-app-category-name": "STREAMING"},
+        ]
+
+    def test_filters_return_none_when_no_matching_entries(self) -> None:
+        source_only_app = [{"app_type": "app", "appname": "netflix"}]
+        assert aos8_role_bwc_excl_filter_appcategory(source_only_app) is None
+
+        source_only_cat = [{"app_type": "appcategory", "appname": "collaboration"}]
+        assert aos8_role_bwc_excl_filter_app(source_only_cat) is None
+
+    def test_empty_input_returns_none(self) -> None:
+        assert aos8_role_bwc_excl_filter_app([]) is None
+        assert aos8_role_bwc_excl_filter_appcategory(None) is None
+
+
 # --------------------------------------------------------------------------- #
 # Registry
 # --------------------------------------------------------------------------- #
@@ -279,6 +313,8 @@ class TestRegistry:
             "aos8_role_bwc_app_filter_appcategory",
             "aos8_role_bwc_web_filter_category",
             "aos8_role_bwc_web_filter_reputation",
+            "aos8_role_bwc_excl_filter_app",
+            "aos8_role_bwc_excl_filter_appcategory",
         ],
     )
     def test_all_transforms_resolve(self, name: str) -> None:

--- a/tests/unit/test_translations_transforms.py
+++ b/tests/unit/test_translations_transforms.py
@@ -1,0 +1,290 @@
+"""Unit tests for translation transforms.
+
+Coverage focuses on the role-specific transforms added in v3.0.1.2 — the
+older shared transforms (direct, direct_int, flag_to_bool,
+split_csv_to_string_array, expand_vlan_id_csv) are exercised end-to-end via
+the engine tests; we don't double up here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.translations.transforms import (
+    aos8_field_present_to_true,
+    aos8_reauth_minutes_value,
+    aos8_reauth_seconds_value,
+    aos8_role_bwc_app_filter_app,
+    aos8_role_bwc_app_filter_appcategory,
+    aos8_role_bwc_basic_to_central,
+    aos8_role_bwc_web_filter_category,
+    aos8_role_bwc_web_filter_reputation,
+    get_transform,
+    vlanstr_to_id_if_numeric,
+    vlanstr_to_name_if_nonnumeric,
+    vlanstr_to_vlan_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# VLAN-string disambiguation transforms
+# --------------------------------------------------------------------------- #
+
+
+class TestVlanstrTransforms:
+    @pytest.mark.parametrize(
+        ("source", "id_out", "name_out", "type_out"),
+        [
+            ("100", 100, None, "VLAN_ID"),
+            ("4094", 4094, None, "VLAN_ID"),
+            ("internal", None, "internal", "VLAN_NAME"),
+            ("user-vlan", None, "user-vlan", "VLAN_NAME"),
+            ("0007", 7, None, "VLAN_ID"),
+            (None, None, None, None),
+            ("", None, None, None),
+            ("  ", None, None, None),
+        ],
+    )
+    def test_vlanstr_disambiguation(
+        self, source: str | None, id_out: int | None, name_out: str | None, type_out: str | None
+    ) -> None:
+        assert vlanstr_to_id_if_numeric(source) == id_out
+        assert vlanstr_to_name_if_nonnumeric(source) == name_out
+        assert vlanstr_to_vlan_type(source) == type_out
+
+    def test_whitespace_stripped(self) -> None:
+        assert vlanstr_to_id_if_numeric("  42  ") == 42
+        assert vlanstr_to_name_if_nonnumeric("  guest  ") == "guest"
+        assert vlanstr_to_vlan_type("  100  ") == "VLAN_ID"
+
+
+# --------------------------------------------------------------------------- #
+# aos8_field_present_to_true
+# --------------------------------------------------------------------------- #
+
+
+class TestFieldPresentToTrue:
+    def test_pattern_b_empty_dict_means_configured(self) -> None:
+        """role__enforce_dhcp: {} (live shape from configured 'parent' role) -> True."""
+        assert aos8_field_present_to_true({}) is True
+
+    def test_pattern_a_present_true_with_flags(self) -> None:
+        """role__cp_acc: {_present: true, _flags: {default: true}} -> True."""
+        assert aos8_field_present_to_true({"_present": True, "_flags": {"default": True}}) is True
+
+    def test_none_input_drops_body_key(self) -> None:
+        """Engine returned None means path lookup raised + optional path applies."""
+        assert aos8_field_present_to_true(None) is None
+
+    @pytest.mark.parametrize("value", [True, False, 0, 1, "string", [1, 2, 3]])
+    def test_any_non_none_returns_true(self, value: object) -> None:
+        """Reaching this transform implies the path resolved; treat any value as 'configured'."""
+        assert aos8_field_present_to_true(value) is True
+
+
+# --------------------------------------------------------------------------- #
+# Reauthentication-interval disambiguator pair
+# --------------------------------------------------------------------------- #
+
+
+class TestReauthDisambiguator:
+    def test_minutes_form_returns_value_when_seconds_absent(self) -> None:
+        """Default form: {reauthperiod: N} (no 'seconds' key) -> minutes side gets N."""
+        source = {"reauthperiod": 30}
+        assert aos8_reauth_minutes_value(source) == 30
+        assert aos8_reauth_seconds_value(source) is None
+
+    def test_seconds_form_returns_value_only_on_seconds_side(self) -> None:
+        """Live shape: {seconds: true, reauthperiod: 3600} -> seconds side gets 3600."""
+        source = {"seconds": True, "reauthperiod": 3600}
+        assert aos8_reauth_minutes_value(source) is None
+        assert aos8_reauth_seconds_value(source) == 3600
+
+    def test_seconds_false_treated_as_minutes(self) -> None:
+        source = {"seconds": False, "reauthperiod": 15}
+        assert aos8_reauth_minutes_value(source) == 15
+        assert aos8_reauth_seconds_value(source) is None
+
+    def test_zero_reauthperiod_preserved(self) -> None:
+        """reauthperiod=0 (AOS 8 default) is still a real value, not None."""
+        source = {"reauthperiod": 0}
+        assert aos8_reauth_minutes_value(source) == 0
+        assert aos8_reauth_seconds_value(source) is None
+
+    def test_missing_reauthperiod_returns_none(self) -> None:
+        assert aos8_reauth_minutes_value({"seconds": True}) is None
+        assert aos8_reauth_seconds_value({}) is None
+
+    def test_non_dict_input_returns_none(self) -> None:
+        for bad in [None, "string", 42, [1, 2]]:
+            assert aos8_reauth_minutes_value(bad) is None
+            assert aos8_reauth_seconds_value(bad) is None
+
+
+# --------------------------------------------------------------------------- #
+# Bandwidth-contract transforms
+# --------------------------------------------------------------------------- #
+
+
+class TestBwcBasic:
+    def test_live_shape_from_blacklisted_role(self) -> None:
+        """Source shape from the 'blacklisted' role at /md/Campus/West."""
+        source = [
+            {"dir_type": "downstream", "name": "blacklisteddownstreamper-roleui"},
+            {"dir_type": "upstream", "name": "blacklistedupstreamper-roleui"},
+        ]
+        assert aos8_role_bwc_basic_to_central(source) == [
+            {"bwc-name": "blacklisteddownstreamper-roleui", "direction": "DOWNSTREAM"},
+            {"bwc-name": "blacklistedupstreamper-roleui", "direction": "UPSTREAM"},
+        ]
+
+    def test_empty_input_returns_none(self) -> None:
+        assert aos8_role_bwc_basic_to_central(None) is None
+        assert aos8_role_bwc_basic_to_central([]) is None
+
+    def test_entries_missing_required_fields_skipped(self) -> None:
+        source = [{"dir_type": "downstream"}, {"dir_type": "upstream", "name": "ok"}]
+        assert aos8_role_bwc_basic_to_central(source) == [{"bwc-name": "ok", "direction": "UPSTREAM"}]
+
+
+class TestBwcAppFilters:
+    def test_filter_app_only_returns_app_entries(self) -> None:
+        """Live source from 'parent' role mixes app + appcategory in role__bwc_app."""
+        source = [
+            {"app_type": "app", "dir": "downstream", "appname": "youtube", "name": "parentyoutubedownstream"},
+            {"app_type": "app", "dir": "upstream", "appname": "youtube", "name": "parentyoutubeupstream"},
+            {
+                "app_type": "appcategory",
+                "dir": "downstream",
+                "appname": "streaming",
+                "name": "parentstreamingdownstream",
+            },
+        ]
+        assert aos8_role_bwc_app_filter_app(source) == [
+            {"appname": "youtube", "bwc-name": "parentyoutubedownstream", "direction": "DOWNSTREAM"},
+            {"appname": "youtube", "bwc-name": "parentyoutubeupstream", "direction": "UPSTREAM"},
+        ]
+
+    def test_filter_appcategory_only_returns_appcategory_entries_uppercased(self) -> None:
+        source = [
+            {"app_type": "app", "dir": "downstream", "appname": "youtube", "name": "skip-me"},
+            {
+                "app_type": "appcategory",
+                "dir": "downstream",
+                "appname": "streaming",
+                "name": "parentstreamingdownstream",
+            },
+            {
+                "app_type": "appcategory",
+                "dir": "upstream",
+                "appname": "streaming",
+                "name": "parentstreamingupstream",
+            },
+        ]
+        assert aos8_role_bwc_app_filter_appcategory(source) == [
+            {"category-name": "STREAMING", "bwc-name": "parentstreamingdownstream", "direction": "DOWNSTREAM"},
+            {"category-name": "STREAMING", "bwc-name": "parentstreamingupstream", "direction": "UPSTREAM"},
+        ]
+
+    def test_filters_return_none_when_no_matching_entries(self) -> None:
+        source_only_app = [{"app_type": "app", "dir": "downstream", "appname": "x", "name": "y"}]
+        assert aos8_role_bwc_app_filter_appcategory(source_only_app) is None
+        source_only_cat = [{"app_type": "appcategory", "dir": "downstream", "appname": "x", "name": "y"}]
+        assert aos8_role_bwc_app_filter_app(source_only_cat) is None
+
+
+class TestBwcWebFilters:
+    def test_filter_web_category_uppercases_and_dashes(self) -> None:
+        """Live shape: webcccatgname='streaming/media' -> 'STREAMING-MEDIA'.
+
+        Note: this slash-and-uppercase mapping doesn't insert connective words
+        some Central enums carry (e.g. 'ENTERTAINMENT-AND-ARTS'). Operators
+        must spot-check categories with multi-word Central forms after
+        migration.
+        """
+        source = [
+            {
+                "webcccatgname": "streaming/media",
+                "web_opt": "web-cc-category",
+                "dir": "downstream",
+                "name": "parent-streaming-down",
+            },
+            {
+                "webcccatgname": "streaming/media",
+                "web_opt": "web-cc-category",
+                "dir": "upstream",
+                "name": "parent-streaming-up",
+            },
+            {"web_rep": "trustworthy", "web_opt": "web-cc-reputation", "dir": "downstream", "name": "skip-me"},
+        ]
+        assert aos8_role_bwc_web_filter_category(source) == [
+            {
+                "webcategory-name": "STREAMING-MEDIA",
+                "bwc-name": "parent-streaming-down",
+                "direction": "DOWNSTREAM",
+            },
+            {
+                "webcategory-name": "STREAMING-MEDIA",
+                "bwc-name": "parent-streaming-up",
+                "direction": "UPSTREAM",
+            },
+        ]
+
+    def test_filter_web_reputation_uppercases_and_underscores(self) -> None:
+        source = [
+            {"web_rep": "trustworthy", "web_opt": "web-cc-reputation", "dir": "downstream", "name": "n1"},
+            {"web_rep": "low-risk", "web_opt": "web-cc-reputation", "dir": "upstream", "name": "n2"},
+            {
+                "webcccatgname": "skip",
+                "web_opt": "web-cc-category",
+                "dir": "downstream",
+                "name": "skip-me",
+            },
+        ]
+        assert aos8_role_bwc_web_filter_reputation(source) == [
+            {"webrepname": "TRUSTWORTHY", "bwc-name": "n1", "direction": "DOWNSTREAM"},
+            {"webrepname": "LOW_RISK", "bwc-name": "n2", "direction": "UPSTREAM"},
+        ]
+
+    def test_empty_or_no_match_returns_none(self) -> None:
+        assert aos8_role_bwc_web_filter_category([]) is None
+        assert aos8_role_bwc_web_filter_reputation(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+
+
+class TestRegistry:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "direct",
+            "direct_str",
+            "direct_int",
+            "flag_to_bool",
+            "split_csv_to_string_array",
+            "expand_vlan_id_csv",
+            "vlanstr_to_id_if_numeric",
+            "vlanstr_to_name_if_nonnumeric",
+            "vlanstr_to_vlan_type",
+            "aos8_field_present_to_true",
+            "aos8_reauth_minutes_value",
+            "aos8_reauth_seconds_value",
+            "aos8_role_bwc_basic_to_central",
+            "aos8_role_bwc_app_filter_app",
+            "aos8_role_bwc_app_filter_appcategory",
+            "aos8_role_bwc_web_filter_category",
+            "aos8_role_bwc_web_filter_reputation",
+        ],
+    )
+    def test_all_transforms_resolve(self, name: str) -> None:
+        fn = get_transform(name)
+        assert callable(fn)
+
+    def test_unknown_transform_raises_with_known_list(self) -> None:
+        with pytest.raises(KeyError, match="Unknown transform"):
+            get_transform("does_not_exist")


### PR DESCRIPTION
## Summary

Reworked from PR #282 after operator-led review. New translation \`central:role\` — AOS 8 user-role REST → Central role profile for the **Gateway** device-function. Body shape is the strict intersection of \"AOS 8 carries it\" + \"Central role schema accepts it for Gateway\".

## What changed from PR #282 (the closed one)

| Issue caught in review | Fix in this PR |
|---|---|
| \`policies[]\` body field doesn't exist on Central's role schema | **Dropped entirely.** Documented inversion: Central back-fills \`role.policies[]\` from policy-side references; ACL/policy binding will be owned by future \`central:policy\` translation. |
| VLAN binding nested under \`vlan-parameters\` | **Moved to root** (\`access-vlan-id\` / \`access-vlan-name\` / \`vlan-type\`). The \`vlan-parameters\` sub-object is for Switch CX / AP / Switch PVOS, NOT Gateway. |
| 5 LLD-INFERRED source field names wrong | **Verified live** on a purpose-configured \`parent\` role at \`/md/Campus/West\`: \`role__reg_role\` (not registration_role), \`role__dpi_disable\` (not dpi_classification), \`role__disable_webcc\` (not web_cc), and the single-underscore quirks \`role_disable_ipclassify\` / \`role_enable_youtubeedu\`. |
| Pattern-A flag transform assumed \`{_present: true}\` shape | **Discovered Pattern B**: empty \`{}\` for newer flags. New \`aos8_field_present_to_true\` handles both. |
| Reauth seconds/minutes disambiguation missing | **Live-verified** \`role__reauth.seconds: true\` discriminator; paired transforms route the value. |
| target_meta included CAMPUS_AP | **MOBILITY_GW only** — AP roles use a different Central schema (named-vlan, vlan-parameters, etc.). |

## Files

- **New**: \`src/hpe_networking_mcp/translations/targets/central/role_v1.json\`
- **New**: \`tests/unit/test_translations_transforms.py\` (36 tests)
- \`transforms.py\` — 6 new transforms + registry entries
- \`engine.py\` — \`_drop_none_keys\` enhanced for empty nested dicts
- \`tests/unit/test_translations_engine.py\` — 13 new role tests
- \`tests/unit/test_translations_loader.py\` — 1 new schema-validation test asserting the corrected source field names + that \`policies\` is absent from the body template
- \`CHANGELOG.md\`, \`README.md\`, \`pyproject.toml\`

## Test plan

- [x] \`uv run ruff check .\` clean
- [x] \`uv run ruff format --check .\` clean
- [x] \`uv run mypy src/ --ignore-missing-imports\` clean
- [x] \`uv run pytest tests/ -q\` — 1089 passed (was 1037; +52 new tests)
- [x] AOS 8 source-side field names cross-referenced against live tenant (55 roles at \`/md/Campus/West\` + purpose-configured \`parent\` test role with full Tier 1 flag set + reauthentication-interval-seconds 3600)
- [x] Central body fields cross-referenced against \`api-endpoints/central/role.json\`'s \`x-supportedDeviceType=Gateway\` annotations
- [ ] End-to-end live POST against Central tenant — deferred to consumer integration (engine doesn't dispatch)

## Deferred to v2

- \`role__bwc\` (bandwidth contracts) — one variant sampled live (basic per-role with \`dir_type\`); 4 other LLD sub-shapes need configured samples before authoring
- \`role__acl\` — handled by future \`central:policy\` translation (the inversion)
- VIA + IP pool families — operator scoped them out (rarely used; alternative products handle the workflow)
- \`session-parameters.disable-cp-gw-translation\` — Gateway-only Central field; AOS 8 source name unknown

## Notes

- Tracked in #279 (translations engine design ledger). Does not close it.
- No consumer wired yet; engine is still pure-data per the v3.0.1.0 design.