### PR TITLE
v3.0.1.8: walker structural-identifier rule for AOS 8 vlan_name shape, fixes #289

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.8] - 2026-05-08
+
+**Patch release — fixes #289: walker structural-identifier rule for AOS 8 list-of-dicts identifier shapes. Production VLAN names that were leaking through cleartext now tokenize correctly.**
+
+### Bug
+
+The PII walker's field-name rule for `vlan_name → NAME` (in `redaction/rules.py:208`) only fires when a string value sits *directly* at a `vlan_name` key. AOS 8's actual response shape is:
+
+```json
+{"_data": {"vlan_name": [{"name": "guest"}, {"name": "local"}]}}
+```
+
+The walker walks the list with `parent_field_name="vlan_name"`, then walks each `{"name": "guest"}` dict — at this point the inner key is `"name"`, which isn't in the field-rule dict. No structural-context rule paired `(vlan_name, name)` either; the existing `STRUCTURAL_SECRET_CONTEXTS` only covered RADIUS/TACACS shared secrets per #277. Result: VLAN names slipped through cleartext on production data. Verified empirically against a live tenant during v3.0.1.6 Stage 9b runs (`guest`, `local`, `vlan20` all unredacted).
+
+### Fix
+
+1. **New `STRUCTURAL_IDENTIFIER_CONTEXTS` table in `redaction/rules.py`** — parallel to the existing `STRUCTURAL_SECRET_CONTEXTS`. Same `(parent_field_name, child_field_name) → TokenKind` shape; classifies as `TOKENIZE_IDENTIFIER` instead of `TOKENIZE_SECRET`.
+
+2. **Wired into `classify_field()`** after the existing structural-secret check and before the field-name lookup. The masked-placeholder skip still runs first so AOS 8's `"********"` placeholders aren't tokenized into the dangerous-illusion shape (#275).
+
+3. **Added the AOS 8 vlan_name patterns:**
+   - `(vlan_name, name): TokenKind.NAME`
+   - `(vlan_name_id, name): TokenKind.NAME`
+
+4. **Six new tests** (parallel to `TestStructuralSecretContexts`):
+   - 4 isolation tests: rule fires for `(vlan_name, name)` and `(vlan_name_id, name)`; bare `name` outside known wrappers still skipped; `name` under unrelated wrapper still skipped.
+   - 2 end-to-end walker tests against the realistic AOS 8 response shape verifying the inner names get tokenized AND non-name fields (`vlan-ids`) survive cleartext.
+
+### Files
+
+- **`src/hpe_networking_mcp/redaction/rules.py`** — adds `STRUCTURAL_IDENTIFIER_CONTEXTS` + `(vlan_name, name)` + `(vlan_name_id, name)` rules; extends `classify_field` to consult the new table.
+- **`tests/unit/test_pii_redaction.py`** — adds `TestStructuralIdentifierContexts` (4 isolation tests) + `TestStructuralIdentifierContextsEndToEnd` (2 walker e2e tests).
+- **`pyproject.toml`** — bump 3.0.1.7 → 3.0.1.8.
+
+### Notes
+
+- 1180 tests pass (was 1174; +6 from the new structural-identifier tests).
+- **Closes #289.**
+- **Live verification recommended after deploying.** Re-run Stage 9b against the tenant; confirm VLAN names appear as `[[NAME:uuid]]` tokens in tool output. The unit tests prove the rule wires correctly against the documented AOS 8 shape; live verification confirms the actual production response matches.
+
+### Out of scope (still open)
+
+- Role / ACL name tokenization. AOS 8 uses `rname` (roles) and `accname` (ACLs), not `name`. Those fields aren't in any rule today. Separate scope decision; not this release.
+- Mist / Central site list audit (`org_sites`, `sites`). Different wrapping field names; needs its own audit. File separately if needed.
+- The diagnostic-dict over-fire (cosmetic) where a literal `"dict"` string at a `vlan_name` key gets tokenized — harmless and rare. Not addressed; would require redesigning the field-name rule to be shape-aware, which is a much bigger change.
+
 ## [3.0.1.7] - 2026-05-08
 
 **Patch release — `aos-migration` Stage 9b prose tightening from a live-run review against Jon's tenant. Five skill-prose fixes; no Python / engine / tool changes.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.7"
+version = "3.0.1.8"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -282,6 +282,32 @@ STRUCTURAL_SECRET_CONTEXTS: dict[tuple[str, str], TokenKind] = {
 
 
 # ---------------------------------------------------------------------------
+# Tier 1.6 — Structural-context identifier rules (parent_field_name + child)
+# ---------------------------------------------------------------------------
+# Same idea as STRUCTURAL_SECRET_CONTEXTS, but for non-credential identifiers.
+# Some platforms wrap identifiers under a parent dict + list shape where the
+# *child* field name is too generic to tokenize unconditionally (e.g. ``name``
+# is also used for endpoint paths, configuration keys, etc.). The wrapping
+# context strongly implies the child holds a sensitive identifier — so pair
+# them and tokenize unconditionally.
+#
+# Concrete motivation (issue #289): AOS 8 returns
+#   ``{"_data": {"vlan_name": [{"name": "guest"}, {"name": "local"}]}}``
+# The field-name rule for ``vlan_name`` only fires on a string value directly
+# at ``vlan_name`` — when the value is a list-of-dicts the rule never fires
+# and ``"guest"``/``"local"`` slip through cleartext. Verified live against
+# a real tenant during v3.0.1.6 Stage 9b runs.
+
+STRUCTURAL_IDENTIFIER_CONTEXTS: dict[tuple[str, str], TokenKind] = {
+    # AOS 8 vlan_name records: list under "vlan_name" with each element {"name": "<vlan-name>", ...}.
+    ("vlan_name", "name"): TokenKind.NAME,
+    # AOS 8 vlan_name_id binding: list under "vlan_name_id" with each element
+    # {"name": "<vlan-name>", "vlan-ids": "..."} — same name we want tokenized.
+    ("vlan_name_id", "name"): TokenKind.NAME,
+}
+
+
+# ---------------------------------------------------------------------------
 # Tier 3 — Free-text fields scanned for embedded secrets/identifiers
 # ---------------------------------------------------------------------------
 
@@ -498,12 +524,19 @@ def classify_field(
     # nested under a wrapping key that strongly implies a credential
     # (e.g. ``rad_key``), tokenize unconditionally. Bypasses the shape check
     # that would otherwise leak short single-class shared secrets like
-    # ``"protocol"`` (issue #277).
+    # ``"protocol"`` (issue #277). Same pattern for identifiers — when an
+    # identifier-class field-name rule (e.g. ``vlan_name``) wraps a list of
+    # dicts each carrying ``{"name": "..."}``, the identifier rule never
+    # fires on the wrapper but the child ``name`` field needs tokenizing
+    # (issue #289).
     if parent_field_name is not None:
         parent_normalized = _normalize_field_name(parent_field_name)
-        struct_kind = STRUCTURAL_SECRET_CONTEXTS.get((parent_normalized, name))
-        if struct_kind is not None:
-            return FieldClassification.TOKENIZE_SECRET, struct_kind
+        struct_secret_kind = STRUCTURAL_SECRET_CONTEXTS.get((parent_normalized, name))
+        if struct_secret_kind is not None:
+            return FieldClassification.TOKENIZE_SECRET, struct_secret_kind
+        struct_identifier_kind = STRUCTURAL_IDENTIFIER_CONTEXTS.get((parent_normalized, name))
+        if struct_identifier_kind is not None:
+            return FieldClassification.TOKENIZE_IDENTIFIER, struct_identifier_kind
 
     # Exact-match secret fields
     if name in SECRET_FIELD_NAMES:

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -494,6 +494,100 @@ class TestStructuralSecretContexts:
         assert cls == FieldClassification.SKIP
 
 
+class TestStructuralIdentifierContexts:
+    """Issue #289 — AOS 8 returns identifier records as
+    ``{"vlan_name": [{"name": "guest"}, {"name": "local"}]}``. The
+    field-name rule for ``vlan_name`` only fires on a string value
+    directly at ``vlan_name``, never on ``name`` inside the list elements.
+    Without a structural-context rule pairing ``(vlan_name, name)``, the
+    inner names slip through cleartext (verified live during v3.0.1.6
+    Stage 9b runs).
+    """
+
+    def test_vlan_name_name_tokenizes_as_name_kind(self) -> None:
+        cls, kind = classify_field("name", "guest", parent_field_name="vlan_name")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.NAME
+
+    def test_vlan_name_id_name_tokenizes_as_name_kind(self) -> None:
+        cls, kind = classify_field("name", "local", parent_field_name="vlan_name_id")
+        assert cls == FieldClassification.TOKENIZE_IDENTIFIER
+        assert kind == TokenKind.NAME
+
+    def test_bare_name_outside_known_wrapper_still_skipped(self) -> None:
+        # A free-floating ``name`` field with no wrapper context — must still
+        # skip, otherwise we'd over-tokenize template references and
+        # configuration-key names.
+        cls, _ = classify_field("name", "guest")
+        assert cls == FieldClassification.SKIP
+
+    def test_name_under_unrelated_wrapper_still_skipped(self) -> None:
+        cls, _ = classify_field("name", "guest", parent_field_name="some_unrelated_object")
+        assert cls == FieldClassification.SKIP
+
+
+class TestStructuralIdentifierContextsEndToEnd:
+    """Walker end-to-end test for issue #289 — verifies the AOS 8
+    list-of-dicts response shape actually plugs the leak when run through
+    the full ``tokenize_response`` pipeline (not just ``classify_field``
+    in isolation).
+    """
+
+    def test_aos8_vlan_name_response_shape_tokenizes_inner_names(self) -> None:
+        from hpe_networking_mcp.redaction.token_store import SessionKeymap
+        from hpe_networking_mcp.redaction.tokenizer import Tokenizer
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-289", max_entries=100)
+
+        # Realistic AOS 8 vlan_name response shape — verified live.
+        response = {
+            "_data": {
+                "vlan_name": [
+                    {"name": "guest"},
+                    {"name": "local"},
+                    {"name": "vlan20"},
+                ]
+            }
+        }
+        out = tokenize_response(response, tokenizer)
+        records = out["_data"]["vlan_name"]
+        for record in records:
+            assert TOKEN_RE.fullmatch(record["name"]) is not None
+            assert TOKEN_RE.fullmatch(record["name"]).group(1) == "NAME"
+        # Sanity: distinct source values produce distinct tokens.
+        assert len({r["name"] for r in records}) == 3
+
+    def test_aos8_vlan_name_id_binding_shape_tokenizes_name_only(self) -> None:
+        from hpe_networking_mcp.redaction.token_store import SessionKeymap
+        from hpe_networking_mcp.redaction.tokenizer import Tokenizer
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-289", max_entries=100)
+
+        # AOS 8 vlan_name_id binding shape: name + vlan-ids field.
+        response = {
+            "_data": {
+                "vlan_name_id": [
+                    {"name": "user", "vlan-ids": "107"},
+                    {"name": "iot", "vlan-ids": "108-110"},
+                ]
+            }
+        }
+        out = tokenize_response(response, tokenizer)
+        bindings = out["_data"]["vlan_name_id"]
+        # ``name`` field tokenized as NAME via the structural rule.
+        for b in bindings:
+            assert TOKEN_RE.fullmatch(b["name"]) is not None
+            assert TOKEN_RE.fullmatch(b["name"]).group(1) == "NAME"
+        # ``vlan-ids`` is plain VLAN-ID data, not an identifier we tokenize —
+        # passes through cleartext.
+        assert bindings[0]["vlan-ids"] == "107"
+        assert bindings[1]["vlan-ids"] == "108-110"
+
+
 class TestVrrpPassphraseRule:
     """Issue #277 — AOS 8 cluster_prof.vrrp_info.vrrp_passphrase is a shared
     key between cluster members. Live captures show it as the deterministic-


### PR DESCRIPTION
## Summary

Closes #289. Production VLAN names were leaking through cleartext on AOS 8 responses because the field-name rule for `vlan_name → NAME` only fires on a string value directly at a `vlan_name` key, but AOS 8 returns:

```json
{"_data": {"vlan_name": [{"name": "guest"}, {"name": "local"}]}}
```

The walker walks the list with `parent_field_name="vlan_name"`, then walks each `{"name": "guest"}` dict — at this point the inner key is `"name"`, which isn't in the field-rule dict. No structural-context rule paired `(vlan_name, name)` either (the existing `STRUCTURAL_SECRET_CONTEXTS` only covered RADIUS/TACACS shared secrets per #277). Result: VLAN names slipped through cleartext.

Verified empirically during v3.0.1.6 + v3.0.1.7 Stage 9b runs against a live tenant.

## Fix

1. **New `STRUCTURAL_IDENTIFIER_CONTEXTS` table** in `redaction/rules.py` parallel to `STRUCTURAL_SECRET_CONTEXTS`. Same `(parent_field_name, child_field_name) → TokenKind` shape; classifies as `TOKENIZE_IDENTIFIER` instead of `TOKENIZE_SECRET`.
2. **Wired into `classify_field()`** after the existing structural-secret check and before the field-name lookup. The masked-placeholder skip still runs first so AOS 8's `"********"` placeholders aren't tokenized into the dangerous-illusion shape (#275).
3. **AOS 8 vlan_name patterns:** `(vlan_name, name) → NAME` and `(vlan_name_id, name) → NAME`.

## Test plan

- [x] 1180 unit tests pass (was 1174; +6 new structural-identifier tests)
- [x] 4 isolation tests: rule fires for both vlan_name patterns; bare `name` outside known wrappers still skipped; `name` under unrelated wrapper still skipped
- [x] 2 end-to-end walker tests against the realistic AOS 8 response shape — confirms inner names tokenize AND non-name fields (`vlan-ids`) survive cleartext
- [x] `ruff check .`, `ruff format --check .`, `mypy src/ --ignore-missing-imports` clean
- [ ] Live verification — re-run Stage 9b against the tenant after merge; confirm VLAN names appear as `[[NAME:uuid]]` tokens in tool output

## Out of scope (still open)

- Role / ACL name tokenization. AOS 8 uses `rname` (roles) and `accname` (ACLs); neither is in any rule today. Separate scope decision.
- Mist / Central site list audit (`org_sites`, `sites`). Different wrapping field names; needs its own audit.
- Diagnostic-dict over-fire (cosmetic) where the existing `vlan_name` rule fires on any string value at a `vlan_name` key in non-config contexts. Harmless and rare; would require redesigning the field-name rule to be shape-aware.