### PR TITLE
v3.0.1.9: walker keymap-replay on outbound SKIP path, fixes #291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.9] - 2026-05-08
+
+**Patch release — fixes #291: walker keymap-replay on outbound SKIP path. Closes the round-trip leak that v3.0.1.8 surfaced — values tokenized once in a session now stay tokenized across every tool's outbound, even when the output field name carries no rule.**
+
+### Bug
+
+After fixing #289 in v3.0.1.8, AOS 8 read responses correctly tokenize VLAN names via the new `(vlan_name, name)` structural rule. The AI receives tokens. **But** the round-trip through any downstream tool re-leaks them — verified live against tenant on v3.0.1.8 (image label confirmed v3.0.1.8).
+
+Concretely, the `aos-migration` Stage 9b flow:
+
+1. `aos8_get_effective_config(object_name="vlan_name")` → middleware tokenizes outbound → AI receives `[[NAME:1]]` ✓
+2. AI calls `central_translation_preview(source_records=[{"name": "[[NAME:1]]"}, ...])`
+3. Middleware **detokenizes inbound** so the tool sees cleartext `"guest"` (this is by design — tools always see cleartext)
+4. Tool returns `{"results": [{"record_id": "guest", "sample_body": {"name": "guest"}, ...}]}`
+5. Middleware outbound: walker checks rules. `record_id` has no rule. `name` under `sample_body` parent has no rule. **Both pass through cleartext.**
+6. AI's summary uses cleartext.
+
+The session keymap already mapped `"guest" → [[NAME:1]]` from step 1. The walker just didn't consult it on subsequent outbounds.
+
+### Fix
+
+**Walker keymap-replay on SKIP path.** When the walker classifies a string value as `FieldClassification.SKIP` (no field rule, no structural-context rule), it now asks the session tokenizer: "have you seen this exact cleartext before?" If yes, restore the existing token. Properties:
+
+- **Keymap-driven, not heuristic.** Only values that have been tokenized via field rules (and recorded in the keymap) get restored. Cleartext values that were never tokenized in this session stay cleartext — no false positives.
+- **Bounded.** O(1) keymap lookup per string value walked.
+- **Fixes every tool automatically.** Not specific to `central_translation_preview`.
+- **Round-trip-safe.** A token issued for `"guest"` in session N gets the SAME token restored anywhere `"guest"` appears in session N's outputs, regardless of which field it lands at.
+- **Idempotent.** Existing `[[KIND:uuid]]` token-shaped strings pass through; we never tokenize a token.
+
+### Implementation
+
+1. **`SessionKeymap` gains a third index:** `by_plaintext_value: dict[str, TokenEntry]` alongside the existing `by_plaintext[(kind, plaintext)]` and `by_token[token]`. Kind-agnostic — last writer wins on the rare case where the same plaintext is allocated under multiple kinds in one session.
+2. **Tokenizer.tokenize populates the new index** alongside the existing two.
+3. **New `Tokenizer.token_for_existing_cleartext(value: str) -> str | None`** method does the reverse lookup. Returns None for empty strings, non-strings, and values that look like existing tokens.
+4. **Walker `_walk_pair` SKIP path** consults the tokenizer's keymap-replay BEFORE running the universal scan. If a token is restored, return it; otherwise fall through to universal scan (which still handles embedded patterns like emails / AWS-signed URLs).
+
+### Files
+
+- **`src/hpe_networking_mcp/redaction/token_store.py`** — adds `by_plaintext_value` index to `SessionKeymap`
+- **`src/hpe_networking_mcp/redaction/tokenizer.py`** — populates the new index in `tokenize`; adds `token_for_existing_cleartext` method
+- **`src/hpe_networking_mcp/redaction/walker.py`** — wires keymap-replay into `_walk_pair`'s SKIP path
+- **`tests/unit/test_pii_redaction.py`** — adds `TestKeymapReplayOnSkipPath` with 6 tests (round-trip, nested-structure round-trip, negative case, idempotency, direct API check, and the realistic `central_translation_preview` shape end-to-end)
+- **`pyproject.toml`** — bump 3.0.1.8 → 3.0.1.9
+
+### Notes
+
+- 1186 tests pass (was 1180; +6 new).
+- **Closes #291.**
+- **Live verification recommended after the new image rolls.** Re-run Stage 9b against the tenant; the VLAN names that came through cleartext on v3.0.1.8 should now appear as `[[NAME:uuid]]` tokens — both in the summary table's `name`/`record_id` column AND in the sample TargetCall body fields.
+- **The fix benefits every tool, not just `central_translation_preview`.** Any tool that emits a previously-tokenized value at a SKIP-classified field now restores the original token. Examples: `aos-migration` Stage 9b's `summary` dict; `change-pre-check` baseline snapshots that re-serialize names without their original wrappers; future translation-execute tools that emit POSTed-body confirmations.
+- **No new tokenization happens via this path.** Replay only restores tokens that were already issued by the existing field-rule path. Untokenized cleartext stays cleartext.
+
+### Out of scope
+
+- Adding new field rules for role/ACL names (`rname`, `accname` aren't in any rule today). Separate scope decision; tracked elsewhere.
+- Mist / Central site list audit. Different wrappers; same shape pattern; needs its own audit.
+
 ## [3.0.1.8] - 2026-05-08
 
 **Patch release — fixes #289: walker structural-identifier rule for AOS 8 list-of-dicts identifier shapes. Production VLAN names that were leaking through cleartext now tokenize correctly.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.8"
+version = "3.0.1.9"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/token_store.py
+++ b/src/hpe_networking_mcp/redaction/token_store.py
@@ -45,7 +45,7 @@ class TokenEntry:
 class SessionKeymap:
     """The bidirectional token map for one MCP session.
 
-    Two indices for O(1) lookup in both directions:
+    Three indices for O(1) lookup in every direction we need:
 
     * ``by_plaintext[(kind, plaintext)]`` -> entry, used during
       tokenization so the same plaintext value gets the same token
@@ -53,10 +53,21 @@ class SessionKeymap:
       requirement from the v2.3.0.10 design).
     * ``by_token[token_string]`` -> entry, used during detokenization
       when the AI passes a token back into a write tool.
+    * ``by_plaintext_value[plaintext]`` -> entry, used by the walker's
+      keymap-replay pass to restore previously-issued tokens for
+      cleartext values that have lost their structural context (e.g.
+      the round-trip through a tool that detokenizes inputs, processes
+      cleartext internally, and re-emits values whose output field
+      name matches no rule). Issue #291. Kind-agnostic — if the same
+      plaintext appears under multiple kinds in this session, the
+      most-recently-allocated entry wins; this is safe because in
+      practice a given plaintext rarely re-appears under a different
+      kind within one session.
     """
 
     by_plaintext: dict[tuple[TokenKind, str], TokenEntry] = field(default_factory=dict)
     by_token: dict[str, TokenEntry] = field(default_factory=dict)
+    by_plaintext_value: dict[str, TokenEntry] = field(default_factory=dict)
 
     # An asyncio lock per session — defensive against future code paths
     # that introduce an ``await`` mid-allocation. Today the operations

--- a/src/hpe_networking_mcp/redaction/tokenizer.py
+++ b/src/hpe_networking_mcp/redaction/tokenizer.py
@@ -119,6 +119,11 @@ class Tokenizer:
         entry = TokenEntry(kind=kind, token=token, plaintext=plaintext)
         self._keymap.by_plaintext[key] = entry
         self._keymap.by_token[token] = entry
+        # Kind-agnostic reverse index for keymap-replay on the walker's
+        # SKIP path (issue #291). Last writer wins on the rare case where
+        # the same plaintext is allocated under multiple kinds in one
+        # session.
+        self._keymap.by_plaintext_value[plaintext] = entry
 
         logger.info(
             "pii.tokenize session={} kind={} token={} value_hash={} entries={}",
@@ -146,6 +151,26 @@ class Tokenizer:
             )
             return None
         return entry.plaintext
+
+    def token_for_existing_cleartext(self, value: str) -> str | None:
+        """Return the existing token for a known cleartext, or None.
+
+        Used by the walker's keymap-replay pass on the SKIP path to
+        restore round-trip stability for values that were tokenized
+        earlier in the session but whose output field name carries no
+        rule (issue #291). Kind-agnostic — looks up by plaintext alone.
+
+        Returns None when:
+        * The value has never been tokenized in this session.
+        * The value is empty / not a string.
+        * The value is already a token (no double-tokenization).
+        """
+        if not isinstance(value, str) or not value:
+            return None
+        if TOKEN_RE.fullmatch(value):
+            return None
+        entry = self._keymap.by_plaintext_value.get(value)
+        return entry.token if entry is not None else None
 
 
 def tokenize_value(

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -234,11 +234,21 @@ def _walk_pair(
     classification, kind = classify_field(key, value, parent_keys=parent_keys, parent_field_name=parent_field_name)
 
     if classification == FieldClassification.SKIP:
-        # Universal scan still runs on un-classified string values so
-        # emails embedded in arbitrary fields (e.g. PSK ``name`` =
-        # ``user@example.com``) and AWS-signed URLs in arbitrary fields
-        # (e.g. ``portal_template_url``) still get tokenized.
+        # Keymap-replay pass first (issue #291): if this exact string was
+        # previously tokenized in this session under any kind, restore the
+        # existing token. Closes the round-trip leak where a tool detokenizes
+        # inputs, processes cleartext internally, and re-emits values whose
+        # output field name carries no rule (e.g. central_translation_preview
+        # returns ``record_id`` and ``sample_body.name`` cleartext even though
+        # the underlying values were tokenized on AOS 8 read).
         if isinstance(value, str):
+            replayed = tokenizer.token_for_existing_cleartext(value)
+            if replayed is not None:
+                return replayed
+            # Universal scan still runs on un-classified string values so
+            # emails embedded in arbitrary fields (e.g. PSK ``name`` =
+            # ``user@example.com``) and AWS-signed URLs in arbitrary fields
+            # (e.g. ``portal_template_url``) still get tokenized.
             return _universal_scan(value, tokenizer)
         return value
     if classification == FieldClassification.TOKENIZE_SECRET and kind is not None:

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -588,6 +588,155 @@ class TestStructuralIdentifierContextsEndToEnd:
         assert bindings[1]["vlan-ids"] == "108-110"
 
 
+class TestKeymapReplayOnSkipPath:
+    """Issue #291 — walker keymap-replay on SKIP path. When a tool emits
+    a previously-tokenized cleartext value at a field that carries no
+    rule (e.g. ``central_translation_preview``'s ``record_id``), the
+    walker should consult the session keymap and restore the existing
+    token. Closes the round-trip leak where tools detokenize inputs,
+    process cleartext internally, and re-emit values that have lost
+    their original structural context.
+    """
+
+    def _new_tokenizer(self):
+        from hpe_networking_mcp.redaction.token_store import SessionKeymap
+        from hpe_networking_mcp.redaction.tokenizer import Tokenizer
+
+        return Tokenizer(SessionKeymap(), session_id="test-session-291", max_entries=100)
+
+    def test_value_tokenized_then_replayed_at_unrelated_field(self) -> None:
+        """The classic round-trip: AOS 8 read tokenizes "guest" via the
+        ``(vlan_name, name)`` structural rule; later, an unrelated tool
+        emits "guest" at a generic ``record_id`` field with no rule. The
+        replay should restore the original token.
+        """
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        tokenizer = self._new_tokenizer()
+
+        # First call: AOS 8 read shape — tokenizes "guest" via structural rule.
+        first = tokenize_response({"_data": {"vlan_name": [{"name": "guest"}]}}, tokenizer)
+        original_token = first["_data"]["vlan_name"][0]["name"]
+        assert TOKEN_RE.fullmatch(original_token) is not None
+        assert original_token.startswith("[[NAME:")
+
+        # Second call: a tool's response carries "guest" at a generic field
+        # (record_id) with no rule. Walker should keymap-replay.
+        second = tokenize_response(
+            {"results": [{"record_id": "guest", "call_count": 7}]},
+            tokenizer,
+        )
+        assert second["results"][0]["record_id"] == original_token
+
+    def test_value_replayed_inside_nested_unrelated_structure(self) -> None:
+        """Round-trip survives when the same cleartext appears inside a
+        nested dict with no structural context (e.g. inside a TargetCall
+        body emitted by ``central_translation_preview``).
+        """
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        tokenizer = self._new_tokenizer()
+        tokenize_response({"_data": {"vlan_name": [{"name": "guest"}]}}, tokenizer)
+
+        nested = tokenize_response(
+            {"sample_body": {"name": "guest", "vlan": {"vlan-alias": "guest"}}},
+            tokenizer,
+        )
+        # Both "guest" values restored to the same token.
+        body = nested["sample_body"]
+        assert body["name"].startswith("[[NAME:")
+        assert body["vlan"]["vlan-alias"] == body["name"]
+
+    def test_value_never_tokenized_stays_cleartext(self) -> None:
+        """Negative: a string that was never tokenized in this session must
+        not be touched by the replay pass. No false positives from random
+        keymap collisions.
+        """
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        tokenizer = self._new_tokenizer()
+        result = tokenize_response({"results": [{"record_id": "never-seen-before"}]}, tokenizer)
+        assert result["results"][0]["record_id"] == "never-seen-before"
+
+    def test_existing_token_not_double_tokenized(self) -> None:
+        """Idempotency: a value that's already a ``[[KIND:uuid]]`` token
+        passes through the replay pass unchanged.
+        """
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        tokenizer = self._new_tokenizer()
+        tokenize_response({"_data": {"vlan_name": [{"name": "guest"}]}}, tokenizer)
+        original_token = tokenizer.token_for_existing_cleartext("guest")
+        assert original_token is not None
+
+        # Walking a response that already contains a token: should pass through.
+        result = tokenize_response({"results": [{"record_id": original_token}]}, tokenizer)
+        assert result["results"][0]["record_id"] == original_token
+
+    def test_token_for_existing_cleartext_lookup_method(self) -> None:
+        """Direct API check on the new method."""
+        tokenizer = self._new_tokenizer()
+        # Empty / non-string / not-yet-tokenized: None.
+        assert tokenizer.token_for_existing_cleartext("") is None
+        assert tokenizer.token_for_existing_cleartext("never-seen") is None
+        # After tokenizing, returns the same token.
+        from hpe_networking_mcp.redaction.rules import TokenKind
+        from hpe_networking_mcp.redaction.tokenizer import tokenize_value
+
+        token = tokenize_value(tokenizer, TokenKind.NAME, "guest")
+        assert tokenizer.token_for_existing_cleartext("guest") == token
+        # Idempotency: passing a token through the lookup returns None
+        # (we never want to "tokenize" a token-shaped value).
+        assert tokenizer.token_for_existing_cleartext(token) is None
+
+    def test_central_translation_preview_record_id_round_trip(self) -> None:
+        """End-to-end shape that mirrors the actual leak from issue #291:
+        AOS 8 read tokenizes the inner ``name`` field; then the
+        ``central_translation_preview`` response shape carries the same
+        cleartext at ``results[].record_id`` (a SKIP-classified field)
+        AND at ``sample_body.name`` (also SKIP). Both must restore the
+        original token via replay.
+        """
+        from hpe_networking_mcp.redaction.walker import tokenize_response
+
+        tokenizer = self._new_tokenizer()
+
+        # 1. AOS 8 read tokenizes via (vlan_name, name) structural rule.
+        tokenize_response(
+            {"_data": {"vlan_name": [{"name": "guest"}, {"name": "local"}]}},
+            tokenizer,
+        )
+        guest_token = tokenizer.token_for_existing_cleartext("guest")
+        local_token = tokenizer.token_for_existing_cleartext("local")
+        assert guest_token is not None
+        assert local_token is not None
+
+        # 2. central_translation_preview-shaped response with cleartext fields.
+        preview_response = {
+            "translation_id": "central:named_vlan",
+            "results": [
+                {
+                    "record_id": "guest",
+                    "call_count": 7,
+                    "target_calls": [
+                        {
+                            "endpoint": "/network-config/v1alpha1/named-vlan/guest",
+                            "body": {"name": "guest", "vlan": {"vlan-alias": "guest"}},
+                        }
+                    ],
+                },
+                {"record_id": "local", "call_count": 9, "target_calls": []},
+            ],
+        }
+        out = tokenize_response(preview_response, tokenizer)
+
+        assert out["results"][0]["record_id"] == guest_token
+        assert out["results"][1]["record_id"] == local_token
+        body = out["results"][0]["target_calls"][0]["body"]
+        assert body["name"] == guest_token
+        assert body["vlan"]["vlan-alias"] == guest_token
+
+
 class TestVrrpPassphraseRule:
     """Issue #277 — AOS 8 cluster_prof.vrrp_info.vrrp_passphrase is a shared
     key between cluster members. Live captures show it as the deterministic-


### PR DESCRIPTION
## Summary

Closes #291. v3.0.1.8 fixed the AOS 8 read step (VLAN names tokenize via `(vlan_name, name)` structural rule), but the round-trip through any downstream tool re-leaked them. Verified live against tenant on v3.0.1.8 — image label confirmed.

The flow:

1. AOS 8 read → middleware tokenizes outbound → AI receives `[[NAME:1]]` ✓
2. AI calls `central_translation_preview(source_records=[{"name": "[[NAME:1]]"}, ...])`
3. Middleware **detokenizes inbound** so the tool sees cleartext `"guest"` (by design — tools always see cleartext)
4. Tool returns `{"record_id": "guest", "sample_body": {"name": "guest"}, ...}`
5. Middleware outbound: walker checks rules. `record_id` has no rule. `name` under `sample_body` parent has no rule. **Both pass cleartext.**

The session keymap already mapped `"guest" → [[NAME:1]]` from step 1's outbound. The walker just didn't consult it on subsequent outbounds.

## Fix

**Walker keymap-replay on SKIP path.** When the walker classifies a string value as `FieldClassification.SKIP`, it now asks the session tokenizer "have you seen this exact cleartext before?" If yes, restore the existing token. Properties:

- **Keymap-driven, not heuristic.** Only previously-tokenized values get restored — no false positives from random string matching.
- **Bounded.** O(1) keymap lookup per string value walked.
- **Fixes every tool automatically.** Not specific to `central_translation_preview` — any tool that emits a previously-tokenized value at a SKIP-classified field now restores the original token.
- **Round-trip-safe.** Same plaintext gets the same token across every outbound in the session.
- **Idempotent.** Existing `[[KIND:uuid]]` token-shaped strings pass through unchanged.

### Implementation

1. `SessionKeymap` gains a third index `by_plaintext_value` (kind-agnostic plaintext → entry) alongside the existing `by_plaintext[(kind, plaintext)]` and `by_token[token]`.
2. `Tokenizer.tokenize` populates the new index.
3. New `Tokenizer.token_for_existing_cleartext(value)` method does the reverse lookup.
4. Walker `_walk_pair` SKIP path consults keymap-replay BEFORE the universal scan; falls through if no token is restored (universal scan still handles embedded patterns like emails / AWS-signed URLs).

## Test plan

- [x] 1186 unit tests pass (was 1180; +6 new round-trip tests)
- [x] 6 new tests cover: round-trip across tool boundaries, nested-structure round-trip, negative case (never-seen-before stays cleartext), idempotency on existing tokens, direct API check on the new lookup method, and the realistic `central_translation_preview` response shape end-to-end
- [x] `ruff check .`, `ruff format --check .`, `mypy src/ --ignore-missing-imports` clean
- [ ] Live verification — re-run Stage 9b against the tenant after this image rolls; VLAN names should now appear as `[[NAME:uuid]]` tokens in `record_id`, `sample_body.name`, body fields, etc.

## Out of scope (still open)

- Role / ACL name tokenization. AOS 8 uses `rname` (roles) and `accname` (ACLs); neither is in any field rule today. Separate scope decision. (Note: with the keymap-replay fix in place, once `rname`/`accname` rules are added, the round-trip across tools will work for them automatically.)
- Mist / Central site list audit (`org_sites`, `sites`). Different wrappers; same shape pattern; needs its own audit.