### PR TITLE
v3.1.0.1: Central config-health tools (device config sync diagnostics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.1] - 2026-05-13
+
+**Patch — adds two Central config-health diagnostic tools for the "device not achieving config sync" troubleshooting flow.**
+
+These wrap the New Central Configuration API at `/network-config/v1alpha1/config-health/*` — endpoints we hadn't surfaced before. Operator-reported gap: an AI client troubleshooting a stuck-out-of-sync device couldn't query the config-health surface because the tools didn't exist.
+
+### What's new
+
+- **`central_get_device_config_issues(serial)`** — returns active configuration issues blocking config sync for a single device, plus recommended actions. Read-only.
+- **`central_get_devices_config_health(limit, offset, sort, filter, search)`** — fleet-wide summary of configuration health. Pageable, sortable on every meaningful field (`activeIssues desc` for worst-offenders-first), OData-filterable, and free-text-searchable. Read-only.
+
+### Files
+
+- **New**: `src/hpe_networking_mcp/platforms/central/tools/config_health.py`, `tests/unit/test_central_config_health.py`
+- **Modified**: `src/hpe_networking_mcp/platforms/central/__init__.py` (adds `config_health` category), `pyproject.toml` (version bump), `docs/TOOLS.md` (new tool entries).
+
+### Notes
+
+- README aggregate tool counts remain stale post-v3.1.0.0 (tracked in #307). The follow-up docs sync after the MemPalace experimentation period will refresh them.
+
 ## [3.1.0.0] - 2026-05-12
 
 **Minor release (substantial new subsystem) — Mist platform rewritten as spec-driven tool generation. Drops the `mistapi` SDK dependency. Closes #304.**
@@ -43,7 +63,7 @@ v3.1.0.0 replaces all of this. The vendored Mist OpenAPI spec at `vendor/mist_op
 
 ### Known gaps shipping with v3.1.0.0
 
-- **Skills + INSTRUCTIONS.md still reference old Mist tool names.** Tracked in #305. The v3.1.0.0-historical names are explicitly allowlisted in `tests/unit/test_skill_tool_references.py` so CI passes, but AI orchestrators following the old names will get "Unknown tool" errors at runtime. The follow-up PR (v3.1.0.1) rewires each call site to the new spec-driven name. Until then, the AI's path is: invoke `mist_list_tools(filter="<keyword>")` from inside `execute()` to discover the current tool name, then dispatch.
+- **Skills + INSTRUCTIONS.md still reference old Mist tool names.** Tracked in #305. The v3.1.0.0-historical names are explicitly allowlisted in `tests/unit/test_skill_tool_references.py` so CI passes, but AI orchestrators following the old names will get "Unknown tool" errors at runtime. A follow-up PR rewires each call site to the new spec-driven name. Until then, the AI's path is: invoke `mist_list_tools(filter="<keyword>")` from inside `execute()` to discover the current tool name, then dispatch.
 - **`mist_get_constants`** (the AOS-specific reference / enum catalog) has no spec-driven equivalent — Mist's constants endpoints are split per-category in the spec. Tools like `mist_list_const_alarm_defs`, `mist_list_const_applications` etc. cover the equivalent surface.
 
 ### Test changes

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -670,7 +670,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (88 tools + 12 prompts)
+## Aruba Central (90 tools + 12 prompts)
 
 ### Sites
 
@@ -1469,6 +1469,30 @@ LLM through a recommended sequence of tool calls for common network operations.
 | `compare_site_health` | site_names (list) | Compare health metrics across multiple sites. |
 | `scope_configuration_overview` | scope_name | View committed configuration resources at a scope with category grouping. |
 | `scope_effective_config` | scope_name | View effective (inherited + committed) configuration as a layered inheritance view. |
+
+### Config Health
+
+Diagnostics for the New Central Configuration API config-health surface (`/network-config/v1alpha1/config-health/*`). Use when troubleshooting "device not achieving config sync" workflows.
+
+#### `central_get_device_config_issues`
+
+> Returns active configuration issues blocking config sync for a single device, plus recommended actions.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| serial | str | Yes | Device serial number. |
+
+#### `central_get_devices_config_health`
+
+> Fleet-wide summary of configuration health across devices. Pageable + sortable + filterable; use to spot which devices have non-zero `activeIssues` before drilling in per-serial with `central_get_device_config_issues`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| limit | int | No | Page size (default 100). |
+| offset | int | No | Page offset (default 0). |
+| sort | str | No | Sort by one of `name`, `serial`, `type`, `siteName`, `configStatus`, `deviceFunction`, `lastConfigTimestamp`, `model`, `deviceGroupName`, `topPriorityIssue`, `recommendedAction`, `role`, `deployment`, `activeIssues`. Append `asc` or `desc` (e.g. `"activeIssues desc"`). |
+| filter | str | No | OData 4.0 filter on `name`, `deviceFunction`, `configStatus`, `type`, `model`, `serial`, `deviceGroupName`, or `activeIssues`. |
+| search | str | No | Free-text search across `name`, `serial`, `siteName`, `topPriorityIssue`, and `recommendedAction` (3-128 chars when supplied). |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.0"
+version = "3.1.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -109,6 +109,10 @@ TOOLS = {
         "central_manage_site_collection",
         "central_manage_device_group",
     ],
+    "config_health": [
+        "central_get_device_config_issues",
+        "central_get_devices_config_health",
+    ],
     "gateway_cluster_intent": [
         "central_get_gateway_cluster_intent_profiles",
         "central_manage_gateway_cluster_intent_profile",

--- a/src/hpe_networking_mcp/platforms/central/tools/config_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_health.py
@@ -1,0 +1,111 @@
+"""Central config-health diagnostics for the New Central Configuration API.
+
+Wraps the ``/network-config/v1alpha1/config-health/*`` endpoints. Used
+when troubleshooting "device not achieving config sync" —
+``central_get_device_config_issues`` returns per-device active issue
+detail (one serial in, list of issues + recommended actions out);
+``central_get_devices_config_health`` returns the fleet-wide summary
+with sort/filter/search for spotting which devices need attention.
+"""
+
+from typing import Any
+
+from fastmcp import Context
+
+from hpe_networking_mcp.platforms.central._registry import tool
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+# Per the upstream OpenAPI: search must be 3-128 chars when supplied.
+_SEARCH_MIN_CHARS = 3
+_SEARCH_MAX_CHARS = 128
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_device_config_issues(
+    ctx: Context,
+    serial: str,
+) -> dict | str:
+    """
+    Returns active configuration issues for a single device.
+
+    Use when a specific device isn't achieving config sync: pass its
+    serial number and get the list of configuration issues blocking
+    sync, plus any recommended actions Central has surfaced.
+
+    To diagnose across multiple devices, call
+    ``central_get_devices_config_health`` first to spot which devices
+    have issues, then drill in here per-serial.
+
+    Parameters:
+        - serial: Device serial number. Required.
+
+    Returns:
+        Dict with the device's active configuration issues per the
+        Central ``/network-config/v1alpha1/config-health/active-issue``
+        response shape.
+    """
+    response = retry_central_command(
+        central_conn=ctx.lifespan_context["central_conn"],
+        api_method="GET",
+        api_path="network-config/v1alpha1/config-health/active-issue",
+        api_params={"serial": serial},
+    )
+    return response.get("msg", {})
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_devices_config_health(
+    ctx: Context,
+    limit: int = 100,
+    offset: int = 0,
+    sort: str | None = None,
+    filter: str | None = None,
+    search: str | None = None,
+) -> dict | str:
+    """
+    Returns a summary of configuration health across devices in the fleet.
+
+    Use to spot which devices have config-sync issues or non-zero
+    activeIssues counts before drilling in with
+    ``central_get_device_config_issues``.
+
+    Parameters:
+        - limit: Page size (1-100, default 100).
+        - offset: Page offset (default 0).
+        - sort: Optional sort by one of: ``name``, ``serial``, ``type``,
+          ``siteName``, ``configStatus``, ``deviceFunction``,
+          ``lastConfigTimestamp``, ``model``, ``deviceGroupName``,
+          ``topPriorityIssue``, ``recommendedAction``, ``role``,
+          ``deployment``, ``activeIssues``. Append ``asc`` or ``desc``
+          (e.g. ``"activeIssues desc"`` for worst-offenders-first).
+        - filter: OData 4.0 filter on ``name``, ``deviceFunction``,
+          ``configStatus``, ``type``, ``model``, ``serial``,
+          ``deviceGroupName``, or ``activeIssues``. Example:
+          ``"configStatus eq 'OUT_OF_SYNC'"``.
+        - search: Free-text search across ``name``, ``serial``,
+          ``siteName``, ``topPriorityIssue``, and ``recommendedAction``.
+          Must be 3-128 characters when supplied.
+
+    Returns:
+        Dict with the devices config-health summary per the Central
+        ``/network-config/v1alpha1/config-health/devices`` response shape.
+    """
+    if search is not None and not (_SEARCH_MIN_CHARS <= len(search) <= _SEARCH_MAX_CHARS):
+        return f"Error: search must be {_SEARCH_MIN_CHARS}-{_SEARCH_MAX_CHARS} chars when supplied, got {len(search)}"
+
+    api_params: dict[str, Any] = {"limit": limit, "offset": offset}
+    if sort is not None:
+        api_params["sort"] = sort
+    if filter is not None:
+        api_params["filter"] = filter
+    if search is not None:
+        api_params["search"] = search
+
+    response = retry_central_command(
+        central_conn=ctx.lifespan_context["central_conn"],
+        api_method="GET",
+        api_path="network-config/v1alpha1/config-health/devices",
+        api_params=api_params,
+    )
+    return response.get("msg", {})

--- a/tests/unit/test_central_config_health.py
+++ b/tests/unit/test_central_config_health.py
@@ -1,0 +1,129 @@
+"""Unit tests for central config_health tools (v3.1.0.1).
+
+Tests the two new diagnostic tools that wrap the New Central Configuration
+API config-health surface (``/network-config/v1alpha1/config-health/*``).
+Mocks ``retry_central_command`` at the import site — it's the only thing
+the wrappers call besides ``ctx.lifespan_context["central_conn"]``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCentralGetDeviceConfigIssues:
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_passes_serial_to_correct_endpoint(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_device_config_issues,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {"issues": [{"id": "x"}]}}
+        result = await central_get_device_config_issues(_ctx(), serial="ABC123")
+
+        mock_cmd.assert_called_once()
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == "network-config/v1alpha1/config-health/active-issue"
+        assert kwargs["api_params"] == {"serial": "ABC123"}
+        assert result == {"issues": [{"id": "x"}]}
+
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_missing_msg_returns_empty_dict(self, mock_cmd):
+        """If the response omits 'msg' for any reason, return {} rather than raising."""
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_device_config_issues,
+        )
+
+        mock_cmd.return_value = {"code": 200}
+        assert await central_get_device_config_issues(_ctx(), serial="X") == {}
+
+
+class TestCentralGetDevicesConfigHealth:
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_defaults_pass_limit_and_offset(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_devices_config_health,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {"items": [], "total": 0}}
+        await central_get_devices_config_health(_ctx())
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == "network-config/v1alpha1/config-health/devices"
+        assert kwargs["api_params"] == {"limit": 100, "offset": 0}
+
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_all_optional_params_pass_through(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_devices_config_health,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {}}
+        await central_get_devices_config_health(
+            _ctx(),
+            limit=50,
+            offset=10,
+            sort="activeIssues desc",
+            filter="configStatus eq 'OUT_OF_SYNC'",
+            search="switch",
+        )
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_params"] == {
+            "limit": 50,
+            "offset": 10,
+            "sort": "activeIssues desc",
+            "filter": "configStatus eq 'OUT_OF_SYNC'",
+            "search": "switch",
+        }
+
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_omits_none_optionals_from_query_params(self, mock_cmd):
+        """sort/filter/search must NOT appear in api_params when None — keeps the query
+        URL clean and avoids upstream rejecting unrecognized empty strings."""
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_devices_config_health,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {}}
+        await central_get_devices_config_health(_ctx(), limit=25, offset=0)
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_params"] == {"limit": 25, "offset": 0}
+
+    @pytest.mark.parametrize("bad_search", ["", "ab", "x" * 129, "x" * 500])
+    async def test_search_length_rejected(self, bad_search):
+        """Search must be 3-128 chars per upstream OpenAPI."""
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_devices_config_health,
+        )
+
+        result = await central_get_devices_config_health(_ctx(), search=bad_search)
+        assert isinstance(result, str)
+        assert "search must be 3-128 chars" in result
+
+    @pytest.mark.parametrize("good_search", ["foo", "x" * 3, "x" * 128, "abc switch"])
+    @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")
+    async def test_search_length_accepted(self, mock_cmd, good_search):
+        from hpe_networking_mcp.platforms.central.tools.config_health import (
+            central_get_devices_config_health,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {"ok": True}}
+        result = await central_get_devices_config_health(_ctx(), search=good_search)
+        # Not a rejection string.
+        assert not (isinstance(result, str) and "search must be" in result)
+        # Search arg made it to the request.
+        assert mock_cmd.call_args.kwargs["api_params"]["search"] == good_search


### PR DESCRIPTION
## Summary

- Adds two read-only Central tools wrapping the New Central Configuration API config-health surface (`/network-config/v1alpha1/config-health/*`)
  - `central_get_device_config_issues(serial)` — active configuration issues blocking sync for a single device + recommended actions
  - `central_get_devices_config_health(limit, offset, sort, filter, search)` — fleet-wide pageable / sortable / OData-filterable / free-text-searchable summary
- Operator-reported gap: an AI client troubleshooting a device stuck out-of-sync had no tool path to these endpoints. The closest neighbors (`central_get_site_health`, the alerts family) cover site-level / event-stream data, not per-device config-sync diagnostics
- Ships during the MemPalace v4.0.0 experiment freeze under the "bug fixes still ship" carve-out — two read-only tools for an active troubleshooting need, isolated to `platforms/central/`, no conflict with the experiment branch on rebase

## Test plan

- [ ] CI: ruff check + ruff format --check + mypy + pytest all pass (validated locally in Docker before push)
- [ ] After merge: `central_list_tools(filter="config_health")` returns both tool names
- [ ] Live tenant verification: `central_get_devices_config_health()` returns a real fleet summary; `central_get_device_config_issues(serial=<stuck device>)` surfaces the expected blocking issues
- [ ] Post-merge cleanup: rebase `feature/mempalace-experiment` onto new main, rebuild experimental image so the new tools are available alongside MemPalace

## Notes

- Broader README + docs/TOOLS.md tool-count staleness (the post-v3.1.0.0 mist tools + aggregate "368 underlying tools") tracked separately in #307; this PR only updates the Aruba Central section header (88 → 90).
- v3.1.0.0's CHANGELOG mention of "v3.1.0.1" as the skills-rewiring follow-up has been reworded to "a follow-up PR" — this patch takes the 3.1.0.1 slot for time-sensitive operator need; skills rewiring will land at v3.1.0.2 or later.