### PR TITLE
v3.0.1.15: tool-discovery hardening (Mike Gallagher Mist report 2026-05-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1.15] - 2026-05-12
+
+**Tool-discovery hardening — three layered fixes targeting the "Mist intermittent" report from Mike Gallagher (2026-05-12, Sonnet 4.6). Closes #293 and #302.**
+
+The reported symptom — *"Mist sometimes works, sometimes doesn't; Central works fine"* — turned out NOT to be a Mist platform bug. Live triage reproduced three layered tool-discovery failures that surface together. Central happens to work despite them because its tool names follow our `<platform>_<action>_<resource>` convention and the AI guesses correctly; Mist's names diverge (ported from Thomas Munzer's upstream mistmcp) so the AI can't guess and falls back on discovery, which was broken in three different ways.
+
+### Layer A — Discovery tool descriptions rewritten
+
+The top-level discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) had generic descriptions like *"Search for available tools by query"* that lost client semantic ranking against more keyword-rich tools from other MCP servers attached to the same client (e.g. the Home Assistant MCP's tools ranked higher when the AI searched for "list mist sites"). Result: the client never surfaced our discovery tools, leaving the AI with only `execute` and no way to find platform tool names except by guessing.
+
+`server.py` now subclasses FastMCP's `Search` / `GetTags` / `GetSchemas` with HPE-Networking-specific descriptions that name the seven platforms (`mist`, `central`, `aos8`, `clearpass`, `apstra`, `axis`, `greenlake`) and describe what they're for — listing sites, getting devices, searching events, managing config, checking health. The skill discovery descriptions in `skills/_engine.py` got the same keyword treatment.
+
+### Layer B — Universal envelope no longer wraps discovery tools (closes #293)
+
+The discovery tools ship with `x-fastmcp-wrap-result: true` output schemas that require a top-level `result` field (FastMCP convention: primitive returns get auto-wrapped as `{"result": <value>}`). When the universal envelope middleware (v3.0.0.0) wrapped them again as `{"ok": ..., "data": {"result": ...}, ...}`, output validation failed because the OUTER envelope has no top-level `result`. Result: when the AI *did* manage to call a discovery tool, it got `Output validation error: 'result' is a required property`.
+
+`ResponseEnvelopeMiddleware` now passes through the five discovery tool names unchanged. They speak their own uniform shape that clients understand.
+
+### Layer C1 — Per-platform meta-tools always registered
+
+Each platform's `register_tools` had `if config.tool_mode == "dynamic":` gating the call to `build_meta_tools`. In code mode the meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) were NOT registered at all. Yet `INSTRUCTIONS.md:25` told the AI to call them inside `execute()` as the code-mode discovery path. Verified live 2026-05-12: `mist_list_tools` and `central_list_tools` both returned `Unknown tool` when invoked via `call_tool` inside `execute()`.
+
+The gate is removed — meta-tools register unconditionally now. In dynamic mode they remain visible at the top level (current behavior unchanged); in code mode they're hidden by `CodeMode.transform_tools`'s catalog replacement but **remain callable via `call_tool` from inside `execute()`**. This gives the AI a foolproof in-sandbox discovery fallback that doesn't depend on the client surfacing the outer discovery tools.
+
+Also: `execute_description` in `server.py` now teaches the in-sandbox discovery path explicitly, and `INSTRUCTIONS.md` describes both discovery paths (outer when the client surfaces them, in-sandbox as fallback).
+
+### Files
+
+- **`src/hpe_networking_mcp/middleware/response_envelope.py`** — added `_NO_ENVELOPE_TOOLS` skip set; early-return for the five discovery tool names.
+- **`src/hpe_networking_mcp/server.py`** — added `_SEARCH_DESCRIPTION` / `_TAGS_DESCRIPTION` / `_GET_SCHEMA_DESCRIPTION` constants; subclassed `Search` / `GetTags` / `GetSchemas` to inject those descriptions; updated `execute_description` to teach the in-sandbox `<platform>_list_tools` discovery path.
+- **`src/hpe_networking_mcp/skills/_engine.py`** — `_SKILLS_LIST_DESC` / `_SKILLS_LOAD_DESC` updated with platform keyword hooks.
+- **`src/hpe_networking_mcp/platforms/<each>/__init__.py`** — removed the `if config.tool_mode == "dynamic":` gate on `build_meta_tools`. 7 platforms + 1 template.
+- **`src/hpe_networking_mcp/INSTRUCTIONS.md`** — line 25 rewritten to describe both code-mode discovery paths accurately.
+- **`tests/unit/test_response_envelope_middleware.py`** — added `TestDiscoveryToolBypass` with 5 parameterized passthrough tests + 1 non-discovery-sanity test.
+- **`tests/unit/test_server_code_mode.py`** — added 3 tests: `test_execute_description_mentions_in_sandbox_discovery_path`, `test_discovery_tool_descriptions_carry_platform_keywords`, and `test_platform_init_registers_meta_tools_unconditionally` (parameterized across the 7 platform `__init__.py` files).
+- **`pyproject.toml`** — bump 3.0.1.14 → 3.0.1.15.
+
+### Test changes
+
+1243 → 1258 passing (+15 net new). Lint + format + mypy clean.
+
+### Notes
+
+- **What this fix does NOT do.** It does not rename Mist tools to follow our `<platform>_<action>_<resource>` convention — that's a separate larger conversation with back-compat implications. The fix here gives the AI a reliable discovery path so the convention divergence doesn't matter.
+- **Backwards-compatible.** No public tool removed. The 21 meta-tools that were code-mode-hidden now exist in code mode too, but as hidden registrations reachable only through `call_tool` inside `execute()` — they don't add to the visible surface count.
+- **Live verification recommended after deploy.** From a Claude client with the MCP attached, ask *"list mist sites"* — the client should surface `hpe-networking:search` for semantic ranking (description hooks now help), and if it doesn't, the AI can fall back to `await call_tool("mist_list_tools", {"filter": "site"})` inside `execute()` and get a useful catalog.
+
 ## [3.0.1.14] - 2026-05-11
 
 **Translations engine — `central:net_group` (AOS 8 `netdst` + `netdst6` → Central `/net-groups`).** Closes #300; references #279.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.0.1.14"
+version = "3.0.1.15"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -22,7 +22,12 @@ Two modes are supported (the `static` mode was removed in v3.0.0.0):
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
     - **2 skills tools** (since v2.3.0.0): `skills_list`, `skills_load`
 
-The discovery patterns below describe **dynamic mode** (the v2.x default). In code mode, the AI calls `await call_tool("<platform>_list_tools", {"filter": "..."})` (or any other tool name) inside `execute()`, gets back the wrapped envelope `{"ok": ..., "data": [...], ...}`, and acts on `result["data"]`.
+The discovery patterns below describe **dynamic mode** (the v2.x default). In **code mode**, two discovery paths work — pick whichever your client surfaced:
+
+* **Top-level discovery tools** (when your client loaded them): call `search(query="...")` / `tags()` / `get_schema(tools=[...])` directly at the outer surface. These are the recommended primary path when available.
+* **In-sandbox discovery** (works regardless of what the client loaded): from inside `execute()`, call `await call_tool("<platform>_list_tools", {"filter": "..."})` to get a name+params catalog, then `await call_tool("<platform>_get_tool_schema", {"name": "..."})` for full schemas, then dispatch via `await call_tool("<tool_name>", {...})`. Useful as a fallback when the client's semantic tool_search didn't surface `search` / `tags` / `get_schema` (verified to happen on Claude Desktop / CoWork for queries like "list mist sites" — see issue #302).
+
+In both code-mode paths the response comes back as the universal envelope `{"ok": ..., "data": [...], ...}` for platform tools (act on `result["data"]`); top-level discovery tools return their own native shape directly.
 
 Every per-platform tool listed below this section is reachable through the meta-tools. **Use this discovery pattern:**
 

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -49,6 +49,23 @@ _PLATFORM_PREFIXES: tuple[str, ...] = (
     "aos8_",
 )
 
+# Discovery tools that ship with their own ``x-fastmcp-wrap-result`` output
+# schema requiring a top-level ``result`` field. The envelope would wrap them
+# as ``{"ok": ..., "data": {"result": ...}}`` which fails output validation
+# because the OUTER envelope has no top-level ``result``. Bypass these tools
+# entirely — they already return a uniform shape the client expects.
+# (Fixes #293, root cause of the "Mist intermittent" report from Mike
+# Gallagher 2026-05-12 / issue #302.)
+_NO_ENVELOPE_TOOLS: frozenset[str] = frozenset(
+    {
+        "tags",
+        "search",
+        "get_schema",
+        "skills_list",
+        "skills_load",
+    }
+)
+
 # Keys an existing envelope-shaped dict must contain (idempotency check).
 _ENVELOPE_REQUIRED_KEYS: frozenset[str] = frozenset({"ok", "data", "tool"})
 
@@ -129,6 +146,17 @@ class ResponseEnvelopeMiddleware(Middleware):
         tool_name = context.message.name
         platform = _infer_platform(tool_name)
         result = await call_next(context)
+
+        # Discovery tools (``tags`` / ``search`` / ``get_schema`` / ``skills_list``
+        # / ``skills_load``) ship with their own ``x-fastmcp-wrap-result`` schema
+        # requiring a top-level ``result`` field. Wrapping them in the envelope
+        # produces ``{"ok": ..., "data": {"result": ...}}``, which fails the
+        # discovery tool's output validation. Pass them through unmodified —
+        # they already speak a uniform shape that AI clients understand.
+        # See issue #293 + #302 for the root-cause history.
+        if tool_name in _NO_ENVELOPE_TOOLS:
+            logger.debug("response_envelope: {} is a discovery tool, pass-through", tool_name)
+            return result  # type: ignore[return-value]
 
         # Determine the raw structured payload, if any.
         raw = getattr(result, "structured_content", None)

--- a/src/hpe_networking_mcp/platforms/_template/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_template/__init__.py
@@ -53,13 +53,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("Template: failed to load module {} -- {}", category, e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("_template", mcp)
-        logger.info(
-            "Template: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("Template: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("_template_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    build_meta_tools("_template", mcp)
+    logger.info(
+        "Template: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/aos8/__init__.py
+++ b/src/hpe_networking_mcp/platforms/aos8/__init__.py
@@ -107,9 +107,15 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     except Exception as e:
         logger.warning("AOS8: failed to load prompts -- {}", e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("aos8", mcp)
-        logger.info("AOS8: registered {} underlying tools + 3 meta-tools (dynamic mode)", total)
-    else:
-        logger.info("AOS8: registered {} underlying tools (code mode)", total)
+    # Meta-tools are always registered. In dynamic mode they're visible at the
+    # top level (per-platform discovery); in code mode they're hidden by
+    # CodeMode's catalog replacement but remain callable via
+    # ``await call_tool("aos8_list_tools", ...)`` from inside ``execute()``.
+    # See issue #302 / "Mist intermittent" triage 2026-05-12.
+    build_meta_tools("aos8", mcp)
+    logger.info(
+        "AOS8: registered {} underlying tools + 3 meta-tools ({} mode)",
+        total,
+        config.tool_mode,
+    )
     return total

--- a/src/hpe_networking_mcp/platforms/apstra/__init__.py
+++ b/src/hpe_networking_mcp/platforms/apstra/__init__.py
@@ -69,16 +69,15 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("Apstra: failed to load module {} -- {}", category, e)
 
-    if config.tool_mode == "dynamic":
-        # Register the three meta-tools on top of the now-populated registry.
-        # Individual tools remain registered with FastMCP but get hidden by
-        # the Visibility(dynamic_managed) transform in server.py.
-        build_meta_tools("apstra", mcp)
-        logger.info(
-            "Apstra: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("Apstra: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In dynamic mode they're
+    # visible at the top level; in code mode they're hidden by CodeMode's
+    # catalog replacement but remain callable via
+    # ``await call_tool("apstra_list_tools", ...)`` from inside ``execute()``.
+    build_meta_tools("apstra", mcp)
+    logger.info(
+        "Apstra: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/axis/__init__.py
+++ b/src/hpe_networking_mcp/platforms/axis/__init__.py
@@ -84,13 +84,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("Axis: failed to load module {} -- {}", category, e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("axis", mcp)
-        logger.info(
-            "Axis: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("Axis: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("axis_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    build_meta_tools("axis", mcp)
+    logger.info(
+        "Axis: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -155,13 +155,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     except Exception as e:
         logger.warning("Central: failed to load prompts -- {}", e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("central", mcp)
-        logger.info(
-            "Central: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("Central: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("central_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    build_meta_tools("central", mcp)
+    logger.info(
+        "Central: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/clearpass/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/__init__.py
@@ -240,13 +240,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("ClearPass: failed to load module {} -- {}", category, e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("clearpass", mcp)
-        logger.info(
-            "ClearPass: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("ClearPass: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("clearpass_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    build_meta_tools("clearpass", mcp)
+    logger.info(
+        "ClearPass: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/greenlake/__init__.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/__init__.py
@@ -41,13 +41,14 @@ def register_tools(mcp_instance: FastMCP, config: ServerConfig) -> int:
         except Exception as e:
             logger.warning("GreenLake: failed to load module {} -- {}", category, e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("greenlake", mcp_instance)
-        logger.info(
-            "GreenLake: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("GreenLake: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("greenlake_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    build_meta_tools("greenlake", mcp_instance)
+    logger.info(
+        "GreenLake: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -98,13 +98,17 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     except Exception as e:
         logger.warning("Mist: failed to load prompts -- {}", e)
 
-    if config.tool_mode == "dynamic":
-        build_meta_tools("mist", mcp)
-        logger.info(
-            "Mist: {} underlying tools + 3 meta-tools registered (dynamic mode)",
-            len(loaded),
-        )
-    else:
-        logger.info("Mist: {} underlying tools registered (code mode)", len(loaded))
+    # Meta-tools are always registered (issue #302). In code mode they're
+    # reachable via ``await call_tool("mist_list_tools", ...)`` from inside
+    # ``execute()`` even though they're hidden from the top-level catalog.
+    # This was the root cause of the "Mist intermittent" report from Mike
+    # Gallagher 2026-05-12 — INSTRUCTIONS.md told the AI to call
+    # mist_list_tools from inside execute() but the gate above blocked it.
+    build_meta_tools("mist", mcp)
+    logger.info(
+        "Mist: {} underlying tools + 3 meta-tools registered ({} mode)",
+        len(loaded),
+        config.tool_mode,
+    )
 
     return len(loaded)

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -360,6 +360,42 @@ def create_server(config: ServerConfig) -> FastMCP:
     return mcp
 
 
+# Discovery tool descriptions — keyword-rich so client-side semantic
+# tool_search (Claude Desktop / web / IDE / CoWork etc.) surfaces them on
+# queries like "list mist sites" / "search central tools". The default
+# fastmcp descriptions ("Search for available tools by query") are too
+# generic and lose the relevance ranking against other MCP servers'
+# more descriptive tools. See issue #302 — Mike Gallagher's
+# "Mist intermittent" report 2026-05-12.
+_SEARCH_DESCRIPTION = (
+    "Find or list available HPE networking tools by name, function, or "
+    "description across mist, central, aos8, clearpass, apstra, axis, "
+    "and greenlake platforms. Use this to discover the exact tool name "
+    "for any networking task — listing sites, getting devices, searching "
+    "events, managing config, checking health, etc. Returns matching tools "
+    "ranked by relevance. Prefer this over guessing tool names: each "
+    "platform has its own naming convention and discovery is faster than "
+    "trial and error."
+)
+
+_TAGS_DESCRIPTION = (
+    "Browse the HPE networking tool catalog grouped by category tag — "
+    "platform name (mist / central / aos8 / clearpass / apstra / axis / "
+    "greenlake), read/write classification, or feature area. Use to scope "
+    "the tool catalog by category before drilling in with `search` or "
+    "`get_schema`. Returns tag names and the tools registered under each."
+)
+
+_GET_SCHEMA_DESCRIPTION = (
+    "Get full parameter schemas, enum values, types, and descriptions for "
+    "one or more HPE networking tools (mist, central, aos8, clearpass, "
+    "apstra, axis, greenlake). Use after `search` or `tags` to confirm a "
+    "tool's exact input shape before invoking it. Each schema returned "
+    "includes the parameter list, defaults, optional/required markers, "
+    "and any nested object or enum types."
+)
+
+
 def _register_code_mode(mcp: FastMCP) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
@@ -384,29 +420,62 @@ def _register_code_mode(mcp: FastMCP) -> None:
         )
         return
 
+    # Subclasses that override the description on the produced Tool so
+    # client semantic tool_search surfaces our discovery tools on queries
+    # like "list mist sites" / "search central tools" (issue #302). The
+    # parent classes' __init__ doesn't accept a description argument, so we
+    # mutate the returned Tool object before it goes upstream.
+
+    class _HpeSearch(Search):
+        def __call__(self, get_catalog):
+            tool = super().__call__(get_catalog)
+            tool.description = _SEARCH_DESCRIPTION
+            return tool
+
+    class _HpeGetTags(GetTags):
+        def __call__(self, get_catalog):
+            tool = super().__call__(get_catalog)
+            tool.description = _TAGS_DESCRIPTION
+            return tool
+
+    class _HpeGetSchemas(GetSchemas):
+        def __call__(self, get_catalog):
+            tool = super().__call__(get_catalog)
+            tool.description = _GET_SCHEMA_DESCRIPTION
+            return tool
+
     limits = ResourceLimits(
         max_duration_secs=30.0,
         max_memory=128 * 1024 * 1024,
         max_recursion_depth=50,
     )
     # Override the default `execute` description with one that lists the
-    # callable platform-tool prefixes AND explicitly notes that the
-    # discovery tools (tags/search/get_schema) are NOT callable from
-    # inside the sandbox. The default fastmcp string only says
-    # "call_tool(name, params) is in scope" without telling the LLM what
-    # `call_tool` can dispatch to — both gemma-4eb and Claude have hit
+    # callable platform-tool prefixes AND notes that the top-level
+    # discovery tools (tags/search/get_schema) are NOT callable from inside
+    # the sandbox — but the per-platform meta-tools (`<platform>_list_tools`
+    # / `_get_tool_schema` / `_invoke_tool`) ARE callable, providing an
+    # in-sandbox discovery fallback when the AI client didn't surface the
+    # outer discovery tools (issue #302). The default fastmcp string only
+    # says "call_tool(name, params) is in scope" without telling the LLM
+    # what `call_tool` can dispatch to — both gemma-4eb and Claude have hit
     # the same `Unknown tool: search` failure as a result. See #208.
     execute_description = (
         "Run Python in a sandbox to compose multiple platform tool calls. "
         "Use `return` to produce output.\n\n"
         "In scope: `await call_tool(name: str, params: dict) -> Any`.\n\n"
-        "`call_tool` ONLY dispatches to platform tools — names start with one "
+        "`call_tool` dispatches to platform tools — names start with one "
         "of: `mist_`, `central_`, `greenlake_`, `clearpass_`, `apstra_`, "
         "`axis_`, `aos8_` — plus the cross-platform `health` tool.\n\n"
-        "The discovery tools `tags`, `search`, `get_schema`, `skills_list`, and "
-        "`skills_load` are NOT callable from inside execute(). They live at the "
-        "outer MCP surface for planning. Call them BEFORE writing your code "
-        "block, then chain platform tools inside execute().\n\n"
+        "Discovery from inside execute(): if you don't know a platform's "
+        'tool names, call `<platform>_list_tools(filter="...")` (e.g. '
+        "`await call_tool('mist_list_tools', {'filter': 'site'})`) to get "
+        "a name+params catalog, then `<platform>_get_tool_schema(name=...)` "
+        "for full schemas, then dispatch.\n\n"
+        "The TOP-LEVEL discovery tools `tags`, `search`, `get_schema`, "
+        "`skills_list`, and `skills_load` are NOT callable from inside "
+        "execute() — they live at the outer MCP surface for planning. "
+        "Use them BEFORE writing your code block when the client surfaces "
+        "them; otherwise use the `<platform>_list_tools` path above.\n\n"
         "Known sandbox limits: `asyncio.gather()` is unavailable — use "
         "sequential `await` calls. OS-access functions are blocked, "
         "including `datetime.now()`, `time.time()`, file I/O, `os.environ`, "
@@ -433,9 +502,9 @@ def _register_code_mode(mcp: FastMCP) -> None:
         CodeMode(
             sandbox_provider=MontySandboxProvider(limits=limits),
             discovery_tools=[
-                GetTags(default_detail="brief"),
-                Search(default_detail="brief"),
-                GetSchemas(default_detail="detailed"),
+                _HpeGetTags(default_detail="brief"),
+                _HpeSearch(default_detail="brief"),
+                _HpeGetSchemas(default_detail="detailed"),
                 SkillsListDiscoveryTool(skill_registry),
                 SkillsLoadDiscoveryTool(skill_registry),
             ],

--- a/src/hpe_networking_mcp/skills/_engine.py
+++ b/src/hpe_networking_mcp/skills/_engine.py
@@ -216,17 +216,24 @@ class SkillRegistry:
 # Tool descriptions — shared between the @mcp.tool path (dynamic / static)
 # and the discovery-tool factory path (code mode).
 _SKILLS_LIST_DESC = (
-    "List available skills (markdown-defined multi-step procedures). "
-    "Returns metadata only; call `skills_load(name)` for the full runbook. "
+    "List available HPE networking skills — markdown-defined multi-step "
+    "procedures for AOS 8 to Central migration, infrastructure health "
+    "check, change pre-check / post-check, WLAN sync validation, scope "
+    "audits (mist / central), and morning network reports. Returns "
+    "skill metadata only; call `skills_load(name)` for the full runbook. "
     "Optional `platform` / `tag` filters each accept a string or list of "
-    "strings and narrow the result to skills tagged accordingly."
+    "strings and narrow the result to skills tagged accordingly. Use "
+    "this when an operator asks to run an audit, migration, change "
+    "validation, or daily report across mist / central / aos8 / "
+    "clearpass / apstra / axis / greenlake platforms."
 )
 
 _SKILLS_LOAD_DESC = (
     "Load a skill's full markdown body — a step-by-step runbook for a "
-    "multi-step network operations procedure. Pass the skill `name` "
-    "(from `skills_list`); a case-insensitive substring match is tried "
-    "if there's no exact match."
+    "multi-step network operations procedure (migration, audit, change "
+    "validation, etc.) across the HPE networking platforms. Pass the "
+    "skill `name` (from `skills_list`); a case-insensitive substring "
+    "match is tried if there's no exact match."
 )
 
 

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -284,3 +284,60 @@ class TestResponseEnvelopeMiddleware:
         assert envelope["platform"] == "aos8"
         assert envelope["data"] == raw
         assert envelope["ok"] is True
+
+
+@pytest.mark.unit
+class TestDiscoveryToolBypass:
+    """v3.0.1.15: discovery tools (`tags`, `search`, `get_schema`,
+    `skills_list`, `skills_load`) ship with their own ``x-fastmcp-wrap-result``
+    output schemas requiring a top-level ``result`` field. Wrapping them in
+    the envelope as ``{"ok": ..., "data": {"result": ...}}`` produces a
+    validation error because the outer envelope has no top-level ``result``.
+    The middleware must pass these tools through unchanged (closes #293,
+    root cause of the "Mist intermittent" report — issue #302).
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tool_name",
+        ["tags", "search", "get_schema", "skills_list", "skills_load"],
+    )
+    async def test_discovery_tool_response_passes_through_unchanged(self, tool_name: str):
+        """Each of the 5 discovery tools' responses must pass through verbatim,
+        retaining the ``{"result": ...}`` shape rather than being wrapped.
+        """
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context(tool_name)
+        # FastMCP's auto-wrap convention: discovery tools that return strings
+        # get serialized as {"result": "<rendered>"}.
+        native = {"result": f"<rendered output from {tool_name}>"}
+        original = _make_tool_result(structured=native)
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        # The exact ToolResult must come back — no rewrapping.
+        assert result is original
+        assert result.structured_content == native
+        # Specifically: it must NOT be wrapped in the envelope shape.
+        assert "ok" not in result.structured_content
+        assert "data" not in result.structured_content
+        assert "tool" not in result.structured_content
+
+    @pytest.mark.asyncio
+    async def test_non_discovery_tool_still_gets_wrapped(self):
+        """Sanity: a tool with a name similar to a discovery tool but not in
+        the bypass set (e.g. an `mcp__hpe-networking__search`-prefixed tool
+        if one ever existed) still gets wrapped normally.
+        """
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_search_clients")
+        raw = {"clients": [{"mac": "aa:bb:cc:dd:ee:ff"}]}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["ok"] is True
+        assert result.structured_content["data"] == raw
+        assert result.structured_content["tool"] == "central_search_clients"
+        assert result.structured_content["platform"] == "central"

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -60,3 +60,80 @@ def test_execute_description_lists_aos8_prefix() -> None:
         "execute_description must include `aos8_` so the code-mode sandbox "
         "knows AOS8 tools are dispatchable via call_tool()."
     )
+
+
+@pytest.mark.unit
+def test_execute_description_mentions_in_sandbox_discovery_path() -> None:
+    """v3.0.1.15 (issue #302): execute_description must teach the AI that
+    `<platform>_list_tools` is callable from inside execute() in code mode,
+    so it has a working discovery path even when the outer discovery tools
+    (`search` / `tags` / `get_schema`) aren't surfaced by the client.
+    """
+    body = _read_execute_description_block()
+    assert "<platform>_list_tools" in body or "list_tools" in body, (
+        "execute_description must mention the in-sandbox <platform>_list_tools discovery path (issue #302)."
+    )
+
+
+@pytest.mark.unit
+def test_discovery_tool_descriptions_carry_platform_keywords() -> None:
+    """v3.0.1.15 (issue #302): top-level discovery tool descriptions must
+    include the HPE networking platform names so client semantic tool_search
+    surfaces them on queries like "list mist sites" / "search central tools".
+    Generic descriptions lose the relevance ranking against other MCP
+    servers' more keyword-rich tools.
+    """
+    # Names of the platforms we expect mentioned in each description.
+    platforms = ("mist", "central", "aos8", "clearpass", "apstra", "axis", "greenlake")
+
+    for name in ("_SEARCH_DESCRIPTION", "_TAGS_DESCRIPTION", "_GET_SCHEMA_DESCRIPTION"):
+        desc: str = getattr(srv, name)
+        assert isinstance(desc, str) and desc, f"server.{name} must be a non-empty string"
+        # Must reference the HPE networking platforms it dispatches to.
+        present = [p for p in platforms if p in desc.lower()]
+        assert len(present) >= 5, (
+            f"server.{name} must reference the HPE networking platforms it "
+            f"dispatches to (found {len(present)} of {len(platforms)}: {present}). "
+            f"Without keyword hooks the client semantic tool_search ranks our "
+            f"discovery tools below other servers' more descriptive tools "
+            f"(issue #302)."
+        )
+        # Must reference "tool" so clients searching for "list tools" / "tool catalog" surface it.
+        assert "tool" in desc.lower(), f"server.{name} must contain the word 'tool'"
+
+
+PLATFORM_INIT_FILES = (
+    "src/hpe_networking_mcp/platforms/aos8/__init__.py",
+    "src/hpe_networking_mcp/platforms/apstra/__init__.py",
+    "src/hpe_networking_mcp/platforms/axis/__init__.py",
+    "src/hpe_networking_mcp/platforms/central/__init__.py",
+    "src/hpe_networking_mcp/platforms/clearpass/__init__.py",
+    "src/hpe_networking_mcp/platforms/greenlake/__init__.py",
+    "src/hpe_networking_mcp/platforms/mist/__init__.py",
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("init_path", PLATFORM_INIT_FILES)
+def test_platform_init_registers_meta_tools_unconditionally(init_path: str) -> None:
+    """v3.0.1.15 (issue #302): each platform's register_tools must call
+    build_meta_tools regardless of config.tool_mode. The historical
+    ``if config.tool_mode == "dynamic":`` gate left meta-tools unregistered
+    in code mode, which contradicted INSTRUCTIONS.md and made
+    `mist_list_tools` etc. uncallable from inside execute().
+    """
+    repo_root = Path(srv.__file__).parent.parent.parent
+    full_path = repo_root / init_path
+    assert full_path.exists(), f"{init_path} not found from repo root {repo_root}"
+
+    body = full_path.read_text(encoding="utf-8")
+    # Must call build_meta_tools at least once.
+    assert "build_meta_tools(" in body, f"{init_path} must call build_meta_tools"
+    # Must NOT gate that call on tool_mode == "dynamic" alone (the old pattern).
+    # The substring search is conservative — if anyone reintroduces the gate
+    # exactly as it was before v3.0.1.15 the test fires.
+    assert 'if config.tool_mode == "dynamic":\n        build_meta_tools' not in body, (
+        f"{init_path} reintroduced the v3.0.1.14-era dynamic-mode gate on "
+        f"build_meta_tools. Meta-tools must register unconditionally so the "
+        f"in-sandbox discovery path works in code mode (issue #302)."
+    )


### PR DESCRIPTION
## Summary

Three layered fixes for the *"Mist sometimes works, sometimes doesn't"* report from Mike Gallagher (2026-05-12, Sonnet 4.6, Claude). Live triage proved the symptom is NOT a Mist platform bug — it's three discovery-layer bugs that surface together. Central works despite them because its tool names are guessable; Mist tools (ported from upstream mistmcp) aren't.

**A. Discovery tool descriptions rewritten** to include HPE networking platform keywords (`mist`, `central`, `aos8`, `clearpass`, `apstra`, `axis`, `greenlake`) so client semantic `tool_search` surfaces them on queries like "list mist sites" / "search central tools." `Search` / `GetTags` / `GetSchemas` are subclassed in `server.py` to inject HPE-Networking-specific descriptions; `skills_list` / `skills_load` get the same treatment in `skills/_engine.py`.

**B. `ResponseEnvelopeMiddleware` no longer wraps discovery tools** (closes #293). They ship with `x-fastmcp-wrap-result: true` output schemas requiring a top-level `result` field; the envelope wrapped them as `{ok, data: {result: ...}, ...}` which fails the outer schema validation. Five tool names (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) pass through unchanged now.

**C1. Per-platform `<platform>_list_tools` meta-tools registered in code mode too.** The `if config.tool_mode == "dynamic":` gate is removed from all 7 platforms (+ template). In dynamic mode they're top-level visible (unchanged); in code mode they're hidden by `CodeMode.transform_tools` but reachable via `call_tool` from inside `execute()` — making `INSTRUCTIONS.md:25`'s code-mode discovery path accurate as shipped. `execute_description` updated to teach this path explicitly.

Closes #293, closes #302.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run mypy src/ --ignore-missing-imports` — clean
- [x] `uv run pytest tests/ -q` — **1258 passed** (was 1243; +15: 6 envelope-bypass + 7 per-platform meta-tools + 1 description-keyword + 1 in-sandbox-discovery path)
- [ ] Post-deploy live verification:
  - From a Claude client, ask *"list mist sites"* — confirm `hpe-networking:search` surfaces in tool_search and returns matching tools (description hooks help client ranking).
  - From inside `execute()`, call `await call_tool("mist_list_tools", {"filter": "site"})` — confirm it returns a catalog instead of `Unknown tool`.
  - Call `hpe-networking:search(query="mist sites")` directly — confirm it returns results instead of the `'result' is a required property` validation error.

## Files

- `src/hpe_networking_mcp/middleware/response_envelope.py` — `_NO_ENVELOPE_TOOLS` skip set + early-return
- `src/hpe_networking_mcp/server.py` — `_SEARCH_DESCRIPTION` / `_TAGS_DESCRIPTION` / `_GET_SCHEMA_DESCRIPTION` constants; `_HpeSearch` / `_HpeGetTags` / `_HpeGetSchemas` subclasses; expanded `execute_description`
- `src/hpe_networking_mcp/skills/_engine.py` — keyword-rich `_SKILLS_LIST_DESC` / `_SKILLS_LOAD_DESC`
- `src/hpe_networking_mcp/platforms/<each>/__init__.py` — removed dynamic-mode gate on `build_meta_tools` (7 platforms + template)
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — line 25 rewritten to describe both code-mode discovery paths
- `tests/unit/test_response_envelope_middleware.py` — `TestDiscoveryToolBypass`
- `tests/unit/test_server_code_mode.py` — `test_execute_description_mentions_in_sandbox_discovery_path`, `test_discovery_tool_descriptions_carry_platform_keywords`, `test_platform_init_registers_meta_tools_unconditionally` (parameterized)
- `CHANGELOG.md`, `pyproject.toml`