### PR TITLE
v3.0.1.10: rewrite central-scope-walker snippet without yield + skill sandbox-compat lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.10] - 2026-05-08
+
+**Patch release — `central-scope-walker` skill snippet rewritten to stack-based iteration. The shipped recursive-generator form was rejected by the MCP code-mode sandbox (`NotImplementedError: The monty syntax parser does not yet support yield expressions`), making the skill non-functional. Reported by Zach via ChatGPT regression testing of v3.0.1.9.**
+
+Plus a regression-prevention test that catches sandbox-incompatible Python in any shipped skill snippet at CI time.
+
+### Bug
+
+`central-scope-walker.md` (and the matching walker snippet in `aos-migration.md` Stage 9b's Step 1) used:
+
+```python
+def walk(node, path):
+    here = path + [...]
+    yield {...}
+    for child in node.get("children") or []:
+        yield from walk(child, here)
+```
+
+The MCP sandbox uses `pydantic-monty` for its Python parser, which currently rejects `yield` / `yield from`. The skill loaded fine via `skills_load`, but the moment the AI pasted the snippet into `execute()`, the sandbox returned `NotImplementedError: The monty syntax parser does not yet support yield expressions` — the operator's actual `central-scope-walker` query failed despite the skill being advertised as paste-and-go.
+
+Verified by Zach's regression run: a stack-based rewrite of the same logic resolved the same scope query (`Owls Nest New Central` → scope_id `46237598667`, type `SITE`, path `<root>/Owls Nest Collection/Owls Nest New Central`, 7 devices, 38 scopes walked).
+
+### Fix
+
+1. **Rewrote both walker snippets to iterative depth-first traversal via an explicit stack.** Same data shape produced, no generators. The traversal is now pure list/loop ops — exactly the kind of idiom small models can paste reliably.
+
+2. **Added `tests/unit/test_skill_snippet_sandbox_compat.py`** — a regression test that scans every shipped skill markdown for sandbox-incompatible Python in fenced `python` code blocks. Catches:
+   - `yield` / `yield from` (this incident)
+   - `async def` (the v3.0.1.5 `async def run()` rule — already in INSTRUCTIONS.md, now enforced for skills)
+   - `import hashlib` (Zach's continued report — sandbox-blocked)
+   - Internal-module imports (`import hpe_networking_mcp.*`)
+   - Other documented sandbox limits: `datetime.now()`, `time.time()`, `os.environ`, `subprocess`, `asyncio.gather()`
+
+   Comments are stripped before scanning so rationale-comments like `# sandbox parser rejects yield` don't false-positive. Per-rule violation messages reference the upstream sandbox limitation so future authors know what to substitute.
+
+### Files
+
+- **`src/hpe_networking_mcp/skills/central-scope-walker.md`** — walker snippet rewritten to stack-based iteration
+- **`src/hpe_networking_mcp/skills/aos-migration.md`** — Stage 9b Step 1's walker snippet rewritten the same way
+- **New: `tests/unit/test_skill_snippet_sandbox_compat.py`** — 10 tests (9 parameterized per-skill + 1 sanity check)
+- **`pyproject.toml`** — bump 3.0.1.9 → 3.0.1.10
+
+### Notes
+
+- 1196 tests pass (was 1186; +10 new sandbox-compat tests).
+- The sandbox-compat test runs on **every** shipped skill, not just the two with walker snippets. Caught nothing else this round but will catch the next instance of any author pasting Python that the sandbox rejects.
+- A separate issue (#293) is filed for an unrelated sandbox-adjacent bug Zach reported: the `search` discovery tool returns `Output validation error: 'result' is a required property` for some queries. Investigation deferred — non-blocking; AI clients can fall back to `tags` or per-platform `<platform>_list_tools`.
+
 ## [3.0.1.9] - 2026-05-08
 
 **Patch release — fixes #291: walker keymap-replay on outbound SKIP path. Closes the round-trip leak that v3.0.1.8 surfaced — values tokenized once in a session now stay tokenized across every tool's outbound, even when the output field name carries no rule.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.9"
+version = "3.0.1.10"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -870,13 +870,20 @@ scope_tree_resp = await call_tool("central_get_scope_tree", {"view": "committed"
 envelope = scope_tree_resp.get("data", scope_tree_resp)
 root = envelope.get("result", envelope) if isinstance(envelope, dict) and "result" in envelope else envelope
 
-def walk(node, path):
+# Iterative DFS via stack — sandbox parser rejects `yield`/`yield from`.
+all_nodes = []
+stack = [(root, [])]
+while stack:
+    node, path = stack.pop()
     here = path + [node.get("scope_name") or node.get("scope_id") or "?"]
-    yield {"scope_id": node.get("scope_id"), "scope_name": node.get("scope_name"),
-           "type": node.get("type"), "path": "/".join(here)}
-    for child in node.get("children") or []:
-        yield from walk(child, here)
-all_nodes = list(walk(root, []))
+    all_nodes.append({
+        "scope_id": node.get("scope_id"),
+        "scope_name": node.get("scope_name"),
+        "type": node.get("type"),
+        "path": "/".join(here),
+    })
+    for child in (node.get("children") or []):
+        stack.append((child, here))
 
 def resolve(central_scope_name: str) -> tuple[str, str]:
     """Return (scope_id, status) — status is 'resolved' or 'placeholder'."""

--- a/src/hpe_networking_mcp/skills/central-scope-walker.md
+++ b/src/hpe_networking_mcp/skills/central-scope-walker.md
@@ -63,20 +63,24 @@ response = await call_tool("central_get_scope_tree", {"view": "committed"})
 envelope = response.get("data", response)
 root = envelope.get("result", envelope) if isinstance(envelope, dict) and "result" in envelope else envelope
 
-def walk(node, path):
+# Iterative depth-first walk via an explicit stack. The MCP sandbox's
+# Python parser does NOT support `yield` / `yield from` — generators are
+# rejected with NotImplementedError. Use a stack/list loop instead.
+all_nodes = []
+stack = [(root, [])]   # each frame is (node, path-from-root)
+while stack:
+    node, path = stack.pop()
     here = path + [node.get("scope_name") or node.get("scope_id") or "?"]
-    yield {
+    all_nodes.append({
         "scope_id":     node.get("scope_id"),
         "scope_name":   node.get("scope_name"),
         "type":         node.get("type"),
         "path":         "/".join(here),
         "device_count": node.get("device_count"),
         "child_scope_count": node.get("child_scope_count"),
-    }
-    for child in node.get("children") or []:
-        yield from walk(child, here)
-
-all_nodes = list(walk(root, []))
+    })
+    for child in (node.get("children") or []):
+        stack.append((child, here))
 
 # Match policy: exact (case-insensitive) name OR exact (case-insensitive) path
 # OR exact scope_id OR case-insensitive substring on name/path. Listed in

--- a/tests/unit/test_skill_snippet_sandbox_compat.py
+++ b/tests/unit/test_skill_snippet_sandbox_compat.py
@@ -1,0 +1,178 @@
+"""Regression test: shipped skill snippets must be runnable inside the
+MCP code-mode sandbox.
+
+The sandbox uses ``pydantic-monty`` for its Python parser, which rejects
+several constructs that are valid Python 3 but not yet implemented in
+the sandbox grammar. Skill snippets that hit any of these constructs
+fail at runtime with a sandbox error, breaking the skill silently.
+
+The blocking incident: ``central-scope-walker.md`` shipped a recursive
+generator using ``yield`` / ``yield from``; the sandbox returned
+``NotImplementedError: The monty syntax parser does not yet support yield
+expressions``. Reported by Zach via ChatGPT regression testing of v3.0.1.9.
+
+This test scans every shipped skill markdown under ``src/.../skills/``,
+extracts ``python`` fenced code blocks, and rejects any that contain
+patterns the sandbox can't run. Patterns are documented per-rule below
+with the runtime error they produce.
+
+Adding new forbidden patterns: extend ``_FORBIDDEN_PATTERNS`` with the
+regex AND a human-readable message that references the upstream sandbox
+limitation. Keep the message specific so authors know what to substitute.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# (regex_pattern, short_name, human-readable explanation)
+_FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        # Bare 'yield' or 'yield from' on its own statement / expression.
+        # Matches "yield ", "yield\n", "yield(", "yield from ".
+        re.compile(r"\byield(?:\s+from)?\b"),
+        "yield",
+        "The monty sandbox parser does not support `yield` / `yield from` "
+        "(reported in #289 and again in v3.0.1.9 regression testing). "
+        "Rewrite the snippet to use an explicit stack/list loop and `return`.",
+    ),
+    (
+        # `async def run()` (or any async def) inside execute() creates an
+        # unawaited coroutine — the sandbox's `execute()` is already async,
+        # so wrapping is a footgun. Documented in INSTRUCTIONS.md as of v3.0.1.5.
+        re.compile(r"\basync\s+def\b"),
+        "async def",
+        "`execute()` already runs in an async context; wrapping in "
+        "`async def run(): ...` creates an unawaited coroutine and the AI "
+        "fabricates output because no real data came back. Inline the "
+        "code at the top level inside execute() instead.",
+    ),
+    (
+        # `import hashlib` (and a couple of other stdlib modules confirmed
+        # blocked by the sandbox in Zach's continued report). Add as encountered.
+        re.compile(r"^\s*import\s+hashlib\b", re.MULTILINE),
+        "import hashlib",
+        "The sandbox blocks `import hashlib` (verified in Zach's continued "
+        "OpenClaw + Qwen3 4B test report). If a skill needs hashing, accept "
+        "a pre-computed digest as an input parameter instead.",
+    ),
+    (
+        # Internal-module imports. The sandbox blocks imports of the
+        # hpe_networking_mcp package — that's the whole reason
+        # central_translation_preview exists as a bridge tool. Catch
+        # any direct imports in skill snippets.
+        re.compile(r"^\s*(?:import|from)\s+hpe_networking_mcp\b", re.MULTILINE),
+        "import hpe_networking_mcp",
+        "Skill snippets cannot `import hpe_networking_mcp.*` — the "
+        "sandbox blocks internal-module imports. Use platform tools via "
+        "`await call_tool(name, params)` instead.",
+    ),
+    (
+        # OS-access functions explicitly listed as blocked in
+        # `server.py:execute_description`. These are the most-cited offenders.
+        re.compile(r"\b(?:datetime\.now|time\.time|os\.environ|subprocess\b|asyncio\.gather)\b"),
+        "OS-access / asyncio.gather",
+        "The sandbox blocks `datetime.now()`, `time.time()`, `os.environ`, "
+        "`subprocess`, and `asyncio.gather()`. Use sequential `await` calls "
+        "for parallelism; accept ISO-8601 strings as parameters for timestamps.",
+    ),
+]
+
+_SKILLS_DIR = Path(__file__).resolve().parents[2] / "src" / "hpe_networking_mcp" / "skills"
+
+
+_COMMENT_RE = re.compile(r"#[^\n]*")
+
+
+def _strip_comments(code: str) -> str:
+    """Replace Python `#` comments with whitespace of the same length.
+
+    Preserves line offsets (so violation line numbers stay accurate) while
+    removing comment text from the regex search surface. Without this, a
+    rationale-comment like ``# sandbox parser rejects yield`` would fire
+    the ``yield`` rule even though the executable code is fine.
+
+    Naive (doesn't handle ``#`` inside strings) but safe for shipped skill
+    snippets — they don't embed ``#`` in strings.
+    """
+    return _COMMENT_RE.sub(lambda m: " " * len(m.group(0)), code)
+
+
+def _extract_python_blocks(markdown: str) -> list[tuple[int, str]]:
+    """Return [(starting_line, code), ...] for every ```python``` block.
+
+    Markdown fenced code blocks use ``` ``` ``` with optional language.
+    We only check blocks tagged ``python`` (case-insensitive) — JSON / shell /
+    other languages have different rules.
+    """
+    blocks: list[tuple[int, str]] = []
+    lines = markdown.splitlines()
+    in_block = False
+    block_start = 0
+    block_lines: list[str] = []
+    for i, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not in_block:
+            if stripped.startswith("```") and stripped.lower().lstrip("`").strip() == "python":
+                in_block = True
+                block_start = i
+                block_lines = []
+        else:
+            if stripped.startswith("```"):
+                blocks.append((block_start, "\n".join(block_lines)))
+                in_block = False
+            else:
+                block_lines.append(line)
+    return blocks
+
+
+def _shipped_skill_paths() -> list[Path]:
+    """All shipped skill markdown files except the TEMPLATE."""
+    if not _SKILLS_DIR.is_dir():
+        return []
+    return sorted(p for p in _SKILLS_DIR.glob("*.md") if p.name != "TEMPLATE.md")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "skill_path",
+    _shipped_skill_paths(),
+    ids=lambda p: p.name,
+)
+def test_skill_python_snippets_are_sandbox_compatible(skill_path: Path) -> None:
+    """Every ```python``` code block in a shipped skill must be runnable
+    inside the MCP code-mode sandbox.
+
+    Catches sandbox-rejected constructs at CI time so they don't ship to
+    operators (and to AI clients running the skill blind).
+    """
+    text = skill_path.read_text()
+    blocks = _extract_python_blocks(text)
+
+    violations: list[str] = []
+    for start_line, code in blocks:
+        scan_target = _strip_comments(code)
+        for pattern, short_name, explanation in _FORBIDDEN_PATTERNS:
+            for match in pattern.finditer(scan_target):
+                # Compute approximate line number within the file.
+                offset_lines = scan_target[: match.start()].count("\n")
+                file_line = start_line + offset_lines
+                violations.append(f"{skill_path.name}:{file_line}: forbidden pattern {short_name!r} — {explanation}")
+
+    assert violations == [], f"Skill {skill_path.name} contains sandbox-incompatible Python:\n  - " + "\n  - ".join(
+        violations
+    )
+
+
+@pytest.mark.unit
+def test_extractor_handles_skills_directory_present() -> None:
+    """Sanity check: the skills directory exists and contains markdown files."""
+    paths = _shipped_skill_paths()
+    assert paths, f"No skill markdown files found under {_SKILLS_DIR}"
+    # Ensure the lint actually ran across at least one block somewhere — if
+    # all skills lack python blocks the test would silently pass.
+    total_blocks = sum(len(_extract_python_blocks(p.read_text())) for p in paths)
+    assert total_blocks > 0, "No python code blocks found in any shipped skill"


### PR DESCRIPTION
## Summary

The shipped `central-scope-walker` snippet used a recursive generator with `yield` / `yield from`. The MCP code-mode sandbox uses `pydantic-monty` for its Python parser, which rejects yield expressions:

```
Sandbox error: NotImplementedError: The monty syntax parser does not yet support yield expressions
```

The skill loaded fine via `skills_load` but failed the moment the AI pasted the snippet into `execute()`. Reported by Zach via ChatGPT regression testing of v3.0.1.9. Verified: a stack-based rewrite of the same logic resolved Zach's tenant query (`Owls Nest New Central` → scope_id `46237598667`).

## Fix

Both walker snippets (`central-scope-walker.md` and the matching one in `aos-migration.md` Stage 9b Step 1) rewritten to iterative depth-first traversal via an explicit stack. Same data shape produced, no generators.

Plus regression-prevention: new `tests/unit/test_skill_snippet_sandbox_compat.py` scans every shipped skill markdown for sandbox-incompatible Python in fenced `python` code blocks. Catches:

- `yield` / `yield from` (this incident)
- `async def` (the v3.0.1.5 `async def run()` footgun — already in INSTRUCTIONS.md, now enforced for skills)
- `import hashlib` (Zach's continued report — sandbox-blocked)
- `import hpe_networking_mcp.*` (sandbox blocks internal imports)
- `datetime.now()`, `time.time()`, `os.environ`, `subprocess`, `asyncio.gather()`

Comments are stripped before scanning so rationale-comments like `# sandbox parser rejects yield` don't false-positive. Per-rule violation messages reference the upstream sandbox limitation so future authors know what to substitute.

## Test plan

- [x] 1196 unit tests pass (was 1186; +10 new sandbox-compat tests)
- [x] All 9 shipped skills pass the sandbox-compat lint
- [x] `ruff check .`, `ruff format --check .`, `mypy src/ --ignore-missing-imports` clean
- [ ] Live verification — re-run Zach's `central-scope-walker` query against v3.0.1.10 image; should resolve scope without sandbox error

## Out of scope

A separate issue (#293) is filed for the unrelated `search` discovery tool bug Zach also reported (returns `Output validation error: 'result' is a required property` for some queries). Non-blocking; deferred for independent investigation.