### PR TITLE
docs: expose ENABLE_PII_TOKENIZATION in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       - ENABLE_AXIS_WRITE_TOOLS=${ENABLE_AXIS_WRITE_TOOLS:-false}
       - ENABLE_AOS8_WRITE_TOOLS=${ENABLE_AOS8_WRITE_TOOLS:-false}
       - DISABLE_ELICITATION=${DISABLE_ELICITATION:-false}
+      # PII tokenization (opt-in). When true, sensitive fields (PSKs, RADIUS
+      # secrets, hostnames, emails, usernames, serials) are replaced with
+      # session-stable [[KIND:uuid]] tokens before responses reach the AI.
+      # Default false — enable if your AI provider is untrusted or you have
+      # data-handling requirements. MAC normalization runs regardless.
+      - ENABLE_PII_TOKENIZATION=${ENABLE_PII_TOKENIZATION:-false}
       # Tool exposure mode (since v3.0.0.0 the application default is "code").
       # Uncomment + set to "dynamic" to opt back into the per-platform meta-tool
       # surface (the v2.x default). The "static" value was REMOVED in v3.0.0.0.


### PR DESCRIPTION
Closes #323.

## Summary

The shipped `docker-compose.yml` listed every operator-facing security toggle in its `environment:` block — all six `ENABLE_*_WRITE_TOOLS` flags, `DISABLE_ELICITATION`, a commented `MCP_TOOL_MODE` — **except `ENABLE_PII_TOKENIZATION`**. It wasn't set, commented, or referenced at all, so operators deploying from the repo got PII tokenization silently off (the `config.py` default) with no hint the feature exists.

Surfaced when a `central_get_clients` flow in code mode returned cleartext PII (usernames, an email) to the AI — root cause was simply that the toggle was never in the deployment's compose file.

## Change

One addition to the `environment:` block — an active line following the same `${VAR:-false}` pattern as the write-tool flags:

```yaml
      - ENABLE_PII_TOKENIZATION=${ENABLE_PII_TOKENIZATION:-false}
```

With a short comment explaining what it does. Discoverable in the file, flippable via shell env / `.env` without editing compose, **default unchanged (false)** — confirmed with the maintainer that opt-in is the right default (local-LLM and risk-tolerant deployments don't need it).

No runtime behavior change. README Configuration table already documents the variable accurately (line 592) — no doc change needed. Docs/config-template only, no version bump.

## Test plan

- [ ] `docker compose config` parses cleanly with the new line
- [ ] With `ENABLE_PII_TOKENIZATION=true` set, container logs show "PII tokenization: ENABLED" on startup
- [ ] With the var unset, logs show "PII tokenization: disabled" (default preserved)