### PR TITLE
v3.1.0.8: add interactive RF visualization step to cross-platform-rf-check skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.8] - 2026-05-14
+
+**Patch — `cross-platform-rf-check` skill gains an interactive RF visualization step.**
+
+The skill previously ended with the ASCII text report. It now has a **Step 9** that produces a channel-spectrum visualization the operator can explore, after the text report (never instead of it):
+
+- **Preferred — self-contained HTML artifact** (when the client renders HTML artifacts, e.g. Claude.ai / Claude Desktop): inline CSS + vanilla JS, no external assets. One panel per band; each radio drawn as a block on its primary channel with width proportional to bandwidth (so channel overlaps are visible); fill color mapped to utilization; hover/click reveals per-AP detail; co-channel clusters flagged; Mist allowed-but-unused channels marked on the axis.
+- **Fallback — rich ASCII spectrum diagram** (when the client can't render artifacts): the same information laid out spatially in monospace text, documented under *Interactive RF visualization* in the skill's output-formatting section.
+
+No new tools referenced — the visualization renders from data the skill already collects in Steps 4–7. `test_skill_tool_references.py` still green.
+
 ## [3.1.0.7] - 2026-05-14
 
 **Patch — fix code-mode payload loss + correct sandbox dispatch guidance. Closes #327 + #328.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.7"
+version = "3.1.0.8"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/cross-platform-rf-check.md
+++ b/src/hpe_networking_mcp/skills/cross-platform-rf-check.md
@@ -22,7 +22,9 @@ tools: [health, mist_list_org_sites, mist_list_site_devices_stats, mist_get_site
 Pull per-AP, per-band radio state (channel, bandwidth, power, channel
 utilization, noise floor) for one site from **both** Mist and Central,
 aggregate per-band channel distribution and airtime pressure, flag
-co-channel clusters and elevated noise, and present a unified RF report.
+co-channel clusters and elevated noise, present a unified RF report, and
+finish with an interactive channel-spectrum visualization the operator
+can explore.
 
 This is the code-mode runbook equivalent of the `site_rf_check`
 cross-platform tool. That tool is only registered in `dynamic` mode; in
@@ -139,6 +141,41 @@ Then flag:
 
 See *Output formatting* below.
 
+### Step 9 — Render the interactive RF visualization
+
+After the text report, produce a channel-spectrum visualization so the
+operator can *explore* the RF picture, not just read it. This always comes
+AFTER the Step 8 text report — never instead of it.
+
+**Preferred — self-contained HTML artifact** (when the client renders HTML
+artifacts, e.g. Claude.ai / Claude Desktop): emit a single self-contained
+HTML document — inline CSS + vanilla JS, no external assets, no network
+calls. It must show:
+
+- One panel per band that has data (2.4 / 5 / 6 GHz) — tabs or stacked.
+- A channel axis; each reporting radio drawn as a block on its primary
+  channel, block **width proportional to channel bandwidth**
+  (20 / 40 / 80 / 160 MHz) so channel overlaps are visible at a glance.
+- Block fill color mapped to channel utilization: green < 40 %, amber
+  40–70 %, red ≥ 70 %.
+- Hover or click a block reveals AP detail: name, platform, model, band,
+  channel, bandwidth, power (dBm), utilization %, noise floor, client count.
+- Co-channel clusters (3+ radios sharing a primary channel on 5 / 6 GHz)
+  visually flagged.
+- If a Mist RF template is present, allowed-but-unused channels marked on
+  the axis.
+
+Keep it dependency-free and compact. If PII tokenization is on, tokenized
+values display verbatim — the artifact is a view, it does not detokenize.
+
+**Fallback — rich ASCII spectrum diagram** (when the client does NOT render
+HTML artifacts): emit the spatial channel-allocation diagram described
+under *Interactive RF visualization* in *Output formatting* below. Same
+information, laid out spatially in monospace text.
+
+When unsure whether the client renders artifacts, pick the ASCII fallback —
+a raw HTML code block is worse than a clean ASCII diagram.
+
 ## Decision matrix
 
 | Condition | Action |
@@ -193,6 +230,44 @@ util avg <n>% / peak <n>% · noise <n> dBm
 
 Keep it scannable — the operator should read the headline + recommendations
 in a few seconds and drill into the band sections only if needed.
+
+## Interactive RF visualization
+
+This is Step 9's output — it comes AFTER the text report above, never
+instead of it. Prefer the self-contained HTML artifact (see Step 9); use
+this ASCII spectrum diagram as the fallback when the client can't render
+artifacts.
+
+The ASCII fallback lays radios out spatially on a channel axis per band —
+block width proportional to bandwidth so channel overlaps are visible:
+
+```
+RF spectrum — <site name>
+
+5 GHz
+  ch:   36         40    44    48    …   149        153   157
+        [HQ-LOBBY-AP  80MHz ]                [HQ-FL2-AP  80MHz ]
+              [HQ-FL1-AP  80MHz ]
+        └─ 3 radios on ch36  ⚠ co-channel
+  util: ▇ 74%   ▃ 52%        …   ▁ 18%
+  allowed-but-unused: 60, 64, 100, 104
+
+6 GHz
+  ch:   37    53    69    …
+        [HQ-LOBBY-AP 80MHz]
+  util: ▃ 41%
+
+2.4 GHz
+  ch:   1              6              11
+        [AP1 20][AP4 20]       [AP2 20]
+  util: ▃ 48%          ▁ 22%          ▃ 55%
+
+util key:  ▁ <40%    ▃ 40–70%    ▇ ≥70%
+```
+
+The block label carries AP name + bandwidth; stacked rows show co-channel
+overlap; the util sparkline under each band conveys the airtime picture.
+Order the bands 5 → 6 → 2.4 — operators triage 5 / 6 GHz first.
 
 ## Example
 


### PR DESCRIPTION
## Summary

The `cross-platform-rf-check` skill ended with the ASCII text report. This adds a **Step 9** that produces an interactive channel-spectrum visualization the operator can explore — after the text report, never instead of it.

Requested after a `Show me like an rf planner tool would show the rf at site HOME` prompt — the idea: give all the technical detail, then a visualizer to actually explore it.

## What Step 9 does

- **Preferred — self-contained HTML artifact** (when the client renders HTML artifacts, e.g. Claude.ai / Claude Desktop): inline CSS + vanilla JS, no external assets, no network calls. One panel per band; each radio drawn as a block on its primary channel with **width proportional to bandwidth** (so channel overlaps are visible at a glance); fill color mapped to utilization (green / amber / red); hover or click reveals per-AP detail (name, platform, model, channel, bandwidth, power, util, noise, clients); co-channel clusters flagged; Mist allowed-but-unused channels marked on the axis.
- **Fallback — rich ASCII spectrum diagram** (clients that don't render HTML artifacts): the same information laid out spatially in monospace text — documented under *Interactive RF visualization* in the skill's output-formatting section. The runbook tells the AI to pick the fallback when unsure (a raw HTML code block is worse than a clean ASCII diagram).

## Notes

- No new tools — the visualization renders entirely from data the skill already collects in Steps 4–7. `test_skill_tool_references.py` stays green (22 skill/snippet tests pass).
- Skill-only + version + CHANGELOG; no Python touched.

## Test plan

- [ ] `skills_load(name="cross-platform-rf-check")` returns the runbook with Step 9
- [ ] In an artifact-capable client, an RF-check query ends with an interactive HTML spectrum chart
- [ ] In a non-artifact client, it ends with the ASCII spectrum diagram instead