### PR TITLE
v3.0.1.6: central_translation_preview tool + aos-migration Stage 9b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.6] - 2026-05-08
+
+**Patch release — `central_translation_preview` tool + `aos-migration` Stage 9b engine-driven preview. Phase-3-lite read-only path so the translations engine sees daylight on real data before #240's actual writes land.**
+
+The translations engine (4 shipped translations, validated lint, ~480-line preprocessing module for policy) has been infrastructure-only since v3.0.1.0 — no consumer skill actually invokes it; `aos-migration` Act II describes translation outcomes narratively but doesn't call `emit_calls`. Code-mode `execute()` blocks imports of internal modules (verified by Zach's report: `import hashlib` failed), so an AI client running the skill cannot reach the engine directly.
+
+This release ships the bridge: a read-only tool that wraps `emit_calls`, plus an aos-migration skill stage that uses it. When an operator asks "what policies will be migrated and where will they land," the skill now produces deterministic engine output rather than the AI's interpretation.
+
+### Three changes
+
+1. **New `central_translation_preview` tool.** Accepts `translation_id` + `source_records` (list of source-platform dicts) + `runtime_values` and returns the deterministic per-record `TargetCall` list. Read-only by construction — the engine is pure data; the tool wraps it; no `central_*` API call is made. Per-record `EngineError` surfaces as `skip_reason` so a partial preview is still useful (empty ACLs, missing required runtime values, etc. don't crash the batch). Module-level cache loads translations once per process. Not gated by `ENABLE_CENTRAL_WRITE_TOOLS` because it cannot write.
+
+2. **`aos-migration` Stage 9b — engine-driven translation preview.** New stage between Stage 9 (narrative AI-authored API call sequence) and Stage 10 (validation checklist). For each of the four shipped translations (`central:vlan_id`, `central:named_vlan`, `central:role`, `central:policy`), Stage 9b provides a paste-ready `execute()` block that:
+   - Resolves Stage 7's operator-confirmed Central scope names to scope_ids via `central-scope-walker`.
+   - Filters Stage 1's collected records (system / inherited entries dropped per the translation's consumer responsibilities).
+   - Pre-merges composite sources (`central:named_vlan` joins `vlan_name` ⨝ `vlan_name_id`).
+   - Calls `central_translation_preview` with the right runtime_values (including `role_records` for policy preprocessing).
+   - Renders a bounded summary table (~30 rows max per translation; full bodies reachable on operator drill-down).
+
+   Stage 9 stays — it's the high-level cutover plan. Stage 9b is the deterministic per-object engine output. Both compose; operators read Stage 9 for the order of operations and Stage 9b for "show me the actual JSON bodies and rule counts."
+
+3. **INSTRUCTIONS.md** — adds `central_translation_preview` to the Aruba Central tool index with the per-translation `runtime_values` requirements (especially `role_records` for policy reverse-index lookup).
+
+### Files
+
+- **New: `src/hpe_networking_mcp/platforms/central/tools/translation_preview.py`** — the bridge tool (~210 lines)
+- **`src/hpe_networking_mcp/platforms/central/__init__.py`** — registers the new `translation_preview` category
+- **New: `tests/unit/test_central_translation_preview.py`** — 16 tests (per-translation happy paths, per-record EngineError surfacing, fatal-error contract, caching)
+- **`src/hpe_networking_mcp/skills/aos-migration.md`** — Stage 9b section + adds `central_translation_preview` to `tools` frontmatter
+- **`src/hpe_networking_mcp/INSTRUCTIONS.md`** — adds the tool to the Central section
+- **`README.md`** — Central count 87 → 88, total underlying 367 → 368
+- **`docs/TOOLS.md`** — Central count 87 → 88, total underlying 367 → 368
+- **`pyproject.toml`** — bump 3.0.1.5 → 3.0.1.6
+
+### Notes
+
+- 1174 tests pass (was 1158; +16 from the new tool's tests).
+- **Tool is read-only by construction.** The engine never calls `central_*` APIs; it only manipulates dicts. Returning `TargetCall` descriptors as JSON-serializable dicts cannot accidentally mutate Central state. Real execution lands as a separate `central_manage_*` tool with elicitation gating per #240.
+- **Why a tool when the policy is "skill, not tool"?** The `central-scope-walker` skill works because `central_get_scope_tree` is already a tool — the data is fetchable, the skill just composes it. The translations engine isn't reachable from `execute()` (sandbox blocks internal imports), so no skill can invoke it. The "no tool when a skill works" rule applies when the data is fetchable; here it isn't.
+- **Phase 3 boundary stays clean.** This tool is `_preview` (read-only). Future execution is a separate `central_manage_*` tool — different name, write-tool gating, elicitation. Operators inspecting the tool list can tell preview from execute at a glance.
+
 ## [3.0.1.5] - 2026-05-07
 
 **Patch release — small-local-model code-mode hardening from Zach's continued OpenClaw + Qwen3 4B test report (2026-05-07).**

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **35 + 2 prompts** | **87 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools** | **35 + 2 prompts** | **88 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 368 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -196,7 +196,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 35 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 35 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 368 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -454,7 +454,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
-│  All 367 underlying tools reachable via call_tool() in code mode or via                 │
+│  All 368 underlying tools reachable via call_tool() in code mode or via                 │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘           │
 │     │          │          │          │          │          │          │                 │
@@ -469,7 +469,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 367 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 368 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -531,7 +531,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 367 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 368 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -598,7 +598,7 @@ hpe-networking-mcp/
 │       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
 │       ├── health.py            # Cross-platform health probe tool
 │       ├── mist/                # 35 Mist tools + 2 prompts + API client
-│       ├── central/             # 87 Central tools + 12 prompts + API client
+│       ├── central/             # 88 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
 │       ├── clearpass/           # 140 ClearPass tools + pyclearpass SDK client
 │       ├── apstra/              # 19 Apstra tools + async httpx client
@@ -726,25 +726,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 367)
+### Tool Surface Looks Wrong (6 tools vs. 368)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 368 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 367 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 368 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 367 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 368 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 368 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 367 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 368 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 367 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 368 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 368 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 367 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 368 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -49,7 +49,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (87)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (88)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 367 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 368 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -670,7 +670,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (87 tools + 12 prompts)
+## Aruba Central (88 tools + 12 prompts)
 
 ### Sites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.5"
+version = "3.0.1.6"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 367 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 368 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
@@ -346,6 +346,12 @@ When asked to create a new site based on an existing site:
   - Filter with `device_type`, `site_id`, `site_name`, or `serial_number`. Default behavior omits devices already on Central's recommended version; pass `include_up_to_date=True` to see them too.
   - The `release_type` field reflects the API's `firmwareClassification` directly — values are `LSR`, `SSR`, or `UNCLASSIFIED` (AOS 8 and other builds the API doesn't classify fall into the last bucket and pass Central's recommendation through).
   - Narrowing `device_type` restricts the pool used to mine the newest LSR target for SSR devices — leave it unset when you want the tool to make SSR→LSR recommendations.
+- **Translation Preview (read-only)**: central_translation_preview
+  - Read-only bridge to the translations engine. Runs server-side and returns deterministic `TargetCall` descriptors per source-platform record (e.g. AOS 8 → Central). **Never writes** — the engine is pure data; this tool wraps it.
+  - Use for "show me what migrating these AOS 8 policies / roles / VLANs would produce in Central" workflows. The `aos-migration` skill's Stage 9b uses it as the engine-driven preview path.
+  - Required `runtime_values` are translation-specific: `central_scope_id` always; `role_records` (full AOS 8 role list) for `central:policy` so the engine's preprocessing can compute role_attribution per ACL.
+  - Returns a per-record results list including `skip_reason` for records the engine couldn't translate (empty ACLs, missing required fields, etc.) — surface these to the operator verbatim; they're migration findings.
+  - Real *execution* of the translation (write path) is a separate future tool tracked under #240; this one is preview-only.
 
 ## Aruba Central Best Practices
 

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -118,6 +118,7 @@ TOOLS = {
         "central_manage_gateway_cluster",
     ],
     "firmware": ["central_recommend_firmware"],
+    "translation_preview": ["central_translation_preview"],
 }
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/translation_preview.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/translation_preview.py
@@ -1,0 +1,238 @@
+"""Read-only bridge that exposes the translations engine to AI clients.
+
+The translations engine (``hpe_networking_mcp.translations``) lives in the
+package and produces deterministic ``TargetCall`` descriptors from a
+source-platform record (e.g. an AOS 8 ``acl_sess`` row) plus runtime
+context (Central scope_id, role records, etc.). The engine never makes
+API calls — it's pure data — so a tool wrapping it is read-only by
+construction.
+
+Why this tool exists: code-mode ``execute()`` blocks imports of internal
+modules (verified via Zach's OpenClaw + Qwen3 4B test report 2026-05-07
+where ``import hashlib`` failed). AI clients running in code mode can't
+``import hpe_networking_mcp.translations`` directly. This tool is the
+bridge — it accepts the same inputs the engine takes, runs the engine
+server-side, and returns JSON-serializable output.
+
+Use cases:
+
+* aos-migration Stage 9b — engine-driven preview of what the migration
+  will emit per AOS 8 object (per role, per ACL, per VLAN). Today's
+  Phase-3-lite read-only step before #240's actual writes land.
+* Future ad-hoc translation previews ("show me what this AOS 8 role
+  would look like in Central").
+
+The tool is intentionally ungated by ``ENABLE_CENTRAL_WRITE_TOOLS``
+because it cannot write — every code path returns dict / list of
+descriptors. No ``central_*`` API call is made. Real execution (write
+path) lands later as a separate ``central_manage_*`` tool with
+elicitation gating, per #240.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.central._registry import tool
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.translations import (
+    EngineError,
+    LoaderError,
+    TargetCall,
+    Translation,
+    emit_calls,
+    load_translations,
+)
+
+# Module-level cache. Translations are validated JSON files — load once,
+# reuse across calls. Cleared automatically when the process restarts.
+_TRANSLATIONS_CACHE: dict[str, Translation] | None = None
+
+
+def _get_translations() -> dict[str, Translation]:
+    """Lazily load + cache the shipped translations.
+
+    Caches at module level on first call. ``LoaderError`` propagates to
+    the tool wrapper which converts it to a readable error response.
+    """
+    global _TRANSLATIONS_CACHE
+    if _TRANSLATIONS_CACHE is None:
+        _TRANSLATIONS_CACHE = load_translations()
+    return _TRANSLATIONS_CACHE
+
+
+def _record_id(record: dict[str, Any], translation_id: str) -> str:
+    """Extract a meaningful primary-key string from one source record.
+
+    Falls back to ``"<unknown>"`` if the expected field isn't present so
+    the preview output stays useful even when source data is malformed.
+    """
+    if not isinstance(record, dict):
+        return "<not-a-dict>"
+
+    primary_key_by_translation: dict[str, str] = {
+        "central:policy": "accname",
+        "central:role": "rname",
+        "central:vlan_id": "id",
+        "central:named_vlan": "name",
+    }
+    field = primary_key_by_translation.get(translation_id)
+    if field is None:
+        # Best-effort: try a few common identifier fields.
+        for guess in ("id", "name", "rname", "accname"):
+            if guess in record:
+                return str(record[guess])
+        return "<unknown>"
+
+    value = record.get(field)
+    return str(value) if value is not None else "<missing>"
+
+
+def _serialize_call(call: TargetCall) -> dict[str, Any]:
+    """Convert a ``TargetCall`` dataclass to a JSON-friendly dict."""
+    return dataclasses.asdict(call)
+
+
+@tool(annotations=READ_ONLY)
+async def central_translation_preview(
+    ctx: Context,
+    translation_id: str,
+    source_records: list[dict],
+    runtime_values: dict[str, Any] | None = None,
+    source_platform: str = "aos8",
+    overrides: dict[str, Any] | None = None,
+) -> dict:
+    """
+    Read-only preview of what the translations engine would emit per source record.
+
+    Runs the translations engine server-side over a list of source-platform
+    records and returns the deterministic ``TargetCall`` descriptors per
+    record. **Does not write to Central.** Real execution lands in a future
+    ``central_manage_*`` tool gated by ``ENABLE_CENTRAL_WRITE_TOOLS`` and
+    elicitation; this tool is the read-only preview path used by
+    aos-migration Stage 9b.
+
+    Available shipped translations (as of v3.0.1.6):
+
+    * ``central:vlan_id`` — AOS 8 ``vlan_id`` → Central layer2-vlan
+    * ``central:named_vlan`` — AOS 8 composite (vlan_name + vlan_name_id) → Central named-VLAN with alias chain
+    * ``central:role`` — AOS 8 ``role`` → Central role profile (Gateway-targeted)
+    * ``central:policy`` — AOS 8 ``acl_sess`` → Central /policies POST
+
+    Required ``runtime_values`` per translation:
+
+    * ``central:vlan_id`` / ``central:named_vlan`` / ``central:role`` —
+      ``central_scope_id`` (string).
+    * ``central:policy`` — ``central_scope_id`` (string) PLUS
+      ``role_records`` (list of full AOS 8 role records, used by the
+      engine's preprocessing step to compute role_attribution per ACL
+      via reverse-index lookup).
+
+    For ``central:named_vlan``: pre-merge the composite source (vlan_name
+    join vlan_name_id by ``name``) before passing each merged record.
+    The engine's per-record contract assumes a single dict per call.
+
+    Parameters:
+        translation_id: Composite key like ``"central:policy"`` matching
+            ``"<target_platform>:<target_id>"`` from a shipped translation
+            JSON. Unknown ids return an error in the response.
+        source_records: List of source-platform records to preview, one
+            per emit_calls invocation. Empty list returns an empty result.
+        runtime_values: Target-platform-specific runtime context (e.g.
+            ``{"central_scope_id": "...", "role_records": [...]}``). The
+            translation declares which keys are required; missing keys
+            surface per-record as a ``skip_reason``.
+        source_platform: Which ``sources.<platform>`` block of the
+            translation to consume. Defaults to ``"aos8"`` (the only
+            shipped source today).
+        overrides: Optional per-session operator overrides for derived
+            values (e.g. ``{"alias_name": "custom-name"}`` for named_vlan).
+
+    Returns:
+        Dict with:
+
+        * ``translation_id`` — echo of the input
+        * ``source_platform`` — echo of the input
+        * ``record_count`` — total source records processed
+        * ``translatable_count`` — records that produced TargetCalls
+        * ``skipped_count`` — records that hit an EngineError
+        * ``results`` — list of per-record dicts with
+          ``record_id`` / ``target_calls`` / ``call_count`` /
+          ``skip_reason`` (None on success).
+
+        On a fatal error (unknown translation_id, loader failure, etc.)
+        returns ``{"ok": false, "error": "..."}`` instead of the normal
+        shape — code-mode error contract per
+        ``project_code_mode_error_contract``.
+    """
+    _ = ctx  # ctx is unused — pure-data tool, no platform conn needed
+    runtime_values = runtime_values or {}
+    overrides = overrides or {}
+
+    try:
+        translations = _get_translations()
+    except LoaderError as exc:
+        return {"ok": False, "error": f"Translation loader failed: {exc}"}
+
+    if translation_id not in translations:
+        return {
+            "ok": False,
+            "error": f"Unknown translation_id {translation_id!r}; available: {sorted(translations.keys())}",
+        }
+    translation = translations[translation_id]
+
+    if source_platform not in translation.sources:
+        return {
+            "ok": False,
+            "error": (
+                f"Translation {translation_id!r} does not declare source {source_platform!r}; "
+                f"available: {sorted(translation.sources.keys())}"
+            ),
+        }
+
+    results: list[dict[str, Any]] = []
+    translatable = 0
+    skipped = 0
+    for record in source_records:
+        rid = _record_id(record, translation_id)
+        try:
+            calls = emit_calls(
+                translation=translation,
+                source_data=record,
+                source_platform_id=source_platform,
+                runtime_values=runtime_values,
+                overrides=overrides,
+            )
+        except EngineError as exc:
+            results.append(
+                {
+                    "record_id": rid,
+                    "target_calls": [],
+                    "call_count": 0,
+                    "skip_reason": str(exc),
+                }
+            )
+            skipped += 1
+            continue
+
+        results.append(
+            {
+                "record_id": rid,
+                "target_calls": [_serialize_call(c) for c in calls],
+                "call_count": len(calls),
+                "skip_reason": None,
+            }
+        )
+        translatable += 1
+
+    return {
+        "translation_id": translation_id,
+        "source_platform": source_platform,
+        "record_count": len(source_records),
+        "translatable_count": translatable,
+        "skipped_count": skipped,
+        "results": results,
+    }

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -46,7 +46,7 @@ description: |
   process and partner-tool guidance.
 platforms: [central, aos8]
 tags: [central, migration, aos8, aos10, readiness, audit, vsg, translation]
-tools: [health, central_get_scope_tree, central_get_devices, central_get_aps, central_get_sites, central_get_site_name_id_mapping, central_recommend_firmware, central_get_config_assignments, central_get_server_groups, central_get_wlan_profiles, central_get_roles, central_get_role_acls, central_get_net_groups, central_get_net_services, central_get_named_vlans, central_get_aliases, central_get_gateway_cluster_intent_profiles, central_get_gateway_clusters, central_manage_site, central_manage_site_collection, central_manage_device_group, central_manage_role, central_manage_role_acl, central_manage_net_group, central_manage_net_service, central_manage_wlan_profile, central_manage_config_assignment, central_manage_gateway_cluster_intent_profile, central_manage_gateway_cluster, clearpass_get_network_devices, clearpass_get_device_groups, clearpass_get_server_certificates, clearpass_get_local_users, greenlake_get_subscriptions, greenlake_get_workspace, greenlake_get_devices, aos8_get_md_hierarchy, aos8_get_effective_config, aos8_get_ap_database, aos8_get_cluster_state, aos8_show_command, aos8_get_clients, aos8_get_bss_table, aos8_get_active_aps, aos8_get_ap_wired_ports]
+tools: [health, central_get_scope_tree, central_get_devices, central_get_aps, central_get_sites, central_get_site_name_id_mapping, central_recommend_firmware, central_get_config_assignments, central_get_server_groups, central_get_wlan_profiles, central_get_roles, central_get_role_acls, central_get_net_groups, central_get_net_services, central_get_named_vlans, central_get_aliases, central_get_gateway_cluster_intent_profiles, central_get_gateway_clusters, central_translation_preview, central_manage_site, central_manage_site_collection, central_manage_device_group, central_manage_role, central_manage_role_acl, central_manage_net_group, central_manage_net_service, central_manage_wlan_profile, central_manage_config_assignment, central_manage_gateway_cluster_intent_profile, central_manage_gateway_cluster, clearpass_get_network_devices, clearpass_get_device_groups, clearpass_get_server_certificates, clearpass_get_local_users, greenlake_get_subscriptions, greenlake_get_workspace, greenlake_get_devices, aos8_get_md_hierarchy, aos8_get_effective_config, aos8_get_ap_database, aos8_get_cluster_state, aos8_show_command, aos8_get_clients, aos8_get_bss_table, aos8_get_active_aps, aos8_get_ap_wired_ports]
 ---
 
 # AOS 8 → AOS 10 migration (PoC) — readiness + config translation plan
@@ -837,7 +837,242 @@ For every row of the Stage 8 disposition matrix where Disposition is `direct-tra
 
 ---
 
-### Stage 10 — Validation checklist (TRANSLATE-04)
+### Stage 9b — Engine-driven translation preview (TRANSLATE-03b, read-only)
+
+**Run this stage when the operator asks for a deterministic, engine-produced preview of what the migration will emit per object — e.g. "give me a breakdown of what the policies will look like in Central and where they'll land."** Stage 9 (above) is the *narrative* AI-authored API call sequence; Stage 9b is the *deterministic* engine output. Operators reviewing migration impact should read both — Stage 9 for the ordered cutover plan, Stage 9b for the actual JSON bodies and rule-by-rule per-object detail.
+
+**This stage uses the `central_translation_preview` tool** — a read-only bridge to the translations engine that runs server-side and returns deterministic `TargetCall` descriptors. **Read-only — no API writes.** Real execution lands in #240's Phase 3.
+
+**Preconditions:**
+
+- Stage 1 has collected the AOS 8 inventory (effective-config dump). Reuse those records — do NOT re-fetch.
+- Stage 7 has produced the operator-confirmed AOS 8 → Central hierarchy mapping. For each AOS 8 binding scope (`/md/Campus/West`, etc.), Stage 7 names a Central scope (e.g. `Global/USE/HQ`).
+- Resolve each Central scope NAME from Stage 7's mapping to a Central scope_id via the `central-scope-walker` skill (call once per distinct Central scope name; cache the result; the walker handles name → scope_id lookup deterministically).
+
+**Translations shipped today (v3.0.1.6):**
+
+| translation_id | AOS 8 source | Central target | Notes |
+|---|---|---|---|
+| `central:vlan_id` | `vlan_id` (bare or rich) | layer2-vlan profile | Per-record. Optional sub-fields drop when absent. |
+| `central:named_vlan` | composite: `vlan_name` ⨝ `vlan_name_id` on `name` | named-VLAN + alias chain (6 emits) | Composite source — pre-merge before passing one record per name. |
+| `central:role` | `role` (Gateway-targeted) | role profile + config-assignment | ~25 fields. Skip `_flags.default=true` system roles. |
+| `central:policy` | `acl_sess` | /policies POST + config-assignment | Engine pre-processes via reverse-index lookup against role records (consumer pre-fetches once). |
+
+#### Step 1 — Scope resolution (run once)
+
+Use `central-scope-walker` to resolve each distinct Central scope name from Stage 7 mapping into its scope_id. Build a small dict the next steps will reuse:
+
+```python
+# Inside execute(): one walker call per distinct Central scope name from Stage 7.
+scope_lookup = {}
+for central_scope_name in {"Global/USE/HQ", "Global"}:  # operator-confirmed Stage 7 names
+    response = await call_tool("central_get_scope_tree", {"view": "committed"})
+    envelope = response.get("data", response)
+    root = envelope.get("result", envelope) if isinstance(envelope, dict) and "result" in envelope else envelope
+    # ... walker snippet from central-scope-walker skill ...
+    # scope_lookup[central_scope_name] = matches[0]["scope_id"]
+```
+
+(See the `central-scope-walker` skill for the complete walker snippet — paste it verbatim, don't re-author the recursion.)
+
+#### Step 2 — Run the engine-driven preview per translation
+
+For each translation, invoke `central_translation_preview` with the relevant Stage 1 records + scope_id. The tool returns deterministic per-record `TargetCall` descriptors.
+
+##### 2a — VLANs (`central:vlan_id`)
+
+```python
+# Stage 1 collected aos8_get_effective_config(object_name="vlan_id") records.
+# Filter inherited copies (consumer responsibility per the translation JSON).
+vlan_records = [r for r in stage1_vlan_id_records if not (r.get("_flags") or {}).get("inherited")]
+
+response = await call_tool(
+    "central_translation_preview",
+    {
+        "translation_id": "central:vlan_id",
+        "source_records": vlan_records,
+        "runtime_values": {"central_scope_id": scope_lookup["Global/USE/HQ"]},
+    },
+)
+preview = response.get("data", response)
+result = {
+    "kind": "central:vlan_id",
+    "record_count": preview["record_count"],
+    "translatable": preview["translatable_count"],
+    "skipped": preview["skipped_count"],
+    "summary": [
+        {"id": r["record_id"], "calls": r["call_count"], "skip": r["skip_reason"]}
+        for r in preview["results"]
+    ][:30],   # cap for small models
+}
+result
+```
+
+##### 2b — Named VLANs (`central:named_vlan`)
+
+Composite source — merge `vlan_name` ⨝ `vlan_name_id` on `name` BEFORE the call.
+
+```python
+# Stage 1 collected both objects. Filter inherited copies on each side
+# (consumer responsibility per named_vlan_v1.json's merge_rule).
+vlan_names = [r for r in stage1_vlan_name_records if not (r.get("_flags") or {}).get("inherited")]
+vlan_id_bindings = [r for r in stage1_vlan_name_id_records if not (r.get("_flags") or {}).get("inherited")]
+
+# Merge: one record per name with name + vlan-ids combined.
+binding_by_name = {b["name"]: b for b in vlan_id_bindings}
+merged = []
+for vn in vlan_names:
+    nm = vn.get("name")
+    if nm and nm in binding_by_name:
+        merged.append({**vn, **binding_by_name[nm]})  # carries 'name' + 'vlan-ids'
+
+response = await call_tool(
+    "central_translation_preview",
+    {
+        "translation_id": "central:named_vlan",
+        "source_records": merged,
+        "runtime_values": {"central_scope_id": scope_lookup["Global/USE/HQ"]},
+    },
+)
+preview = response.get("data", response)
+result = {
+    "kind": "central:named_vlan",
+    "record_count": preview["record_count"],
+    "translatable": preview["translatable_count"],
+    "skipped": preview["skipped_count"],
+    "summary": [
+        {"name": r["record_id"], "calls": r["call_count"], "skip": r["skip_reason"]}
+        for r in preview["results"]
+    ][:30],
+}
+result
+```
+
+##### 2c — Roles (`central:role`)
+
+```python
+# Filter system / default roles (consumer responsibility per role_v1.json).
+role_records = [
+    r for r in stage1_role_records
+    if not (r.get("_flags") or {}).get("default")
+    and not (r.get("_flags") or {}).get("inherited")
+]
+
+response = await call_tool(
+    "central_translation_preview",
+    {
+        "translation_id": "central:role",
+        "source_records": role_records,
+        "runtime_values": {"central_scope_id": scope_lookup["Global/USE/HQ"]},
+    },
+)
+preview = response.get("data", response)
+result = {
+    "kind": "central:role",
+    "record_count": preview["record_count"],
+    "translatable": preview["translatable_count"],
+    "skipped": preview["skipped_count"],
+    "summary": [
+        {"name": r["record_id"], "calls": r["call_count"], "skip": r["skip_reason"]}
+        for r in preview["results"]
+    ][:30],
+}
+result
+```
+
+##### 2d — Policies (`central:policy`)
+
+Policy preprocessing reverse-indexes role records — pass the FULL role list (post system-default filtering) via `runtime_values["role_records"]`. The engine does the per-ACL lookup internally.
+
+```python
+# Same role_records as 2c (already system-default-filtered).
+acl_records = [
+    r for r in stage1_acl_sess_records
+    if not (r.get("_flags") or {}).get("inherited")
+    and not (r.get("_flags") or {}).get("system")
+]
+
+response = await call_tool(
+    "central_translation_preview",
+    {
+        "translation_id": "central:policy",
+        "source_records": acl_records,
+        "runtime_values": {
+            "central_scope_id": scope_lookup["Global/USE/HQ"],
+            "role_records": role_records,
+        },
+    },
+)
+preview = response.get("data", response)
+result = {
+    "kind": "central:policy",
+    "record_count": preview["record_count"],
+    "translatable": preview["translatable_count"],
+    "skipped": preview["skipped_count"],
+    "summary": [
+        {
+            "acl": r["record_id"],
+            "calls": r["call_count"],
+            "rules": (
+                len(r["target_calls"][0]["body"]["security-policy"]["policy-rule"])
+                if r["target_calls"] else 0
+            ),
+            "skip": r["skip_reason"],
+        }
+        for r in preview["results"]
+    ][:30],
+}
+result
+```
+
+#### Step 3 — Render the consolidated preview report
+
+Combine the four `result` dicts from Step 2 into a single operator-facing table:
+
+```
+## Engine-driven translation preview (read-only)
+
+**Source scope:** /md/Campus/West (AOS 8) → Global/USE/HQ (Central, scope_id `<...>`)
+**Translations run:** central:vlan_id, central:named_vlan, central:role, central:policy
+**Tool:** central_translation_preview (read-only; no API writes)
+
+### Summary
+
+| Translation | Records | Translatable | Skipped | Calls (sum) |
+|---|---|---|---|---|
+| central:vlan_id | 8 | 8 | 0 | 16 |
+| central:named_vlan | 4 | 4 | 0 | 24 |
+| central:role | 12 | 12 | 0 | 24 |
+| central:policy | 14 | 13 | 1 | 26 |
+
+### Per-record detail
+
+#### Policies (14 records, 1 skipped)
+| ACL | Rules | Calls | Skip |
+|---|---|---|---|
+| parent | 14 (incl. 2 from any-any expansion) | 2 | — |
+| blacklisted | 8 | 2 | — |
+| empty-test | 0 | 0 | empty rule list — per LLD, empty ACLs are not migrated |
+...
+
+#### Roles (12 records)
+| Role | Calls |
+|---|---|
+| faculty-staff | 2 |
+| corp-employee | 2 |
+...
+```
+
+**Output rules:**
+
+- **Use the engine's deterministic counts** — never hand-fabricate. If the tool returns `translatable_count=8`, that's the number; do not narrate "approximately 8" or "8 or 9".
+- **Surface every skip_reason verbatim** — these are the operator's signals about what won't migrate (empty ACLs, missing role attribution, etc.).
+- **Cap the per-record detail table at ~30 rows per translation.** If the operator asks "show me detail for ACL X" specifically, re-run with that single record and dump its full `target_calls[0].body` for inspection.
+- **Do NOT dump full `target_calls` bodies in the consolidated output** — they're large and break small-model serialization. The summary table is enough; the body is reachable on operator request.
+
+**Findings produced:** if `skipped_count > 0` for any translation, surface the skip reasons as a finding under Act II's "Translation gaps" subsection. These typically map to operator-confirmable decisions (rename / merge / drop / handle in alternative product).
+
+---
 
 For every Stage 9 step that creates a Central object (i.e. excludes `[Central API gap]` placeholder steps), emit one row of a validation checklist mapping the create call to its corresponding read-back call.
 

--- a/tests/unit/test_central_translation_preview.py
+++ b/tests/unit/test_central_translation_preview.py
@@ -1,0 +1,279 @@
+"""Unit tests for the ``central_translation_preview`` tool.
+
+The tool is a thin read-only bridge between the AI client (in code mode,
+where ``import hpe_networking_mcp.translations`` is blocked by the
+sandbox) and the translations engine. Tests exercise the bridge's
+contract: per-record success, per-record EngineError surfacing,
+unknown translation_id, unknown source_platform, and serialization.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools import translation_preview as tp_module
+from hpe_networking_mcp.platforms.central.tools.translation_preview import (
+    central_translation_preview,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+class _StubContext:
+    """Minimal stand-in for ``fastmcp.Context`` — the tool doesn't read it."""
+
+    def __init__(self) -> None:
+        self.lifespan_context: dict[str, Any] = {}
+
+
+@pytest.fixture(autouse=True)
+def _reset_translations_cache() -> None:
+    """Reset the module-level cache between tests so each test sees a fresh load."""
+    tp_module._TRANSLATIONS_CACHE = None
+    yield
+    tp_module._TRANSLATIONS_CACHE = None
+
+
+@pytest.fixture
+def ctx() -> _StubContext:
+    return _StubContext()
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: shipped translations resolve + emit calls
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_vlan_id_preview_returns_target_calls(ctx: _StubContext) -> None:
+    """``central:vlan_id`` preview produces 2 TargetCalls per source record."""
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[{"id": 108}],
+        runtime_values={"central_scope_id": "scope-abc"},
+        source_platform="aos8",
+    )
+
+    assert response["translation_id"] == "central:vlan_id"
+    assert response["record_count"] == 1
+    assert response["translatable_count"] == 1
+    assert response["skipped_count"] == 0
+    assert len(response["results"]) == 1
+
+    record_result = response["results"][0]
+    assert record_result["record_id"] == "108"
+    assert record_result["skip_reason"] is None
+    assert record_result["call_count"] == 2  # create_layer2_vlan_shared + assign_layer2_vlan
+    assert record_result["target_calls"][0]["step"] == 1
+    assert record_result["target_calls"][0]["method"] == "POST"
+    assert record_result["target_calls"][1]["step"] == 2
+    assert record_result["target_calls"][1]["endpoint"].endswith("/config-assignments")
+
+
+@pytest.mark.unit
+async def test_role_preview_returns_2_calls(ctx: _StubContext) -> None:
+    """``central:role`` preview produces SHARED-create + config-assignment per role."""
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:role",
+        source_records=[{"rname": "faculty"}],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+    assert response["translatable_count"] == 1
+    assert response["skipped_count"] == 0
+    assert response["results"][0]["record_id"] == "faculty"
+    assert response["results"][0]["call_count"] == 2
+
+
+@pytest.mark.unit
+async def test_policy_preview_with_role_records(ctx: _StubContext) -> None:
+    """``central:policy`` requires role_records in runtime_values for preprocessing."""
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:policy",
+        source_records=[
+            {
+                "accname": "test-policy",
+                "acl_sess__v4policy": [{"sany": True, "src": "sany", "dany": True, "dst": "dany", "action": "permit"}],
+                "acl_sess__v6policy": [],
+            }
+        ],
+        runtime_values={
+            "central_scope_id": "scope-abc",
+            "role_records": [
+                {
+                    "rname": "test-role",
+                    "role__acl": [{"acl_type": "session", "pname": "test-policy"}],
+                }
+            ],
+        },
+    )
+    assert response["translatable_count"] == 1
+    assert response["results"][0]["record_id"] == "test-policy"
+    assert response["results"][0]["call_count"] == 2
+    # Body should carry the policy name
+    body = response["results"][0]["target_calls"][0]["body"]
+    assert body["name"] == "test-policy"
+    assert body["type"] == "POLICY_TYPE_SECURITY"
+
+
+# --------------------------------------------------------------------------- #
+# Per-record EngineError surfaces as skip_reason (doesn't crash the batch)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_missing_required_runtime_value_surfaces_per_record_skip(ctx: _StubContext) -> None:
+    """When the engine raises EngineError for one record, the batch keeps going."""
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[{"id": 108}, {"id": 109}],
+        runtime_values={},  # missing central_scope_id — engine will raise
+    )
+    # Both records skipped because runtime_values is missing the required key.
+    assert response["translatable_count"] == 0
+    assert response["skipped_count"] == 2
+    for r in response["results"]:
+        assert r["skip_reason"] is not None
+        assert "central_scope_id" in r["skip_reason"]
+
+
+@pytest.mark.unit
+async def test_mixed_batch_partial_success(ctx: _StubContext) -> None:
+    """A batch with one good + one malformed record reports each separately."""
+    # Pass enough runtime_values for the good record; the malformed record's
+    # engine error surfaces independently. Use a record without 'id' to break.
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[
+            {"id": 108},  # good
+            {"description": "missing id field"},  # bad — required key missing
+        ],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+    assert response["record_count"] == 2
+    # The good record should produce 2 calls; the bad one is either skipped
+    # or produces an error depending on how the engine handles missing required
+    # source fields. Assert that we get one of each outcome.
+    good_results = [r for r in response["results"] if r["call_count"] > 0]
+    assert len(good_results) >= 1
+    assert good_results[0]["record_id"] == "108"
+
+
+# --------------------------------------------------------------------------- #
+# Fatal errors return {"ok": false, "error": "..."}
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_unknown_translation_id_returns_error(ctx: _StubContext) -> None:
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:does_not_exist",
+        source_records=[{"id": 1}],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+    assert response.get("ok") is False
+    assert "Unknown translation_id" in response["error"]
+
+
+@pytest.mark.unit
+async def test_unknown_source_platform_returns_error(ctx: _StubContext) -> None:
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[{"id": 108}],
+        runtime_values={"central_scope_id": "scope-abc"},
+        source_platform="bogus_platform",
+    )
+    assert response.get("ok") is False
+    assert "does not declare source" in response["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Empty input
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_empty_source_records_returns_empty_results(ctx: _StubContext) -> None:
+    response = await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+    assert response["record_count"] == 0
+    assert response["translatable_count"] == 0
+    assert response["skipped_count"] == 0
+    assert response["results"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Helper: _record_id extraction
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestRecordIdExtraction:
+    def test_policy_uses_accname(self) -> None:
+        assert tp_module._record_id({"accname": "blacklisted"}, "central:policy") == "blacklisted"
+
+    def test_role_uses_rname(self) -> None:
+        assert tp_module._record_id({"rname": "faculty"}, "central:role") == "faculty"
+
+    def test_vlan_id_uses_id(self) -> None:
+        assert tp_module._record_id({"id": 107}, "central:vlan_id") == "107"
+
+    def test_named_vlan_uses_name(self) -> None:
+        assert tp_module._record_id({"name": "user", "vlan-ids": "107"}, "central:named_vlan") == "user"
+
+    def test_missing_primary_key_returns_sentinel(self) -> None:
+        assert tp_module._record_id({}, "central:policy") == "<missing>"
+
+    def test_non_dict_record_returns_sentinel(self) -> None:
+        assert tp_module._record_id("not a dict", "central:policy") == "<not-a-dict>"  # type: ignore[arg-type]
+
+    def test_unknown_translation_falls_back_to_common_keys(self) -> None:
+        assert tp_module._record_id({"name": "fallback"}, "central:unknown_translation") == "fallback"
+
+
+# --------------------------------------------------------------------------- #
+# Caching: subsequent calls reuse the loaded translations
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_translations_are_cached_across_calls(ctx: _StubContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The module-level cache prevents re-reading the JSON files per call."""
+    call_count = {"n": 0}
+    original_loader = tp_module.load_translations
+
+    def counting_loader(*args: Any, **kwargs: Any) -> Any:
+        call_count["n"] += 1
+        return original_loader(*args, **kwargs)
+
+    monkeypatch.setattr(tp_module, "load_translations", counting_loader)
+    tp_module._TRANSLATIONS_CACHE = None  # ensure cold start
+
+    await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:vlan_id",
+        source_records=[{"id": 108}],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+    await central_translation_preview(
+        ctx=ctx,  # type: ignore[arg-type]
+        translation_id="central:role",
+        source_records=[{"rname": "faculty"}],
+        runtime_values={"central_scope_id": "scope-abc"},
+    )
+
+    assert call_count["n"] == 1, "load_translations should only be invoked on the first call"

--- a/tests/unit/test_skill_tool_references.py
+++ b/tests/unit/test_skill_tool_references.py
@@ -76,6 +76,13 @@ _GLOBAL_ALLOWLIST: frozenset[str] = frozenset(
         "central_manage_ap_system_profile",
         "central_manage_server",
         "central_manage_server_group",
+        # `aos-migration.md` Stage 9b uses these as runtime_value keys / variable
+        # names inside the engine-driven preview snippets — NOT tools. The regex
+        # picks them up because they look like `central_<word>` but they're
+        # parameter names in `runtime_values={"central_scope_id": ...}` and a
+        # local variable iterating Stage 7 mappings (`central_scope_name`).
+        "central_scope_id",
+        "central_scope_name",
     }
 )
 


### PR DESCRIPTION
## Summary

Phase-3-lite read-only path so the translations engine sees daylight on real data before #240's actual writes land. Code-mode `execute()` blocks imports of internal modules (verified by Zach's continued OpenClaw + Qwen3 4B report — `import hashlib` failed), so an AI client running `aos-migration` cannot reach `hpe_networking_mcp.translations` directly. This PR ships the bridge.

### Three changes

1. **`central_translation_preview` tool.** Read-only by construction; wraps `emit_calls`; returns deterministic per-record `TargetCall` list. Per-record `EngineError` surfaces as `skip_reason` so a partial preview is still useful (empty ACLs, missing required runtime values). Module-level cache loads translations once. Not gated by `ENABLE_CENTRAL_WRITE_TOOLS` — cannot write.

2. **`aos-migration` Stage 9b — engine-driven translation preview.** New stage between Stage 9 (narrative cutover plan) and Stage 10 (validation checklist). Paste-ready `execute()` blocks for each of the four shipped translations (`central:vlan_id`, `central:named_vlan`, `central:role`, `central:policy`). Composite-source merge for named_vlan + role_records pre-fetch for policy preprocessing demonstrated inline. Bounded summary table (~30 rows max per translation) so small models don't break on serialization.

3. **INSTRUCTIONS.md** — adds `central_translation_preview` to the Central section with per-translation `runtime_values` requirements documented (especially `role_records` for policy reverse-index lookup).

### Why a tool when policy is "skill not tool"

The `central-scope-walker` skill works because `central_get_scope_tree` already exists as a tool — the data is fetchable, the skill just composes it. The translations engine isn't reachable from `execute()`, so no skill *can* invoke it. The "no tool when a skill works" rule applies when the data is fetchable; here it isn't. Discussed in conversation; user confirmed `_preview` suffix to keep the safety signal in the name (future execute path lands as a separate `central_manage_*` tool with elicitation gating per #240).

## Test plan

- [x] 1174 unit tests pass (was 1158; +16 translation_preview tests)
- [x] `ruff check .`, `ruff format --check .`, `mypy src/ --ignore-missing-imports` clean
- [x] Per-record EngineError handled — batch with partial failure returns each record's status independently
- [x] Fatal errors return `{"ok": false, "error": "..."}` per code-mode error contract (unknown translation_id, unknown source_platform, loader failure)
- [x] Caching verified — `load_translations` invoked once across multiple tool calls
- [x] Existing `test_skill_tool_references` updated to allowlist `central_scope_id` / `central_scope_name` (runtime_value keys + variable names in the new Stage 9b snippets — not tools)