### PR TITLE
v3.1.0.2: ValidationCatchMiddleware envelope contract (closes #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.2] - 2026-05-13
+
+**Patch — `ValidationCatchMiddleware` now returns a properly-shaped envelope on Pydantic validation rejections. Closes #309.**
+
+Before this fix, the middleware returned `ToolResult(content=error_text)` — text content only, no `structured_content`. Code-mode callers using `await call_tool(...)` received a bare string instead of the universal `{ok, status, data, message, tool, platform}` envelope, and any attempt to branch on `response.get("ok")` failed with `AttributeError: 'str' object has no attribute 'get'`.
+
+Surfaced during a GPT troubleshooting session that called `central_get_clients(status="ACTIVE")` and `("CONNECTED")` against the Pydantic `Literal["Connected", "Failed"]` enum. Each rejection crashed the sandbox before the AI could recover with the correctly-cased value.
+
+### What changed
+
+- **`middleware/validation_catch.py`** — when catching `pydantic.ValidationError`, the middleware now builds an envelope via the same helpers `ResponseEnvelopeMiddleware` uses (`_build_envelope`, `_infer_platform` from `middleware/response_envelope.py`) and returns `ToolResult(content=error_text, structured_content=envelope)`. The envelope carries `ok=False, status=422, data=None, message=<readable error>, tool=<name>, platform=<inferred>`.
+- **Idempotency preserved**: `ResponseEnvelopeMiddleware._is_envelope_shape` recognizes the structured payload by `{ok, data, tool}` key presence and passes it through unchanged. No double-wrap.
+- **Existing behavior preserved**: text content is still set so clients that read the text channel see the same readable error.
+
+### Test changes
+
+- **New: `tests/unit/test_validation_catch.py`** — 6 unit tests covering: envelope shape contract (`ok=False`, `status=422`, `data=None`), readable message content, content / message parity, platform inference across all 7 platform prefixes + cross-platform tools (`health`, `execute`), pass-through for non-`ValidationError` exceptions, pass-through for normal results.
+
+### Files
+
+- **Modified**: `src/hpe_networking_mcp/middleware/validation_catch.py`, `pyproject.toml` (version)
+- **New**: `tests/unit/test_validation_catch.py`
+
+### Notes
+
+- AI client code that does the standard `response = await call_tool(...); if response.get("ok"): ...` now branches cleanly through validation rejections — same code path as any other tool's error case.
+
 ## [3.1.0.1] - 2026-05-13
 
 **Patch — adds two Central config-health diagnostic tools for the "device not achieving config sync" troubleshooting flow.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.1"
+version = "3.1.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/validation_catch.py
+++ b/src/hpe_networking_mcp/middleware/validation_catch.py
@@ -1,17 +1,25 @@
-"""SPIKE — Pydantic ValidationError catch middleware.
+"""Pydantic ``ValidationError`` catch middleware.
 
-Goal: in MCP_TOOL_MODE=code, a tool whose parameters fail Pydantic validation
-currently propagates as MontyRuntimeError and crashes the AI's whole
-execute() block. The AI's try/except inside the sandbox cannot catch it.
+In ``MCP_TOOL_MODE=code``, a tool whose parameters fail Pydantic validation
+would otherwise propagate as ``MontyRuntimeError`` and crash the AI's whole
+``execute()`` block — the AI's try/except inside the sandbox cannot catch it.
 
-This middleware catches ValidationError at the on_call_tool layer (BEFORE it
-reaches FastMCP's exception transform) and returns a structured ToolResult
-with a string error the AI can branch on — same shape as tools that
-explicitly return error strings (Axis, ClearPass).
+This middleware catches ``ValidationError`` at the ``on_call_tool`` layer
+(BEFORE it reaches FastMCP's exception transform) and returns a
+properly-shaped envelope ``ToolResult`` so the AI's
+``response.get("ok")`` style code branches cleanly.
 
-If the spike works, this becomes the permanent fix for #202's out-of-scope
-follow-up (Apstra Pydantic field validators + any future similar pattern
-across all platforms).
+The fix shape (#309): we return a ``ToolResult`` with BOTH ``content``
+(text for clients that read the text channel) AND ``structured_content``
+(envelope dict for clients that read the structured channel — which is
+every code-mode caller via ``await call_tool(...)``). Without
+``structured_content``, code-mode callers receive a bare string and
+hit ``AttributeError: 'str' object has no attribute 'get'`` when they
+treat the response like every other tool's response.
+
+``ResponseEnvelopeMiddleware``'s idempotency check (`_is_envelope_shape`)
+recognizes the envelope by ``{ok, data, tool}`` key presence and passes
+it through unchanged, so the wrap is not double-applied.
 """
 
 from __future__ import annotations
@@ -24,13 +32,23 @@ from fastmcp.tools.tool import ToolResult
 from loguru import logger
 from pydantic import ValidationError
 
+from hpe_networking_mcp.middleware.response_envelope import _build_envelope, _infer_platform
+
+# HTTP-style status code for parameter validation failures. Matches what
+# the envelope's ``status`` field would carry if the tool itself had
+# raised a 422 — keeps RetryMiddleware's status-code-based decision
+# tree consistent across validation rejections and upstream API 422s.
+_VALIDATION_STATUS = 422
+
 
 class ValidationCatchMiddleware(Middleware):
-    """Convert Pydantic ValidationError into a structured tool-result string.
+    """Convert Pydantic ``ValidationError`` into a properly-enveloped tool result.
 
     Without this, the error fires inside FastMCP's tool dispatcher, becomes
-    MontyRuntimeError in code mode, and crashes execute(). With this, the
-    AI sees a normal-looking string return and can recover.
+    ``MontyRuntimeError`` in code mode, and crashes ``execute()``. With this,
+    the AI receives a normal envelope-shaped dict response with
+    ``ok=False, status=422, message=<readable error>`` and can branch on it
+    the same way it branches on any other tool's error path.
     """
 
     async def on_call_tool(
@@ -43,7 +61,7 @@ class ValidationCatchMiddleware(Middleware):
         except ValidationError as e:
             tool_name = getattr(context.message, "name", "unknown")
             # Format the ValidationError details into a readable string —
-            # mirrors what Pydantic's str(e) gives us but trimmed.
+            # mirrors what Pydantic's ``str(e)`` gives us but trimmed.
             error_lines = [f"Error: validation failed for tool '{tool_name}':"]
             for err in e.errors():
                 loc = ".".join(str(x) for x in err.get("loc", []))
@@ -55,4 +73,17 @@ class ValidationCatchMiddleware(Middleware):
                     error_lines.append(f"  - {loc}: {msg}")
             error_text = "\n".join(error_lines)
             logger.debug("ValidationCatchMiddleware: caught {} → {}", tool_name, error_text)
-            return ToolResult(content=error_text)
+
+            # Build a proper envelope so code-mode callers receive a dict
+            # via ``call_tool(...)`` instead of a bare string (#309). The
+            # text content is preserved for clients that read the text
+            # channel — both surfaces carry the same readable error.
+            envelope = _build_envelope(
+                ok=False,
+                data=None,
+                status=_VALIDATION_STATUS,
+                message=error_text,
+                tool=tool_name,
+                platform=_infer_platform(tool_name),
+            )
+            return ToolResult(content=error_text, structured_content=envelope)

--- a/tests/unit/test_validation_catch.py
+++ b/tests/unit/test_validation_catch.py
@@ -1,0 +1,157 @@
+"""Unit tests for ValidationCatchMiddleware envelope-contract fix (#309).
+
+Before the fix, a Pydantic ValidationError caught by this middleware
+returned ``ToolResult(content=error_text)`` — content-only, no
+structured_content. Code-mode callers using ``await call_tool(...)``
+received a bare string and crashed with ``AttributeError: 'str' object
+has no attribute 'get'`` when they did the standard ``response.get('ok')``
+check.
+
+The fix returns a properly-shaped envelope via ``structured_content``,
+so code-mode callers always receive a dict envelope they can branch on.
+
+These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp.tools.tool import ToolResult
+from pydantic import BaseModel, ValidationError
+
+from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
+
+pytestmark = pytest.mark.unit
+
+
+class _Sample(BaseModel):
+    """Minimal pydantic model used to trigger a real ValidationError."""
+
+    count: int
+
+
+def _trigger_validation_error() -> ValidationError:
+    """Produce a real ValidationError to feed the middleware via raise."""
+    try:
+        _Sample(count="not-an-int")  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
+def _make_context(tool_name: str) -> MagicMock:
+    """Build a MiddlewareContext mock matching the middleware's expectations."""
+    ctx = MagicMock()
+    ctx.message = MagicMock()
+    ctx.message.name = tool_name
+    return ctx
+
+
+class TestValidationCatchEnvelope:
+    """The fix: response carries a structured envelope, not just text content."""
+
+    async def test_returns_envelope_with_ok_false(self):
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("central_get_alerts")
+
+        async def raising_next(_: Any) -> Any:
+            raise _trigger_validation_error()
+
+        result = await middleware.on_call_tool(ctx, raising_next)
+
+        assert isinstance(result, ToolResult)
+        env = result.structured_content
+        assert env is not None, "structured_content must be present (#309 fix)"
+        assert env["ok"] is False
+        assert env["status"] == 422
+        assert env["data"] is None
+        assert env["tool"] == "central_get_alerts"
+        assert env["platform"] == "central"
+
+    async def test_message_carries_readable_error(self):
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("mist_list_org_devices")
+
+        async def raising_next(_: Any) -> Any:
+            raise _trigger_validation_error()
+
+        result = await middleware.on_call_tool(ctx, raising_next)
+
+        env = result.structured_content
+        assert env is not None
+        assert "validation failed" in env["message"]
+        assert "count" in env["message"]  # the field name from _Sample model
+
+    async def test_content_field_matches_message(self):
+        """Text content and envelope message carry the same human-readable string."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("apstra_get_blueprints")
+
+        async def raising_next(_: Any) -> Any:
+            raise _trigger_validation_error()
+
+        result = await middleware.on_call_tool(ctx, raising_next)
+
+        env = result.structured_content
+        assert env is not None
+        # ``content`` is a list of ContentBlocks (mcp.types). Extract text.
+        content_text = next(
+            (block.text for block in result.content if hasattr(block, "text")),
+            None,
+        )
+        assert content_text == env["message"]
+
+    async def test_platform_inference_for_each_prefix(self):
+        """Every platform prefix should be inferred correctly into the envelope."""
+        cases = [
+            ("mist_anything", "mist"),
+            ("central_anything", "central"),
+            ("greenlake_anything", "greenlake"),
+            ("clearpass_anything", "clearpass"),
+            ("apstra_anything", "apstra"),
+            ("axis_anything", "axis"),
+            ("aos8_anything", "aos8"),
+            ("health", None),  # cross-platform tool — no prefix match
+            ("execute", None),  # code-mode entry — no prefix match
+        ]
+        middleware = ValidationCatchMiddleware()
+
+        for tool_name, expected_platform in cases:
+            ctx = _make_context(tool_name)
+
+            async def raising_next(_: Any) -> Any:
+                raise _trigger_validation_error()
+
+            result = await middleware.on_call_tool(ctx, raising_next)
+            env = result.structured_content
+            assert env is not None
+            assert env["platform"] == expected_platform, (
+                f"tool {tool_name!r} should infer platform={expected_platform!r}, got {env['platform']!r}"
+            )
+
+    async def test_non_validation_errors_propagate(self):
+        """Anything that isn't a ValidationError must NOT be caught here."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("central_get_alerts")
+
+        async def raising_next(_: Any) -> Any:
+            raise RuntimeError("not a validation error")
+
+        with pytest.raises(RuntimeError, match="not a validation error"):
+            await middleware.on_call_tool(ctx, raising_next)
+
+    async def test_passes_through_normal_results(self):
+        """When call_next succeeds, the middleware must return its result unchanged."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("central_get_sites")
+
+        expected = ToolResult(content="ok", structured_content={"ok": True, "data": "ok", "tool": "x"})
+
+        async def succeeding_next(_: Any) -> Any:
+            return expected
+
+        result = await middleware.on_call_tool(ctx, succeeding_next)
+        assert result is expected


### PR DESCRIPTION
## Summary

- Fixes #309 — ValidationCatchMiddleware now returns a properly-shaped envelope on Pydantic validation rejections, so code-mode callers using `await call_tool(...)` receive a dict envelope (`ok=False, status=422, data=None, message=<error>, tool=<name>, platform=<inferred>`) instead of a bare string.
- Surfaced empirically during a GPT troubleshooting session that hit `central_get_clients(status="ACTIVE")` against the `Literal["Connected","Failed"]` enum. Each rejection crashed the sandbox with `AttributeError: 'str' object has no attribute 'get'` before the AI could recover.
- One-file middleware change + 6 new unit tests. Patch version bump v3.1.0.1 → v3.1.0.2.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy src/ --ignore-missing-imports` clean (399 source files)
- [x] New tests: `tests/unit/test_validation_catch.py` — 6/6 passing (envelope shape, message content, content/message parity, platform inference, non-ValidationError passthrough, normal-result passthrough)
- [x] Full unit suite: `1190 passed, 1 skipped` — no regressions
- [ ] CI runs same checks on PR
- [ ] After merge: AI clients that previously crashed on validation errors should now branch through cleanly

## Notes

- The fix preserves the existing text-content behavior (clients reading the text channel still see the readable error). The new payload sits on `structured_content` for the code-mode call_tool path.
- `ResponseEnvelopeMiddleware._is_envelope_shape` recognizes the envelope by `{ok, data, tool}` key presence and passes through unchanged — no double-wrap.
- `status=422` chosen to match how RetryMiddleware would classify an upstream API 422 — keeps the retry decision tree consistent across validation rejections and upstream validation errors.