### PR TITLE
v3.1.0.5: rewrite source-masked secrets to REPLACE_ME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.5] - 2026-05-14
+
+**Patch — rewrite source-masked secrets to `REPLACE_ME` during migration reads. Closes #276.**
+
+Source platforms like AOS 8 mask shared secrets server-side: `show aaa rfc-3576-server <ip>` and `show aaa authentication-server radius <name>` both return `Key: "********"` rather than the cleartext value — the real secret never leaves the controller, even in a full flash backup.
+
+Until now the redaction walker *skipped* masked placeholders — `********` flowed through unchanged. `********` reads as "redacted/hidden", which is ambiguous: an AI orchestrator can't tell whether there's a recoverable value behind it. This release rewrites the masked value to the literal directive `REPLACE_ME` — an unambiguous "operator must set this" marker. During an AOS 8 → Central migration the operator gets a clear to-do marker in the output instead of a vague mask.
+
+### What changed
+
+- **`redaction/rules.py`**:
+  - New `FieldClassification.MASKED_SECRET` — `classify_field` returns this (instead of the bare `SKIP`) when `is_masked_placeholder(value)` is true.
+  - New `MASKED_SECRET_PLACEHOLDER = "REPLACE_ME"` constant + `is_known_placeholder(value)` helper.
+  - `classify_field` now checks `is_known_placeholder` first → `SKIP`. Critical guard: `REPLACE_ME` landing in an exact-match secret field like `coa_secret` / `shared_secret` would otherwise be tokenized, burying the operator signal behind an opaque token. This guard also keeps the walk idempotent.
+- **`redaction/walker.py`** — `_walk_pair` handles the `MASKED_SECRET` classification by returning the literal `REPLACE_ME`.
+
+### Scope
+
+The descope from the originally-filed #276 is deliberate and confirmed with the maintainer: **no secrets vault, no synthesis, no ClearPass propagation.** The entire mechanism is the single `********` → `REPLACE_ME` walker rewrite. The operator sets the real value in Central themselves.
+
+Gated on `ENABLE_PII_TOKENIZATION` — the rewrite happens via `classify_field`, which only runs when the tokenizer is active. Deployments with PII tokenization off still see `********` (unchanged behavior).
+
+### Verified
+
+- `TestMaskedSecretRewrite` (8 new tests): the rewrite, the `is_known_placeholder` guard, idempotency, `REPLACE_ME` not tokenized in an exact-match secret field, real secrets still tokenizing alongside masked ones, `detokenize_arguments` leaving `REPLACE_ME` untouched.
+- Existing `TestIsMaskedPlaceholder` + `test_aos8_aaa_radius_detail_after_flatten_tokenizes_host` updated for the new `MASKED_SECRET` classification and `REPLACE_ME` output.
+- All 1236 unit tests + 1 skip pass; ruff + format + mypy clean.
+
+### Unblocks
+
+- **#322** — the combined CoA + RADIUS migration tool. Its masked secrets become `REPLACE_ME` automatically via the walker; the tool needs no secret-handling logic of its own.
+
 ## [3.1.0.4] - 2026-05-13
 
 **Patch — plug AOS 8 rfc-3576 detail-form wrapper-key IP leak + align CoA secrets to the RAD token family. Closes #319 + #321.**

--- a/README.md
+++ b/README.md
@@ -370,6 +370,12 @@ Tool responses are walked before reaching the AI:
 | **Private-key PEM in free-text** | PEM key blocks in `description` / `notes` / `comment` | `[[KEY:uuid]]` |
 | **Generic (shape-checked)** | `password`, `pwd` → PASSWORD; `secret` → RAD; `token`, `key` → APITOKEN. Only when value passes length ≥ 8 + character-class diversity check (suppresses `{"key": "ssid"}`). | varies |
 
+**Source-masked secrets** — when the source platform itself masks the value (v3.1.0.4 / #276):
+
+| Source value | Rewritten to | Notes |
+|--------------|:------------:|-------|
+| `********` (any field — AOS 8 masks RADIUS / TACACS / RFC-3576 shared secrets server-side) | `REPLACE_ME` | Literal directive, **not a token**. An unambiguous "operator must set this" marker for migration output — `********` reads as "redacted/hidden", `REPLACE_ME` reads as an instruction. The walk is idempotent and `REPLACE_ME` is never tokenized even in an exact-match secret field. |
+
 **Identifiers** — tokenized when the field name matches:
 
 | Category | Field names | Token form |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.4"
+version = "3.1.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -94,6 +94,10 @@ class FieldClassification(StrEnum):
     TOKENIZE_SECRET = "tokenize_secret"  # nosec B105 — enum classification label, not a credential
     TOKENIZE_IDENTIFIER = "tokenize_identifier"
     SCAN_FREE_TEXT = "scan_free_text"
+    # Source-platform-masked secret (e.g. AOS 8's "********"). The walker
+    # rewrites these to the MASKED_SECRET_PLACEHOLDER directive — never a
+    # token. See issue #276.
+    MASKED_SECRET = "masked_secret"  # nosec B105 — enum classification label, not a credential
 
 
 # ---------------------------------------------------------------------------
@@ -493,11 +497,37 @@ def is_masked_placeholder(value: str) -> bool:
     added as they surface.
 
     See [issue #235](https://github.com/nowireless4u/hpe-networking-mcp/issues/235)
-    for the AOS 8 ``Key: "********"`` case.
+    for the AOS 8 ``Key: "********"`` case, and
+    [issue #276](https://github.com/nowireless4u/hpe-networking-mcp/issues/276)
+    for the rewrite-to-``REPLACE_ME`` behaviour the walker applies on top.
     """
     if not isinstance(value, str) or not value:
         return False
     return len(value) >= 4 and all(c == "*" for c in value)
+
+
+# The literal directive the walker substitutes for a source-masked secret
+# (e.g. AOS 8's "********"). It is NOT a token — it is an unambiguous
+# "operator must set this" marker that flows through to migration output.
+# "********" reads as "redacted/hidden" (ambiguous — is there a recoverable
+# value behind it?); "REPLACE_ME" is an explicit directive. See issue #276.
+MASKED_SECRET_PLACEHOLDER = "REPLACE_ME"  # nosec B105 — directive string, not a credential
+
+
+def is_known_placeholder(value: str) -> bool:
+    """Return True if ``value`` is the walker-emitted ``REPLACE_ME`` directive.
+
+    Once the walker rewrites a source-masked ``********`` to ``REPLACE_ME``,
+    that literal must never be tokenized — even when it lands in an
+    exact-match secret field like ``coa_secret`` or ``shared_secret``.
+    Tokenizing it would bury the "operator must set this" signal behind an
+    opaque token. This guard also keeps the walk idempotent: a second walk
+    sees ``REPLACE_ME`` (not ``********``), classifies it ``SKIP``, and
+    leaves it alone.
+
+    See [issue #276](https://github.com/nowireless4u/hpe-networking-mcp/issues/276).
+    """
+    return isinstance(value, str) and value == MASKED_SECRET_PLACEHOLDER
 
 
 _COMMON_ENUM_VALUES: frozenset[str] = frozenset(
@@ -578,12 +608,20 @@ def classify_field(
         return FieldClassification.SKIP, None
     name = _normalize_field_name(field_name)
 
-    # Source-platform-masked placeholders (e.g. AOS 8's ``"********"``) must
-    # never be tokenized regardless of which rule path matches the field name.
-    # See ``is_masked_placeholder`` for the rationale (dangerous illusion of
-    # a tokenized real secret; round-trip restores only the placeholder).
-    if isinstance(value, str) and is_masked_placeholder(value):
+    # The walker-emitted ``REPLACE_ME`` directive must never be re-classified
+    # — not tokenized (even in an exact-match secret field), not re-rewritten.
+    # Checked before everything else so it survives a second walk intact and
+    # the loud operator signal is preserved (issue #276).
+    if isinstance(value, str) and is_known_placeholder(value):
         return FieldClassification.SKIP, None
+
+    # Source-platform-masked placeholders (e.g. AOS 8's ``"********"``) are
+    # rewritten by the walker to the ``REPLACE_ME`` directive — never a token,
+    # regardless of which rule path matches the field name. See
+    # ``is_masked_placeholder`` for the rationale (a tokenized placeholder is
+    # a dangerous illusion; the round-trip restores only the mask).
+    if isinstance(value, str) and is_masked_placeholder(value):
+        return FieldClassification.MASKED_SECRET, None
 
     # Structural-context rules — when a generic field name (e.g. ``key``) is
     # nested under a wrapping key that strongly implies a credential

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -33,6 +33,7 @@ from hpe_networking_mcp.redaction.mac_normalizer import (
 from hpe_networking_mcp.redaction.rules import (
     AWS_SIGNED_URL_RE,
     EMAIL_RE,
+    MASKED_SECRET_PLACEHOLDER,
     PEM_BLOCK_RE,
     WRAPPER_KEY_PATTERNS,
     FieldClassification,
@@ -262,6 +263,14 @@ def _walk_pair(
         return value
 
     classification, kind = classify_field(key, value, parent_keys=parent_keys, parent_field_name=parent_field_name)
+
+    if classification == FieldClassification.MASKED_SECRET:
+        # Source platform masked this secret (e.g. AOS 8's ``"********"``).
+        # Rewrite to the ``REPLACE_ME`` directive — never a token — so the
+        # operator gets a loud, actionable marker in migration output rather
+        # than an ambiguous mask. Idempotent: a re-walk sees ``REPLACE_ME``,
+        # which classifies SKIP via ``is_known_placeholder`` (issue #276).
+        return MASKED_SECRET_PLACEHOLDER
 
     if classification == FieldClassification.SKIP:
         # Keymap-replay pass first (issue #291): if this exact string was

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -13,11 +13,13 @@ from hpe_networking_mcp.redaction.mac_normalizer import (
     normalize_macs_in_value,
 )
 from hpe_networking_mcp.redaction.rules import (
+    MASKED_SECRET_PLACEHOLDER,
     TOKEN_RE,
     FieldClassification,
     TokenKind,
     classify_field,
     is_known_enum_value,
+    is_known_placeholder,
     is_masked_placeholder,
     looks_like_credential,
 )
@@ -401,10 +403,12 @@ class TestTokenStoreLifecycle:
 
 
 class TestIsMaskedPlaceholder:
-    """is_masked_placeholder() recognizes source-platform-masked values
-    that must not be tokenized (they would create the illusion of a
-    tokenized real secret while the round-trip restores only the
-    placeholder). See issue #235."""
+    """is_masked_placeholder() recognizes source-platform-masked values.
+
+    These must never be tokenized — a tokenized placeholder is a dangerous
+    illusion (issue #235). Since issue #276 the walker goes further: it
+    rewrites the masked value to the literal ``REPLACE_ME`` directive so the
+    operator gets a loud, actionable marker in migration output."""
 
     def test_eight_asterisks_is_placeholder(self) -> None:
         assert is_masked_placeholder("********")
@@ -429,25 +433,106 @@ class TestIsMaskedPlaceholder:
         assert not is_masked_placeholder(None)
         assert not is_masked_placeholder(42)
 
-    def test_classify_field_skips_masked_secret_field(self) -> None:
+    def test_classify_field_masked_secret_field_returns_masked_secret(self) -> None:
         # ``shared_secret`` is in SECRET_FIELD_NAMES — would normally
-        # tokenize unconditionally. Masked placeholder must short-circuit
-        # to SKIP.
+        # tokenize unconditionally. A masked placeholder must short-circuit
+        # to MASKED_SECRET (walker rewrites to REPLACE_ME), not tokenize.
         cls, _ = classify_field("shared_secret", "********")
-        assert cls == FieldClassification.SKIP
+        assert cls == FieldClassification.MASKED_SECRET
 
-    def test_classify_field_skips_masked_generic_credential_field(self) -> None:
+    def test_classify_field_masked_generic_credential_field_returns_masked_secret(self) -> None:
         # ``key`` is in GENERIC_CREDENTIAL_FIELD_NAMES with shape-check.
         # Even though ``********`` passes looks_like_credential, the
-        # placeholder check fires first.
+        # placeholder check fires first → MASKED_SECRET.
         cls, _ = classify_field("key", "********")
-        assert cls == FieldClassification.SKIP
+        assert cls == FieldClassification.MASKED_SECRET
 
     def test_classify_field_still_tokenizes_real_credential(self) -> None:
-        # Sanity: the placeholder skip must not affect real values.
+        # Sanity: the placeholder path must not affect real values.
         cls, kind = classify_field("shared_secret", "MyRealSecret123!")
         assert cls == FieldClassification.TOKENIZE_SECRET
         assert kind == TokenKind.RAD
+
+
+class TestMaskedSecretRewrite:
+    """Issue #276 — source-masked ``********`` values are rewritten to the
+    literal ``REPLACE_ME`` directive by the walker (never tokenized), giving
+    the operator a loud, actionable marker in migration output. The walk is
+    idempotent and ``REPLACE_ME`` is never tokenized even in an exact-match
+    secret field."""
+
+    def _tokenizer(self, label: str) -> Tokenizer:
+        return Tokenizer(SessionKeymap(), session_id=f"test-session-276-{label}", max_entries=100)
+
+    def test_is_known_placeholder_recognizes_replace_me(self) -> None:
+        assert is_known_placeholder("REPLACE_ME")
+        assert is_known_placeholder(MASKED_SECRET_PLACEHOLDER)
+
+    def test_is_known_placeholder_rejects_other_values(self) -> None:
+        assert not is_known_placeholder("********")
+        assert not is_known_placeholder("replace_me")  # case-sensitive
+        assert not is_known_placeholder("MyRealSecret123!")
+        assert not is_known_placeholder(None)
+
+    def test_classify_field_replace_me_is_skipped(self) -> None:
+        # REPLACE_ME landing in an exact-match secret field must NOT
+        # tokenize — the is_known_placeholder guard returns SKIP.
+        cls, kind = classify_field("shared_secret", "REPLACE_ME")
+        assert cls == FieldClassification.SKIP
+        assert kind is None
+
+    def test_walker_rewrites_masked_secret_to_replace_me(self) -> None:
+        tokenizer = self._tokenizer("rewrite")
+        response = {"shared_secret": "********", "auth_port": "1812"}
+        out = tokenize_response(response, tokenizer)
+        assert out["shared_secret"] == "REPLACE_ME"
+        # Non-masked siblings untouched.
+        assert out["auth_port"] == "1812"
+
+    def test_walker_rewrites_masked_secret_in_any_field(self) -> None:
+        # The masked check fires regardless of field name — a transposed
+        # AOS 8 row carries the masked secret in a generic ``Value`` field.
+        tokenizer = self._tokenizer("anyfield")
+        response = {"Parameter": "Key", "Value": "********"}
+        out = tokenize_response(response, tokenizer)
+        assert out["Value"] == "REPLACE_ME"
+
+    def test_walk_is_idempotent_on_replace_me(self) -> None:
+        # A second walk sees REPLACE_ME (not ********) and leaves it alone.
+        tokenizer = self._tokenizer("idempotent")
+        response = {"shared_secret": "********"}
+        first = tokenize_response(response, tokenizer)
+        second = tokenize_response(first, tokenizer)
+        assert first["shared_secret"] == "REPLACE_ME"
+        assert second["shared_secret"] == "REPLACE_ME"
+
+    def test_replace_me_not_tokenized_in_exact_match_secret_field(self) -> None:
+        # A tool emitting REPLACE_ME directly into coa_secret (an exact-match
+        # SECRET_FIELD_NAMES entry) must not have it tokenized — that would
+        # bury the operator signal behind an opaque token.
+        tokenizer = self._tokenizer("guard")
+        response = {"coa_secret": "REPLACE_ME"}
+        out = tokenize_response(response, tokenizer)
+        assert out["coa_secret"] == "REPLACE_ME"
+        assert TOKEN_RE.fullmatch(out["coa_secret"]) is None
+
+    def test_real_secret_still_tokenizes_alongside_masked_one(self) -> None:
+        # Mixed response: one masked secret, one cleartext secret. The
+        # masked one becomes REPLACE_ME; the real one still tokenizes.
+        tokenizer = self._tokenizer("mixed")
+        response = {"radius_secret": "********", "coa_secret": "RealCoaSecret123!"}
+        out = tokenize_response(response, tokenizer)
+        assert out["radius_secret"] == "REPLACE_ME"
+        assert TOKEN_RE.fullmatch(out["coa_secret"]).group(1) == "RAD"
+
+    def test_detokenize_arguments_leaves_replace_me_untouched(self) -> None:
+        # REPLACE_ME is a literal, not a token — the inbound walker leaves
+        # it alone and does not flag it as an unknown token.
+        tokenizer = self._tokenizer("inbound")
+        args = {"payload": {"coa_secret": "REPLACE_ME"}}
+        restored, unknown = detokenize_arguments(args, tokenizer)
+        assert restored["payload"]["coa_secret"] == "REPLACE_ME"
+        assert unknown == []
 
 
 class TestStructuralSecretContexts:
@@ -486,12 +571,13 @@ class TestStructuralSecretContexts:
         cls, _ = classify_field("key", "ssid", parent_field_name="some_unknown_wrapper")
         assert cls == FieldClassification.SKIP
 
-    def test_masked_placeholder_under_rad_key_still_skipped(self) -> None:
-        # The placeholder skip runs BEFORE the structural rule so an AOS-8
-        # masked secret nested under rad_key doesn't get tokenized
-        # (would create the dangerous-illusion problem from PR #275).
+    def test_masked_placeholder_under_rad_key_returns_masked_secret(self) -> None:
+        # The masked-placeholder check runs BEFORE the structural rule so an
+        # AOS-8 masked secret nested under rad_key doesn't get tokenized.
+        # Since issue #276 it classifies MASKED_SECRET (walker rewrites to
+        # REPLACE_ME) rather than the bare SKIP from PR #275.
         cls, _ = classify_field("key", "********", parent_field_name="rad_key")
-        assert cls == FieldClassification.SKIP
+        assert cls == FieldClassification.MASKED_SECRET
 
 
 class TestSchemaLabelPassthrough:
@@ -1240,12 +1326,12 @@ class TestTokenizeResponse:
         # value never leaves the controller. The walker MUST NOT tokenize
         # it: a tokenized placeholder creates the dangerous illusion that
         # the AI has a real tokenized secret it can pass to a write tool.
-        # The detokenize round-trip would restore only ``"********"``,
-        # which Central / AOS 10 would accept as a literal RADIUS shared
-        # secret — RADIUS auth then fails silently in production. Skipping
-        # the tokenization makes the AI see ``"********"`` directly and
-        # know it has to ask the operator for the real secret.
-        assert record["Key"] == "********"
+        # Since issue #276 the walker rewrites the masked value to the
+        # literal ``REPLACE_ME`` directive — an unambiguous "operator must
+        # set this" marker, never a token. Central / AOS 10 would still
+        # reject ``REPLACE_ME`` loudly if it were ever committed, and the
+        # aos-migration skill is preview-first so it surfaces in the plan.
+        assert record["Key"] == "REPLACE_ME"
 
         # Non-PII config values stay cleartext.
         assert record["Auth Port"] == "1812"


### PR DESCRIPTION
Closes #276.

## Summary

Source platforms like AOS 8 mask shared secrets server-side — `show aaa rfc-3576-server <ip>` and `show aaa authentication-server radius <name>` both return `Key: "********"`. The real secret never leaves the controller.

The redaction walker used to `SKIP` masked placeholders, so `********` flowed through unchanged. `********` reads as "redacted/hidden" — ambiguous; an AI orchestrator can't tell whether there's a recoverable value behind it. This rewrites the masked value to the literal directive `REPLACE_ME` — an unambiguous "operator must set this" marker for migration output.

## Changes

- **`rules.py`**:
  - New `FieldClassification.MASKED_SECRET` — `classify_field` returns this (instead of bare `SKIP`) for `is_masked_placeholder` values.
  - New `MASKED_SECRET_PLACEHOLDER = "REPLACE_ME"` constant + `is_known_placeholder()` helper.
  - `classify_field` checks `is_known_placeholder` **first** → `SKIP`. Critical guard: `REPLACE_ME` landing in an exact-match secret field like `coa_secret` / `shared_secret` would otherwise be tokenized, burying the operator signal behind an opaque token. Also keeps the walk idempotent.
- **`walker.py`** — `_walk_pair` handles `MASKED_SECRET` by returning the literal `REPLACE_ME`.

## Scope

Descope from the originally-filed #276 is deliberate and confirmed with the maintainer: **no secrets vault, no synthesis, no ClearPass propagation.** The entire mechanism is the single `********` → `REPLACE_ME` walker rewrite. The operator sets the real value in Central themselves.

Gated on `ENABLE_PII_TOKENIZATION` — the rewrite runs via `classify_field`, which only fires when the tokenizer is active. PII-off deployments still see `********` (unchanged).

## Verified

- `TestMaskedSecretRewrite` — 8 new tests: the rewrite, the `is_known_placeholder` guard, idempotency, `REPLACE_ME` not tokenized in an exact-match secret field, real secrets still tokenizing alongside masked ones, `detokenize_arguments` leaving `REPLACE_ME` untouched.
- Existing `TestIsMaskedPlaceholder` + `test_aos8_aaa_radius_detail_after_flatten_tokenizes_host` updated for the new classification.
- All 1236 unit tests + 1 skip pass; ruff + format + mypy clean.

## Unblocks

- **#322** — combined CoA + RADIUS migration tool. Masked secrets become `REPLACE_ME` automatically via the walker; the tool needs no secret-handling logic of its own.

## Test plan

- [ ] `********` in any field → `REPLACE_ME` when PII tokenization is enabled
- [ ] `REPLACE_ME` in `coa_secret` / `shared_secret` is NOT tokenized
- [ ] Re-walking a `REPLACE_ME` response is idempotent
- [ ] Real cleartext secrets still tokenize normally
- [ ] `detokenize_arguments` leaves `REPLACE_ME` alone, no unknown-token error