### PR TITLE
v3.1.3.1: version-align the trigger-coverage fix from #351

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3.1] - 2026-05-18
+
+**Patch — version-aligns the trigger-coverage fix that landed in #351.**
+
+PR #351 hardened the `clearpass-policy-walker` skill triggering (see commit `add2747`) but was merged as "docs-only" with no version bump. That was a misclassification — `src/hpe_networking_mcp/INSTRUCTIONS.md` and the skill `.md` files under `src/hpe_networking_mcp/skills/` are **shipped runtime artifacts**: the server reads INSTRUCTIONS.md at startup (see `server.py:12`, `server.py:255`) and surfaces it as the MCP `serverInstructions` field. Skill files are read by `skills_list` / `skills_load` at runtime. Operators who consume the Docker image have no way to receive trigger fixes without a tagged release.
+
+This patch bumps `pyproject.toml` so the v3.1.3.1 git tag aligns with the package version + triggers the `Docker Publish` workflow against a release event, making the fix actually reachable for image consumers.
+
+### Versioning rule clarification
+
+Going forward: a version bump is required for any change to a file the server loads at runtime — including INSTRUCTIONS.md, every skill markdown under `src/.../skills/`, and any other content shipped inside `src/`. Pure documentation files (`README.md`, `CHANGELOG.md`, `docs/TOOLS.md`, source comments) that don't affect runtime behavior still don't need a version bump.
+
+### What changed in #351 (re-summarized for the release notes)
+
+- Extended the `clearpass-policy-walker` skill's `description` frontmatter (what `skills_list` returns) to cover ClearPass-native phrasings — *"auth service"*, *"authentication service"*, *"policy service"*, *"ClearPass service"* — and casual-name handling (e.g. *"No Wireless For You"*).
+- Added *visualize*, *render*, *diagram*, *flowchart*, *draw*, *walk the flow*, *show me how X decides* to the universal-trigger-words list in INSTRUCTIONS.md so any pairing with a ClearPass service name forces a `skills_list()` call before the model answers.
+- Added an explicit CRITICAL clause in the skill description: never guess at a named service; always call the tools first.
+
 ## [3.1.3.0] - 2026-05-18
 
 **Minor — ClearPass policy visualizer: render a service's full decision flow (service match → authentication → role mapping → enforcement) as a Mermaid flowchart. Ships as 2 new tools + 1 new skill, backed by an internal compilation engine ported (and adapted for REST) from an existing standalone project. Closes #349.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.3.0"
+version = "3.1.3.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

PR #351 hardened the `clearpass-policy-walker` skill triggering but landed without a version bump because I incorrectly categorized it as docs-only. That blocked image consumers from receiving the fix — Docker Publish only fires on **release** events, and there's no release without a tag.

This patch:
- Bumps `pyproject.toml` from 3.1.3.0 → 3.1.3.1 so the package version matches the git tag I'm about to create.
- Adds a CHANGELOG entry covering both the version alignment and re-summarizing what #351 actually shipped, so the release notes are self-contained.

## Why the original PR should have bumped

`src/hpe_networking_mcp/INSTRUCTIONS.md` and the skill markdown files under `src/hpe_networking_mcp/skills/` are **shipped runtime artifacts** — `server.py:12` reads INSTRUCTIONS.md at startup and surfaces it as the MCP `serverInstructions` field; skill files are read by `skills_list` / `skills_load`. Operators consuming the Docker image have no way to receive trigger fixes without a tagged release.

## Versioning rule going forward

Version bump required for: any file under `src/` that the server loads at runtime — including INSTRUCTIONS.md, every skill markdown under `src/.../skills/`, and any other shipped content.

Version bump NOT required for: README.md, CHANGELOG.md, docs/TOOLS.md, source-file comments — anything that doesn't affect runtime behavior.

## Test plan

- [x] `pyproject.toml` version matches the planned tag (v3.1.3.1)
- [ ] Merge this PR
- [ ] Tag v3.1.3.1 at the merge commit + create GitHub release → triggers Docker Publish workflow
- [ ] After image build completes, `docker compose pull && docker compose up -d --force-recreate` to receive the trigger fix