### PR TITLE
v3.1.0.15: relocate Mist tool generator out of src/ into scripts/

### DIFF
--- a/.github/workflows/sync-mist-openapi.yml
+++ b/.github/workflows/sync-mist-openapi.yml
@@ -138,7 +138,7 @@ jobs:
           Blob SHA: ${{ steps.sha.outputs.sha }}
 
           Tool regeneration not run by this workflow — maintainer runs
-          \`uv run python -m hpe_networking_mcp.platforms.mist.regenerate\`
+          \`uv run python scripts/regenerate_mist_tools.py\`
           at release time before tagging."
           git push origin main
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -28,7 +28,7 @@ paths = [
     # Generated Mist tool files — descriptions embed example values pulled
     # verbatim from the OpenAPI spec, so they trip the same rules as the
     # source spec.  These files are auto-emitted by
-    # hpe_networking_mcp.platforms.mist._generator; regenerating from a
-    # current spec produces fresh examples.  See vendor/mist_openapi.SOURCE.md.
+    # scripts/_mist_generator.py; regenerating from a current spec produces
+    # fresh examples.  See vendor/mist_openapi.SOURCE.md.
     '''src/hpe_networking_mcp/platforms/mist/tools/.*\.py$''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0.15] - 2026-05-15
+
+**Patch — relocate the Mist tool generator out of `src/` into `scripts/` so it no longer ships dead in the runtime Docker image.**
+
+The Mist generator (`_generator.py`) and its CLI (`regenerate.py`) lived inside the runtime package but were never invoked at server startup — they only run at release time, manually by the maintainer. Shipping ~640 LOC of dead code in every Docker image was a quirk from when Mist was first ported to spec-driven generation (v3.1.0.0), never reconsidered. Moving them outside `src/` keeps the regen workflow functionally identical while removing the dead bytes from production builds. Sets up the same `scripts/`-based home for the next PR's Central one-shot import script.
+
+### What moved
+
+- `src/hpe_networking_mcp/platforms/mist/_generator.py` → `scripts/_mist_generator.py`
+- `src/hpe_networking_mcp/platforms/mist/regenerate.py` → `scripts/regenerate_mist_tools.py`
+
+The CLI imports its sibling generator via a `sys.path.insert(0, ...)` at the top so `scripts/` doesn't need to be a Python package.
+
+### What stayed (intentionally)
+
+- Generator logic itself — verbatim port, no behavior change.
+- Vendored spec at `vendor/mist_openapi.json`.
+- Daily sync workflow at `.github/workflows/sync-mist-openapi.yml` (still runs, still commits to `main`).
+- Auto-emitted Mist tool files at `src/.../mist/tools/` — only their docstring headers (the `emitted by` and `Regenerate via:` lines) were mechanically updated to point at the new path. Function bodies untouched.
+
+### Workflow change
+
+The release-time regen command changes from:
+
+```bash
+uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+```
+
+to:
+
+```bash
+uv run python scripts/regenerate_mist_tools.py
+```
+
+`docker-compose.dev.yml` now mounts `./scripts:/app/scripts` so the regen runs in Python 3.12 with the project's deps, same as before. The production `docker-compose.yml` is unaffected; the production `Dockerfile` already copies only `src/` (plus `pyproject.toml` and `README.md`), so excluding the generator from the image is structurally enforced by the Dockerfile, not just by `.dockerignore`.
+
+### Reference updates
+
+- `.github/workflows/sync-mist-openapi.yml` — the commit-message hint now quotes the new path.
+- `vendor/mist_openapi.SOURCE.md` — the "Regeneration runs at release time" block now quotes the new path.
+- `.gitleaks.toml` — the comment over the `mist/tools/` allow-path now names `scripts/_mist_generator.py`.
+- `src/.../mist/__init__.py` — module docstring's regen instruction quotes the new path.
+
+### Verified
+
+- AST parse of both relocated `scripts/*.py` files.
+- Container import: `_mist_generator` loads cleanly under Python 3.12 inside the dev image with the sibling `sys.path` tweak; `generate_tool_files` symbol is exposed as before.
+
+### Follow-up
+
+Next PR brings in the 197 net-new Central config tools as hand-curated-style wrappers via a new one-shot import script at `scripts/import_central_config_tools.py`. The bigger "should Central also be spec-driven via a maintained generator" decision is deferred and tracked separately.
+
 ## [3.1.0.14] - 2026-05-15
 
 **Patch — harden `cross-platform-rf-check` against three operator-transcript failure modes. Closes #340 and #342.**

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,3 +11,8 @@ services:
       # Vendored OpenAPI specs (read-only — sync happens via GitHub Actions
       # on the host, not in-container).
       - ./vendor:/app/vendor:ro
+      # Dev-only generator / import scripts (Mist regen + Central import).
+      # Read-write so the scripts can write generated tool files back into
+      # ./src under their own mount. Never copied into the production image
+      # by the Dockerfile (only ./src is COPYed).
+      - ./scripts:/app/scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.0.14"
+version = "3.1.0.15"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/scripts/_mist_generator.py
+++ b/scripts/_mist_generator.py
@@ -2,13 +2,15 @@
 
 Reads ``vendor/mist_openapi.json`` (the upstream Juniper Mist OpenAPI 3.1
 spec) and emits one Python file per OpenAPI tag under
-``platforms/mist/tools/``. Each emitted module is a list of decorated
-async functions that proxy to ``mist_request`` in ``_client.py``.
+``src/hpe_networking_mcp/platforms/mist/tools/``. Each emitted module is
+a list of decorated async functions that proxy to ``mist_request`` in
+``_client.py``.
 
 The generator is invoked at release time via
-``uv run python -m hpe_networking_mcp.platforms.mist.regenerate``. The
-generated files are committed to the repo so PR diffs show what changed
-when the upstream spec ships new endpoints.
+``uv run python scripts/regenerate_mist_tools.py``. It lives outside
+``src/`` so it never ships in the runtime Docker image. The generated
+files **are** committed to the repo so PR diffs show what changed when
+the upstream spec ships new endpoints.
 
 Naming convention: ``mist_<snake_case_operationId>``. Per-operationId
 uniqueness in the upstream spec (verified at sync time) makes tool
@@ -302,10 +304,10 @@ def resolve_operation(
 
 _FILE_HEADER_BASE = '''"""Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
-from ``vendor/mist_openapi.json``. Regenerate via:
+This file was emitted by ``scripts/_mist_generator.py`` from
+``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``{tag}``
 Operations in this file: {n_ops}

--- a/scripts/regenerate_mist_tools.py
+++ b/scripts/regenerate_mist_tools.py
@@ -2,7 +2,7 @@
 
 Run from the repo root as:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 This is intended to run **at release time** by the maintainer. The
 vendored spec (``vendor/mist_openapi.json``) is auto-synced daily by
@@ -11,7 +11,8 @@ deliberately so the maintainer can review the tool diff before tagging.
 
 The CLI:
 
-1. Deletes every ``.py`` file under ``platforms/mist/tools/`` (clean slate).
+1. Deletes every ``.py`` file under
+   ``src/hpe_networking_mcp/platforms/mist/tools/`` (clean slate).
 2. Re-generates one ``.py`` file per OpenAPI tag from the vendored spec.
 3. Emits the barrel ``__init__.py`` that imports every generated module.
 4. Reports a per-tag summary so the maintainer can spot drift.
@@ -24,6 +25,10 @@ passes shake out any drift from the canonical form.
 
 Exit code is 0 on success, non-zero on failure. Generated files should
 be committed with the release.
+
+This script lives outside ``src/`` so it never ships in the runtime
+Docker image. The sibling ``_mist_generator.py`` (the actual code
+emitter) is imported via a ``sys.path`` insert at the top of this file.
 """
 
 from __future__ import annotations
@@ -32,7 +37,12 @@ import shutil
 import sys
 from pathlib import Path
 
-from hpe_networking_mcp.platforms.mist._generator import generate_tool_files
+# Make sibling ``_mist_generator.py`` importable without making
+# ``scripts/`` a package. Insert this script's directory at the front of
+# ``sys.path`` so ``import _mist_generator`` resolves locally.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _mist_generator import generate_tool_files  # noqa: E402  (sys.path tweak above)
 
 
 def _repo_root() -> Path:
@@ -45,7 +55,7 @@ def _repo_root() -> Path:
 
 
 def main() -> int:
-    """Entry point for ``python -m hpe_networking_mcp.platforms.mist.regenerate``."""
+    """Entry point for ``uv run python scripts/regenerate_mist_tools.py``."""
     root = _repo_root()
     spec_path = root / "vendor" / "mist_openapi.json"
     tools_dir = root / "src" / "hpe_networking_mcp" / "platforms" / "mist" / "tools"

--- a/src/hpe_networking_mcp/platforms/mist/__init__.py
+++ b/src/hpe_networking_mcp/platforms/mist/__init__.py
@@ -8,7 +8,7 @@ naming convention and calls into ``_client.mist_request`` for transport.
 
 Regenerate the tool surface from the current vendored spec via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 The vendored spec auto-syncs daily via
 ``.github/workflows/sync-mist-openapi.yml``. Tool regeneration is a

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins_login.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins_login.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins Login``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins_login_oauth2.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins_login_oauth2.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins Login - OAuth2``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins_logout.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins_logout.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins Logout``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins_lookup.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins_lookup.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins Lookup``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/admins_recover_password.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/admins_recover_password.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Admins Recover Password``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/constants_definitions.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/constants_definitions.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Constants Definitions``
 Operations in this file: 16

--- a/src/hpe_networking_mcp/platforms/mist/tools/constants_events.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/constants_events.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Constants Events``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/constants_models.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/constants_models.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Constants Models``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/installer.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/installer.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Installer``
 Operations in this file: 23

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_admins.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_admins.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Admins``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_inventory.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_inventory.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Inventory``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_licenses.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_licenses.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Licenses``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_logo.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_logo.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Logo``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_logs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_logs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Logs``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_marvis.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_marvis.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Marvis``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_org_groups.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_org_groups.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Org Groups``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_orgs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_orgs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Orgs``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_sles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_sles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs SLEs``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_sso.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_sso.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs SSO``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_sso_roles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_sso_roles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs SSO Roles``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/msps_tickets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/msps_tickets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``MSPs Tickets``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_admins.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_admins.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Admins``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_advanced_anti_malware_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_advanced_anti_malware_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Advanced Anti Malware Profiles``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_alarm_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_alarm_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Alarm Templates``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_alarms.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_alarms.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Alarms``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_antivirus_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_antivirus_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Antivirus Profiles``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_ap_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_ap_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs AP Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_api_tokens.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_api_tokens.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs API Tokens``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_asset_filters.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_asset_filters.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Asset Filters``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_assets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_assets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Assets``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_cert.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_cert.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Cert``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_marvis.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_marvis.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - Marvis``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_nac.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_nac.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - NAC``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_sdk.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_sdk.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - SDK``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wan.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wan.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - Wan``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wired.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wired.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - Wired``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wireless.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_clients_wireless.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Clients - Wireless``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_crl.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_crl.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs CRL``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_device_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_device_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Device Profiles``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Devices``
 Operations in this file: 10

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_aos.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_aos.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Devices - AOS``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_others.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_others.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Devices - Others``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_ssr.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_devices_ssr.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Devices - SSR``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_events.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_events.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Events``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_evpn_topologies.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_evpn_topologies.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs EVPN Topologies``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_gateway_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_gateway_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Gateway Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_guests.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_guests.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Guests``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_idp_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_idp_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs IDP Profiles``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_cradlepoint.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_cradlepoint.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Integration Cradlepoint``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_jse.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_jse.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Integration JSE``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_juniper.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_juniper.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Integration Juniper``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_skyatp.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_skyatp.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Integration SkyATP``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_zscaler.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_integration_zscaler.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Integration Zscaler``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_inventory.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_inventory.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Inventory``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_jsi.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_jsi.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs JSI``
 Operations in this file: 10

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_licenses.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_licenses.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Licenses``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_linked_applications.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_linked_applications.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Linked Applications``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_logs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_logs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Logs``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_maps.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_maps.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Maps``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_marvis.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_marvis.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Marvis``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_marvis_invites.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_marvis_invites.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Marvis Invites``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxclusters.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxclusters.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs MxClusters``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxedges.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxedges.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs MxEdges``
 Operations in this file: 22

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxtunnels.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_mxtunnels.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs MxTunnels``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_crl.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_crl.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs NAC CRL``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_idp.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_idp.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs NAC IDP``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_portals.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_portals.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs NAC Portals``
 Operations in this file: 11

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_rules.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_rules.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs NAC Rules``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_tags.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_nac_tags.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs NAC Tags``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_network_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_network_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Network Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_networks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_networks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Networks``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_premium_analytics.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_premium_analytics.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Premium Analytics``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_psk_portals.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_psk_portals.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Psk Portals``
 Operations in this file: 11

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_psks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_psks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Psks``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_reports.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_reports.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Reports``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_rf_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_rf_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs RF Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_scep.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_scep.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SCEP``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sdk_invites.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sdk_invites.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SDK Invites``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sdk_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sdk_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SDK Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_secintel_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_secintel_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SecIntel Profiles``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_security_policies.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_security_policies.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Security Policies``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_service_policies.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_service_policies.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Service Policies``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_services.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_services.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Services``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_setting.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_setting.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Setting``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_site_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_site_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Site Templates``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sitegroups.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sitegroups.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Sitegroups``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sites.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sites.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Sites``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SLEs``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sso.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sso.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SSO``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_sso_roles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_sso_roles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs SSO Roles``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_assets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_assets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Assets``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_bgp_peers.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_bgp_peers.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - BGP Peers``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_devices.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Devices``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_mxedges.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_mxedges.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - MxEdges``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_ospf.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_ospf.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Ospf``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_other_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_other_devices.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Other Devices``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_ports.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_ports.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Ports``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_sites.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_sites.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Sites``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_tunnels.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_tunnels.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - Tunnels``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_vpn_peers.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_stats_vpn_peers.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Stats - VPN Peers``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_tickets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_tickets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Tickets``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_ui_settings.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_ui_settings.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs UI Settings``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_user_macs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_user_macs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs User MACs``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_vars.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_vars.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Vars``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_vpns.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_vpns.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs VPNs``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_webhooks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Webhooks``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_wlan_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_wlan_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs WLAN Templates``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_wlans.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_wlans.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs Wlans``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxrules.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxrules.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs WxRules``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxtags.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxtags.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs WxTags``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxtunnels.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/orgs_wxtunnels.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Orgs WxTunnels``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_account.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_account.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self Account``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_alarms.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_alarms.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self Alarms``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_api_token.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_api_token.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self API Token``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_audit_logs.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self Audit Logs``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_mfa.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_mfa.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self MFA``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/self_oauth2.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/self_oauth2.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Self OAuth2``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_advanced_anti_malware_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_advanced_anti_malware_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Advanced Anti Malware Profiles``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_alarms.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_alarms.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Alarms``
 Operations in this file: 10

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_anomaly.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_anomaly.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Anomaly``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_antivirus_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_antivirus_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Antivirus Profiles``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_ap_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_ap_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites AP Templates``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_applications.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_applications.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Applications``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_asset_filters.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_asset_filters.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Asset Filters``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_assets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_assets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Assets``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_auto_map_assignment.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_auto_map_assignment.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Auto Map Assignment``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_beacons.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_beacons.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Beacons``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_nac.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_nac.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Clients - NAC``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wan.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wan.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Clients - Wan``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wired.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wired.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Clients - Wired``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wireless.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_clients_wireless.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Clients - Wireless``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_device_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_device_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Device Profiles``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices``
 Operations in this file: 16

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_others.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_others.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices - Others``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wan_cluster.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wan_cluster.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices - WAN Cluster``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wired.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wired.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices - Wired``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wired_virtual_chassis.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wired_virtual_chassis.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices - Wired - Virtual Chassis``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wireless.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_devices_wireless.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Devices - Wireless``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_events.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_events.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Events``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_evpn_topologies.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_evpn_topologies.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites EVPN Topologies``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_gateway_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_gateway_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Gateway Templates``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_guests.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_guests.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Guests``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_idp_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_idp_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites IDP Profiles``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_insights.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_insights.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Insights``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_jse.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_jse.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites JSE``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_licenses.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_licenses.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Licenses``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_location.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_location.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Location``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_map_stacks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_map_stacks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Map Stacks``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_maps.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_maps.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Maps``
 Operations in this file: 13

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_maps_auto_placement.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_maps_auto_placement.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Maps - Auto-placement``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_maps_auto_zone.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_maps_auto_zone.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Maps - Auto-Zone``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_mxedges.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_mxedges.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites MxEdges``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_nac_fingerprints.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_nac_fingerprints.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites NAC Fingerprints``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_network_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_network_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Network Templates``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_networks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_networks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Networks``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_psks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_psks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Psks``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_rf_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_rf_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites RF Templates``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_rfdiags.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_rfdiags.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Rfdiags``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_rogues.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_rogues.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Rogues``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_rrm.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_rrm.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites RRM``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_rssi_zones.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_rssi_zones.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites RSSI Zones``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_secintel_profiles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_secintel_profiles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites SecIntel Profiles``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_service_policies.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_service_policies.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Service Policies``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_services.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_services.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Services``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_setting.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_setting.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Setting``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_site_templates.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_site_templates.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Site Templates``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_skyatp.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_skyatp.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Skyatp``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_sles.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_sles.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites SLEs``
 Operations in this file: 19

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_spectrum_analysis.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_spectrum_analysis.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Spectrum Analysis``
 Operations in this file: 3

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_apps.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_apps.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Apps``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_assets.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_assets.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Assets``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_beacons.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_beacons.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Beacons``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_bgp_peers.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_bgp_peers.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - BGP Peers``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_calls.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_calls.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Calls``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_clients_sdk.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_clients_sdk.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Clients SDK``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_clients_wireless.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_clients_wireless.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Clients Wireless``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_devices.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_devices.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Devices``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_discovered_switches.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_discovered_switches.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Discovered Switches``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_iot_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_iot_endpoints.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - IoT Endpoints``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_mxedges.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_mxedges.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - MxEdges``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_ospf.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_ospf.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Ospf``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_ports.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_ports.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Ports``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_wxrules.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_wxrules.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - WxRules``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_zones.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_stats_zones.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Stats - Zones``
 Operations in this file: 4

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_synthetic_tests.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_synthetic_tests.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Synthetic Tests``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_ui_settings.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_ui_settings.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites UI Settings``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_vbeacons.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_vbeacons.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites vBeacons``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_vpns.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_vpns.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites VPNs``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_wan_usages.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_wan_usages.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites WAN Usages``
 Operations in this file: 2

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_webhooks.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Webhooks``
 Operations in this file: 8

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_wlans.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_wlans.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Wlans``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_wxrules.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_wxrules.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites WxRules``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_wxtags.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_wxtags.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites WxTags``
 Operations in this file: 6

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_wxtunnels.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_wxtunnels.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites WxTunnels``
 Operations in this file: 5

--- a/src/hpe_networking_mcp/platforms/mist/tools/sites_zones.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/sites_zones.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Sites Zones``
 Operations in this file: 7

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_common.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_common.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities Common``
 Operations in this file: 24

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_lan.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_lan.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities LAN``
 Operations in this file: 18

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_location.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_location.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities Location``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_mxedge.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_mxedge.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities MxEdge``
 Operations in this file: 1

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_pcaps.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_pcaps.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities PCAPs``
 Operations in this file: 9

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_upgrade.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_upgrade.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities Upgrade``
 Operations in this file: 29

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_wan.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_wan.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities WAN``
 Operations in this file: 14

--- a/src/hpe_networking_mcp/platforms/mist/tools/utilities_wi_fi.py
+++ b/src/hpe_networking_mcp/platforms/mist/tools/utilities_wi_fi.py
@@ -1,9 +1,9 @@
 """Generated Mist tools — DO NOT EDIT BY HAND.
 
-This file was emitted by ``hpe_networking_mcp.platforms.mist._generator``
+This file was emitted by ``scripts/_mist_generator.py``
 from ``vendor/mist_openapi.json``. Regenerate via:
 
-    uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+    uv run python scripts/regenerate_mist_tools.py
 
 Tag: ``Utilities Wi-Fi``
 Operations in this file: 14

--- a/vendor/mist_openapi.SOURCE.md
+++ b/vendor/mist_openapi.SOURCE.md
@@ -43,7 +43,7 @@ The GitHub Actions workflow at `.github/workflows/sync-mist-openapi.yml` runs da
 **Tool regeneration does NOT happen on auto-sync.** Regeneration runs at release time, manually by the maintainer:
 
 ```bash
-uv run python -m hpe_networking_mcp.platforms.mist.regenerate
+uv run python scripts/regenerate_mist_tools.py
 ```
 
 This decouples spec freshness from release cadence — the vendored spec is always current, but the live Mist tool surface only changes when the maintainer deliberately ships.


### PR DESCRIPTION
## Summary

- Moves the Mist tool generator (`_generator.py` + `regenerate.py`) out of `src/hpe_networking_mcp/platforms/mist/` into `scripts/` so it no longer ships dead in the runtime Docker image (~640 LOC removed from every image build).
- Generator logic is a verbatim port — no behavior change. Same diff-able regenerated output if you run the new CLI against the same vendored spec.
- Sets up `scripts/` as the home for the upcoming one-shot Central import script (separate follow-up PR).

## What moved

- `src/.../mist/_generator.py` → `scripts/_mist_generator.py`
- `src/.../mist/regenerate.py` → `scripts/regenerate_mist_tools.py`

The new CLI imports its sibling via `sys.path.insert` so `scripts/` doesn't need to become a Python package.

## Workflow change

Release-time regen command changes from:

\`\`\`bash
uv run python -m hpe_networking_mcp.platforms.mist.regenerate
\`\`\`

to:

\`\`\`bash
uv run python scripts/regenerate_mist_tools.py
\`\`\`

`docker-compose.dev.yml` now mounts `./scripts:/app/scripts` so the regen still runs in Python 3.12 with the project's deps. Production `docker-compose.yml` and the production `Dockerfile` are unaffected — the Dockerfile only `COPY src/`, so excluding the generator from the image is structurally enforced.

## Reference updates

- `.github/workflows/sync-mist-openapi.yml` commit-message hint
- `vendor/mist_openapi.SOURCE.md` regen command
- `.gitleaks.toml` comment over the `mist/tools/` allow-path
- `src/.../mist/__init__.py` module docstring
- 196 generated tool files in `src/.../mist/tools/` — docstring headers only (`emitted by` + `Regenerate via:` lines); function bodies untouched

## Not in this PR (deferred)

Per current direction we're holding off on broader generator changes:
- Kill the daily-sync GHA
- Delete `vendor/mist_openapi.json` + `SOURCE.md`
- Add fetch-from-upstream logic to the generator

Those will be revisited when we circle back to the generator. This PR is purely relocation.

## Test plan

- [x] AST parse of both `scripts/*.py` files
- [x] Container import of `_mist_generator` under Python 3.12 in the dev image — `generate_tool_files` symbol still exposed
- [x] Pre-push checklist: `ruff check .` ✓, `ruff format --check .` ✓, `mypy src/ --ignore-missing-imports` ✓, `pytest tests/ -q` → 1266 passed, 1 skipped
- [ ] CI: lint + format + type check + tests + Docker build