### PR TITLE
v3.0.1.14: central:net_group translation (AOS 8 netdst + netdst6 -> Central /net-groups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.14] - 2026-05-11
+
+**Translations engine — `central:net_group` (AOS 8 `netdst` + `netdst6` → Central `/net-groups`).** Closes #300; references #279.
+
+This is the fifth shipped translation and the **missing dependency for `central:policy`**. Before v3.0.1.14, `central:policy`'s rule bodies referenced `net-group` aliases by name (via `host-address-alias`) — but no current translation created those alias objects, so policy POSTs would fail at Central with an unknown-alias error unless the operator had pre-populated matching names in the target tenant. The Stage 8 disposition prose in v3.0.1.13 also misdescribed the architecture as if both `net_group` and `net_service` already shipped; corrected here.
+
+### What ships
+
+- **`translations/targets/central/net_group_v1.json`** — multi-source translation handling both `netdst` (IPv4) and `netdst6` (IPv6) AOS 8 source schemas. Two emits per source record: `POST /net-groups/{name}` + `POST /config-assignments`. The address-family discriminator (`netdestination-type` enum: `IPV4_ONLY` / `IPV6_ONLY` — Central explicitly doesn't support `IPV4_IPV6_MIXED`) is inferred by preprocessing from which `__entry` key the source record carries.
+- **`translations/preprocessing/aos8_net_group.py`** — preprocessing module that:
+  - Routes records to the right address family based on `netdst__entry` vs `netdst6__entry` presence.
+  - Maps each per-entry `_objname` discriminator to a Central items[] element: `netdst__host` → `HOST` + `address`; `netdst__network` → `NETWORK` + computed `prefix` (CIDR); `netdst__name` → `FQDN` + `fqdn`.
+  - Converts AOS 8 dotted-quad netmasks (e.g. `255.255.255.0`) to CIDR prefix lengths (`/24`) via `_netmask_to_prefix`. Non-contiguous masks (e.g. `255.0.255.0`) raise rather than silently corrupting the prefix.
+  - Skips per-entry `_flags.default=true` / `_flags.system=true` markers. Record-level filtering (`inherited` / `default` / empty entries) is consumer responsibility, matching the convention in `central:role` and `central:policy`.
+
+### Skill updates
+
+- **`aos-migration.md` COLLECT-01** — `OBJECT_TYPES` extended with `netdst` and `netdst6` (CLI nouns `netdestination` / `netdestination6` differ from REST schema names — surfaced in the comment block).
+- **`aos-migration.md` Stage 8 disposition matrix** —
+  - `acl_sess` row corrected: describes the actual shipped architecture (`central:policy` references `net-group` aliases that ship via `central:net_group`; `net-service` aliases pending).
+  - New row for `netdst` / `netdst6`: documents the `central:net_group` translation, the must-run-before-`central:policy` dependency, and per-entry mapping rules.
+  - Source-type enumeration includes `netdst` and `netdst6`; clarifies CLI-vs-REST naming discrepancy and the `netsvc` deferral.
+- **`aos-migration.md` Stage 9b** — adds preview block 2e for `central:net_group`. Block intentionally placed after policies in display order with a *"despite appearing last in the preview, this translation runs FIRST in execution"* call-out. Step 3 prose now says "five `result` dicts."
+
+### Coverage scope
+
+Live-verified against the maintainer's tenant: 8 operator-authored `netdst` aliases (mix of host, network, FQDN entries; one alias holds ~100 CIDR rows). `netdst6` schema is recognized but the tenant has zero records — first tenant with IPv6 aliases configured will validate the assumed sibling-naming shape; the preprocessing function detects v4 vs v6 by which `__entry` key is present so a `netdst6` record matching the documented shape works without code change.
+
+### `central:net_service` deferred
+
+Per the real-captured-fixtures-only convention (memory: `feedback_real_captured_fixtures.md`), the `central:net_service` translation is **not authored** in this release. The maintainer's tenant has zero `netsvc` records — the schema is recognized but unused. AOS 8 `acl_sess` rules in this tenant reference only Central's built-in `svc-*` catalog (which `central:policy` already passes through verbatim via `services.net-service` + `RULE_NET_SERVICE`). Will revisit once a tenant with custom `netsvc` records becomes available.
+
+### Files
+
+- **`src/hpe_networking_mcp/translations/targets/central/net_group_v1.json`** — new translation file.
+- **`src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py`** — new preprocessing module.
+- **`src/hpe_networking_mcp/skills/aos-migration.md`** — COLLECT-01, Stage 8 (disposition matrix + source-type enum), Stage 9b (preview block + counts).
+- **`tests/unit/test_translations_preprocessing_aos8_net_group.py`** — new preprocessing unit tests (24 tests covering address-family detection, all three entry-type mappings, mixed-entry order preservation, per-entry flag filtering, IPv6 path including the `/128` fallback for prefix-less network entries, netmask → CIDR parametrized over 6 contiguous + 4 non-contiguous cases).
+- **`tests/unit/test_translations_engine.py`** — appends 9 new engine-level tests covering the net_group translation end-to-end (host / network / FQDN / mixed / v6 / device-function override / missing-source / preprocessing error propagation).
+- **`pyproject.toml`** — bump 3.0.1.13 → 3.0.1.14.
+
+### Notes
+
+- **Dependency order at execution time:** `central:net_group` must run BEFORE `central:policy` in any consumer-orchestrated migration. The Stage 9b preview reflects this in prose; Phase 3 execution (issue #240) will enforce it via the translation file's `dependencies` block.
+- **Idempotency:** if a `net-group` profile with the same name already exists, the POST returns HTTP 409. Consumer must handle 409 idempotently.
+- **Tests:** 1206 → 1243 passing (+37 net new). Lint + format + mypy clean.
+
 ## [3.0.1.13] - 2026-05-11
 
 **Patch release — `aos-migration` skill drops `acl_eth` (Ethertype ACL) and `acl_mac` (MAC ACL) from Stage 1 collection. Closes #298.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.13"
+version = "3.0.1.14"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -191,8 +191,11 @@ OBJECT_TYPES = [
     "server_group_prof", "dot1x_auth_profile", "mac_auth_profile",
     "cp_auth_profile",
     # RBAC / ACLs (acl_eth / acl_mac excluded — unique-use cases not encountered
-    # in real migrations; see issue #298)
-    "role", "acl_sess",
+    # in real migrations; see issue #298). netdst / netdst6 are the IPv4 / IPv6
+    # netdestination aliases referenced by acl_sess rules via salias / dalias
+    # discriminators; central:net_group translation creates them in Central
+    # before central:policy POSTs the rules that reference them by name.
+    "role", "acl_sess", "netdst", "netdst6",
     # Cluster (paired — cluster_prof defines the profile, group_membership
     # binds devices to it)
     "cluster_prof", "group_membership",
@@ -758,7 +761,8 @@ The VSG **does not** contain per-object translation tables for most object types
 | **MAC-auth profile** (`mac_auth_profile`) | (none) | `operator-driven` — VSG silent. Emit `OPERATOR-MAP`. Target tool: `central_manage_wlan_profile` (mac-auth opmodes are flags inside it). |
 | **Captive portal profile** (`cp_auth_profile`) | (none, passing mention only) | `operator-driven` — assigned through a role's `captive-portal` field on `central_manage_role`. Emit `OPERATOR-MAP`. Target tool: `central_manage_role` (captive-portal field). |
 | **User role** (`role`) | §1173-§1176 (AOS 8 supported-features list) | `transform` — role name + VLAN + ACL + bandwidth-contract + qos + captive-portal + session-timeout map directly. Per-attribute mapping is operator-driven; VSG only confirms roles "are supported." Emit `OPERATOR-MAP` per role. Target tool: `central_manage_role`. |
-| **Session ACL** (`acl_sess`) | (none — implied via role) | `transform` — the `central:policy` translation (engine-driven) emits `/policies` POSTs with rule bodies that reference Central `net-group` and `net-service` aliases. The aliases themselves come from the `central:net_group` / `central:net_service` translations (sourced from AOS 8 `netdestination` / `netservice`). Per-rule mapping is engine-handled; operator decisions only when LLD-skip reasons surface. (Note: `acl_eth` and `acl_mac` are intentionally out of scope — issue #298.) Target tool: `central_manage_policy`. |
+| **Session ACL** (`acl_sess`) | (none — implied via role) | `transform` — the `central:policy` translation (engine-driven) emits `/policies` POSTs with rule bodies that reference Central `net-group` and `net-service` aliases. `net-group` aliases ship via the `central:net_group` translation (see the row below — sourced from AOS 8 `netdst` / `netdst6`). `net-service` aliases (sourced from AOS 8 `netsvc`) are **deferred** pending live shape verification; `central:policy` rules that reference a `netsvc` name today will fail at Central with an unknown-service error unless the operator has pre-populated matching service names. Per-rule mapping is engine-handled; operator decisions only when LLD-skip reasons surface. (Note: `acl_eth` and `acl_mac` are intentionally out of scope — issue #298.) Target tool: `central_manage_policy`. |
+| **Network destination alias** (`netdst`, `netdst6`) | (none) | `transform` — the `central:net_group` translation emits one `POST /net-groups/{name}` + config-assignment per source record. Per-entry mapping is engine-handled (host / network / FQDN → Central `HOST` / `NETWORK` / `FQDN` items). Must run BEFORE `central:policy` because policy rule bodies reference these aliases by name. AOS 8 system defaults (`_flags.default=true` — e.g. `localip`, `controller`, `mswitch`) are filtered by preprocessing; inherited copies must be filtered by the consumer at definition scope. (Note: AOS 8 `netsvc` — service aliases — is deferred to a future release; see the `acl_sess` row.) Target tool: `central_manage_net_group` (when the wrapper tool lands — preview today via `central_translation_preview`). |
 | **AP system profile** (`ap_sys_prof`) | §1651-§1657 (LMS prerequisite), §412-§415 (regulatory domain replaced) | Mixed: LMS-IP `transform` (must be VRRP VIP, not individual controller IP — already enforced as Act I REGRESSION rule); `reg_domain_prof` `deprecated`; `arm_prof` / `ht_radio_prof` `deprecated` (replaced by RF Profiles in AOS 10); syslog targets `operator-driven` (mapped to Central UI). **Central API gap — no `central_manage_ap_system_profile` tool today.** Target tool: `[Central API gap — manual UI]`. |
 | **WLAN SSID profile** (`ssid_prof`) | §2127-§2219 (CorpNet 802.1X), §2222-§2308 (OpsNet WPA3-Personal) | `direct-translate` — ESSID, opmode, VLAN, forwarding-mode, key-management, RADIUS pointers map to the `central_manage_wlan_profile` payload schema. The two VSG worked examples are the gold-standard reference for field-by-field mapping; emit per-WLAN-profile rows that cite them. Target tool: `central_manage_wlan_profile`. |
 | **VAP profile** (`virtual_ap`) | §2169-§2192 (Allowed bands "in the VAP", VLAN ID "in the VAP") | `transform` — AOS 8 VAP fields collapse INTO the WLAN profile in AOS 10; VAP is not a standalone object. Mark as `transform → folded into WLAN profile`. Target tool: `central_manage_wlan_profile` (collapsed). |
@@ -775,7 +779,7 @@ Emit a **single master table** with one row per legacy object discovered, **incl
 |---|---|---|---|---|---|---|---|---|---|
 
 - **Source name** — name as it appears in the source config (`corp-radius-1`, `corp-employee-role`, `corp-ssid-prof`).
-- **Source type** — AOS 8 REST schema name (verified against developer.arubanetworks.com/aos8/reference). One of: `rad_server`, `tacacs_server`, `ldap_server`, `server_group_prof`, `dot1x_auth_profile`, `mac_auth_profile`, `cp_auth_profile`, `role`, `acl_sess`, `ap_sys_prof`, `ssid_prof`, `virtual_ap`, `arm_prof`, `ht_radio_prof`, `reg_domain_prof`, `cluster_prof`, `group_membership`. (Notes: `internal_db_server` is intentionally absent — Central replaces internal-DB auth entirely; the F2 REGRESSION finding flags local-user migration via the `local-userdb` text dump, not via a REST-object lookup. `acl_eth` and `acl_mac` are also intentionally absent — see issue #298.)
+- **Source type** — AOS 8 REST schema name (verified against developer.arubanetworks.com/aos8/reference). One of: `rad_server`, `tacacs_server`, `ldap_server`, `server_group_prof`, `dot1x_auth_profile`, `mac_auth_profile`, `cp_auth_profile`, `role`, `acl_sess`, `netdst`, `netdst6`, `ap_sys_prof`, `ssid_prof`, `virtual_ap`, `arm_prof`, `ht_radio_prof`, `reg_domain_prof`, `cluster_prof`, `group_membership`. (Notes: REST schema names differ from CLI nouns — e.g. CLI `netdestination` is REST `netdst`. `internal_db_server` is intentionally absent — Central replaces internal-DB auth entirely; the F2 REGRESSION finding flags local-user migration via the `local-userdb` text dump, not via a REST-object lookup. `acl_eth` and `acl_mac` are also intentionally absent — see issue #298. `netsvc` — AOS 8 service aliases — is also absent pending live-shape verification; once captured, will be added with the corresponding `central:net_service` translation.)
 - **Source scope** — the `/md/...` node where the object is defined (e.g. `/md`, `/md/ACX`, `/md/ACX/dallas-hq/floor-3`). Captured during the Stage 1 hierarchy walk; **never assume an object lives at `/md` root**.
 - **Usage state** — one of: `assigned-and-active` (referenced by an ap-group or other object that's currently bound to active devices), `assigned-but-inactive` (referenced but the binding scope has no active devices), `configured-but-unassigned` (defined but not referenced by any other object), `orphaned` (referenced only by objects that are themselves unused). **This is metadata only — never a basis for excluding the row from migration.** Customers regularly migrate unused config because *"unused right now"* is a different statement from *"won't be needed after migration."*
 - **Disposition** — one of: `direct-translate` / `transform` / `drop` / `deprecated` / `operator-driven` / `inconclusive`.
@@ -846,18 +850,19 @@ For every row of the Stage 8 disposition matrix where Disposition is `direct-tra
 
 **Preconditions (soft — Stage 9b runs against partial inputs):**
 
-- Stage 1 has collected the AOS 8 inventory (effective-config dump). If the operator jumps straight to Stage 9b without Act I, run a **minimal Stage 1 collection** first — pull `role`, `acl_sess`, `vlan_id`, `vlan_name`, `vlan_name_id` from the AOS 8 path the operator named (e.g. `/md/Campus/West`). Do NOT do the full Act I hierarchy walk — that's overkill for a preview.
+- Stage 1 has collected the AOS 8 inventory (effective-config dump). If the operator jumps straight to Stage 9b without Act I, run a **minimal Stage 1 collection** first — pull `role`, `acl_sess`, `vlan_id`, `vlan_name`, `vlan_name_id`, `netdst`, `netdst6` from the AOS 8 path the operator named (e.g. `/md/Campus/West`). Do NOT do the full Act I hierarchy walk — that's overkill for a preview.
 - Stage 7 has produced the operator-confirmed AOS 8 → Central hierarchy mapping. **If Stage 7 was not run, target Global as a fallback** with a clearly-marked placeholder note in the output (see Step 1 below). The preview is engine output regardless of where the operator plans to land it; making Stage 9b strict on Stage 7 would defeat its purpose.
 - The target Central hierarchy does NOT need to exist in Central yet. Stage 9 builds the hierarchy as the FIRST cutover step; Stage 9b previews the per-object work that follows. Walker may legitimately return no match for a Stage-7 Central scope name — in that case use a placeholder scope_id (see Step 1).
 
-**Translations shipped today (v3.0.1.7):**
+**Translations shipped today (v3.0.1.14):**
 
 | translation_id | AOS 8 source | Central target | Notes |
 |---|---|---|---|
 | `central:vlan_id` | `vlan_id` (bare or rich) | layer2-vlan profile | Per-record. Optional sub-fields drop when absent. |
 | `central:named_vlan` | composite: `vlan_name` ⨝ `vlan_name_id` on `name` | named-VLAN + alias chain (6 emits) | Composite source — pre-merge before passing one record per name. |
 | `central:role` | `role` (Gateway-targeted) | role profile + config-assignment | ~25 fields. Skip `_flags.default=true` system roles. |
-| `central:policy` | `acl_sess` | /policies POST + config-assignment | Engine pre-processes via reverse-index lookup against role records (consumer pre-fetches once). |
+| `central:net_group` | `netdst` (IPv4) or `netdst6` (IPv6) | net-group profile + config-assignment | Address family inferred from source record. Per-entry host/network/FQDN mapped to Central HOST/NETWORK/FQDN items. Must run BEFORE `central:policy`. |
+| `central:policy` | `acl_sess` | /policies POST + config-assignment | Engine pre-processes via reverse-index lookup against role records (consumer pre-fetches once). References `net-group` aliases by name (created by `central:net_group`); `net-service` aliases pending. |
 
 #### Step 1 — Scope resolution (walker-optional, fall back to placeholder)
 
@@ -1089,11 +1094,71 @@ result = {
 result
 ```
 
+##### 2e — Net groups (`central:net_group`)
+
+Aliases referenced by `acl_sess` rules via the `salias` / `dalias` discriminator. **Despite appearing last in the preview, this translation runs FIRST in execution** — `central:policy` rule bodies reference these aliases by name and Central rejects the policy POST if the alias doesn't exist.
+
+```python
+# Stage 1 collected both netdst (IPv4) and netdst6 (IPv6) records.
+# Filter inherited / system / default aliases — consumer responsibility per
+# net_group_v1.json's ignored_variants.
+def _is_translatable(r: dict) -> bool:
+    flags = r.get("_flags") or {}
+    if flags.get("inherited") or flags.get("system") or flags.get("default"):
+        return False
+    # Skip empty aliases (no entries — Central rejects empty items[]).
+    entries = r.get("netdst__entry") or r.get("netdst6__entry") or []
+    return bool(entries)
+
+netdst_records = [r for r in (stage1_netdst_records + stage1_netdst6_records) if _is_translatable(r)]
+empty_or_system = [
+    r.get("dstname", "<unknown>")
+    for r in (stage1_netdst_records + stage1_netdst6_records)
+    if not _is_translatable(r)
+]
+
+response = await call_tool(
+    "central_translation_preview",
+    {
+        "translation_id": "central:net_group",
+        "source_records": netdst_records,
+        "runtime_values": {"central_scope_id": scope_lookup["Global"]},  # or your Stage-7 Central name
+    },
+)
+preview = response.get("data", response)
+result = {
+    "kind": "central:net_group",
+    "record_count": preview["record_count"],
+    "translatable": preview["translatable_count"],
+    "skipped": preview["skipped_count"],
+    "skipped_per_lld": empty_or_system,   # surface in Translation gaps
+    "summary": [
+        {
+            "alias": r["record_id"],
+            "calls": r["call_count"],
+            "items": (
+                len(r["target_calls"][0]["body"]["items"])
+                if r["target_calls"] else 0
+            ),
+            "family": (
+                r["target_calls"][0]["body"]["netdestination-type"]
+                if r["target_calls"] else None
+            ),
+            "skip": r["skip_reason"],
+        }
+        for r in preview["results"]
+    ][:30],
+}
+result
+```
+
 **Note on Ethernet/MAC ACL bindings.** AOS 8 roles can technically reference `acl_eth` or `acl_mac` entries via `role__acl[]` with `acl_type="eth"` / `acl_type="mac"`. Those ACL types are out of scope for this skill (issue #298 — unique-use cases). If you encounter a role binding one, leave the binding noted in the disposition matrix row's notes column but do NOT attempt to translate it; Stage 1 collection no longer enumerates these ACL types.
+
+**Note on `netsvc` (AOS 8 service aliases).** AOS 8 `acl_sess` rules may reference custom service aliases via `service-name` plus the AOS 8 `netsvc` schema. `central:net_service` is **deferred** to a future release pending live shape verification — Central rejects policy POSTs that reference unknown service aliases. If preview surfaces policy rules using non-`svc-*` service names (`svc-http` / `svc-https` / etc. come from Central's built-in catalog and work today), surface those in Translation gaps under "Service aliases pending translation" so the operator knows to pre-populate Central or wait for the translation to ship.
 
 #### Step 3 — Render the consolidated preview report
 
-Combine the four `result` dicts from Step 2 into a single operator-facing report. The report has THREE parts: (a) summary table, (b) per-record detail tables, (c) **sample TargetCall bodies** as JSON code blocks. Operators reviewing the migration need (c) — the actual JSON the migration will POST — not just counts.
+Combine the five `result` dicts from Step 2 into a single operator-facing report. The report has THREE parts: (a) summary table, (b) per-record detail tables, (c) **sample TargetCall bodies** as JSON code blocks. Operators reviewing the migration need (c) — the actual JSON the migration will POST — not just counts.
 
 ```
 ## Engine-driven translation preview (read-only)

--- a/src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py
+++ b/src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py
@@ -1,0 +1,134 @@
+"""Preprocessing for ``central:net_group`` (AOS 8 netdst / netdst6 → Central net-group).
+
+The translation JSON declares this module's ``preprocess_net_group`` function
+in its top-level ``preprocessing`` field. The engine invokes the function
+before ``key_mappings`` run, and the function returns an augmented
+``source_data`` dict with two new fields:
+
+* ``_address_family`` — ``"IPV4_ONLY"`` or ``"IPV6_ONLY"`` based on which
+  ``__entry`` key the source record carries (``netdst__entry`` →
+  ``IPV4_ONLY``; ``netdst6__entry`` → ``IPV6_ONLY``).
+* ``_central_items`` — the Central ``items[]`` array, with each AOS 8
+  ``netdst__entry`` mapped to a Central item via the ``_objname``
+  discriminator (``netdst__host`` → ``HOST``; ``netdst__network`` →
+  ``NETWORK`` with computed CIDR prefix; ``netdst__name`` → ``FQDN``).
+
+Per the translations authoring guide (``AUTHORING.md``), preprocessing lives
+in this module because the per-entry build needs a discriminator switch +
+the netmask → CIDR-prefix helper, which doesn't fit a per-field
+1-arg transform.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+
+
+def preprocess_net_group(source_data: dict[str, Any], runtime_values: dict[str, Any]) -> dict[str, Any]:
+    """Augment a single netdst / netdst6 record with ``_address_family`` + ``_central_items``.
+
+    Args:
+        source_data: One AOS 8 ``netdst`` or ``netdst6`` record. Must carry
+            either ``netdst__entry`` or ``netdst6__entry`` as a list of
+            per-entry dicts. ``dstname`` is read by the JSON's regular
+            ``key_mappings``; this function only augments the items
+            and address-family fields.
+        runtime_values: Engine-supplied; unused for net-group preprocessing
+            (no cross-record lookups, no caller-supplied context needed).
+
+    Returns:
+        A NEW dict ``{**source_data, "_address_family": ..., "_central_items": [...]}``.
+        Input is not mutated.
+
+    Raises:
+        ValueError: If the record carries neither ``netdst__entry`` nor
+            ``netdst6__entry``, or if a NETWORK entry's netmask is
+            non-contiguous (rare AOS 8 syntax; explicit failure preferred
+            over silent corruption of the CIDR prefix).
+    """
+    del runtime_values  # unused
+
+    if "netdst__entry" in source_data:
+        family = "IPV4_ONLY"
+        entries = source_data.get("netdst__entry") or []
+    elif "netdst6__entry" in source_data:
+        family = "IPV6_ONLY"
+        entries = source_data.get("netdst6__entry") or []
+    else:
+        raise ValueError(
+            "net_group preprocessing: source record carries neither 'netdst__entry' nor "
+            "'netdst6__entry' — cannot determine address family"
+        )
+
+    items: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        # Skip per-entry inherited/system markers — consumer should filter at
+        # the record level, but defend against partial-inheritance shapes.
+        flags = entry.get("_flags") or {}
+        if flags.get("default") is True or flags.get("system") is True:
+            continue
+        built = _build_item(entry, family)
+        if built is not None:
+            items.append(built)
+
+    return {**source_data, "_address_family": family, "_central_items": items}
+
+
+def _build_item(entry: dict[str, Any], family: str) -> dict[str, Any] | None:
+    """Map one AOS 8 ``__entry`` element to one Central ``items[]`` element.
+
+    Returns ``None`` for unknown discriminators (silently dropped per
+    the JSON's ``unmapped_fields`` policy — surface as a non_empty_regression
+    finding at the consumer level if needed).
+    """
+    objname = entry.get("_objname")
+    if objname in ("netdst__host", "netdst6__host"):
+        address = entry.get("address")
+        if not address:
+            return None
+        return {"type": "HOST", "address": str(address)}
+
+    if objname in ("netdst__network", "netdst6__network"):
+        address = entry.get("address")
+        if not address:
+            return None
+        if family == "IPV6_ONLY":
+            # IPv6 networks carry the prefix length directly (e.g. as 'prefix-length' or
+            # in the address itself). Trust the operator-supplied address; if it already
+            # carries '/', pass through, otherwise default to the value plus assumed
+            # full-host length (128) — corrected on first live-verification.
+            prefix = str(address) if "/" in str(address) else f"{address}/128"
+            return {"type": "NETWORK", "prefix": prefix}
+        # IPv4: netmask is dotted-quad; convert to CIDR prefix length.
+        netmask = entry.get("netmask")
+        if not netmask:
+            return None
+        cidr_len = _netmask_to_prefix(str(netmask))
+        return {"type": "NETWORK", "prefix": f"{address}/{cidr_len}"}
+
+    if objname in ("netdst__name", "netdst6__name"):
+        host_name = entry.get("host_name")
+        if not host_name:
+            return None
+        return {"type": "FQDN", "fqdn": str(host_name)}
+
+    return None
+
+
+def _netmask_to_prefix(netmask: str) -> int:
+    """Convert a dotted-quad IPv4 netmask to a CIDR prefix length.
+
+    Raises ValueError on non-contiguous masks (e.g. ``'255.0.255.0'``) —
+    AOS 8 syntactically allows them but Central CIDR notation cannot
+    represent them. Explicit failure preferred over silent corruption.
+    """
+    try:
+        return ipaddress.IPv4Network(f"0.0.0.0/{netmask}", strict=False).prefixlen
+    except ValueError as exc:
+        raise ValueError(
+            f"net_group preprocessing: non-contiguous IPv4 netmask {netmask!r} cannot be "
+            f"expressed as a CIDR prefix; Central NETWORK entries require a prefix length"
+        ) from exc

--- a/src/hpe_networking_mcp/translations/targets/central/net_group_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/net_group_v1.json
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "target_platform": "central",
+  "target_id": "net_group",
+  "preprocessing": "hpe_networking_mcp.translations.preprocessing.aos8_net_group.preprocess_net_group",
+  "target_emits": [
+    {
+      "step":     1,
+      "name":     "create_net_group",
+      "purpose":  "Create the net-group (netdestination) profile in the Library. The address-family discriminator and per-entry items[] are pre-computed by the preprocessing function from the source record's __entry sub-list (mapping AOS 8 host/network/name entries to Central HOST/NETWORK/FQDN entries).",
+      "endpoint": "/network-config/v1alpha1/net-groups/{name}",
+      "method":   "POST",
+      "query_params": {},
+      "body": {
+        "name":                "{name}",
+        "netdestination-type": "{netdestination_type}",
+        "items":               "{items}"
+      },
+      "iteration": "once",
+      "iteration_notes": "One POST per source netdst / netdst6 record.",
+      "depends_on": []
+    },
+    {
+      "step":     2,
+      "name":     "assign_net_group",
+      "purpose":  "Assign the net-group profile to the target scope. Multi-device-function array packed into a single POST.",
+      "endpoint": "/network-config/v1alpha1/config-assignments",
+      "method":   "POST",
+      "query_params": {},
+      "body_template": {
+        "config-assignment": [
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='net-group', profile-instance='{name}' }}"
+        ]
+      },
+      "iteration": "once",
+      "iteration_notes": "One POST; all device-functions share the array.",
+      "depends_on": [1]
+    }
+  ],
+  "target_meta": {
+    "device_functions": ["MOBILITY_GW"],
+    "device_function_filtering_rule": "Net-group profiles are referenced by session ACL rules on Mobility Gateways. The Central net-group schema marks the items[] address list as supported on Gateway + Switch PVOS only (Access Points read the alias indirectly via pushed policies). For AOS 8 -> Central GW migration we target MOBILITY_GW; operators with AP-direct or switch use cases can override device_functions in runtime_values."
+  },
+  "target_scope_id_resolution": {
+    "rule":   "Central scope_id is supplied by the consuming skill at runtime, derived from the AOS 8 netdst / netdst6 record's binding scope.",
+    "input":  "Source binding scope (string path / identifier); skill-specific",
+    "output": "Central scope_id (string), supplied via runtime_values['central_scope_id']"
+  },
+  "required_runtime_values": ["central_scope_id"],
+  "derived": {},
+  "dependencies": [
+    {
+      "depends_on":  "(none — this is a foundational translation; runs before central:policy)",
+      "depended_by": [
+        {
+          "target_id": "central:policy",
+          "field":     "security-policy.policy-rule[].condition.{source,destination}.host-address.host-address-alias",
+          "relation":  "policy rules reference net-group profiles by name",
+          "notes":     "When an AOS 8 acl_sess rule uses the salias/dalias discriminator (named netdestination reference), the central:policy translation emits a policy-rule body that references the alias by name via host-address-alias. The referenced alias must exist in the Central tenant before the policy POST or Central returns an unknown-alias error. This translation creates the prerequisite alias objects."
+        }
+      ]
+    }
+  ],
+  "tokenize_kind_per_field": {},
+  "sources": {
+    "aos8": {
+      "kind":         "rest",
+      "mapping_kind": "simple",
+      "objects": [
+        {
+          "object":      "netdst",
+          "object_path": "/v1/configuration/object/netdst",
+          "role":        "ipv4_netdestination_alias",
+          "docs": {
+            "get":  "https://developer.arubanetworks.com/aos8/reference/get_object-netdst",
+            "post": "https://developer.arubanetworks.com/aos8/reference/post_object-netdst"
+          },
+          "live_shape_example": "[{\"dstname\": \"cppm\", \"netdst__entry\": [{\"address\": \"192.0.2.10\", \"hosttag\": \"address\", \"_objname\": \"netdst__host\"}, {\"host_name\": \"cppm.example.com\", \"_objname\": \"netdst__name\"}]}, {\"dstname\": \"foreign-badnetworks\", \"netdst__entry\": [{\"address\": \"14.0.0.0\", \"networktag\": \"network_opts\", \"netmask\": \"255.0.0.0\", \"_objname\": \"netdst__network\"}]}]",
+          "notes": "Live-verified across 8 operator-authored aliases in the maintainer's tenant (mix of host / network / FQDN entries; ~100-entry alias for blacklist-range lists). REST schema name is 'netdst' (CLI noun: netdestination). Per-entry discriminator is '_objname' on each netdst__entry element: 'netdst__host' = single IP (fields: address, hosttag); 'netdst__network' = CIDR (fields: address, networktag, netmask); 'netdst__name' = FQDN (field: host_name). Inheritance: copies appear at descendant scopes with _flags.inherited=true; consumer must filter those out before iterating."
+        },
+        {
+          "object":      "netdst6",
+          "object_path": "/v1/configuration/object/netdst6",
+          "role":        "ipv6_netdestination_alias",
+          "docs": {
+            "get":  "https://developer.arubanetworks.com/aos8/reference/get_object-netdst6"
+          },
+          "live_shape_example": "(zero records in maintainer's tenant; schema recognized, structural symmetry with netdst assumed)",
+          "notes": "REST schema name is 'netdst6' (CLI noun: netdestination6). Schema recognized in maintainer's tenant but zero records configured — the assumed wrapper-and-entry shape (netdst6 with netdst6__entry children carrying _objname='netdst6__host' / 'netdst6__network' / 'netdst6__name') follows the netdst schema convention. First live-verification of the netdst6 record shape MUST happen after v3.0.1.14 deploys to a tenant with IPv6 aliases configured. The preprocessing function falls back to scanning either netdst__entry or netdst6__entry on the source record so a netdst6 record with the documented sibling-name shape works without changes."
+        }
+      ],
+      "key_mappings": {
+        "name": {
+          "from":      "dstname",
+          "to":        "Central net-group 'name' (path param on step 1, profile-instance on step 2, body 'name')",
+          "transform": "direct_str",
+          "notes":     "Required. AOS 8 'dstname' -> Central net-group 'name'. 1-63 char limit per the Central schema; consumer should validate length before dispatch."
+        },
+        "netdestination_type": {
+          "from":      "_address_family",
+          "to":        "Central net-group body 'netdestination-type' (enum: IPV4_ONLY / IPV6_ONLY)",
+          "transform": "direct_str",
+          "notes":     "Pre-computed by the preprocessing function based on which __entry key the source record carries ('netdst__entry' -> IPV4_ONLY; 'netdst6__entry' -> IPV6_ONLY). Central schema explicitly notes the enum value IPV4_IPV6_MIXED is not supported on any devices, so a single source record always maps to one address family."
+        },
+        "items": {
+          "from":      "_central_items",
+          "to":        "Central net-group body 'items[]' array",
+          "transform": "direct",
+          "notes":     "Pre-computed by the preprocessing function. Each AOS 8 __entry maps to one Central items[] element with the discriminator-appropriate fields: netdst__host -> {type: HOST, address}; netdst__network -> {type: NETWORK, prefix=address/netmask_to_prefix(netmask)}; netdst__name -> {type: FQDN, fqdn}. Engine substitutes the array verbatim."
+        }
+      },
+      "unmapped_fields": [
+        {
+          "from":            "AOS 8 netdst-level _flags (inherited / default / readonly / system)",
+          "reason":          "Inheritance and system markers are AOS 8-internal metadata, not body content. Consumer must filter inherited copies (_flags.inherited == True) at definition scope before iterating; default / system / readonly entries (e.g. AOS 8's built-in alias families) should be skipped entirely rather than POSTed to Central where they may collide with Central's own built-ins.",
+          "severity_rule":   "always_operator_map"
+        },
+        {
+          "from":            "AOS 8 ADDRESS_RANGE / VLAN / PORT / INTERFACE entries",
+          "reason":          "Central's net-group items[] type enum supports ADDRESS_RANGE, VLAN, PORT, INTERFACE but AOS 8 netdst entries don't surface these forms — verified live across the maintainer's tenant (only netdst__host, netdst__network, netdst__name appear). Add per discriminator when configured samples surface.",
+          "severity_rule":   "non_empty_regression"
+        },
+        {
+          "from":            "Central net-group 'description' / 'invert' / 'exclude' / 'preemptive-failover'",
+          "reason":          "Optional Central body fields with no AOS 8 source-side counterpart in netdst / netdst6 records. Leaving body keys unset = Central defaults apply (invert=false, no exclude, etc.). Operator can override via overrides post-translation.",
+          "severity_rule":   "always_operator_map"
+        }
+      ],
+      "ignored_variants": [
+        {
+          "form":   "netdst record with _flags.default=true (system / built-in alias)",
+          "reason": "AOS 8 ships built-in netdestinations (e.g. 'localip', 'controller', 'mswitch'). These are virtual aliases generated by the controller and shouldn't be migrated as user-defined net-groups in Central — Central provides equivalent semantics via type=ADDRESS_LOCAL on the policy-rule side, not via a net-group lookup. **Consumer responsibility**: filter records with _flags.default=true / _flags.system=true / _flags.inherited=true (at definition scope) BEFORE calling emit_calls. Preprocessing only filters per-entry _flags; record-level filtering matches the same convention as central:role and central:policy."
+        },
+        {
+          "form":   "netdst record with empty netdst__entry list (no addresses)",
+          "reason": "An alias with no entries is a placeholder; Central rejects POSTs with empty items[]. Preprocessing returns the empty items array unchanged; consumer should filter these from the migration set."
+        }
+      ]
+    }
+  },
+  "draft_notes": [
+    "v1 translation, Gateway-targeted. POST /net-groups/{name} with the pre-computed items[] array supplied by the aos8_net_group preprocessing function (engine auto-invokes via the top-level preprocessing field).",
+    "TEMPLATE COMPLIANCE: standard Paradigm-B (per-field key_mappings + structurally complete body). The discriminator-based items[] build lives in the preprocessing function (translations/preprocessing/aos8_net_group.py); the JSON is thin and reviewable.",
+    "DEPENDENCY: central:policy references net-group profiles by name on the policy-side via host-address-alias. Run this translation BEFORE central:policy. Without it, AOS 8 acl_sess rules that reference netdestinations via salias / dalias produce Central policy bodies whose alias references fail at Central with an unknown-alias error.",
+    "v6 SHAPE: the netdst6 source record shape is structurally assumed (sibling-naming convention against the live-verified netdst schema). First tenant with netdst6 records configured will validate; the preprocessing function detects v4 vs v6 by which __entry key is present so a netdst6 record matching the assumed shape works without code change.",
+    "NETMASK -> CIDR PREFIX: AOS 8 netdst__network entries carry a dotted-quad netmask (e.g. '255.255.255.0'); Central NETWORK entries carry a CIDR-prefix string (e.g. '192.168.1.0/24'). Preprocessing converts via a contiguous-bitmask helper; non-contiguous masks (e.g. '255.0.255.0', rare but legal AOS 8 syntax) raise EngineError on the offending record rather than corrupting the prefix.",
+    "Idempotency: if a net-group profile with the same name already exists, the SHARED POST returns HTTP 409. Consumer must handle 409 idempotently."
+  ]
+}

--- a/tests/unit/test_translations_engine.py
+++ b/tests/unit/test_translations_engine.py
@@ -1604,3 +1604,154 @@ def test_policy_any_any_with_empty_role_attribution_falls_back_to_address_any(po
     rule = body["security-policy"]["policy-rule"][0]
     assert rule["condition"]["source"] == {"type": "ADDRESS_ANY"}
     assert rule["condition"]["destination"] == {"type": "ADDRESS_ANY"}
+
+
+# --------------------------------------------------------------------------- #
+# central:net_group — netdst / netdst6 → Central /net-groups
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def net_group(translations: dict):
+    return translations["central:net_group"]
+
+
+def _ng_runtime(scope_id: str = "SCOPE", device_functions: list[str] | None = None) -> dict:
+    rv: dict = {"central_scope_id": scope_id}
+    if device_functions is not None:
+        rv["device_functions"] = device_functions
+    return rv
+
+
+def test_net_group_host_only_record_emits_two_calls(net_group) -> None:
+    """Simple host alias — step 1 creates the net-group with items[]; step 2 assigns."""
+    source = {
+        "dstname": "cppm",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "192.168.20.70", "hosttag": "address"},
+        ],
+    }
+    calls = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime("SCOPE-A"))
+    assert len(calls) == 2
+    assert [c.step for c in calls] == [1, 2]
+
+    step1 = calls[0]
+    assert step1.method == "POST"
+    assert step1.endpoint == "/network-config/v1alpha1/net-groups/cppm"
+    assert step1.body == {
+        "name": "cppm",
+        "netdestination-type": "IPV4_ONLY",
+        "items": [{"type": "HOST", "address": "192.168.20.70"}],
+    }
+
+
+def test_net_group_mixed_entries_render_in_source_order(net_group) -> None:
+    """Host + network + FQDN entries on one record all land in items[] in order."""
+    source = {
+        "dstname": "cppm",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "192.168.20.70"},
+            {"_objname": "netdst__network", "address": "10.10.0.0", "netmask": "255.255.0.0"},
+            {"_objname": "netdst__name", "host_name": "cppm.example.com"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["items"] == [
+        {"type": "HOST", "address": "192.168.20.70"},
+        {"type": "NETWORK", "prefix": "10.10.0.0/16"},
+        {"type": "FQDN", "fqdn": "cppm.example.com"},
+    ]
+
+
+def test_net_group_netmask_conversion_handles_common_prefixes(net_group) -> None:
+    """Spot-check the netmask -> CIDR conversion through emit_calls."""
+    source = {
+        "dstname": "lan",
+        "netdst__entry": [
+            {"_objname": "netdst__network", "address": "10.0.0.0", "netmask": "255.0.0.0"},
+            {"_objname": "netdst__network", "address": "172.16.0.0", "netmask": "255.240.0.0"},
+            {"_objname": "netdst__network", "address": "192.168.1.0", "netmask": "255.255.255.0"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["items"] == [
+        {"type": "NETWORK", "prefix": "10.0.0.0/8"},
+        {"type": "NETWORK", "prefix": "172.16.0.0/12"},
+        {"type": "NETWORK", "prefix": "192.168.1.0/24"},
+    ]
+
+
+def test_net_group_v6_record_sets_ipv6_only_family(net_group) -> None:
+    """netdst6__entry source → IPV6_ONLY netdestination-type."""
+    source = {
+        "dstname": "ipv6-block",
+        "netdst6__entry": [
+            {"_objname": "netdst6__network", "address": "2001:db8::/32"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["netdestination-type"] == "IPV6_ONLY"
+    assert body["items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32"}]
+
+
+def test_net_group_step2_assigns_to_mobility_gw_by_default(net_group) -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}],
+    }
+    calls = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime("SCOPE-X"))
+    step2 = calls[1]
+    assert step2.endpoint == "/network-config/v1alpha1/config-assignments"
+    items = (step2.body or {})["config-assignment"]
+    assert len(items) == 1
+    assert items[0] == {
+        "scope-id": "SCOPE-X",
+        "device-function": "MOBILITY_GW",
+        "profile-type": "net-group",
+        "profile-instance": "x",
+    }
+
+
+def test_net_group_runtime_device_functions_override(net_group) -> None:
+    """Operator-supplied device_functions overrides target_meta default."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}],
+    }
+    calls = emit_calls(
+        net_group,
+        source,
+        "aos8",
+        runtime_values=_ng_runtime(device_functions=["MOBILITY_GW", "CAMPUS_AP"]),
+    )
+    items = (calls[1].body or {})["config-assignment"]
+    assert {i["device-function"] for i in items} == {"MOBILITY_GW", "CAMPUS_AP"}
+    assert all(i["profile-type"] == "net-group" for i in items)
+    assert all(i["profile-instance"] == "x" for i in items)
+
+
+def test_net_group_missing_dstname_raises(net_group) -> None:
+    """Missing required 'dstname' source field — engine raises rather than emit
+    a malformed call with an unsubstituted placeholder.
+    """
+    source = {"netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}]}
+    with pytest.raises(EngineError, match=r"\{name\}"):
+        emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())
+
+
+def test_net_group_record_without_entry_key_raises(net_group) -> None:
+    """Preprocessing failure propagates as EngineError."""
+    source = {"dstname": "broken"}
+    with pytest.raises(EngineError, match="neither 'netdst__entry' nor 'netdst6__entry'"):
+        emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())
+
+
+def test_net_group_non_contiguous_netmask_raises(net_group) -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__network", "address": "10.0.0.0", "netmask": "255.0.255.0"},
+        ],
+    }
+    with pytest.raises(EngineError, match="non-contiguous"):
+        emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())

--- a/tests/unit/test_translations_preprocessing_aos8_net_group.py
+++ b/tests/unit/test_translations_preprocessing_aos8_net_group.py
@@ -1,0 +1,283 @@
+"""Unit tests for ``translations/preprocessing/aos8_net_group.py``.
+
+Covers the preprocessing function directly:
+* Address-family detection from `netdst__entry` vs `netdst6__entry`.
+* Per-entry discriminator mapping (`netdst__host` / `netdst__network` /
+  `netdst__name`) into Central items[] elements.
+* IPv4 netmask → CIDR prefix conversion (including non-contiguous mask
+  failure).
+* Per-entry `_flags.default` / `_flags.system` filtering.
+
+Engine-level integration of these results lives in
+``test_translations_engine.py`` under the ``central:net_group`` section.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.translations.preprocessing.aos8_net_group import (
+    _netmask_to_prefix,
+    preprocess_net_group,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# Address-family detection
+# --------------------------------------------------------------------------- #
+
+
+def test_netdst_record_is_ipv4_only() -> None:
+    source = {"dstname": "x", "netdst__entry": []}
+    out = preprocess_net_group(source, {})
+    assert out["_address_family"] == "IPV4_ONLY"
+    assert out["_central_items"] == []
+
+
+def test_netdst6_record_is_ipv6_only() -> None:
+    source = {"dstname": "x", "netdst6__entry": []}
+    out = preprocess_net_group(source, {})
+    assert out["_address_family"] == "IPV6_ONLY"
+    assert out["_central_items"] == []
+
+
+def test_record_without_entry_key_raises() -> None:
+    with pytest.raises(ValueError, match="neither 'netdst__entry' nor 'netdst6__entry'"):
+        preprocess_net_group({"dstname": "x"}, {})
+
+
+def test_input_dict_not_mutated() -> None:
+    source = {"dstname": "x", "netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}]}
+    snapshot = dict(source)
+    snapshot_entries = list(source["netdst__entry"])
+    preprocess_net_group(source, {})
+    assert source == snapshot
+    assert source["netdst__entry"] == snapshot_entries
+
+
+# --------------------------------------------------------------------------- #
+# Per-entry discriminator → Central items[] element
+# --------------------------------------------------------------------------- #
+
+
+def test_netdst_host_entry_maps_to_host_type() -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "192.168.20.70", "hosttag": "address"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "192.168.20.70"}]
+
+
+def test_netdst_network_entry_maps_to_network_with_cidr_prefix() -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__network", "address": "10.0.0.0", "netmask": "255.0.0.0"},
+            {"_objname": "netdst__network", "address": "192.168.1.0", "netmask": "255.255.255.0"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [
+        {"type": "NETWORK", "prefix": "10.0.0.0/8"},
+        {"type": "NETWORK", "prefix": "192.168.1.0/24"},
+    ]
+
+
+def test_netdst_name_entry_maps_to_fqdn() -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [{"_objname": "netdst__name", "host_name": "cppm.example.com"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "FQDN", "fqdn": "cppm.example.com"}]
+
+
+def test_mixed_entry_types_preserve_source_order() -> None:
+    """Host, network, FQDN entries on one alias all map and preserve order."""
+    source = {
+        "dstname": "cppm",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "192.168.20.70"},
+            {"_objname": "netdst__network", "address": "10.10.0.0", "netmask": "255.255.0.0"},
+            {"_objname": "netdst__name", "host_name": "cppm.example.com"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [
+        {"type": "HOST", "address": "192.168.20.70"},
+        {"type": "NETWORK", "prefix": "10.10.0.0/16"},
+        {"type": "FQDN", "fqdn": "cppm.example.com"},
+    ]
+
+
+def test_unknown_objname_silently_skipped() -> None:
+    """Per the JSON's unmapped_fields: unknown _objname discriminators are dropped."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1"},
+            {"_objname": "netdst__future_type", "weird_field": "..."},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+
+
+def test_entry_missing_required_field_is_dropped() -> None:
+    """Defensive: host entry without 'address' is skipped, not an error."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host"},  # no address
+            {"_objname": "netdst__network", "address": "10.0.0.0"},  # no netmask
+            {"_objname": "netdst__name"},  # no host_name
+            {"_objname": "netdst__host", "address": "10.0.0.1"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+
+
+def test_non_dict_entry_silently_skipped() -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            "not-a-dict",
+            None,
+            {"_objname": "netdst__host", "address": "10.0.0.1"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+
+
+# --------------------------------------------------------------------------- #
+# Per-entry _flags filtering
+# --------------------------------------------------------------------------- #
+
+
+def test_entry_with_default_flag_filtered() -> None:
+    """Per-entry _flags.default=true skips the entry."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1", "_flags": {"default": True}},
+            {"_objname": "netdst__host", "address": "10.0.0.2"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2"}]
+
+
+def test_entry_with_system_flag_filtered() -> None:
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1", "_flags": {"system": True}},
+            {"_objname": "netdst__host", "address": "10.0.0.2"},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2"}]
+
+
+def test_entry_with_inherited_flag_passes_through() -> None:
+    """_flags.inherited is consumer-filtered at the record level, not entry level —
+    inherited per-entry markers should NOT cause preprocessing to drop entries
+    (the consumer already decided to translate this record).
+    """
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1", "_flags": {"inherited": True}},
+        ],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+
+
+# --------------------------------------------------------------------------- #
+# IPv6 path (assumed shape; structural symmetry with v4)
+# --------------------------------------------------------------------------- #
+
+
+def test_netdst6_host_entry_maps_to_host() -> None:
+    source = {
+        "dstname": "x6",
+        "netdst6__entry": [{"_objname": "netdst6__host", "address": "2001:db8::1"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "HOST", "address": "2001:db8::1"}]
+
+
+def test_netdst6_network_with_cidr_already_in_address() -> None:
+    """v6 networks carry the prefix length in the address string; pass through."""
+    source = {
+        "dstname": "x6",
+        "netdst6__entry": [{"_objname": "netdst6__network", "address": "2001:db8::/32"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32"}]
+
+
+def test_netdst6_network_without_cidr_defaults_to_128() -> None:
+    """Defensive default: v6 NETWORK entry without '/' falls back to /128.
+    First live verification will refine this if needed.
+    """
+    source = {
+        "dstname": "x6",
+        "netdst6__entry": [{"_objname": "netdst6__network", "address": "2001:db8::1"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::1/128"}]
+
+
+# --------------------------------------------------------------------------- #
+# Netmask → CIDR prefix helper
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "netmask,expected_prefix",
+    [
+        ("255.255.255.255", 32),
+        ("255.255.255.128", 25),
+        ("255.255.255.0", 24),
+        ("255.255.0.0", 16),
+        ("255.0.0.0", 8),
+        ("0.0.0.0", 0),
+    ],
+)
+def test_netmask_to_prefix_contiguous(netmask: str, expected_prefix: int) -> None:
+    assert _netmask_to_prefix(netmask) == expected_prefix
+
+
+@pytest.mark.parametrize(
+    "netmask",
+    [
+        "255.0.255.0",  # non-contiguous (gap in middle)
+        "255.255.0.255",
+        "not-a-mask",
+        "256.0.0.0",
+    ],
+)
+def test_netmask_to_prefix_invalid_raises(netmask: str) -> None:
+    with pytest.raises(ValueError, match="non-contiguous|net_group"):
+        _netmask_to_prefix(netmask)
+
+
+def test_network_entry_with_non_contiguous_mask_raises_in_preprocessing() -> None:
+    """Non-contiguous netmask surfaces from preprocessing, not silently corrupted."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [
+            {"_objname": "netdst__network", "address": "10.0.0.0", "netmask": "255.0.255.0"},
+        ],
+    }
+    with pytest.raises(ValueError, match="non-contiguous"):
+        preprocess_net_group(source, {})


### PR DESCRIPTION
## Summary

Fifth shipped translation and the **missing dependency for `central:policy`**. Before v3.0.1.14, `central:policy` emitted rule bodies that referenced `net-group` aliases by name — but no translation created those alias objects, so policy POSTs would fail at Central with an unknown-alias error unless the operator had pre-populated matching names.

This PR also fixes a wrong claim in v3.0.1.13's Stage 8 prose that described both `net_group` and `net_service` translations as if they already shipped.

- **Translation file**: `translations/targets/central/net_group_v1.json` — multi-source (netdst + netdst6). Address family inferred from source record (`netdestination-type` enum: `IPV4_ONLY` / `IPV6_ONLY` — Central explicitly does not support `IPV4_IPV6_MIXED`). Per-record: `POST /net-groups/{name}` + `POST /config-assignments`.
- **Preprocessing**: `translations/preprocessing/aos8_net_group.py` — entry-type discriminator (`netdst__host` → HOST, `netdst__network` → NETWORK with computed CIDR prefix, `netdst__name` → FQDN). Non-contiguous netmasks raise rather than silently corrupting the CIDR prefix.
- **Skill updates**: COLLECT-01 extends `OBJECT_TYPES` with `netdst` + `netdst6`; Stage 8 disposition matrix corrected + new row for netdst/netdst6; Stage 9b adds preview block 2e.

`central:net_service` is **deferred** — the maintainer's tenant has zero `netsvc` records; per the real-captured-fixtures-only convention we won't hand-approximate the source shape.

Fixes #300. References #279.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — **1243 passed** (was 1206 in v3.0.1.13; +37 net new across preprocessing-direct + engine-e2e tests).
- [x] Smoke-tested via `emit_calls` against captured tenant fixtures: 'cppm' (host + FQDN entries), 'lan' (CIDR network entries), 'ipv6-block' (assumed v6 shape) — all produce correctly-shaped Central POST bodies.
- [ ] Post-deploy: live-verify against a tenant that has `netdst6` records configured (assumed-shape branch; first tenant validates).

## Files

- `src/hpe_networking_mcp/translations/targets/central/net_group_v1.json` — new
- `src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py` — new
- `tests/unit/test_translations_preprocessing_aos8_net_group.py` — new (24 tests)
- `tests/unit/test_translations_engine.py` — +9 net_group e2e tests
- `src/hpe_networking_mcp/skills/aos-migration.md` — COLLECT-01, Stage 8, Stage 9b
- `CHANGELOG.md`, `pyproject.toml`