### PR TITLE
docs: drop asymmetric (gated) annotation from AOS8 CRUD cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Session Control / Client Disconnect** | ✅ | ✅ | — | ✅ | — | — | ✅ |
 | **Configuration Management** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
-| **Configuration Write (CRUD)** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ (gated) |
+| **Configuration Write (CRUD)** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
 | **Radio Resource Management** | ✅ | — | — | — | — | — | ✅ |
 | **Rogue AP Detection** | ✅ | — | — | — | — | — | ✅ |
 | **Firmware Management** | ✅ | ✅ | — | — | — | — | ✅ |


### PR DESCRIPTION
## Summary

The Configuration Write (CRUD) row marked AOS8 as \`✅ (gated)\` while the other five write-capable platforms (Mist, Central, ClearPass, Apstra, Axis) just had \`✅\`. Per CLAUDE.md every one of them is gated by \`ENABLE_<PLATFORM>_WRITE_TOOLS=true\`, so the annotation was misleading — it read like only AOS8 was gated.

Gating is documented in the README body and CLAUDE.md. Cleaner to just have ✅ for all six.

No version bump (docs-only).

## Test plan

- [ ] README table renders with all six write cells consistent.