### PR TITLE
v3.1.0.7: fix code-mode payload loss (#327) + correct sandbox dispatch guidance (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.7] - 2026-05-14
+
+**Patch — fix code-mode payload loss + correct sandbox dispatch guidance. Closes #327 + #328.**
+
+Both bugs surfaced from one operator transcript: a code-mode Claude session testing the `cross-platform-rf-check` skill reported `mist_list_site_devices_stats` "consistently returns null data."
+
+### #327 — response envelope dropped bare-JSON-array payloads
+
+Any tool whose endpoint returns a **bare top-level JSON array** came back as `{"ok": true, "data": null, ...}` — the payload silently discarded before the AI ever saw it.
+
+**Root cause** (verified live in the dev container): FastMCP populates `structured_content` for a `-> Any` tool only when it returns a **dict**. A bare-list return under `-> Any` leaves `structured_content` as `None`, with the payload stranded in the `content` blocks as JSON text. The response envelope read only `structured_content`, so it wrapped `None` → `data: null`. Both the ~1000 generated Mist tools and every `<platform>_invoke_tool` meta-tool are `-> Any`, so this hit every `mist_list_*` call and every meta-tool dispatch to one. Confirmed live: `mist_list_org_sites` and `mist_list_site_devices_stats` both returned `data: null` against an org/site with real data.
+
+**Fix** — `middleware/response_envelope.py`: new `_payload_from_content()` helper recovers the payload from the `content` TextContent JSON block when `structured_content` is `None`. Middleware-layer fix, so it covers every bare-array-returning tool on every platform, present and future. Dict-returning tools, already-enveloped responses, and non-JSON content are all unaffected (no regression). 13 new tests in `TestPayloadFromContent` + `TestContentFallbackRecovery`.
+
+### #328 — `execute` description over-promised direct platform-tool dispatch
+
+The `execute` tool description and INSTRUCTIONS.md told the AI that `call_tool` dispatches to platform tools "by names starting with `mist_`, `central_`, ...". True for hand-curated platforms, **false for Mist**: `call_tool("mist_get_self", {})` inside the sandbox raises `Unknown tool`. The ~1000 spec-driven Mist tools are registered with FastMCP but deliberately **not listed** in the catalog (keeps the surface small); CodeMode's sandbox `call_tool` resolves names against the *listed* catalog, so Mist tools are unreachable by bare name — only via `mist_invoke_tool`.
+
+**Fix** — doc/guidance only:
+- `server.py` — rewrote the `execute` description to steer the AI to `<platform>_invoke_tool(name=..., params=...)` as the universal dispatch path, explicitly noting the Mist tools are reachable *only* that way.
+- `INSTRUCTIONS.md` — same correction in the code-mode discovery section: dispatch via `<platform>_invoke_tool`, not by bare tool name.
+
+### Verified
+
+- All 1249 unit tests + 1 skip pass; ruff + format + mypy clean.
+- FastMCP `-> Any` vs `-> list` structured-content behaviour confirmed by direct dev-container probe before writing the fix.
+
 ## [3.1.0.6] - 2026-05-14
 
 **Patch — new `cross-platform-rf-check` skill: a code-mode runbook equivalent of the `site_rf_check` tool.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.6"
+version = "3.1.0.7"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1368 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1368 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
@@ -25,7 +25,9 @@ Two modes are supported (the `static` mode was removed in v3.0.0.0):
 The discovery patterns below describe **dynamic mode** (the v2.x default). In **code mode**, two discovery paths work — pick whichever your client surfaced:
 
 * **Top-level discovery tools** (when your client loaded them): call `search(query="...")` / `tags()` / `get_schema(tools=[...])` directly at the outer surface. These are the recommended primary path when available.
-* **In-sandbox discovery** (works regardless of what the client loaded): from inside `execute()`, call `await call_tool("<platform>_list_tools", {"filter": "..."})` to get a name+params catalog, then `await call_tool("<platform>_get_tool_schema", {"name": "..."})` for full schemas, then dispatch via `await call_tool("<tool_name>", {...})`. Useful as a fallback when the client's semantic tool_search didn't surface `search` / `tags` / `get_schema` (verified to happen on Claude Desktop / CoWork for queries like "list mist sites" — see issue #302).
+* **In-sandbox discovery** (works regardless of what the client loaded): from inside `execute()`, call `await call_tool("<platform>_list_tools", {"filter": "..."})` to get a name+params catalog, then `await call_tool("<platform>_get_tool_schema", {"name": "..."})` for full schemas, then dispatch via `await call_tool("<platform>_invoke_tool", {"name": "<tool_name>", "params": {...}})`. Useful as a fallback when the client's semantic tool_search didn't surface `search` / `tags` / `get_schema` (verified to happen on Claude Desktop / CoWork for queries like "list mist sites" — see issue #302).
+
+  **Always dispatch per-platform tools via `<platform>_invoke_tool`** — NOT by their bare name. `await call_tool("mist_get_self", {})` raises `Unknown tool` because the ~1000 spec-driven Mist tools are registered but not in the sandbox's resolvable catalog; only `mist_invoke_tool` reaches them. Hand-curated platform tools happen to also be directly callable, but `<platform>_invoke_tool` is the one pattern that works for every platform (issue #328).
 
 In both code-mode paths the response comes back as the universal envelope `{"ok": ..., "data": [...], ...}` for platform tools (act on `result["data"]`); top-level discovery tools return their own native shape directly.
 

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -30,12 +30,14 @@ passes through without re-wrapping (idempotency check via ``_is_envelope_shape``
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import mcp.types
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from loguru import logger
+from mcp.types import TextContent
 
 # Platform prefixes used to derive the ``platform`` envelope field. Cross-platform
 # tools (those without one of these prefixes) end up with ``platform: null``.
@@ -107,6 +109,31 @@ def _is_envelope_shape(value: Any) -> bool:
     return isinstance(value, dict) and _ENVELOPE_REQUIRED_KEYS.issubset(value.keys())
 
 
+def _payload_from_content(content: list | None) -> Any:
+    """Recover a tool's JSON payload from its content blocks.
+
+    FastMCP leaves ``structured_content`` as ``None`` for a tool annotated
+    ``-> Any`` that returns a **non-dict** value — most importantly a bare
+    JSON array, the shape ~189 generated ``mist_list_*`` tools and every
+    ``<platform>_invoke_tool`` meta-tool produce. (A dict return *does*
+    populate ``structured_content``; a list return under ``-> Any`` does
+    not.) The payload is still serialized into the content blocks as JSON
+    text, so recover it here — otherwise the envelope's ``data`` is
+    ``null`` and the AI never sees the result. See issue #327.
+
+    Returns the parsed JSON of the first JSON-parseable ``TextContent``
+    block, or ``None`` when no block parses (the envelope then falls back
+    to ``data: null`` — the pre-fix behaviour, no regression).
+    """
+    for block in content or []:
+        if isinstance(block, TextContent) and block.text:
+            try:
+                return json.loads(block.text)
+            except (ValueError, TypeError):
+                continue
+    return None
+
+
 def _build_envelope(
     *,
     ok: bool,
@@ -160,6 +187,15 @@ class ResponseEnvelopeMiddleware(Middleware):
 
         # Determine the raw structured payload, if any.
         raw = getattr(result, "structured_content", None)
+
+        # FastMCP only populates ``structured_content`` for dict-shaped
+        # returns from ``-> Any`` tools; a bare JSON array (every
+        # ``mist_list_*`` tool, every ``<platform>_invoke_tool`` dispatch
+        # to one) leaves it ``None`` with the payload stranded in the
+        # content blocks. Recover it so ``data`` carries the real result
+        # instead of ``null``. See issue #327.
+        if raw is None:
+            raw = _payload_from_content(result.content)
 
         if raw is not None and _is_envelope_shape(raw):
             # Tool already returned an envelope — respect it.

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -456,28 +456,39 @@ def _register_code_mode(mcp: FastMCP) -> None:
         max_memory=128 * 1024 * 1024,
         max_recursion_depth=50,
     )
-    # Override the default `execute` description with one that lists the
-    # callable platform-tool prefixes AND notes that the top-level
-    # discovery tools (tags/search/get_schema) are NOT callable from inside
-    # the sandbox — but the per-platform meta-tools (`<platform>_list_tools`
-    # / `_get_tool_schema` / `_invoke_tool`) ARE callable, providing an
-    # in-sandbox discovery fallback when the AI client didn't surface the
-    # outer discovery tools (issue #302). The default fastmcp string only
-    # says "call_tool(name, params) is in scope" without telling the LLM
-    # what `call_tool` can dispatch to — both gemma-4eb and Claude have hit
-    # the same `Unknown tool: search` failure as a result. See #208.
+    # Override the default `execute` description. It must steer the LLM to
+    # the ONE dispatch pattern that works for every platform tool:
+    # `<platform>_invoke_tool`. The spec-driven Mist tools (~1000 of them)
+    # are registered with FastMCP but deliberately not *listed* in the
+    # catalog — so CodeMode's sandbox `call_tool`, which resolves names
+    # against the listed catalog, raises `Unknown tool` for a direct
+    # `call_tool('mist_get_self', ...)`. Hand-curated platform tools
+    # (central_/aos8_/etc.) happen to be directly callable, but telling the
+    # LLM "names start with mist_/central_/..." over-promises and produces
+    # `Unknown tool` failures on Mist (issue #328). The default fastmcp
+    # string is even thinner — it doesn't say what `call_tool` reaches at
+    # all, which caused the `Unknown tool: search` failures in #208/#302.
     execute_description = (
         "Run Python in a sandbox to compose multiple platform tool calls. "
         "Use `return` to produce output.\n\n"
         "In scope: `await call_tool(name: str, params: dict) -> Any`.\n\n"
-        "`call_tool` dispatches to platform tools — names start with one "
-        "of: `mist_`, `central_`, `greenlake_`, `clearpass_`, `apstra_`, "
-        "`axis_`, `aos8_` — plus the cross-platform `health` tool.\n\n"
+        "`call_tool` reaches three things:\n"
+        "  - `<platform>_invoke_tool(name=<tool>, params=<dict>)` — the "
+        "universal way to call ANY per-platform tool (mist / central / "
+        "greenlake / clearpass / apstra / axis / aos8). The ~1000 "
+        "spec-driven Mist tools are reachable ONLY this way — a direct "
+        "`call_tool('mist_get_self', ...)` raises `Unknown tool`. Prefer "
+        "`<platform>_invoke_tool` for every per-platform tool.\n"
+        "  - `<platform>_list_tools` / `<platform>_get_tool_schema` — "
+        "per-platform discovery meta-tools.\n"
+        "  - `health` — cross-platform reachability.\n\n"
         "Discovery from inside execute(): if you don't know a platform's "
         'tool names, call `<platform>_list_tools(filter="...")` (e.g. '
         "`await call_tool('mist_list_tools', {'filter': 'site'})`) to get "
-        "a name+params catalog, then `<platform>_get_tool_schema(name=...)` "
-        "for full schemas, then dispatch.\n\n"
+        "a name+params catalog, then "
+        "`await call_tool('<platform>_get_tool_schema', {'name': ...})` for "
+        "full schemas, then dispatch via "
+        "`await call_tool('<platform>_invoke_tool', {'name': ..., 'params': ...})`.\n\n"
         "The TOP-LEVEL discovery tools `tags`, `search`, `get_schema`, "
         "`skills_list`, and `skills_load` are NOT callable from inside "
         "execute() — they live at the outer MCP surface for planning. "

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -10,16 +10,19 @@ inference) all behave correctly.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.tools.tool import ToolResult
+from mcp.types import TextContent
 
 from hpe_networking_mcp.middleware.response_envelope import (
     ResponseEnvelopeMiddleware,
     _extract_status,
     _infer_platform,
     _is_envelope_shape,
+    _payload_from_content,
 )
 
 # ---------------------------------------------------------------------------
@@ -284,6 +287,139 @@ class TestResponseEnvelopeMiddleware:
         assert envelope["platform"] == "aos8"
         assert envelope["data"] == raw
         assert envelope["ok"] is True
+
+
+def _text(payload: object) -> list[TextContent]:
+    """One JSON TextContent block, the way FastMCP serializes a tool return."""
+    return [TextContent(type="text", text=json.dumps(payload))]
+
+
+@pytest.mark.unit
+class TestPayloadFromContent:
+    """Issue #327 — `_payload_from_content` recovers a tool's JSON payload
+    from its content blocks when `structured_content` is None."""
+
+    def test_recovers_bare_array(self):
+        payload = [{"id": "site-1"}, {"id": "site-2"}]
+        assert _payload_from_content(_text(payload)) == payload
+
+    def test_recovers_dict(self):
+        payload = {"name": "mcp", "privileges": []}
+        assert _payload_from_content(_text(payload)) == payload
+
+    def test_non_json_text_returns_none(self):
+        assert _payload_from_content([TextContent(type="text", text="not json")]) is None
+
+    def test_empty_or_none_content_returns_none(self):
+        assert _payload_from_content([]) is None
+        assert _payload_from_content(None) is None
+
+    def test_first_json_parseable_block_wins(self):
+        blocks = [
+            TextContent(type="text", text="not json"),
+            TextContent(type="text", text=json.dumps({"recovered": True})),
+        ]
+        assert _payload_from_content(blocks) == {"recovered": True}
+
+
+@pytest.mark.unit
+class TestContentFallbackRecovery:
+    """Issue #327 — FastMCP leaves `structured_content` None for a tool
+    annotated `-> Any` that returns a non-dict (a bare JSON array — the
+    shape every `mist_list_*` tool and every `<platform>_invoke_tool`
+    dispatch to one produces). The payload survives only in the content
+    TextContent block. The middleware must recover it so the envelope's
+    `data` carries the real result, not `null`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bare_array_recovered_from_content(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("mist_list_org_sites")
+        payload = [{"id": "site-1", "name": "HQ"}, {"id": "site-2", "name": "BRANCH-1"}]
+        original = _make_tool_result(structured=None, content=_text(payload))
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == payload
+        assert result.structured_content["ok"] is True
+        assert result.structured_content["tool"] == "mist_list_org_sites"
+        assert result.structured_content["platform"] == "mist"
+
+    @pytest.mark.asyncio
+    async def test_meta_tool_dispatch_to_bare_array_recovered(self):
+        """`mist_invoke_tool` dispatching to a list-returning underlying tool:
+        the meta-tool is `-> Any`, structured_content is None, payload lives
+        in content. This is the exact path the operator transcript hit."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("mist_invoke_tool")
+        payload = [{"mac": "aa:bb:cc:dd:ee:ff", "radio_stat": {"band_5": {}}}]
+        original = _make_tool_result(structured=None, content=_text(payload))
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == payload
+
+    @pytest.mark.asyncio
+    async def test_dict_in_content_recovered_when_structured_none(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("mist_get_self")
+        payload = {"name": "mcp", "privileges": [{"org_id": "abc"}]}
+        original = _make_tool_result(structured=None, content=_text(payload))
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == payload
+
+    @pytest.mark.asyncio
+    async def test_already_enveloped_in_content_passes_through(self):
+        """If the recovered payload is itself envelope-shaped, the idempotency
+        check still fires — no double-wrap."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("mist_invoke_tool")
+        envelope = {
+            "ok": True,
+            "data": [1, 2],
+            "status": None,
+            "message": None,
+            "tool": "x",
+            "platform": "mist",
+        }
+        original = _make_tool_result(structured=None, content=_text(envelope))
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result is original
+
+    @pytest.mark.asyncio
+    async def test_non_json_content_still_yields_null_data(self):
+        """No regression: non-JSON text content → data: None (pre-fix behaviour)."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("health")
+        original = _make_tool_result(structured=None, content=[TextContent(type="text", text="plain text, not json")])
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] is None
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_structured_content_takes_precedence_over_content(self):
+        """When structured_content IS populated, content is not consulted."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_get_sites")
+        structured = {"sites": ["from_structured_content"]}
+        original = _make_tool_result(structured=structured, content=_text({"sites": ["from_content_block"]}))
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == structured
 
 
 @pytest.mark.unit

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -1,11 +1,16 @@
 """Regression tests for the code-mode `execute_description` literal.
 
-The string is hand-coded in `server.py` and lists which platform prefixes
-the sandboxed `execute()` LLM may dispatch via `call_tool`. When a new
-platform is added but this literal is not updated, the in-sandbox LLM
-produces `Unknown tool` errors despite the tool being registered.
+The string is hand-coded in `server.py` and tells the sandboxed `execute()`
+LLM how to reach platform tools via `call_tool`. The contract (corrected
+in #328): every per-platform tool is dispatched via
+`<platform>_invoke_tool` — NOT by bare tool name. The ~1000 spec-driven
+Mist tools are registered but not listed in the sandbox's resolvable
+catalog, so `call_tool("mist_get_self", ...)` raises `Unknown tool`; only
+`mist_invoke_tool` reaches them. The description must steer the LLM to the
+`<platform>_invoke_tool` pattern and must name every platform so the LLM
+knows the full set.
 
-These tests guard the contract so the drift cannot recur silently.
+These tests guard that contract so the drift cannot recur silently.
 """
 
 from __future__ import annotations
@@ -17,14 +22,14 @@ import pytest
 
 import hpe_networking_mcp.server as srv
 
-PLATFORM_PREFIXES = (
-    "mist_",
-    "central_",
-    "greenlake_",
-    "clearpass_",
-    "apstra_",
-    "axis_",
-    "aos8_",
+PLATFORM_NAMES = (
+    "mist",
+    "central",
+    "greenlake",
+    "clearpass",
+    "apstra",
+    "axis",
+    "aos8",
 )
 
 
@@ -42,23 +47,31 @@ def _read_execute_description_block() -> str:
 
 
 @pytest.mark.unit
-def test_execute_description_lists_all_platform_prefixes() -> None:
-    """Every registered platform prefix must appear as a backticked token."""
+def test_execute_description_names_all_platforms() -> None:
+    """Every platform must be named in the description so the in-sandbox LLM
+    knows the full set it can dispatch to via `<platform>_invoke_tool`."""
     body = _read_execute_description_block()
-    missing = [p for p in PLATFORM_PREFIXES if f"`{p}`" not in body]
+    missing = [p for p in PLATFORM_NAMES if p not in body]
     assert not missing, (
-        f"execute_description is missing platform prefix(es): {missing}. "
-        f"Update the literal in server.py to include all 7 platforms."
+        f"execute_description is missing platform name(s): {missing}. "
+        f"Update the literal in server.py to name all 7 platforms."
     )
 
 
 @pytest.mark.unit
-def test_execute_description_lists_aos8_prefix() -> None:
-    """Specific guard for the AOS8 prefix (Phase 9 fix)."""
+def test_execute_description_steers_to_invoke_tool() -> None:
+    """#328: the description must steer the LLM to `<platform>_invoke_tool`
+    as the dispatch path — NOT bare-name `call_tool("mist_get_self", ...)`,
+    which raises `Unknown tool` for the unlisted spec-driven Mist tools."""
     body = _read_execute_description_block()
-    assert "`aos8_`" in body, (
-        "execute_description must include `aos8_` so the code-mode sandbox "
-        "knows AOS8 tools are dispatchable via call_tool()."
+    assert "_invoke_tool" in body, (
+        "execute_description must direct the LLM to `<platform>_invoke_tool` "
+        "as the universal per-platform dispatch path (issue #328)."
+    )
+    # And it must explicitly warn that direct Mist dispatch fails — that is
+    # the concrete footgun the operator transcript hit.
+    assert "Unknown tool" in body and "mist" in body.lower(), (
+        "execute_description must warn that a direct call_tool('mist_...') raises `Unknown tool` (issue #328)."
     )
 
 


### PR DESCRIPTION
Closes #327 and #328.

Both bugs surfaced from one operator transcript — a code-mode Claude session testing the `cross-platform-rf-check` skill reported `mist_list_site_devices_stats` "consistently returns null data."

## #327 — response envelope dropped bare-JSON-array payloads

Any tool whose endpoint returns a **bare top-level JSON array** came back as `{"ok": true, "data": null, ...}` — the payload silently discarded before the AI saw it.

**Root cause** (verified live in the dev container): FastMCP populates `structured_content` for a `-> Any` tool only when it returns a **dict**. A bare-list return under `-> Any` leaves `structured_content` as `None`, with the payload stranded in the `content` blocks as JSON text. The envelope read only `structured_content` → wrapped `None` → `data: null`. Both the ~1000 generated Mist tools and every `<platform>_invoke_tool` meta-tool are `-> Any`, so this hit every `mist_list_*` call and every meta-tool dispatch to one. Confirmed live: `mist_list_org_sites` and `mist_list_site_devices_stats` both returned `data: null` against an org/site with real data.

**Fix** — `middleware/response_envelope.py`: new `_payload_from_content()` recovers the payload from the `content` TextContent JSON block when `structured_content` is `None`. Middleware-layer fix → covers every bare-array-returning tool, every platform, present and future. Dict-returning tools, already-enveloped responses, and non-JSON content are unaffected. 13 new tests.

## #328 — `execute` description over-promised direct platform-tool dispatch

The `execute` description and INSTRUCTIONS.md told the AI `call_tool` dispatches platform tools "by names starting with `mist_`, `central_`, ...". True for hand-curated platforms — **false for Mist**: `call_tool("mist_get_self", {})` raises `Unknown tool`. The ~1000 spec-driven Mist tools are registered with FastMCP but **not listed** in the catalog (keeps the surface small); CodeMode's sandbox `call_tool` resolves names against the *listed* catalog, so Mist tools are reachable only via `mist_invoke_tool`.

**Fix** — doc/guidance only:
- `server.py` — rewrote the `execute` description to steer the AI to `<platform>_invoke_tool(name=..., params=...)` as the universal dispatch path, explicitly noting Mist tools are reachable *only* that way.
- `INSTRUCTIONS.md` — same correction in the code-mode discovery section.
- `test_server_code_mode.py` — replaced the two prefix-listing regression tests (which enforced the *buggy* framing) with contract guards for the corrected `invoke_tool`-centric description.

## Verified

- All 1249 unit tests + 1 skip pass; ruff + format + mypy clean.
- FastMCP `-> Any` vs `-> list` structured-content behaviour confirmed by direct dev-container probe before writing the fix.

## Test plan

- [ ] A bare-array tool (`mist_list_org_sites` via `mist_invoke_tool`) returns its array in `data`, not `null`
- [ ] Dict-returning tools and already-enveloped responses unchanged
- [ ] `execute` description names all 7 platforms and steers to `<platform>_invoke_tool`