### PR TITLE
v3.0.1.11: INSTRUCTIONS.md sandbox-stdlib reference + tool-call-first rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.11] - 2026-05-08
+
+**Patch release — INSTRUCTIONS.md additions targeting the small-local-model orchestration issues from Zach's continued OpenClaw + Qwen3 4B test report. Two prose changes; no code, no skills, no tools.**
+
+The continued report surfaced several model-side failure modes that don't have direct server-side fixes — they're mitigated by clearer prompt language. Two specific gaps the existing instructions didn't cover:
+
+1. **Sandbox-stdlib reference.** The `execute_description` in `server.py` documents some blocked items (`asyncio.gather`, `datetime.now`, `time.time`, file I/O, `os.environ`, `subprocess`) but doesn't name `hashlib` (verified blocked by Zach's continued report) or `yield` / `yield from` (verified blocked in v3.0.1.9 regression testing). Operators authoring skill snippets had no single place to look up "what's allowed in `execute()`?". Added a Sandbox-stdlib reference section under the existing `Code-mode execute() patterns` section in INSTRUCTIONS.md with a known-working / known-blocked table and substitute guidance per blocked item. Note that the table will grow as more failures surface — and the corresponding `tests/unit/test_skill_snippet_sandbox_compat.py` lint (added v3.0.1.10) is the enforcement side of the same evidence.
+
+2. **Tool-call-first idiom for identifier queries.** Existing `CRITICAL RULES` rule #3 (*"Only answer based on data returned by tools"*) is generic. The continued report showed Qwen reliably skipping tool calls and answering from training-data memory or earlier-session context — even when the user's question named a specific identifier (AP name, scope name, ACL name, etc.). Tightened rule #3 with an explicit "you MUST first call the matching read tool" obligation when a question names any specific identifier, plus a worked good/bad example showing the difference between calling `central_get_ap_details(ap_name="corp-ap-01")` first vs. answering from stale memory.
+
+### Files
+
+- **`src/hpe_networking_mcp/INSTRUCTIONS.md`** — new Sandbox-stdlib reference section under `Code-mode execute() patterns`; expanded `CRITICAL RULES` rule #3 with the tool-call-first idiom + worked example.
+- **`pyproject.toml`** — bump 3.0.1.10 → 3.0.1.11.
+
+### Notes
+
+- 1196 tests pass (no test-count change — pure docs release).
+- These are the two model-side issues from Zach's continued report that the existing instructions didn't already cover. Other model behaviors (`async def run()` wrapping, large-payload final-answer truncation, fabricated counts, bounded-output patterns) were already addressed by v3.0.1.5 / v3.0.1.7 INSTRUCTIONS.md additions and Stage 9b prose. The aos-migration skill carries explicit anti-fabrication language ("Use the engine's deterministic counts — never hand-fabricate").
+- The new Sandbox-stdlib reference table is intentionally living documentation. Issue templates around skill-snippet bugs should reference it; `test_skill_snippet_sandbox_compat.py` enforces the blocklist mechanically.
+
 ## [3.0.1.10] - 2026-05-08
 
 **Patch release — `central-scope-walker` skill snippet rewritten to stack-based iteration. The shipped recursive-generator form was rejected by the MCP code-mode sandbox (`NotImplementedError: The monty syntax parser does not yet support yield expressions`), making the skill non-functional. Reported by Zach via ChatGPT regression testing of v3.0.1.9.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.10"
+version = "3.0.1.11"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -72,6 +72,14 @@ Use the cross-platform tools directly when they apply — they replace several p
 1. **Never assume IDs or MAC addresses.** Always retrieve them with the appropriate tools before using them. This especially applies to org_id — ALWAYS call `mist_get_self(action_type=account_info)` first to get the correct org_id. Do NOT use an org_id from memory, a previous conversation, or any other source.
 2. **Only send parameters that are needed.** Do not pass empty, null, or irrelevant parameters.
 3. **Only answer based on data returned by tools.** Never infer, estimate, or fabricate network state.
+
+   **Tool-call-first idiom for identifier queries.** Before answering any question that names a specific identifier — site name, device serial, MAC, IP, scope name, AP name, WLAN/SSID name, ACL name, role name, alias, server group, policy name, etc. — you MUST first call the matching read tool. Do NOT answer from conversation context, training-data memory, or recall of similar setups in other tenants.
+
+   ✅ Correct: user asks *"what's the channel on AP `corp-ap-01`?"* → call `central_get_ap_details(ap_name="corp-ap-01")` first → report the channel from the response.
+
+   ❌ Wrong: user asks *"what's the channel on AP `corp-ap-01`?"* → answer from a previous session's context or guess based on a similar AP. Even if `corp-ap-01` came up earlier in the conversation, channel state changes; re-fetch.
+
+   Cost of the tool call is ~one round-trip. Cost of an answer based on stale memory is the operator acts on bad data — in maintenance windows that means deployment decisions made on wrong assumptions.
 4. If a tool returns no data or an error, say so explicitly. Do not guess.
 5. **MANDATORY: use the information you already have from `<platform>_list_tools` before invoking.** Every tool entry from `list_tools` includes a `params` map showing parameter names + types (and `?` suffix for optional) — always check it before calling `invoke_tool`. Never invoke with `params={}` or guessed names when the `list_tools` output already told you what's required.
 6. **Call `<platform>_get_tool_schema(name=...)` when the `list_tools` params map isn't sufficient.** Specifically: when a param's type is an enum class name (e.g. `"Action_type"`) and you don't yet know its valid values, when you need field descriptions to understand parameter semantics, or when a `dict`/`payload` param needs a nested schema. You do NOT need to re-read a schema you've already fetched in the same conversation; cache it mentally.
@@ -190,6 +198,33 @@ result
 ```
 
 This applies even to "small" lists — anything > ~30 items is risky for small models in final-answer space. When in doubt, reduce in the sandbox.
+
+### 3. Sandbox-stdlib reference — what works, what's blocked
+
+The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports a subset of Python 3 — most data manipulation works, but several common modules and constructs are blocked. Authoring code that runs first try means staying inside the supported surface.
+
+**Known-working** (verified in shipped skills + tests):
+- Built-in types: `str`, `int`, `float`, `bool`, `list`, `dict`, `set`, `tuple`, `None`
+- Comprehensions: list / dict / set / generator (the LATTER is fine when consumed eagerly via `list(...)`; bare generators that need `yield` syntax are NOT — see below)
+- Control flow: `if` / `elif` / `else`, `for`, `while`, `break`, `continue`, `try`/`except`/`finally`
+- Operators, slicing, f-strings, basic string methods
+- `json` (verified — Stage 9b uses it for body inspection)
+- `re` (verified — used by Stage 9b filtering helpers)
+- The injected `await call_tool(name, params)` for platform tool dispatch
+
+**Known-blocked** — using any of these returns a sandbox error:
+
+| Construct / module | Error | Substitute |
+|---|---|---|
+| `yield` / `yield from` | `NotImplementedError: monty syntax parser does not yet support yield expressions` | Use an explicit stack/list loop and `return` |
+| `async def` (any function) | unawaited-coroutine footgun (sandbox already runs in async context) | Inline the code at the top level inside `execute()` |
+| `import hashlib` | `ModuleNotFoundError` | Accept a pre-computed digest as an input parameter |
+| `import hpe_networking_mcp.*` | `ModuleNotFoundError` | Use platform tools via `await call_tool(name, params)` |
+| `datetime.now()`, `time.time()` | `RuntimeError: OS access blocked` | Accept ISO-8601 timestamps as parameters; or hardcode literal ISO strings |
+| `os.environ`, `subprocess`, file I/O | `RuntimeError: OS access blocked` | Accept config values as parameters |
+| `asyncio.gather()` | unavailable | Use sequential `await` calls — same wall-clock cost matters less here than in production async code |
+
+**This list grows as more failures surface.** If you hit a sandbox error not listed here, file an issue with the exact error message — both the documented blocklist and the `tests/unit/test_skill_snippet_sandbox_compat.py` lint update from the same evidence.
 
 ---
 


### PR DESCRIPTION
## Summary

Two INSTRUCTIONS.md additions targeting the small-local-model orchestration issues from Zach's continued OpenClaw + Qwen3 4B test report. No code, no skills, no tools — pure prose.

### Two changes

1. **Sandbox-stdlib reference** under the existing `Code-mode execute() patterns` section. Adds a known-working / known-blocked table covering everything we've empirically verified, with a substitute per blocked item. Specifically calls out `hashlib` (verified blocked in Zach's continued report) and `yield` / `yield from` (verified blocked in v3.0.1.9 regression testing) alongside the existing OS-access / `asyncio.gather()` blocklist. Living documentation — `tests/unit/test_skill_snippet_sandbox_compat.py` (added in v3.0.1.10) is the enforcement side of the same evidence.

2. **Tool-call-first idiom** expansion of `CRITICAL RULES` rule #3. The existing language (*"Only answer based on data returned by tools"*) was generic; Qwen reliably skipped tool calls and answered from training-data memory when the user's question named a specific identifier. Tightened with an explicit *"you MUST first call the matching read tool"* obligation when the question names ANY specific identifier (site/device/scope/AP/WLAN/ACL/role/alias/policy name), plus a worked good/bad example showing the difference.

### Why these two and not others

The other model-side issues from Zach's continued report (`async def run()` wrapping, large-payload final-answer truncation, fabricated counts, bounded-output patterns) were already addressed in v3.0.1.5 / v3.0.1.7. These two were the gaps the existing instructions didn't cover.

## Test plan

- [x] 1196 unit tests pass (no test-count change — pure docs release)
- [x] `ruff check .`, `ruff format --check .`, `mypy src/ --ignore-missing-imports` clean
- [ ] Live verification — re-run Zach's regression test against v3.0.1.11 image; AI should call read tools first on identifier-specific queries instead of answering from memory