### PR TITLE
docs: refresh tool counts I missed in #312 (table + diagram cells)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **35 + 2 prompts** | **88 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools** | **516 + 2 prompts** | **90 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
@@ -451,7 +451,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │516 tool│ │90 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
 │  All 847 underlying tools reachable via call_tool() in code mode or via                 │

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -49,7 +49,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (88)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (516 tools)`, `central (90)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |


### PR DESCRIPTION
## Summary

Follow-up to [#312](../pull/312). My grep pattern was too narrow — required adjacent "Mist" or "tools + N prompts" keyword — so three spots slipped through where the stale number sits in a tighter cell context.

## Fixed

1. **`README.md:55`** — comparison table "Underlying tools" row: Mist `35 + 2 prompts` → `516 + 2 prompts`, Central `88 + 12 prompts` → `90 + 12 prompts`.
2. **`README.md:454`** — architecture-diagram ASCII boxes: Mist `35 tools` → `516 tool` (truncated to fit the 8-char ASCII cell, mirroring how the existing `140 tool` ClearPass cell handles 3-digit counts), Central `87 tools` → `90 tools`.
3. **`docs/TOOLS.md:52`** — tags() description example: `mist (35 tools), central (88)` → `mist (516 tools), central (90)`.

## Verified

`grep -nE "\b(35|87|88)\s*(tools?|\+)"` against README + TOOLS.md + INSTRUCTIONS.md returns no remaining stale references adjacent to platform names or "tools" keyword.

Docs-only — no version bump.