### PR TITLE
v3.1.0.4: plug AOS 8 rfc-3576 wrapper-key IP leak + align CoA secrets to RAD family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.0.4] - 2026-05-13
 
-**Patch — plug AOS 8 rfc-3576 detail-form wrapper-key IP leak. Closes #319.**
+**Patch — plug AOS 8 rfc-3576 detail-form wrapper-key IP leak + align CoA secrets to the RAD token family. Closes #319 + #321.**
+
+### CoA secret realignment (#321)
+
+CoA secrets joined the RAD token family because RFC-3576 ("Dynamic Authorization Extensions to RADIUS") is a RADIUS extension and the shared secret is reused on the same physical server. Operator decision: TACACS+ stays its own kind (different service); CoA endpoint identifiers (IPs / server names) stay `[[COA:uuid]]` (identifiers stay distinct per kind).
+
+| Field | Before | After |
+|---|---|---|
+| `coa_servers[].secret` (Mist) | `[[COA:uuid]]` | `[[RAD:uuid]]` |
+| `coa_secret` flat field (combined-tool output) | (no rule — cleartext) | `[[RAD:uuid]]` |
+| `coa_servers[].ip` | `[[COA:uuid]]` | unchanged |
+| `rfc_3576_server_list[].name` | `[[COA:uuid]]` | unchanged |
+
+The realignment lets the forthcoming combined CoA + RADIUS migration tool (#322) emit the same plaintext in both `radius_secret` and `coa_secret` fields and have the keymap return a single `[[RAD:uuid]]` token across the entire structure — no walker-side cross-kind dedup or association map required.
+
+---
+
+### AOS 8 rfc-3576 wrapper-key IP leak (#319)
 
 Live audit of the AOS 8 `show aaa rfc-3576-server <ip>` response shape surfaced a leak the structural-context rules didn't catch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.4] - 2026-05-13
+
+**Patch — plug AOS 8 rfc-3576 detail-form wrapper-key IP leak. Closes #319.**
+
+Live audit of the AOS 8 `show aaa rfc-3576-server <ip>` response shape surfaced a leak the structural-context rules didn't catch:
+
+```json
+{"RFC 3576 Server 192.168.20.70": [
+    {"Parameter": "Key", "Value": "********"},
+    ...
+]}
+```
+
+The walker classifies fields by their *normalized* names — `rfc_3576_server_192.168.20.70` doesn't match any rule, so the IP-bearing wrapper key passed through to the AI cleartext. The list-form companion shape (`{"RFC 3576 Server List": [{"Name": "192.168.20.70", ...}]}`) was already covered by the v3.0.1.12 structural rule (#296); the detail-form wrapper was the remaining gap.
+
+### What changed
+
+- **`redaction/rules.py`** — added `WRAPPER_KEY_PATTERNS`, a list of `(regex, TokenKind)` pairs. The walker rewrites any matching dict key by tokenizing the captured substring in place. First entry: `re.compile(r"^RFC 3576 Server (?!List$)(\S+)$")` → `TokenKind.COA`. The negative lookahead excludes the list-form wrapper (`"RFC 3576 Server List"`), which is handled by the existing `rfc_3576_server_list[].name` structural rule on the list elements.
+- **`redaction/walker.py`** — `_walk_dict` now calls `_rewrite_wrapper_key()` on each key before placing it in the output dict. Same token kind as the list-form rule (`COA`), so the same IP appearing in both the list and detail forms within one session resolves to a single `[[COA:uuid]]` token via the keymap — required for migration tooling that fans out across shapes.
+- **`redaction/walker.py::_detokenize_walk`** — extended to detokenize dict KEYS, not just values. If the AI ever passes the rewritten wrapper-key dict back as an argument, the inbound walker restores the cleartext IP before the call hits the platform.
+
+### Verified
+
+- New test class `TestWrapperKeyRewrite` in `tests/unit/test_pii_redaction.py` covers four cases:
+  - Rewrite: the IP-bearing wrapper key is replaced with the tokenized form
+  - Same-token correlation: list-form and detail-form responses tokenizing the same IP share the same `[[COA:uuid]]` token within a session
+  - Round-trip: `detokenize_arguments` on a dict carrying the rewritten key restores the cleartext IP
+  - No-op: dicts whose keys don't match any wrapper pattern pass through unchanged
+- All 1225 unit tests + 1 skip pass; ruff + format + mypy clean.
+
+### Operator-facing detail
+
+The AOS 8 single-server detail also returns the shared secret under `Parameter: "Key"` / `Value: "********"`. The `is_masked_placeholder` check skips tokenization on that placeholder — the real secret never leaves the controller, so there's nothing useful to tokenize. (Per the verified-live note in `feedback_aos8_secret_visibility.md`: AOS 8 server-side masks RADIUS / TACACS / RFC-3576 shared secrets but ships PSKs cleartext.)
+
 ## [3.1.0.3] - 2026-05-13
 
 **Patch — rewires skills + INSTRUCTIONS.md to the v3.1.0.0 spec-driven Mist tool names. Closes #305.**

--- a/README.md
+++ b/README.md
@@ -352,10 +352,10 @@ Tool responses are walked before reaching the AI:
 | **WPA2 / WPA3 keys** | `psk`, `passphrase`, `wpa_passphrase`, `wpa2_passphrase`, `wpa3_psk`, `ppsk` | `[[PSK:uuid]]` |
 | **SAE / Personal-Plus** | `sae_password`, `sae_pwd` | `[[PSK:uuid]]` |
 | **VRRP cluster key** | `vrrp_passphrase` | `[[PSK:uuid]]` |
-| **RADIUS shared secret** | `shared_secret`, `radius_secret`, `radsec_secret`; structural pair `rad_key.key` | `[[RAD:uuid]]` |
+| **RADIUS shared secret** | `shared_secret`, `radius_secret`, `radsec_secret`, `coa_secret` (v3.1.0.4 / #321); structural pairs `rad_key.key`, `coa_servers[].secret` | `[[RAD:uuid]]` |
 | **EAP / inner password** | `eap_password`, `inner_password` | `[[RAD:uuid]]` |
 | **TACACS+** | structural pair `tacacs_key.key` | `[[TACACS:uuid]]` |
-| **CoA / RFC-3576** | `coa_servers[].secret`, `coa_servers[].ip`, `rfc_3576_server_list[].name`; AOS 8 single-server detail-form wrapper key `"RFC 3576 Server <ip>"` rewritten in place (v3.1.0.4 / #319) | `[[COA:uuid]]` |
+| **CoA / RFC-3576 endpoint identifiers** | `coa_servers[].ip`, `rfc_3576_server_list[].name`; AOS 8 single-server detail-form wrapper key `"RFC 3576 Server <ip>"` rewritten in place (v3.1.0.4 / #319) | `[[COA:uuid]]` |
 | **SNMP community** | `community`, `community_string` | `[[SNMP:uuid]]` |
 | **SNMP v3 passwords** | `auth_password`, `priv_password`, `snmp_v3_auth_pass`, `snmp_v3_priv_pass` | `[[SNMP:uuid]]` |
 | **Admin / enable passwords** | `admin_password`, `manager_password`, `support_user_password`, `enable_password`, `enable_secret`, `cli_password` | `[[PASSWORD:uuid]]` |

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Tool responses are walked before reaching the AI:
 | **RADIUS shared secret** | `shared_secret`, `radius_secret`, `radsec_secret`; structural pair `rad_key.key` | `[[RAD:uuid]]` |
 | **EAP / inner password** | `eap_password`, `inner_password` | `[[RAD:uuid]]` |
 | **TACACS+** | structural pair `tacacs_key.key` | `[[TACACS:uuid]]` |
-| **CoA / RFC-3576** | `coa_servers[].secret`, `coa_servers[].ip`, `rfc_3576_server_list[].name` | `[[COA:uuid]]` |
+| **CoA / RFC-3576** | `coa_servers[].secret`, `coa_servers[].ip`, `rfc_3576_server_list[].name`; AOS 8 single-server detail-form wrapper key `"RFC 3576 Server <ip>"` rewritten in place (v3.1.0.4 / #319) | `[[COA:uuid]]` |
 | **SNMP community** | `community`, `community_string` | `[[SNMP:uuid]]` |
 | **SNMP v3 passwords** | `auth_password`, `priv_password`, `snmp_v3_auth_pass`, `snmp_v3_priv_pass` | `[[SNMP:uuid]]` |
 | **Admin / enable passwords** | `admin_password`, `manager_password`, `support_user_password`, `enable_password`, `enable_secret`, `cli_password` | `[[PASSWORD:uuid]]` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.3"
+version = "3.1.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -118,12 +118,20 @@ SECRET_FIELD_NAMES: dict[str, TokenKind] = {
     "ppsk": TokenKind.PSK,
     "wep_key": TokenKind.PSK,
     "wep_passphrase": TokenKind.PSK,
-    # RADIUS / RadSec / 802.1X
+    # RADIUS / RadSec / 802.1X / CoA (RFC-3576).
+    # CoA is a RADIUS extension — RFC-3576 / RFC-5176 dynamic-authorization
+    # reuses the RADIUS shared secret on the same server. Joining ``coa_secret``
+    # to the RAD family means the combined CoA + RADIUS migration tool (#322)
+    # can emit the same plaintext in ``radius_secret`` and ``coa_secret``
+    # fields and the keymap will hand back a single ``[[RAD:uuid]]`` token
+    # for both (#321). CoA endpoint IPs / server names stay TokenKind.COA
+    # (identifiers stay distinct per kind).
     "shared_secret": TokenKind.RAD,
     "radius_secret": TokenKind.RAD,
     "radsec_secret": TokenKind.RAD,
     "eap_password": TokenKind.RAD,
     "inner_password": TokenKind.RAD,
+    "coa_secret": TokenKind.RAD,  # combined CoA+RADIUS tool field (#321 / #322)
     # SNMP
     "community": TokenKind.SNMP_COMMUNITY,
     "community_string": TokenKind.SNMP_COMMUNITY,
@@ -287,7 +295,14 @@ STRUCTURAL_SECRET_CONTEXTS: dict[tuple[str, str], TokenKind] = {
     # {"ip": "...", "port": 3799, "secret": "...", "enabled": True}. The
     # CoA shared secret is auth-fabric-critical — tokenize unconditionally.
     # See schemas_data.py "coa_servers" entry (v3.0.1.12).
-    ("coa_servers", "secret"): TokenKind.COA,
+    #
+    # Issue #321: realigned from TokenKind.COA → TokenKind.RAD so that
+    # plaintexts coming through ``radius_secret`` / ``coa_secret`` /
+    # ``coa_servers[].secret`` all dedupe to a single ``[[RAD:uuid]]`` token
+    # via the existing keymap. CoA is a RADIUS extension and the secret is
+    # frequently reused on co-located RADIUS/CoA servers; one token across
+    # forms is what the migration tooling needs.
+    ("coa_servers", "secret"): TokenKind.RAD,
 }
 
 

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -322,6 +322,42 @@ STRUCTURAL_IDENTIFIER_CONTEXTS: dict[tuple[str, str], TokenKind] = {
 
 
 # ---------------------------------------------------------------------------
+# Tier 1.7 — Wrapper-key patterns (dict keys with embedded sensitive values)
+# ---------------------------------------------------------------------------
+# Some platforms surface single-record detail blocks under a wrapper dict
+# key that embeds the record identifier (e.g. AOS 8's
+# ``show aaa rfc-3576-server <ip>`` returns ``{"RFC 3576 Server <ip>": [...]}``).
+# The structural-context rules only consult NORMALIZED field names, so the
+# original key string carrying the IP still surfaces to the AI verbatim.
+#
+# Each pattern has ONE regex capture group identifying the variable suffix
+# to tokenize. The walker rewrites the key by tokenizing the captured
+# substring in place; the rewritten key form is ``"<prefix> [[KIND:uuid]]"``.
+# Round-trippable via the keymap on inbound arguments (the detokenize walk
+# is extended to walk keys, not just values).
+#
+# Token-kind alignment matters: when the same IP/identifier also appears
+# under a list-form structural rule (e.g. ``rfc_3576_server_list[].name``
+# tokenizes as COA), the pattern here MUST use the same kind so the
+# keymap deduplicates to a single token across both shapes (issue #319).
+
+WRAPPER_KEY_PATTERNS: list[tuple[re.Pattern[str], TokenKind]] = [
+    # AOS 8 single rfc-3576-server detail wrapper (issue #319).
+    # ``show aaa rfc-3576-server <name>`` → ``{"RFC 3576 Server <name>": [...]}``
+    # where ``<name>`` is typically the server IP (matches the ``Name`` field
+    # in the list form). Same TokenKind.COA as the list-form rule so both
+    # shapes deduplicate to a single token per server.
+    #
+    # Negative lookahead ``(?!List$)`` excludes the list-form wrapper
+    # (``"RFC 3576 Server List"`` itself) — that wrapper is handled by the
+    # ``rfc_3576_server_list`` structural rule on the list ELEMENTS, not
+    # the wrapper key. ``\S+`` keeps server names to a single token (AOS 8
+    # rejects names with spaces at config time).
+    (re.compile(r"^RFC 3576 Server (?!List$)(\S+)$"), TokenKind.COA),
+]
+
+
+# ---------------------------------------------------------------------------
 # Tier 3 — Free-text fields scanned for embedded secrets/identifiers
 # ---------------------------------------------------------------------------
 

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -34,6 +34,7 @@ from hpe_networking_mcp.redaction.rules import (
     AWS_SIGNED_URL_RE,
     EMAIL_RE,
     PEM_BLOCK_RE,
+    WRAPPER_KEY_PATTERNS,
     FieldClassification,
     TokenKind,
     _normalize_field_name,
@@ -157,6 +158,32 @@ def _scan_free_text(text: str, tokenizer: Tokenizer) -> str:
     return result
 
 
+def _rewrite_wrapper_key(key: str, tokenizer: Tokenizer) -> str:
+    """Rewrite a wrapper dict key by tokenizing any embedded sensitive
+    substring matching one of ``WRAPPER_KEY_PATTERNS``.
+
+    Plug for the leak where a platform surfaces a single-record detail
+    block under a wrapper key embedding the record identifier (e.g. AOS
+    8's ``"RFC 3576 Server 192.168.20.70"`` wrapper). The structural
+    rules only look at NORMALIZED field names, so the raw key still
+    surfaces the IP to the AI unless we rewrite it (issue #319).
+
+    Returns the key unchanged when no pattern matches. Tokenization is
+    keymap-deduplicated, so the same captured value gets the same token
+    across this wrapper-key rewrite and any list-form structural rule
+    using the same ``TokenKind`` (e.g. ``rfc_3576_server_list[].name``).
+    """
+    for pattern, kind in WRAPPER_KEY_PATTERNS:
+        match = pattern.match(key)
+        if not match:
+            continue
+        captured = match.group(1)
+        replacement = tokenize_value(tokenizer, kind, captured)
+        if isinstance(replacement, str) and replacement != captured:
+            return key[: match.start(1)] + replacement + key[match.end(1) :]
+    return key
+
+
 def _walk_dict(
     data: dict,
     tokenizer: Tokenizer | None,
@@ -189,7 +216,10 @@ def _walk_dict(
             parent_keys=parent_keys,
             parent_field_name=parent_field_name,
         )
-        out[key] = new_value
+        new_key = key
+        if tokenizer is not None and isinstance(key, str):
+            new_key = _rewrite_wrapper_key(key, tokenizer)
+        out[new_key] = new_value
     return out
 
 
@@ -344,7 +374,20 @@ def _detokenize_walk(
         return data
 
     if isinstance(data, dict):
-        return {key: _detokenize_walk(value, tokenizer, unknown, depth=depth + 1) for key, value in data.items()}
+        # Detokenize KEYS too, not just values. The outbound walker
+        # rewrites wrapper keys like ``"RFC 3576 Server 192.168.20.70"``
+        # to ``"RFC 3576 Server [[COA:uuid]]"``; if the AI passes one of
+        # those keys back, we need to restore the cleartext IP before the
+        # downstream platform sees it (issue #319).
+        out_dict: dict = {}
+        for key, value in data.items():
+            new_key = key
+            if isinstance(key, str):
+                replaced, missing = detokenize_string(tokenizer, key)
+                unknown.extend(missing)
+                new_key = replaced
+            out_dict[new_key] = _detokenize_walk(value, tokenizer, unknown, depth=depth + 1)
+        return out_dict
     if isinstance(data, list):
         return [_detokenize_walk(item, tokenizer, unknown, depth=depth + 1) for item in data]
     if isinstance(data, str):

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -610,6 +610,109 @@ class TestStructuralCoaContextsEndToEnd:
         assert servers[0]["enabled"] is True
 
 
+class TestWrapperKeyRewrite:
+    """Issue #319 — when a platform surfaces a single-record detail block
+    under a wrapper key embedding the record identifier (e.g. AOS 8's
+    ``show aaa rfc-3576-server <ip>`` returns ``{"RFC 3576 Server <ip>":
+    [...]}``), the walker must rewrite the key so the embedded value is
+    tokenized.
+
+    The structural rules only consult NORMALIZED field names, so the raw
+    key string carrying the IP would otherwise surface verbatim. The fix
+    is keyed off ``WRAPPER_KEY_PATTERNS`` in ``rules.py`` and applies
+    in ``_walk_dict``; round-trip detokenization is extended to dict
+    keys in ``_detokenize_walk``.
+    """
+
+    def test_aos8_rfc_3576_detail_wrapper_key_gets_rewritten(self) -> None:
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-319-detail", max_entries=100)
+
+        # Live-captured AOS 8 shape from ``show aaa rfc-3576-server 192.168.20.70``.
+        response = {
+            "RFC 3576 Server 192.168.20.70": [
+                {"Parameter": "Key", "Value": "********"},
+                {"Parameter": "RadSec", "Value": "Disabled"},
+                {"Parameter": "Window Duration", "Value": "300"},
+            ],
+        }
+        out = tokenize_response(response, tokenizer)
+
+        # The original IP-bearing key is gone.
+        assert "RFC 3576 Server 192.168.20.70" not in out
+        # A rewritten key with a COA token is present.
+        rewritten_keys = list(out.keys())
+        assert len(rewritten_keys) == 1
+        rewritten_key = rewritten_keys[0]
+        assert rewritten_key.startswith("RFC 3576 Server ")
+        token_part = rewritten_key[len("RFC 3576 Server ") :]
+        match = TOKEN_RE.fullmatch(token_part)
+        assert match is not None, f"expected COA token, got {token_part!r}"
+        assert match.group(1) == "COA"
+
+    def test_same_ip_in_list_and_detail_forms_share_a_token(self) -> None:
+        """Migration tooling depends on the same IP across list-form and
+        detail-form wrappers getting the same token — fans out correctly
+        when the AI references the server by either shape.
+        """
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-319-correlate", max_entries=100)
+
+        # List form first (matches the existing ``rfc_3576_server_list[].name``
+        # structural rule → COA).
+        list_resp = {
+            "RFC 3576 Server List": [
+                {"Name": "192.168.20.70", "Profile Status": None, "References": "0"},
+            ],
+        }
+        list_out = tokenize_response(list_resp, tokenizer)
+        list_token = list_out["RFC 3576 Server List"][0]["Name"]
+        assert TOKEN_RE.fullmatch(list_token).group(1) == "COA"
+
+        # Detail form second — same IP. New wrapper-key rewrite must use
+        # the SAME token via the keymap (same kind, same plaintext).
+        detail_resp = {
+            "RFC 3576 Server 192.168.20.70": [{"Parameter": "Key", "Value": "********"}],
+        }
+        detail_out = tokenize_response(detail_resp, tokenizer)
+        detail_key = next(iter(detail_out.keys()))
+        detail_token = detail_key[len("RFC 3576 Server ") :]
+        assert detail_token == list_token, "list-form and detail-form must share the COA token"
+
+    def test_wrapper_key_round_trips_via_detokenize_arguments(self) -> None:
+        """If the AI passes the rewritten wrapper-key dict back as an
+        argument, the inbound walker must restore the cleartext IP before
+        the call hits the downstream platform.
+        """
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-319-roundtrip", max_entries=100)
+
+        response = {
+            "RFC 3576 Server 192.168.20.70": [{"Parameter": "Key", "Value": "********"}],
+        }
+        tokenized = tokenize_response(response, tokenizer)
+        rewritten_key = next(iter(tokenized.keys()))
+
+        # AI hands the dict back as an argument.
+        arguments = {"payload": tokenized}
+        restored_args, unknown = detokenize_arguments(arguments, tokenizer)
+
+        assert unknown == []
+        restored_payload = restored_args["payload"]
+        assert "RFC 3576 Server 192.168.20.70" in restored_payload
+        assert rewritten_key not in restored_payload
+
+    def test_wrapper_pattern_no_match_is_noop(self) -> None:
+        """A dict whose keys don't match any wrapper pattern is unchanged."""
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-319-noop", max_entries=100)
+
+        response = {"some_unrelated_key": {"inner": "value"}}
+        out = tokenize_response(response, tokenizer)
+        assert "some_unrelated_key" in out
+        assert out["some_unrelated_key"] == {"inner": "value"}
+
+
 class TestKeymapReplayOnSkipPath:
     """Issue #291 — walker keymap-replay on SKIP path. When a tool emits
     a previously-tokenized cleartext value at a field that carries no

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -548,10 +548,21 @@ class TestStructuralCoaContexts:
         assert cls == FieldClassification.TOKENIZE_IDENTIFIER
         assert kind == TokenKind.COA
 
-    def test_coa_servers_secret_classifies_as_coa_secret(self) -> None:
+    def test_coa_servers_secret_classifies_as_rad_secret(self) -> None:
+        # Issue #321: CoA secrets joined the RAD family so the combined
+        # CoA + RADIUS migration tool (#322) can emit the same plaintext
+        # in radius_secret + coa_secret + coa_servers[].secret and have
+        # the keymap return a single [[RAD:uuid]] for all three.
         cls, kind = classify_field("secret", "MyCoaSecret123!", parent_field_name="coa_servers")
         assert cls == FieldClassification.TOKENIZE_SECRET
-        assert kind == TokenKind.COA
+        assert kind == TokenKind.RAD
+
+    def test_coa_secret_flat_field_classifies_as_rad(self) -> None:
+        # Issue #321: the flat ``coa_secret`` field name is what the
+        # combined migration tool emits in its output structure.
+        cls, kind = classify_field("coa_secret", "MyCoaSecret123!")
+        assert cls == FieldClassification.TOKENIZE_SECRET
+        assert kind == TokenKind.RAD
 
     def test_bare_ip_outside_coa_wrapper_still_passes_through(self) -> None:
         # Per v2.3.1.2: plain ``ip`` is not a tokenized field. Only the
@@ -587,7 +598,9 @@ class TestStructuralCoaContextsEndToEnd:
             assert TOKEN_RE.fullmatch(record["Name"]).group(1) == "COA"
         assert len({r["Name"] for r in records}) == 2
 
-    def test_mist_coa_servers_shape_tokenizes_ip_and_secret(self) -> None:
+    def test_mist_coa_servers_shape_tokenizes_ip_as_coa_and_secret_as_rad(self) -> None:
+        # Issue #321: split CoA endpoint identifier (COA prefix) from
+        # CoA shared secret (RAD prefix, joining the RADIUS family).
         keymap = SessionKeymap()
         tokenizer = Tokenizer(keymap, session_id="test-session-coa-mist", max_entries=100)
 
@@ -601,13 +614,38 @@ class TestStructuralCoaContextsEndToEnd:
         out = tokenize_response(response, tokenizer)
         servers = out["coa_servers"]
         for server in servers:
+            # IP — identifier — keeps COA prefix.
             assert TOKEN_RE.fullmatch(server["ip"]) is not None
             assert TOKEN_RE.fullmatch(server["ip"]).group(1) == "COA"
+            # Secret — joined to RAD family for combined-tool dedup (#321 / #322).
             assert TOKEN_RE.fullmatch(server["secret"]) is not None
-            assert TOKEN_RE.fullmatch(server["secret"]).group(1) == "COA"
+            assert TOKEN_RE.fullmatch(server["secret"]).group(1) == "RAD"
         # Operational metadata passes through.
         assert servers[0]["port"] == 3799
         assert servers[0]["enabled"] is True
+
+    def test_radius_secret_and_coa_secret_share_token_when_same_plaintext(self) -> None:
+        """Issue #321 / #322 — the combined CoA + RADIUS migration tool
+        emits the same plaintext in both ``radius_secret`` and ``coa_secret``
+        fields when servers are co-located. Both fields now classify as
+        ``TokenKind.RAD``, so the keymap returns a single token for both,
+        and the AI sees the secret reused literally across the structure.
+        """
+        keymap = SessionKeymap()
+        tokenizer = Tokenizer(keymap, session_id="test-session-321-shared", max_entries=100)
+
+        response = {
+            "radius_server": "192.168.20.70",
+            "radius_secret": "aruba123!",
+            "coa_endpoint": "192.168.20.70",
+            "coa_secret": "aruba123!",
+            "co_located": True,
+        }
+        out = tokenize_response(response, tokenizer)
+
+        # Same plaintext + same TokenKind → same token via keymap.
+        assert out["radius_secret"] == out["coa_secret"]
+        assert TOKEN_RE.fullmatch(out["radius_secret"]).group(1) == "RAD"
 
 
 class TestWrapperKeyRewrite:


### PR DESCRIPTION
Closes #319 and #321.

## Summary

Two CoA-redaction refinements bundled as one patch release.

### Part 1 — wrapper-key IP leak (#319)

Live audit of \`show aaa rfc-3576-server <ip>\` surfaced a leak the structural-context rules didn't catch:

\`\`\`json
{"RFC 3576 Server 192.168.20.70": [
    {"Parameter": "Key", "Value": "********"}, ...
]}
\`\`\`

The walker classifies fields by *normalized* names — \`rfc_3576_server_192.168.20.70\` matches no rule, so the IP-bearing wrapper key flowed through cleartext.

**Fix:** \`WRAPPER_KEY_PATTERNS\` list in \`rules.py\` (extensible); \`_walk_dict\` rewrites matching keys via \`_rewrite_wrapper_key()\`. Same kind (\`COA\`) as the list-form structural rule so the same IP gets the same token across both shapes within a session. \`_detokenize_walk\` extended to detokenize dict KEYS too for round-trip.

### Part 2 — CoA secrets join the RAD token family (#321)

CoA secrets share the RAD prefix because RFC-3576 ("Dynamic Authorization Extensions to RADIUS") is a RADIUS extension and the shared secret is reused on the same physical server. Operator-confirmed design: TACACS+ stays its own kind (different service); CoA endpoint *identifiers* stay \`[[COA:uuid]]\` (identifiers stay distinct per kind).

| Field | Before | After |
|---|---|---|
| \`coa_servers[].secret\` (Mist) | \`[[COA:uuid]]\` | \`[[RAD:uuid]]\` |
| \`coa_secret\` flat field (new — combined-tool output) | (no rule, cleartext) | \`[[RAD:uuid]]\` |
| \`coa_servers[].ip\` | \`[[COA:uuid]]\` | unchanged |
| \`rfc_3576_server_list[].name\` | \`[[COA:uuid]]\` | unchanged |
| \`"RFC 3576 Server <ip>"\` wrapper key | leaked cleartext | \`[[COA:uuid]]\` |

Enables the forthcoming combined CoA + RADIUS migration tool (#322) to emit the same plaintext in \`radius_secret\` + \`coa_secret\` + \`coa_servers[].secret\` and have the keymap return a single \`[[RAD:uuid]]\` across the entire response — no walker-level cross-kind dedup or association map needed.

## Verified

- 131/131 PII redaction tests pass (3 new + 1 modified).
- All 1227 unit tests + 1 skip pass; ruff + format + mypy clean.

## Test plan

- [ ] AOS 8 rfc-3576 detail wrapper key rewrites to \`"RFC 3576 Server [[COA:uuid]]"\`
- [ ] List-form + detail-form responses share the same COA token for the same IP
- [ ] \`coa_secret\` flat field tokenizes as \`[[RAD:uuid]]\`
- [ ] \`radius_secret\` and \`coa_secret\` with same plaintext share a token
- [ ] Round-trip via \`detokenize_arguments\` restores the cleartext wrapper key