### PR TITLE
v3.1.0.12: skills_list output pushes the AI to skills_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.12] - 2026-05-14
+
+**Patch — `skills_list` output now pushes the AI to `skills_load`. Closes #336.**
+
+An AI client recognized a skill trigger, called `skills_list()` three times, saw the metadata (description + tool list), and **never called `skills_load(name=...)`** to fetch the actual runbook body — it improvised the procedure (and the visualization) from the metadata hint instead. Its own post-mortem: *"the metadata gives enough of a hint that a visualization is involved, but not how — that detail only exists in the body."*
+
+Root cause: `skills_list` returned `{"count", "skills"}` with nothing in the **response** telling the AI this is metadata-only and `skills_load` is the required next step. The tool *description* says so, but the AI reads the description once and the output every call — the output is the high-signal surface and carried no directive.
+
+### Fix
+
+`_engine.py::_make_skills_list_fn` — the `skills_list` response now carries:
+- a top-level **`next_step`** directive — when there are matches: "this is metadata only, NOT the runbook; you MUST `skills_load(name=...)` and follow every step including its output format; do NOT improvise." When there are no matches: "no skills matched — proceed with per-platform tools."
+- a per-entry **`load_with`** field — the literal `skills_load(name='<skill>')` call, so the AI has the exact next call in front of it for each matched skill.
+
+One change covers both the code-mode discovery-tool path and the dynamic-mode `@mcp.tool` path (shared body).
+
+### Verified
+
+- 2 updated/new tests in `test_skills.py::TestDiscoveryToolFactories` — the matched-result `next_step` + `load_with` fields, and the empty-result fallback directive.
+- All unit tests + ruff + format + mypy clean.
+
 ## [3.1.0.11] - 2026-05-14
 
 **Patch — rewrite the `cross-platform-rf-check` skill's Step 9 to a precise RF-planner widget layout.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.11"
+version = "3.1.0.12"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/_engine.py
+++ b/src/hpe_networking_mcp/skills/_engine.py
@@ -237,6 +237,22 @@ _SKILLS_LOAD_DESC = (
 )
 
 
+# Directives carried in the ``skills_list`` *response* (not just the tool
+# description) so the AI sees them on every call. Issue #336: an AI client
+# called ``skills_list`` three times, saw the metadata, and improvised a
+# procedure instead of ever calling ``skills_load`` — because nothing in
+# the *output* pushed it to the next step.
+_SKILLS_LIST_NEXT_STEP_MATCHED = (
+    "This is skill METADATA only — NOT the runbook. If any skill above "
+    "matches the request, you MUST call `skills_load(name=...)` (see each "
+    "entry's `load_with`) to get its full step-by-step body, then follow "
+    "every step — including its output / visualization format. Do NOT "
+    "improvise a procedure from this metadata: the metadata names the "
+    "skill, but the body is where the actual procedure lives."
+)
+_SKILLS_LIST_NEXT_STEP_EMPTY = "No skills matched these filters. Proceed with per-platform tools."
+
+
 def _make_skills_list_fn(registry: SkillRegistry):
     """Build the async ``skills_list`` body that closes over a registry."""
 
@@ -246,9 +262,16 @@ def _make_skills_list_fn(registry: SkillRegistry):
         tag: str | list[str] | None = None,
     ) -> dict[str, Any]:
         results = registry.filter(platform=platform, tag=tag)
+        skills: list[dict[str, Any]] = []
+        for s in results:
+            entry = s.to_metadata()
+            # The literal next call to make for this skill — issue #336.
+            entry["load_with"] = f"skills_load(name={s.name!r})"
+            skills.append(entry)
         return {
             "count": len(results),
-            "skills": [s.to_metadata() for s in results],
+            "skills": skills,
+            "next_step": (_SKILLS_LIST_NEXT_STEP_MATCHED if results else _SKILLS_LIST_NEXT_STEP_EMPTY),
         }
 
     return skills_list

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -319,6 +319,27 @@ class TestDiscoveryToolFactories:
         assert result["count"] == 2
         names = {s["name"] for s in result["skills"]}
         assert names == {"alpha", "beta"}
+        # Issue #336: the response itself must push the AI to skills_load —
+        # a next_step directive plus a per-entry literal load call.
+        assert "skills_load" in result["next_step"]
+        assert "MUST" in result["next_step"]
+        for entry in result["skills"]:
+            assert entry["load_with"] == f"skills_load(name={entry['name']!r})"
+
+    @pytest.mark.asyncio
+    async def test_skills_list_factory_empty_result_has_fallback_next_step(self):
+        """Issue #336: with no matches, next_step tells the AI to fall back
+        to per-platform tools rather than (wrongly) pushing skills_load."""
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry([_skill("alpha", platforms=("mist",))])
+        tool = SkillsListDiscoveryTool(reg)(get_catalog=None)
+        result = await tool.fn(platform="central")  # no match
+
+        assert result["count"] == 0
+        assert result["skills"] == []
+        assert "per-platform tools" in result["next_step"]
+        assert "skills_load" not in result["next_step"]
 
     @pytest.mark.asyncio
     async def test_skills_list_factory_filters_by_platform(self):


### PR DESCRIPTION
Closes #336.

## Problem

An AI client recognized a skill trigger, called `skills_list()` three times, saw the metadata (description + tool list), and **never called `skills_load(name=...)`** — it improvised the procedure (and the visualization) from the metadata hint instead of fetching the runbook body. Its own post-mortem:

> The skill metadata gives enough of a hint that a visualization is involved, but not *how* — that detail only exists in the body. Loading the skill first is the whole point of having the skill system.

## Root cause

`skills_list` returned `{"count", "skills"}` — nothing in the **response** told the AI this is metadata-only and `skills_load` is the required next step. The tool *description* says so, but the AI reads the description once at registration and the **output** on every call. The output is the high-signal surface and carried no directive.

## Fix

`_engine.py::_make_skills_list_fn` — the `skills_list` response now carries:

- a top-level **`next_step`** directive — matches → "this is metadata only, NOT the runbook; you MUST `skills_load(name=...)` and follow every step including its output format; do NOT improvise." No matches → "proceed with per-platform tools."
- a per-entry **`load_with`** field — the literal `skills_load(name='<skill>')` call, so the AI has the exact next call in front of it for each matched skill.

One change covers both the code-mode discovery-tool path and the dynamic-mode `@mcp.tool` path (shared body).

## Verified

- 2 updated/new tests in `test_skills.py::TestDiscoveryToolFactories` — matched-result `next_step` + per-entry `load_with`, and the empty-result fallback directive.
- All 1252 unit tests + 1 skip pass; ruff + format + mypy clean.

## Test plan

- [ ] `skills_list()` response includes `next_step` (must-skills_load when matched; per-platform fallback when empty) and each entry has a `load_with` call
- [ ] An RF-check query: the AI sees the `next_step` directive and calls `skills_load` before touching data tools