### PR TITLE
v3.1.0.10: catch ToolError in _invoke_tool so a 4xx doesn't crash the whole execute() block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.10] - 2026-05-14
+
+**Patch — a tool's `ToolError` no longer crashes the entire code-mode `execute()` block. Closes #333.**
+
+When a platform tool dispatched via `<platform>_invoke_tool` raised `ToolError` — which `mist_request` does for **every** Mist 4xx/5xx — the exception propagated through the code-mode sandbox's `call_tool` and aborted the whole `execute()` block, taking every successful call in that block down with it. The AI saw `Sandbox error: Exception: {'status_code': 400, ...}` instead of an inspectable error.
+
+Surfaced in an operator transcript: a code-mode RF-check session lost a successful `mist_get_site_current_channel_planning` result because a *later* `mist_get_site_channel_scores` call in the same block returned a 400.
+
+### Fix
+
+`platforms/_common/meta_tools.py::_invoke_tool` now catches `ToolError` and returns it as a structured error dict — matching its existing `not_found` / `forbidden` / `invalid_params` convention:
+
+```python
+except ToolError as exc:
+    payload = exc.args[0] if exc.args else str(exc)
+    if isinstance(payload, dict):
+        return {"status": "tool_error", **payload}   # preserves status_code + message
+    return {"status": "tool_error", "message": str(payload)}
+```
+
+`_invoke_tool` is the universal dispatch path `build_meta_tools` installs for all 7 platforms, so the one fix covers every platform. A Mist 400 now comes back as `{"status": "tool_error", "status_code": 400, "message": ...}` — the AI can inspect it and continue the block, or self-correct (e.g. the `mist_list_site_rrm_events` "valid band is required" 400 becomes a retryable error rather than a fatal crash).
+
+### Verified
+
+- 2 new tests in `test_meta_tools.py::TestInvokeTool` — dict-payload and string-payload `ToolError` both return `{"status": "tool_error", ...}` with no exception.
+- All unit tests + ruff + format + mypy clean.
+
 ## [3.1.0.9] - 2026-05-14
 
 **Patch — harden `cross-platform-rf-check` skill: response-shape guidance + RF-planner-style coverage-map visualization. Two fixes from operator transcripts.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.9"
+version = "3.1.0.10"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -18,6 +18,7 @@ import inspect
 from typing import Any, get_args, get_origin, get_type_hints
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from mcp.types import ToolAnnotations
 from pydantic import ConfigDict, ValidationError, create_model
@@ -444,6 +445,21 @@ def build_meta_tools(platform: str, mcp: FastMCP) -> None:
 
         try:
             return await spec.func(ctx, **coerced)
+        except ToolError as exc:
+            # A platform tool raised ToolError — e.g. mist_request converts
+            # every Mist 4xx/5xx into ToolError({"status_code": ..., "message": ...}).
+            # In normal MCP dispatch FastMCP turns ToolError into an error
+            # response, but a ToolError propagating through the code-mode
+            # sandbox's call_tool kills the WHOLE execute() block — every
+            # successful call in the block dies with it. Return it as a
+            # structured error dict (matching the not_found / forbidden /
+            # invalid_params convention) so the caller can inspect and
+            # continue (issue #333). exc.args[0] is the structured payload
+            # when the raiser passed a dict — mist_request always does.
+            payload = exc.args[0] if exc.args else str(exc)
+            if isinstance(payload, dict):
+                return {"status": "tool_error", **payload}
+            return {"status": "tool_error", "message": str(payload)}
         except TypeError as exc:
             # Residual TypeError after validation — typically a signature
             # issue (missing ctx param on the tool, or a mismatch between

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastmcp import Context as FastMCPContext
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from hpe_networking_mcp.config import ServerConfig
@@ -258,6 +259,33 @@ class TestInvokeTool:
         )
         assert result["status"] == "invalid_params"
         assert "bogus" in result["message"]
+
+    async def test_tool_error_dict_payload_returned_as_data(self, mcp_with_meta_tools, stub_apstra_registry):
+        """#333: a tool raising ToolError with a structured dict payload — the
+        shape mist_request uses for every Mist 4xx/5xx — must come back as a
+        {"status": "tool_error", ...} dict, never propagate as an exception
+        that would kill the whole code-mode execute() block."""
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        stub_apstra_registry["get_blueprints"].side_effect = ToolError(
+            {"status_code": 400, "message": '{"detail": "data temporary unavailable"}'}
+        )
+        result = await tool.fn(_fake_ctx(config), name="apstra_get_blueprints")
+        assert result["status"] == "tool_error"
+        assert result["status_code"] == 400
+        assert "data temporary unavailable" in result["message"]
+
+    async def test_tool_error_string_payload_returned_as_data(self, mcp_with_meta_tools, stub_apstra_registry):
+        """#333: a ToolError raised with a plain string still comes back as a
+        structured dict, not an exception."""
+        tool = await mcp_with_meta_tools.get_tool("apstra_invoke_tool")
+        config = ServerConfig()
+
+        stub_apstra_registry["get_blueprints"].side_effect = ToolError("upstream exploded")
+        result = await tool.fn(_fake_ctx(config), name="apstra_get_blueprints")
+        assert result["status"] == "tool_error"
+        assert "upstream exploded" in result["message"]
 
 
 # ---- Fixtures for coercion tests -----------------------------------------


### PR DESCRIPTION
Closes #333.

## Problem

When a platform tool dispatched via `<platform>_invoke_tool` raised `ToolError` — which `mist_request` does for **every** Mist 4xx/5xx — the exception propagated through the code-mode sandbox's `call_tool` and aborted the entire `execute()` block, taking every successful call in that block down with it. The AI saw `Sandbox error: Exception: {'status_code': 400, ...}` instead of an inspectable error.

Operator transcript: a code-mode RF-check session lost a successful `mist_get_site_current_channel_planning` result because a *later* `mist_get_site_channel_scores` call in the same block returned a 400.

## Root cause

- `mist_request` raises `ToolError({"status_code": ..., "message": ...})` on any non-2xx.
- Generated Mist tools are `return await mist_request(...)` — they don't catch.
- `_invoke_tool` only caught `ValidationError` / `TypeError` — not `ToolError`.
- So `ToolError` propagated → FastMCP re-raised it → the sandbox surfaced it as a fatal exception → whole block aborted.

## Fix

`platforms/_common/meta_tools.py::_invoke_tool` now catches `ToolError` and returns it as a structured error dict, matching its existing `not_found` / `forbidden` / `invalid_params` convention:

```python
except ToolError as exc:
    payload = exc.args[0] if exc.args else str(exc)
    if isinstance(payload, dict):
        return {"status": "tool_error", **payload}   # preserves status_code + message
    return {"status": "tool_error", "message": str(payload)}
```

`_invoke_tool` is the universal dispatch path `build_meta_tools` installs for all 7 platforms — one fix covers every platform. A Mist 400 now comes back as `{"status": "tool_error", "status_code": 400, "message": ...}`; the AI can inspect it and continue the block, or self-correct (the `mist_list_site_rrm_events` "valid band is required" 400 becomes a retryable error, not a fatal crash).

## Verified

- 2 new tests in `test_meta_tools.py::TestInvokeTool` — dict-payload and string-payload `ToolError` both return `{"status": "tool_error", ...}`, no exception propagates.
- All 1251 unit tests + 1 skip pass; ruff + format + mypy clean.

## Test plan

- [ ] A Mist tool returning a 400 via `mist_invoke_tool` inside `execute()` returns a `{"status": "tool_error", ...}` dict
- [ ] A second `call_tool` after an erroring one in the same block still runs — block doesn't abort