### PR TITLE
docs: comparison-table audit — fix 8 stale cells, collapse SLE row

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 
 | Category | Mist | Central | GreenLake | ClearPass | Apstra | Axis | AOS8 |
 |----------|:----:|:-------:|:---------:|:---------:|:------:|:----:|:----:|
-| **Sites / Health Overview** | ✅ | ✅ | — | — | — | — | ✅ |
+| **Site Health & Performance Metrics** | ✅ | ✅ | — | — | — | — | ✅ |
 | **WLANs / SSIDs** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Device Inventory** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Device Details (AP/Switch/GW)** | ✅ | ✅ | — | — | — | — | ✅ |
@@ -25,21 +25,20 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Alerts / Alarms** | ✅ | ✅ | — | ✅ | ✅ | — | ✅ |
 | **Audit Logs** | ✅ | ✅ | ✅ | ✅ | — | — | ✅ |
 | **Application Visibility** | — | ✅ | — | — | — | ✅ | — |
-| **SLE / Performance Metrics** | ✅ | — | — | — | — | — | — |
 | **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — | — | — | — | ✅ |
-| **Session Control / Client Disconnect** | — | ✅ | — | ✅ | — | — | ✅ |
-| **Configuration Management** | ✅ | — | — | ✅ | ✅ | ✅ | ✅ |
-| **Configuration Write (CRUD)** | ✅ | — | — | ✅ | ✅ | ✅ | ✅ (gated) |
+| **Session Control / Client Disconnect** | ✅ | ✅ | — | ✅ | — | — | ✅ |
+| **Configuration Management** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
+| **Configuration Write (CRUD)** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ (gated) |
 | **Radio Resource Management** | ✅ | — | — | — | — | — | ✅ |
 | **Rogue AP Detection** | ✅ | — | — | — | — | — | ✅ |
-| **Firmware Management** | ✅ | — | — | — | — | — | ✅ |
+| **Firmware Management** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Subscriptions / Licensing** | — | — | ✅ | ✅ | — | — | ✅ |
 | **User Management** | — | — | ✅ | ✅ | — | ✅ | — |
 | **Workspaces** | — | — | ✅ | — | — | — | — |
-| **Scope & Configuration Hierarchy** | — | ✅ | — | — | — | ✅ | ✅ |
+| **Scope & Configuration Hierarchy** | ✅ | ✅ | — | — | — | ✅ | ✅ |
 | **Guest Management** | — | — | — | ✅ | — | — | — |
-| **NAC / Policy Management** | — | — | — | ✅ | — | — | — |
-| **Endpoint Profiling** | — | — | — | ✅ | — | — | — |
+| **NAC / Policy Management** | ✅ | ✅ | — | ✅ | — | — | — |
+| **Endpoint Profiling** | ✅ | — | — | ✅ | — | — | — |
 | **Certificates** | — | — | — | ✅ | — | — | — |
 | **Datacenter Blueprints / Templates** | — | — | — | — | ✅ | — | — |
 | **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ | — | — |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **35 + 2 prompts** | **88 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools** | **516 + 2 prompts** | **90 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
@@ -451,7 +451,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │35 tools│ │87 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │516 tool│ │90 tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
 │  All 847 underlying tools reachable via call_tool() in code mode or via                 │

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -49,7 +49,7 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 
 | Tier | Tool | What the LLM calls |
 |---|---|---|
-| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (35 tools)`, `central (88)`, `axis (25)`, etc.) plus module categories |
+| 1 | `tags(detail="brief")` | Browse the tag space — returns platform buckets (`mist (516 tools)`, `central (90)`, `axis (25)`, etc.) plus module categories |
 | 2 | `search(query, tags=[...], detail)` | BM25 search the catalog, optionally scoped by tag |
 | 3 | `get_schema(tools=[...], detail)` | Fetch parameter shape for named tools |
 | 4 | `execute(code)` | Run async Python; `call_tool(name, params)` available in scope |


### PR DESCRIPTION
## Summary

Audit pass on the README comparison table after noticing several cells understated Mist and Central capabilities. Eight cell corrections + one row collapse.

| Row | Cell | From | To | Evidence |
|---|---|---|---|---|
| 18 (renamed) | Sites / Health Overview → **Site Health & Performance Metrics** | — | — | Collapses old row 28 (SLE / Performance Metrics) into row 18. Branding artifact, not a real capability gap. |
| 29 | Mist Session Control / Client Disconnect | — | ✅ | \`mist_disconnect_site_multiple_clients\`, \`mist_disconnect_site_wireless_client\`, \`mist_disconnect_org_mx_edge_tunterm_aps\` |
| 30 | Central Configuration Management | — | ✅ | \`security_policy.py\`, \`scope.py\`, \`wlan_profiles.py\`, \`configuration.py\`, \`config_assignments.py\`, \`roles.py\` |
| 31 | Central Configuration Write (CRUD) | — | ✅ | All \`central_manage_*\` tools (gated by \`ENABLE_CENTRAL_WRITE_TOOLS\`) |
| 34 | Central Firmware Management | — | ✅ | \`central_recommend_firmware\` |
| 38 | Mist Scope & Configuration Hierarchy | — | ✅ | \`orgs_*_templates\` (alarm/ap/gateway/network/rf/sdk/site/wlan), \`orgs_sitegroups\` |
| 40 | Mist NAC / Policy Management | — | ✅ | \`orgs_nac_rules\`, \`orgs_nac_tags\`, \`orgs_nac_portals\`, \`orgs_nac_idp\`, \`orgs_security_policies\`, \`orgs_psks\` |
| 40 | Central NAC / Policy Management | — | ✅ | \`security_policy.py\` — net_groups, net_services, object_groups, role_acls, policies + \`roles.py\` |
| 41 | Mist Endpoint Profiling | — | ✅ | \`mist_list_fingerprint_types\`, \`mist_search_site_client_fingerprints\`, \`sites_nac_fingerprints.py\` |

Central Radio Resource Management stays \`—\` — that's a genuine tool gap (AirMatch exists in CNX but no \`central_*\` tools yet). Tracked in #315.

Docs-only PR, no version bump per the maintainer convention.

## Test plan

- [ ] Visual scan of the README table renders cleanly with the collapsed row.
- [ ] Confirm row indices below the table (footnote about default tool surface) still make sense — no positional references.