### PR TITLE
v3.1.1.1: add central_get_wids_monitored_aps for WIDS detected APs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1.1] - 2026-05-15
+
+**Patch — add `central_get_wids_monitored_aps`, wrapping the `network-services/v1alpha1/wids-monitored-aps` undocumented-but-in-policy endpoint. Surfaces neighbor / rogue / suspect / interfering APs detected by the caller's APs, plus the fabric's containment status for each.**
+
+The endpoint is undocumented in Central's public API reference but lives under the in-policy `network-*/v1alpha1` path family (per the 2026-05-15 build-rule), is tenant-scoped (no cross-tenant exposure), and was already live-probed during the undocumented-endpoint catalog work. No secrets in the response — BSSIDs ride existing MAC normalization rules; everything else is normal tenant data.
+
+### Tool surface
+
+- **`central_get_wids_monitored_aps(classification=..., contained_only=False, site_id=..., odata_filter=..., limit=100, offset=0)`** — GET wrapper with structured args that compose into an OData filter, plus an `odata_filter` raw pass-through escape hatch. Validates that the two paths are mutually exclusive (raw filter OR structured args, not both) and returns a clear error string if mixed.
+
+Each record carries: `id`, `bssid`, `ssid`, `classification` (`ROGUE` / `SUSPECT_ROGUE` / `INTERFERING` / `VALID`), `classificationMethod`, `classificationRule`, `containmentStatus` (e.g. `CONTAINED`), `encryption`, `signal`, `macVendor`, `type`, `portData`, `firstSeen` / `lastSeen` timestamps, the detecting-device names + serials (first / most-recent), plus `siteId` / `siteName` of the detecting AP.
+
+### Tool surface delta
+
+- **Mist**: 1037 (unchanged)
+- **Central**: 479 → **480** (+1)
+- **GreenLake**: 10 (unchanged)
+- **ClearPass**: 140 (unchanged)
+- **Apstra**: 19 (unchanged)
+- **Axis**: 25 (unchanged)
+- **AOS8**: 47 (unchanged)
+- **Server-wide total**: 1757 → **1758**
+
+### Verified
+
+- `ruff check .` ✓
+- `ruff format --check .` ✓
+- `mypy src/ --ignore-missing-imports` ✓
+- Live registration smoke test: `register_tools(mcp, ...)` returns 480 underlying Central tools
+- Endpoint was already live-probed during the undocumented-endpoint catalog work — shape is stable; PII review pre-done
+
 ## [3.1.1.0] - 2026-05-15
 
 **Minor — bulk-import the Aruba Central config-model OpenAPI surface as 197 new typed config-object types (389 net-new tools across 19 new modules). Unlocks AAA, AOS-CX interface/routing/services/system, certificates, AirGroup, NAC (CDA), telemetry, and the wider device-level config-model so design work no longer blocks on per-type tool authoring.**

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **1037 + 2 prompts** | **479 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools** | **1037 + 2 prompts** | **480 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1757 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1758 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -195,7 +195,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1757 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1758 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -511,10 +511,10 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │ 1037   │ │479tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │ 1037   │ │480tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
-│  All 1757 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1758 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘           │
 │     │          │          │          │          │          │          │                 │
@@ -529,7 +529,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1757 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1758 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -591,7 +591,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1757 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1758 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -786,25 +786,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1757)
+### Tool Surface Looks Wrong (6 tools vs. 1758)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1757 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1758 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1757 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1758 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1757 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1758 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1757 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1758 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1757 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1758 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1757 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1758 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1757 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1758 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1757 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1758 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1757 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1758 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -671,7 +671,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (479 tools + 12 prompts)
+## Aruba Central (480 tools + 12 prompts)
 
 > **v3.1.1.0**: bulk-imported 197 net-new config-model object types (389 net-new tools across 19 new modules) from the gitignored local snapshot at `api-endpoints/central/config/`. See the **Config-Model Tools** section at the end of the Central section for the new module inventory and the `central_get_<type>` / `central_manage_<type>` naming convention. The 15 hand-curated tool pairs documented in detail below (sites, devices, alerts, security_policy, wlan_profiles, gateway_clusters, named_vlans, aliases, server_groups, config_assignments, scope, gateway_cluster_intent) keep their tuned docstrings and edge-case handling.
 
@@ -1496,6 +1496,29 @@ Diagnostics for the New Central Configuration API config-health surface (`/netwo
 | sort | str | No | Sort by one of `name`, `serial`, `type`, `siteName`, `configStatus`, `deviceFunction`, `lastConfigTimestamp`, `model`, `deviceGroupName`, `topPriorityIssue`, `recommendedAction`, `role`, `deployment`, `activeIssues`. Append `asc` or `desc` (e.g. `"activeIssues desc"`). |
 | filter | str | No | OData 4.0 filter on `name`, `deviceFunction`, `configStatus`, `type`, `model`, `serial`, `deviceGroupName`, or `activeIssues`. |
 | search | str | No | Free-text search across `name`, `serial`, `siteName`, `topPriorityIssue`, and `recommendedAction` (3-128 chars when supplied). |
+
+---
+
+### WIDS (Wireless Intrusion Detection) (v3.1.1.1)
+
+Wraps the `network-services/v1alpha1/wids-monitored-aps` endpoint — undocumented in the public Central API reference but tenant-scoped (no cross-tenant exposure) and in-policy under the `network-*/v1alpha1` rule. Returns the caller's APs' reports of neighbor / rogue / suspect / interfering APs they've detected.
+
+#### `central_get_wids_monitored_aps`
+
+> Returns WIDS monitored-AP records (neighbor / rogue / suspect / interfering) detected by the caller's APs. Tenant-scoped. Supports structured filtering by classification / containment / site, or raw OData passthrough.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| classification | `Literal["ROGUE","SUSPECT_ROGUE","INTERFERING","VALID"]` | No | Narrow to one WIDS classification. Omit for all. |
+| contained_only | bool | No | If True, narrow to APs where `containmentStatus == 'CONTAINED'` (fabric is actively de-authing / jamming them). Composable with `classification`. |
+| site_id | str | No | Narrow to a specific Central site. Get site IDs from `central_get_site_name_id_mapping`. |
+| odata_filter | str | No | Raw OData 4.0 filter (e.g. `encryption eq 'OPEN' and signal gt -70`). Mutually exclusive with the structured args. |
+| limit | int | No | Results per page (1-1000, default 100). |
+| offset | int | No | Pagination offset (default 0). Page through via `offset += count` until `offset + count >= total`. |
+
+Each record carries: `id`, `bssid`, `ssid`, `classification`, `classificationMethod`, `classificationRule`, `containmentStatus`, `encryption`, `signal`, `macVendor`, `type`, `portData`, `firstSeen`, `lastSeen`, `firstDetDeviceName`, `firstDetDeviceSerial`, `lastDetDeviceName`, `lastDetDeviceSerial`, `siteId`, `siteName`.
+
+Classification semantics: **ROGUE** (confirmed unauthorized), **SUSPECT_ROGUE** (suspected unauthorized), **INTERFERING** (non-rogue but contributing to RF interference), **VALID** (neighboring authorized AP).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.1.0"
+version = "3.1.1.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1757 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1758 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
@@ -397,6 +397,12 @@ When asked to create a new site based on an existing site:
   - Filter with `device_type`, `site_id`, `site_name`, or `serial_number`. Default behavior omits devices already on Central's recommended version; pass `include_up_to_date=True` to see them too.
   - The `release_type` field reflects the API's `firmwareClassification` directly — values are `LSR`, `SSR`, or `UNCLASSIFIED` (AOS 8 and other builds the API doesn't classify fall into the last bucket and pass Central's recommendation through).
   - Narrowing `device_type` restricts the pool used to mine the newest LSR target for SSR devices — leave it unset when you want the tool to make SSR→LSR recommendations.
+- **WIDS (Wireless Intrusion Detection)**: central_get_wids_monitored_aps
+  - Reads neighbor / rogue / suspect / interfering APs detected by the caller's APs at `network-services/v1alpha1/wids-monitored-aps`. Tenant-scoped.
+  - Use `classification="ROGUE" | "SUSPECT_ROGUE" | "INTERFERING" | "VALID"` to narrow; `contained_only=True` for APs the fabric is actively de-authing; `site_id` to scope by site.
+  - For filters not covered by the structured args, pass `odata_filter` (raw OData 4.0). Mutually exclusive with the structured args — pick one or the other.
+  - Page through via `limit` + `offset`; envelope returns `total` for pagination accounting.
+  - Each record: `bssid`, `ssid`, `classification`, `classificationMethod`, `classificationRule`, `containmentStatus`, `encryption`, `signal`, `macVendor`, `type`, `portData`, `firstSeen` / `lastSeen`, detecting-device `firstDetDeviceName/Serial` + `lastDetDeviceName/Serial`, plus `siteId` / `siteName`.
 - **Translation Preview (read-only)**: central_translation_preview
   - Read-only bridge to the translations engine. Runs server-side and returns deterministic `TargetCall` descriptors per source-platform record (e.g. AOS 8 → Central). **Never writes** — the engine is pure data; this tool wraps it.
   - Use for "show me what migrating these AOS 8 policies / roles / VLANs would produce in Central" workflows. The `aos-migration` skill's Stage 9b uses it as the engine-driven preview path.

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -123,6 +123,7 @@ TOOLS = {
     ],
     "firmware": ["central_recommend_firmware"],
     "translation_preview": ["central_translation_preview"],
+    "wids": ["central_get_wids_monitored_aps"],
     "application_experience": [
         "central_get_app_bandwidth_contract",
         "central_manage_app_bandwidth_contract",

--- a/src/hpe_networking_mcp/platforms/central/tools/wids.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wids.py
@@ -1,0 +1,171 @@
+"""Aruba Central WIDS (Wireless Intrusion Detection) tools.
+
+Wraps the ``network-services/v1alpha1/wids-monitored-aps`` endpoint. The
+endpoint is undocumented in the public Central API reference but tenant-
+scoped (no cross-tenant exposure) and lives under the in-policy
+``network-*/v1alpha1`` path family, so building it as a tool is allowed
+per the 2026-05-15 build-policy guidance recorded in
+``docs/central-undocumented-endpoints.md``.
+
+Returns the caller's APs' reports of nearby APs they've detected,
+classified as one of:
+
+- ``ROGUE`` — confirmed unauthorized AP
+- ``SUSPECT_ROGUE`` — suspected unauthorized AP
+- ``INTERFERING`` — non-rogue but contributing to interference
+- ``VALID`` — neighboring authorized AP
+
+Records also carry a ``containmentStatus`` flag — ``CONTAINED`` when the
+fabric is actively jamming/de-authing the BSSID.
+"""
+
+from typing import Annotated, Literal
+
+from fastmcp import Context
+from pydantic import Field
+
+from hpe_networking_mcp.platforms.central._registry import tool
+from hpe_networking_mcp.platforms.central.tools import READ_ONLY
+from hpe_networking_mcp.platforms.central.utils import retry_central_command
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_wids_monitored_aps(
+    ctx: Context,
+    classification: Annotated[
+        Literal["ROGUE", "SUSPECT_ROGUE", "INTERFERING", "VALID"] | None,
+        Field(
+            description=(
+                "Narrow to one WIDS classification: ``ROGUE`` (confirmed "
+                "unauthorized), ``SUSPECT_ROGUE`` (suspected), ``INTERFERING`` "
+                "(non-rogue but causing RF interference), or ``VALID`` "
+                "(neighboring authorized AP). Omit for all classifications."
+            ),
+        ),
+    ] = None,
+    contained_only: Annotated[
+        bool,
+        Field(
+            description=(
+                "If True, narrow to APs whose ``containmentStatus == "
+                "'CONTAINED'`` — i.e. the fabric is actively de-authing or "
+                "jamming them. Composable with ``classification``."
+            ),
+        ),
+    ] = False,
+    site_id: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Narrow to a specific Central site by ``siteId``. Get site "
+                "IDs from ``central_get_site_name_id_mapping``."
+            ),
+        ),
+    ] = None,
+    odata_filter: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Raw OData 4.0 filter passed through to the endpoint. Use "
+                "this for filters not covered by ``classification`` / "
+                "``contained_only`` / ``site_id`` (e.g. ``encryption eq "
+                "'OPEN'``, ``signal gt -70``). Mutually exclusive with the "
+                "structured args."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=1000,
+            description="Results per page (1-1000, default 100).",
+        ),
+    ] = 100,
+    offset: Annotated[
+        int,
+        Field(
+            ge=0,
+            description=(
+                "Pagination offset (default 0). Use the ``total`` field in the response to drive subsequent pages."
+            ),
+        ),
+    ] = 0,
+) -> dict | str:
+    """Get WIDS monitored-AP records from Central.
+
+    Reads the ``network-services/v1alpha1/wids-monitored-aps`` endpoint
+    which lists neighbor / rogue / suspect / interfering APs detected by
+    the caller's APs. Tenant-scoped.
+
+    Each record carries: ``id``, ``bssid``, ``ssid``, ``classification``,
+    ``classificationMethod``, ``classificationRule``, ``containmentStatus``,
+    ``encryption``, ``signal``, ``macVendor``, ``type``, ``portData``,
+    ``firstSeen`` / ``lastSeen`` timestamps, the detecting devices that
+    first / most-recently saw it (``firstDetDeviceName`` /
+    ``firstDetDeviceSerial`` / ``lastDetDeviceName`` /
+    ``lastDetDeviceSerial``), and the ``siteId`` / ``siteName`` of the
+    detecting AP.
+
+    Returns:
+        Envelope with ``items`` (list of records), ``offset``, ``total``,
+        and ``count``. Page through via ``offset += count`` until
+        ``offset + count >= total``.
+
+    Examples:
+        Get all confirmed rogue APs at a specific site::
+
+            central_get_wids_monitored_aps(
+                classification="ROGUE",
+                site_id="<site-id>",
+            )
+
+        Get APs the fabric is currently containing (any classification)::
+
+            central_get_wids_monitored_aps(contained_only=True)
+
+        Custom OData filter::
+
+            central_get_wids_monitored_aps(
+                odata_filter="encryption eq 'OPEN' and signal gt -70",
+            )
+    """
+    structured_args = (classification, contained_only, site_id)
+    if odata_filter is not None and any(structured_args):
+        return (
+            "Error: pass either ``odata_filter`` (raw) OR the structured "
+            "``classification`` / ``contained_only`` / ``site_id`` args, "
+            "not both. The structured args compose into an OData filter "
+            "under the hood; mixing the two is ambiguous."
+        )
+
+    if odata_filter is None:
+        clauses: list[str] = []
+        if classification:
+            clauses.append(f"classification eq '{classification}'")
+        if contained_only:
+            clauses.append("containmentStatus eq 'CONTAINED'")
+        if site_id:
+            clauses.append(f"siteId eq '{site_id}'")
+        odata_filter = " and ".join(clauses) if clauses else None
+
+    api_params: dict = {"limit": limit, "offset": offset}
+    if odata_filter:
+        api_params["filter"] = odata_filter
+
+    conn = ctx.lifespan_context["central_conn"]
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path="network-services/v1alpha1/wids-monitored-aps",
+        api_params=api_params,
+    )
+
+    code = response.get("code", 0)
+    if 200 <= code < 300:
+        return response.get("msg", {})
+    return {
+        "status": "error",
+        "code": code,
+        "message": response.get("msg", "Unknown error"),
+    }


### PR DESCRIPTION
## Summary

Wraps `network-services/v1alpha1/wids-monitored-aps` — undocumented in the public Central API reference but tenant-scoped (no cross-tenant exposure) and **in-policy** under the 2026-05-15 build rule (URI matches `network-*/v1alpha1`). Endpoint shape was already live-probed during the undocumented-endpoint catalog work; no secrets in the response.

Returns the caller's APs' reports of nearby APs they've detected, classified as **ROGUE** (confirmed unauthorized), **SUSPECT_ROGUE** (suspected), **INTERFERING** (non-rogue RF interference), or **VALID** (neighbor). Each record also carries a `containmentStatus` — `CONTAINED` when the fabric is actively de-authing or jamming the BSSID.

## Tool surface

**`central_get_wids_monitored_aps`** (read-only):

- `classification` — `Literal["ROGUE","SUSPECT_ROGUE","INTERFERING","VALID"]`
- `contained_only` — bool (composable with `classification`)
- `site_id` — string (get IDs from `central_get_site_name_id_mapping`)
- `odata_filter` — raw OData passthrough; mutually exclusive with the structured args
- `limit` / `offset` — pagination (envelope returns `total` + `count`)

Structured args compose into an OData filter under the hood. Raw `odata_filter` is the escape hatch for filters the structured args don't cover (e.g. `encryption eq 'OPEN' and signal gt -70`). Mixing both returns a clear error string.

Each record: `id`, `bssid`, `ssid`, `classification`, `classificationMethod`, `classificationRule`, `containmentStatus`, `encryption`, `signal`, `macVendor`, `type`, `portData`, `firstSeen` / `lastSeen`, detecting-device first / most-recent names+serials, plus `siteId` / `siteName`.

## Tool surface delta

- Central: 479 → **480** (+1)
- Server-wide: 1757 → **1758**

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `pytest tests/ -q` — 1266 passed, 1 skipped
- [x] Live registration smoke test: `register_tools(mcp, ...)` returns 480 underlying Central tools
- [ ] CI: lint + format + type check + tests + Docker build
- [ ] Live tenant exercise post-merge (one query per classification + a contained-only run)

## Docs updated in the same PR

- `CHANGELOG.md` — new v3.1.1.1 entry
- `README.md` — comparison table + architecture diagram tool counts
- `docs/TOOLS.md` — new "WIDS (Wireless Intrusion Detection)" subsection + count
- `src/hpe_networking_mcp/INSTRUCTIONS.md` — new "WIDS" tool category
- `pyproject.toml` — bumped to `3.1.1.1`