### PR TITLE
v3.1.2.1: feature-matrix audit (12 rows) + fix asset-tag docstrings (BLE asset tracking, not metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2.1] - 2026-05-16
+
+**Patch — correct the feature-comparison matrix in README.md (12-row audit) + fix the `central_get_asset_tags` / `central_get_asset_tag` / `central_manage_asset_tag_metadata` docstrings to describe what they actually wrap.**
+
+### README feature-matrix audit
+
+Full audit of the README feature-comparison table against actual tool inventory across all 7 platforms. **7 rows corrected, 5 new rows added.**
+
+| Row | Change | Why |
+|---|---|---|
+| **Rogue AP Detection** | Central — → ✅ | `central_get_wids_monitored_aps` shipped v3.1.1.1 |
+| **Endpoint Profiling** | Central — → ✅ | `central_get_devicefingerprinting*` + `central_get_client_insight` (config) + fingerprinted attrs on `central_get_clients` (data) — shipped v3.1.1.0 |
+| **Application Visibility** | Mist — → ✅ | `orgs_applications` + `orgs_linked_applications` |
+| **Subscriptions / Licensing** | Mist — → ✅ | `orgs_licenses` / `msps_licenses` / `sites_licenses` |
+| **User Management** | Mist + Central — → ✅ | Mist: `orgs_admins` / `orgs_sso*` / `msps_admins` / `msps_sso*`. Central: `central_get_management_user` / `_management_user_group` from v3.1.1.0 |
+| **Guest Management** | Mist + Central — → ✅ | Mist: `orgs_guests` / `sites_guests`. Central: `central_get_aaa_captive_portal` + `central_get_cda_portal_*` |
+| **Certificates** | Mist + Central — → ✅ | Mist: `orgs_cert` / `orgs_crl` / `orgs_scep` / `orgs_nac_crl`. Central: `central_get_certificate*` family from v3.1.1.0 |
+
+New rows added (5):
+
+- **Webhooks** — Mist + Central
+- **Reports / Scheduled Reports** — Mist + Central + ClearPass
+- **Floor Plans / Sitemaps** — Mist + Central
+- **BLE Asset Tracking / IoT Beacons** — Mist + Central (see asset-tag docstring fix below)
+- **Marvis / AI Assistant** — Mist only
+
+### Asset-tag docstring fix (the row that nearly went wrong)
+
+The v3.1.2.0 import described Central's `network-services/v1/asset-tags` endpoints as "user-defined metadata you attach to devices for grouping / filtering" — which was wrong. The Postman example response confirmed: each record carries a BLE `macAddress`, `deviceClassifications` like `"ArubaAssetTag"` / `"Blyott"` (Blyott is a BLE beacon vendor), `firstSeen` timestamps from AP detection, and "last known location." These ARE BLE asset tags — physical beacons attached to tracked assets (laptops, medical equipment, inventory) that APs detect and locate. The `/metadata` sub-resource is the inventory annotation layer (name, owner, asset class, etc.) you attach to each detected tag.
+
+Docstrings on `central_get_asset_tags` / `central_get_asset_tag` / `central_manage_asset_tag_metadata` rewritten to reflect that. The `BLE Asset Tracking / IoT Beacons` matrix row gained Central ✅ as part of the audit.
+
+### Deliberate non-changes
+
+- **Radio Resource Management — Central**: stayed —. Central has `central_get_radio` (config-model radio profile) but the actual auto-tuning RRM engine is AirMatch, which lives under `airmatch/v1/` and is out-of-policy per the 2026-05-15 build rule.
+- **Workspaces — Central**: stayed —. Workspaces are a GreenLake-specific construct.
+
+### Verified
+
+- `ruff check .` ✓
+- `ruff format --check .` ✓
+- `mypy src/ --ignore-missing-imports` ✓
+- `pytest tests/ -q` ✓ (1266 passed, 1 skipped)
+
 ## [3.1.2.0] - 2026-05-15
 
 **Minor — bulk-import the Aruba Central MRT API surface (Monitoring / Reporting / Troubleshooting / Notifications / Services / MSP / Sitemaps) as 133 net-new typed tools across 13 new modules. Central: 480 → 613; server-wide: 1758 → 1891.**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Webhooks** | ✅ | ✅ | — | — | — | — | — |
 | **Reports / Scheduled Reports** | ✅ | ✅ | — | ✅ | — | — | — |
 | **Floor Plans / Sitemaps** | ✅ | ✅ | — | — | — | — | — |
-| **BLE Asset Tracking / IoT Beacons** | ✅ | — | — | — | — | — | — |
+| **BLE Asset Tracking / IoT Beacons** | ✅ | ✅ | — | — | — | — | — |
 | **Marvis / AI Assistant** | ✅ | — | — | — | — | — | — |
 | **Datacenter Blueprints / Templates** | — | — | — | — | ✅ | — | — |
 | **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ | — | — |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Configuration Management** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
 | **Configuration Write (CRUD)** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
 | **Radio Resource Management** | ✅ | — | — | — | — | — | ✅ |
-| **Rogue AP Detection** | ✅ | — | — | — | — | — | ✅ |
+| **Rogue AP Detection** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Firmware Management** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Subscriptions / Licensing** | — | — | ✅ | ✅ | — | — | ✅ |
 | **User Management** | — | — | ✅ | ✅ | — | ✅ | — |
@@ -38,7 +38,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Scope & Configuration Hierarchy** | ✅ | ✅ | — | — | — | ✅ | ✅ |
 | **Guest Management** | — | — | — | ✅ | — | — | — |
 | **NAC / Policy Management** | ✅ | ✅ | — | ✅ | — | — | — |
-| **Endpoint Profiling** | ✅ | — | — | ✅ | — | — | — |
+| **Endpoint Profiling** | ✅ | ✅ | — | ✅ | — | — | — |
 | **Certificates** | — | — | — | ✅ | — | — | — |
 | **Datacenter Blueprints / Templates** | — | — | — | — | ✅ | — | — |
 | **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ | — | — |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Events** | ✅ | ✅ | — | ✅ | — | — | ✅ |
 | **Alerts / Alarms** | ✅ | ✅ | — | ✅ | ✅ | — | ✅ |
 | **Audit Logs** | ✅ | ✅ | ✅ | ✅ | — | — | ✅ |
-| **Application Visibility** | — | ✅ | — | — | — | ✅ | — |
+| **Application Visibility** | ✅ | ✅ | — | — | — | ✅ | — |
 | **Troubleshooting (Ping/Traceroute/Bounce)** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Session Control / Client Disconnect** | ✅ | ✅ | — | ✅ | — | — | ✅ |
 | **Configuration Management** | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ |
@@ -32,14 +32,19 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Radio Resource Management** | ✅ | — | — | — | — | — | ✅ |
 | **Rogue AP Detection** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Firmware Management** | ✅ | ✅ | — | — | — | — | ✅ |
-| **Subscriptions / Licensing** | — | — | ✅ | ✅ | — | — | ✅ |
-| **User Management** | — | — | ✅ | ✅ | — | ✅ | — |
+| **Subscriptions / Licensing** | ✅ | — | ✅ | ✅ | — | — | ✅ |
+| **User Management** | ✅ | ✅ | ✅ | ✅ | — | ✅ | — |
 | **Workspaces** | — | — | ✅ | — | — | — | — |
 | **Scope & Configuration Hierarchy** | ✅ | ✅ | — | — | — | ✅ | ✅ |
-| **Guest Management** | — | — | — | ✅ | — | — | — |
+| **Guest Management** | ✅ | ✅ | — | ✅ | — | — | — |
 | **NAC / Policy Management** | ✅ | ✅ | — | ✅ | — | — | — |
 | **Endpoint Profiling** | ✅ | ✅ | — | ✅ | — | — | — |
-| **Certificates** | — | — | — | ✅ | — | — | — |
+| **Certificates** | ✅ | ✅ | — | ✅ | — | — | — |
+| **Webhooks** | ✅ | ✅ | — | — | — | — | — |
+| **Reports / Scheduled Reports** | ✅ | ✅ | — | ✅ | — | — | — |
+| **Floor Plans / Sitemaps** | ✅ | ✅ | — | — | — | — | — |
+| **BLE Asset Tracking / IoT Beacons** | ✅ | — | — | — | — | — | — |
+| **Marvis / AI Assistant** | ✅ | — | — | — | — | — | — |
 | **Datacenter Blueprints / Templates** | — | — | — | — | ✅ | — | — |
 | **Virtual Networks / EVPN / Routing Zones** | — | — | — | — | ✅ | — | — |
 | **Connectivity Templates / Policy Apply** | — | — | — | — | ✅ | — | — |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.2.0"
+version = "3.1.2.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -85,10 +85,21 @@ async def central_get_asset_tags(
     limit: int = 100,
     offset: int = 0,
 ) -> dict | str:
-    """List asset tags configured in Central.
+    """List BLE asset tags detected by the tenant's APs.
 
-    Asset tags are user-defined metadata you attach to devices for
-    grouping / filtering in reports, alerts, and policies.
+    Asset tags are physical BLE beacons (e.g. ArubaAssetTag, Blyott)
+    attached to assets you want to track — laptops, medical equipment,
+    inventory, etc. APs detect the BLE broadcasts and report the tags
+    along with their last-known location. Each record carries the tag's
+    BLE ``macAddress``, ``deviceClassifications`` (vendor / type),
+    ``firstSeen`` / lastSeen timestamps, and the ``metadata`` block —
+    user-attached descriptive fields (name, owner, asset category, etc.)
+    populated via ``central_manage_asset_tag_metadata``.
+
+    Use ``central_start_ap_ranging_scan`` to calibrate AP-to-AP
+    distances on a floor for accurate location, and the device-location
+    / wifi-clients-locations endpoints alongside this for the full
+    location-services picture.
     """
     conn = ctx.lifespan_context["central_conn"]
     params: dict = {"limit": limit, "offset": offset}
@@ -100,9 +111,16 @@ async def central_get_asset_tags(
 @tool(annotations=READ_ONLY)
 async def central_get_asset_tag(
     ctx: Context,
-    asset_tag_id: Annotated[str, Field(description="Asset-tag identifier.")],
+    asset_tag_id: Annotated[
+        str,
+        Field(description="Asset-tag identifier (assigned by Central on first detection)."),
+    ],
 ) -> dict | str:
-    """Get one asset tag by ID."""
+    """Get one BLE asset tag's full record.
+
+    Returns classifications, BLE MAC, first/last seen, attached metadata,
+    and the last-known location for the tracked tag.
+    """
     conn = ctx.lifespan_context["central_conn"]
     return _get(conn, f"network-services/v1/asset-tags/{asset_tag_id}")
 
@@ -113,16 +131,32 @@ async def central_manage_asset_tag_metadata(
     asset_tag_id: Annotated[str, Field(description="Asset-tag identifier.")],
     action_type: Annotated[
         Literal["create", "update", "delete"],
-        Field(description="``'create'`` (POST), ``'update'`` (PUT), or ``'delete'``."),
+        Field(
+            description=(
+                "``'create'`` (POST), ``'update'`` (PUT — replaces wholesale), "
+                "or ``'delete'`` (clears all metadata fields)."
+            ),
+        ),
     ],
     payload: Annotated[
         dict | None,
-        Field(description="Metadata key/value pairs. Ignored for delete."),
+        Field(
+            description=(
+                "Descriptive fields to attach to the BLE asset tag — typically "
+                "``{name, description, ownership info, asset category, ...}``. "
+                "These are inventory-style attributes; they don't change what's "
+                "detected, they let you label what each detected tag *is*. "
+                "Ignored for delete."
+            ),
+        ),
     ] = None,
 ) -> dict | str:
-    """Manage the metadata attached to an asset tag.
+    """Create / update / delete the descriptive metadata attached to a BLE asset tag.
 
-    Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``.
+    The metadata is the inventory record for a tracked asset — name,
+    owner, asset class, etc. It doesn't affect detection; APs detect the
+    BLE broadcast regardless. PUT (``update``) replaces the metadata
+    wholesale. Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``.
     """
     conn = ctx.lifespan_context["central_conn"]
     method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}


### PR DESCRIPTION
## Summary

Full audit of the README feature-comparison table — **7 rows corrected, 5 new rows added** — plus a docstring fix for the Central asset-tag tools (I had them framed wrong as \"device metadata tagging\" when they're actually BLE asset tracking).

Patch bump (3.1.2.0 → 3.1.2.1) since this includes a docstring change to live tools.

## Asset-tag docstring fix

The v3.1.2.0 import described \`central_get_asset_tags\` / \`central_get_asset_tag\` / \`central_manage_asset_tag_metadata\` as \"user-defined metadata you attach to devices for grouping / filtering.\" That was wrong.

The Postman example response confirmed: each record carries a BLE \`macAddress\`, \`deviceClassifications\` like \`\"ArubaAssetTag\"\` / \`\"Blyott\"\` (Blyott is a BLE beacon vendor), \`firstSeen\` timestamps from AP detection, and \"last known location.\" These ARE BLE asset tags — physical beacons attached to tracked assets (laptops, medical equipment, inventory) that APs detect and locate. The \`/metadata\` sub-resource is the inventory annotation layer (name / owner / asset class) you attach to each detected tag.

Docstrings rewritten to reflect that. Same group of tools, same wire path — just correctly described now.

## Existing rows updated (7)

| Row | Change | Why |
|---|---|---|
| **Rogue AP Detection** | Central — → ✅ | \`central_get_wids_monitored_aps\` shipped v3.1.1.1 |
| **Endpoint Profiling** | Central — → ✅ | \`central_get_devicefingerprinting*\` + \`_client_insight\` (config) + fingerprinted attrs on \`central_get_clients\` (data) — v3.1.1.0 |
| **Application Visibility** | Mist — → ✅ | \`orgs_applications\` + \`orgs_linked_applications\` |
| **Subscriptions / Licensing** | Mist — → ✅ | \`orgs_licenses\` / \`msps_licenses\` / \`sites_licenses\` |
| **User Management** | Mist + Central — → ✅ | Mist: \`orgs_admins\` / \`orgs_sso*\` / \`msps_admins\` / \`msps_sso*\`. Central: \`central_get_management_user\` / \`_management_user_group\` from v3.1.1.0 |
| **Guest Management** | Mist + Central — → ✅ | Mist: \`orgs_guests\` / \`sites_guests\`. Central: \`central_get_aaa_captive_portal\` + \`central_get_cda_portal_*\` |
| **Certificates** | Mist + Central — → ✅ | Mist: \`orgs_cert\` / \`orgs_crl\` / \`orgs_scep\` / \`orgs_nac_crl\`. Central: \`central_get_certificate*\` family from v3.1.1.0 |

## New rows added (5)

| Row | Coverage | Source |
|---|---|---|
| **Webhooks** | Mist ✅, Central ✅ | Mist: \`orgs_webhooks\` / \`sites_webhooks\`. Central: \`mrt_webhooks.py\` from v3.1.2.0 |
| **Reports / Scheduled Reports** | Mist ✅, Central ✅, ClearPass ✅ | Mist: \`orgs_reports\` + \`orgs_premium_analytics\`. Central: \`mrt_reporting.py\` from v3.1.2.0. ClearPass: \`clearpass_get_insight_reports\` |
| **Floor Plans / Sitemaps** | Mist ✅, Central ✅ | Mist: \`orgs_maps\` / \`sites_maps\` / \`installer_maps\`. Central: \`mrt_sitemaps.py\` from v3.1.2.0 |
| **BLE Asset Tracking / IoT Beacons** | Mist ✅, Central ✅ | Mist: \`orgs_assets\` + \`sites_assets\` + \`sites_beacons\` + \`sites_vbeacons\`. Central: \`central_get_asset_tags\` + \`_asset_tag\` + \`_manage_asset_tag_metadata\` from v3.1.2.0 (corrected in this PR) |
| **Marvis / AI Assistant** | Mist only | \`orgs_marvis\` / \`sites_marvis\` / \`msps_marvis\`. Central's \`/insights\` is recommendation-style, not an AI assistant |

## Deliberate non-changes

- **Radio Resource Management — Central**: stayed —. Central has \`central_get_radio\` (config-model radio profile) but the actual auto-tuning RRM engine is AirMatch, which lives under \`airmatch/v1/\` and is out-of-policy per the 2026-05-15 build rule.
- **Workspaces — Central**: stayed —. Workspaces are a GreenLake-specific construct.

## Test plan

- [x] \`ruff check .\` — clean
- [x] \`ruff format --check .\` — clean
- [x] \`mypy src/ --ignore-missing-imports\` — clean
- [x] \`pytest tests/ -q\` — 1266 passed, 1 skipped
- [ ] CI: lint + format + type check + tests + Docker build