### PR TITLE
v3.1.3.3: make rendered ClearPass policy diagrams readable for large policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3.3] - 2026-05-18
+
+**Patch — make the rendered ClearPass policy flow readable for large policies. Operator's screenshot showed the diagram correctly produced but rendered as one tall narrow column with tiny text, because Mermaid's default `flowchart TD` + the verbose multi-line decision labels collapsed under the conversation's width constraint.**
+
+### Three coordinated fixes
+
+1. **`expr_to_compact_label()` — single-line condition summaries.** New helper in `conditions.py` that produces a compact rendering: drops the namespace prefix (`Authorization:[Guest Device Repository]:Device Role ID` → `Device Role ID`), uses short operator glyphs (`=` `≠` `~=` `∈` `&` `|`), prefers `displayValue` over numeric IDs, and truncates long values with an ellipsis. Caps at 80 chars by default.
+
+   Compare:
+
+   ```
+   # expr_to_node_label (verbose — 3 lines per predicate, for inspector tooltips):
+   Authorization:[Guest Device Repository]:Device Role ID
+   EQUALS
+   21
+
+   # expr_to_compact_label (compact single-line, for diagram nodes):
+   Device Role ID = 21
+   ```
+
+2. **`FlowNode.short_label` field** populated by `compile_service()` for every decision node. Diagram renderers (Mermaid, Graphviz) should prefer this for the visible node text; `label` stays around for inspector / tooltip / details-block content where verbosity is fine. For non-decision nodes (`start`, `process`, `action`, `end`), `short_label` defaults to `label` via `__post_init__` so existing rendering paths still work unchanged.
+
+3. **Skill template rewritten for legibility.**
+   - Default direction switched to `flowchart LR` (left-right). Long chains lay out horizontally instead of stacking vertically.
+   - Added Mermaid `%%{init: ...}%%` directive prescribing reasonable `nodeSpacing` / `rankSpacing`.
+   - Template now uses `short_label` for every node, NOT `label`.
+   - New **Step 3b — Sectioned rendering** REQUIRED for policies with ≥ 8 decision nodes: render service-intake / role-mapping / enforcement as three separate Mermaid blocks instead of one giant diagram. Each block fits on screen, operators zoom each independently.
+
+### Why this matters
+
+A real ClearPass MAC-auth + MPSK enforcement policy on the operator's tenant has ~30 decision diamonds across role-mapping + enforcement chains. With the prior template (`TD` + verbose `label`), the rendered Mermaid was unreadable in the chat client — the whole graph got scaled to fit the conversation width while being many screens tall, making every label tiny. After the fix the chains lay out horizontally with one-line condition labels, or split across three readable blocks.
+
+### Files changed
+
+- `src/.../platforms/clearpass/policy_visualizer/conditions.py` — `expr_to_compact_label()` + `_OP_SHORT` glyph map + extracted `_pick_rhs_for_display()`.
+- `src/.../platforms/clearpass/policy_visualizer/flow_graph.py` — `FlowNode.short_label` field with `__post_init__` default; every decision-node construction populates it via `expr_to_compact_label`.
+- `src/.../skills/clearpass-policy-walker.md` — Step 3 rewritten with `LR` default + `short_label` requirement + Mermaid init directive; new Step 3b on sectioned rendering for large policies.
+- `tests/unit/test_clearpass_policy_visualizer_adapter.py` — `TestCompactLabel` (6 cases).
+- `tests/unit/test_clearpass_policy_visualizer_flow.py` — `TestShortLabelPropagation` (3 cases) verifying decision nodes get `short_label` and non-decision nodes default.
+
+### Counts
+
+- ClearPass tools: still 142
+- pytest: 1328 → **1337 passed** (9 new tests)
+
+### Verified
+
+- `ruff check .` ✓
+- `ruff format --check .` ✓
+- `mypy src/ --ignore-missing-imports` ✓
+- `pytest tests/ -q` ✓
+
 ## [3.1.3.2] - 2026-05-18
 
 **Patch — fix four operator-reported bugs in the ClearPass policy visualizer: strict name matching, internal IDs leaking to the user, every enforcement rule mis-labeled "Access: DENY" on real MPSK policies, and the visualization not explaining roles that come from auth-source attributes rather than role-mapping rules.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.3.2"
+version = "3.1.3.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
@@ -207,12 +207,104 @@ _NUMERIC_CSV = re.compile(r"^\d+(?:,\d+)*$")
 _INTERNAL_REF = re.compile(r"^[A-Za-z][A-Za-z0-9_]*:\d+(?:,[A-Za-z][A-Za-z0-9_]*:\d+)*$")
 
 
+_OP_SHORT = {
+    Op.equals: "=",
+    Op.not_equals: "≠",
+    Op.contains: "⊇",
+    Op.not_contains: "⊉",
+    Op.starts_with: "^=",
+    Op.not_starts_with: "^≠",
+    Op.ends_with: "$=",
+    Op.not_ends_with: "$≠",
+    Op.regex: "~=",
+    Op.not_regex: "~≠",
+    Op.in_: "∈",
+    Op.matches_all: "≡",
+    Op.exists: "∃",
+    Op.not_exists: "∄",
+    Op.less_than: "<",
+    Op.less_than_or_equals: "≤",
+    Op.greater_than: ">",
+    Op.greater_than_or_equals: "≥",
+}
+
+
+def expr_to_compact_label(expr: BooleanExpr | None, max_len: int = 80) -> str:
+    """Render a compact single-line label suitable for dense diagrams.
+
+    Trades verbosity for legibility — drops the namespace prefix, uses
+    short operator glyphs, and joins multi-predicate boolean wrappers
+    inline with ``&`` / ``|``. Designed for Mermaid decision-diamond
+    labels in policies with many rules where the multi-line
+    :func:`expr_to_node_label` output collapses into an unreadable
+    column.
+
+    Examples::
+
+        # Single predicate
+        "Device Role ID = 21"
+        # Two-predicate AND
+        "Role = 'IoT Device' & Status = 'Active'"
+        # Long values truncated
+        "memberOf = 'CN=Tier-2-Wireless-Den...'"
+    """
+    if expr is None:
+        return "(no condition)"
+
+    def _trim_rhs(raw: str, display: str, budget: int) -> str:
+        chosen = _pick_rhs_for_display(raw, display)
+        if len(chosen) > budget:
+            chosen = chosen[: max(1, budget - 3)] + "..."
+        return chosen
+
+    def _pred(e: Predicate, budget: int) -> str:
+        attr = e.attribute or e.namespace or "?"
+        op = _OP_SHORT.get(e.op, e.op.value)
+        rhs = _trim_rhs(e.rhs_raw, e.rhs_display, max(8, budget - len(attr) - len(op) - 3))
+        # Quote strings that aren't bare numerics / simple tokens
+        if rhs and not rhs.isdigit() and not all(c.isalnum() or c in "._-" for c in rhs):
+            rhs = f"'{rhs}'"
+        return f"{attr} {op} {rhs}"
+
+    def _render(e: BooleanExpr, budget: int) -> str:
+        if isinstance(e, Predicate):
+            return _pred(e, budget)
+        if isinstance(e, And):
+            parts = [_render(o, budget // max(1, len(e.operands))) for o in e.operands]
+            return " & ".join(parts)
+        if isinstance(e, Or):
+            parts = [_render(o, budget // max(1, len(e.operands))) for o in e.operands]
+            return " | ".join(parts)
+        if isinstance(e, Not):
+            return f"!({_render(e.operand, max(8, budget - 3))})"
+        return str(e)
+
+    label = _render(expr, max_len)
+    if len(label) > max_len:
+        label = label[: max_len - 3] + "..."
+    return label
+
+
+def _pick_rhs_for_display(raw: str, display: str) -> str:
+    """Prefer ``displayValue`` when ``value`` is a bare numeric ID or
+    internal reference token (e.g. ``NadGroup:3004``) — these would
+    otherwise leak opaque IDs into the label.
+    """
+    raw_stripped = raw.strip()
+    if display.strip() and (_NUMERIC_CSV.match(raw_stripped) or _INTERNAL_REF.match(raw_stripped)):
+        return display.strip()
+    return raw
+
+
 def expr_to_node_label(expr: BooleanExpr | None) -> str:
     """Render a multi-line label for a flowchart decision node.
 
     Each predicate becomes three lines (attribute / operator / value).
     Long values wrap at comma boundaries (suitable for AD DNs). AND/OR
     separators appear between predicates.
+
+    For dense diagrams where this verbosity makes the rendered output
+    unreadable, prefer :func:`expr_to_compact_label`.
     """
     if expr is None:
         return "(no condition)"
@@ -234,18 +326,10 @@ def expr_to_node_label(expr: BooleanExpr | None) -> str:
             lines.append(remaining)
         return "\n".join(lines)
 
-    def _pick_rhs(raw: str, display: str) -> str:
-        """Prefer display when raw is a bare numeric ID, numeric CSV, or
-        internal ClearPass reference token (e.g. ``NadGroup:3004``)."""
-        raw_stripped = raw.strip()
-        if display.strip() and (_NUMERIC_CSV.match(raw_stripped) or _INTERNAL_REF.match(raw_stripped)):
-            return display.strip()
-        return raw
-
     def _pred(e: Predicate) -> str:
         attr = f"{e.namespace}:{e.attribute}" if e.namespace else e.attribute
         op = e.raw_operator or e.op.value.upper()
-        rhs = _wrap_value(_pick_rhs(e.rhs_raw, e.rhs_display))
+        rhs = _wrap_value(_pick_rhs_for_display(e.rhs_raw, e.rhs_display))
         return f"{attr}\n{op}\n{rhs}"
 
     def _lines(e: BooleanExpr) -> list[str]:

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from .conditions import expr_to_node_label
+from .conditions import expr_to_compact_label, expr_to_node_label
 from .policy_model import (
     ApplyProfiles,
     EnforcementProfile,
@@ -40,9 +40,20 @@ class FlowNode:
     id: str
     type: NodeType
     label: str
+    # short_label is a compact single-line summary of the same content as
+    # ``label`` — diagram renderers (Mermaid, Graphviz) should prefer this
+    # for the visual node text to keep dense policies legible, and fall
+    # back to ``label`` for inspector/tooltip text where verbosity is fine.
+    # Populated by compile_service() for decision nodes; for non-decision
+    # nodes it's left equal to ``label``.
+    short_label: str = ""
     trace_rule_id: str = ""
     sub_label: str = ""
     rank_group: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.short_label:
+            self.short_label = self.label
 
 
 @dataclass
@@ -136,11 +147,13 @@ def compile_service(service: Service, model: PolicyModel) -> FlowGraph:
     # Service match decision
     # -----------------------------------------------------------------------
     match_label = expr_to_node_label(service.match)
+    match_short = expr_to_compact_label(service.match)
     svc_match = flow.add_node(
         FlowNode(
             id=f"{sid}__match",
             type="decision",
             label=f"Service Match?\n{match_label}",
+            short_label=f"Service Match? {match_short}",
             trace_rule_id=f"{sid}__match",
         )
     )
@@ -188,11 +201,13 @@ def compile_service(service: Service, model: PolicyModel) -> FlowGraph:
         for i, rule in enumerate(enf_rules):
             is_last_enf = i == len(enf_rules) - 1
             cond_label = expr_to_node_label(rule.when)
+            cond_short = expr_to_compact_label(rule.when)
             dec = flow.add_node(
                 FlowNode(
                     id=f"{sid}__enf_rule_{rule.index}",
                     type="decision",
                     label=cond_label,
+                    short_label=cond_short,
                     trace_rule_id=rule.id,
                     rank_group="enf_chain",
                 )
@@ -311,11 +326,13 @@ def compile_service(service: Service, model: PolicyModel) -> FlowGraph:
             for i, rule in enumerate(rm_rules):
                 is_last_rm = i == len(rm_rules) - 1
                 cond_label = expr_to_node_label(rule.when)
+                cond_short = expr_to_compact_label(rule.when)
                 dec = flow.add_node(
                     FlowNode(
                         id=f"{sid}__rm_rule_{rule.index}",
                         type="decision",
                         label=cond_label,
+                        short_label=cond_short,
                         trace_rule_id=rule.id,
                         rank_group="rm_chain",
                     )

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -180,21 +180,37 @@ services = await call_tool("clearpass_list_policy_services", {"limit": 100})
 
 ### Step 3 — Render the FlowGraph as Mermaid
 
-Use this exact template (don't improvise — the consistency across
-sessions is the point of the skill):
+**Critical readability rules (read first):**
+
+1. **Use `flowchart LR` (left-right)**, not `TD`. Role-mapping and
+   enforcement chains often have 12+ rules each — `TD` produces a
+   tall narrow column that the client shrinks to fit width, making
+   every label tiny and unreadable. `LR` lays the chain out
+   horizontally with reasonable node spacing.
+2. **Use `short_label` for every node, NOT `label`.** Each FlowNode
+   carries both: `label` is verbose (3 lines per predicate, full
+   namespace) suitable for inspector tooltips; `short_label` is a
+   compact single-line summary suitable for the diagram. With many
+   rules, `label` produces dense unreadable diamonds.
+3. **For large policies (≥ 8 decision nodes total), split the
+   rendering into 2–3 separate Mermaid blocks** instead of one giant
+   diagram. See "Step 3b — Sectioned rendering" below.
+
+Mermaid template (single-block version, fine for small policies):
 
 ```mermaid
-flowchart TD
-    %% --- nodes ---
+flowchart LR
+    %%{init: {'flowchart': {'nodeSpacing': 30, 'rankSpacing': 50, 'curve': 'basis'}}}%%
+
+    %% --- nodes (use short_label, NOT label) ---
     %% For each node in flow.nodes, emit ONE line:
-    %%   start        →  <id>([service_name])
-    %%   process      →  <id>[label]
-    %%   decision     →  <id>{label}
-    %%   action       →  <id>[/label/]
-    %%   end (allow)  →  <id>(((label)))
-    %%   end (deny)   →  <id>(((label))):::deny
-    %%   end (skip)   →  <id>(((label))):::skip
-    %% Multi-line labels: replace \n with <br/>
+    %%   start        →  <id>([short_label])
+    %%   process      →  <id>[short_label]
+    %%   decision     →  <id>{short_label}
+    %%   action       →  <id>[/short_label/]
+    %%   end (allow)  →  <id>(((short_label)))
+    %%   end (deny)   →  <id>(((short_label))):::deny
+    %%   end (skip)   →  <id>(((short_label))):::skip
 
     %% --- edges ---
     %% For each edge in flow.edges:
@@ -212,10 +228,51 @@ flowchart TD
 
 End-node classification rules (for `:::deny` / `:::skip`):
 
-- `:::deny` if the label starts with `Access: DENY` or `Auth Failed`.
-- `:::skip` if the label starts with `Skip` (the service-no-match
-  branch).
+- `:::deny` if the `short_label` starts with `Access: DENY` or contains
+  `Auth Failed`.
+- `:::skip` if the `short_label` starts with `Skip` (the
+  service-no-match branch).
 - No class (default styling) for `Access: ALLOW` and any non-end node.
+
+### Step 3b — Sectioned rendering (REQUIRED for ≥ 8 decision nodes)
+
+When the policy is large, ONE Mermaid block becomes unreadable even
+with `LR` + `short_label`. Split into:
+
+**Block A — Service intake** (start + service-match + auth + auth-fail):
+
+```
+nodes with id matching <sid>__start, <sid>__match, <sid>__no_match,
+<sid>__auth, <sid>__auth_fail
+plus edges between them
+```
+
+**Block B — Role mapping** (the `rm_chain` rank_group):
+
+```
+nodes with id matching <sid>__rm_rule_*, <sid>__rm_action_*, <sid>__rm_default,
+<sid>__no_role
+plus edges between them
+end this block with a "→ enforcement" placeholder edge to a stub node
+```
+
+**Block C — Enforcement** (the `enf_chain` rank_group):
+
+```
+nodes with id matching <sid>__enf_rule_*, <sid>__enf_action_*, <sid>__enf_end_*,
+<sid>__enf_default_action, <sid>__enf_default_end, <sid>__enf_implicit_deny,
+<sid>__enf_no_policy
+plus edges between them
+start this block with a stub node receiving from "← from role mapping"
+```
+
+Each block gets its own `flowchart LR` + init directive. Operators can
+zoom each section independently. Below the three blocks, add a
+one-sentence connection note: *"All role-mapping outcomes converge to
+the enforcement chain in Block C."*
+
+When in doubt about sizing: if the policy has more than 8 total
+decision nodes across role-mapping + enforcement, split.
 
 ### Step 4 — Output format
 

--- a/tests/unit/test_clearpass_policy_visualizer_adapter.py
+++ b/tests/unit/test_clearpass_policy_visualizer_adapter.py
@@ -14,6 +14,7 @@ from hpe_networking_mcp.platforms.clearpass.policy_visualizer.conditions import 
     Op,
     Or,
     Predicate,
+    expr_to_compact_label,
     expr_to_label,
     expr_to_node_label,
     normalize,
@@ -138,6 +139,79 @@ class TestLabels:
         label = expr_to_node_label(p)
         assert "Employee" in label
         assert "\n1" not in label  # raw "1" should be replaced
+
+
+class TestCompactLabel:
+    """Compact single-line labels for dense diagram nodes."""
+
+    def test_none_input(self):
+        assert expr_to_compact_label(None) == "(no condition)"
+
+    def test_single_predicate_drops_namespace_uses_short_op(self):
+        p = Predicate(
+            namespace="Authorization:[Guest Device Repository]",
+            attribute="Device Role ID",
+            op=Op.equals,
+            rhs_raw="21",
+            rhs_display="",
+        )
+        label = expr_to_compact_label(p)
+        # Namespace dropped, op short, no newlines
+        assert "Authorization:" not in label
+        assert "Device Role ID" in label
+        assert "=" in label
+        assert "21" in label
+        assert "\n" not in label
+        # Reasonable max length
+        assert len(label) < 80
+
+    def test_picks_display_value_over_numeric_raw(self):
+        p = Predicate(
+            namespace="GuestUser",
+            attribute="Role ID",
+            op=Op.equals,
+            rhs_raw="1",
+            rhs_display="Employee",
+        )
+        label = expr_to_compact_label(p)
+        assert "Employee" in label
+        # raw "1" replaced
+        assert label.count("1") == 0 or "Employee" in label
+
+    def test_multi_predicate_and_uses_ampersand(self):
+        expr = And(
+            operands=[
+                Predicate(namespace="Tips", attribute="Role", op=Op.equals, rhs_raw="IoT", rhs_display=""),
+                Predicate(namespace="Endpoint", attribute="Status", op=Op.equals, rhs_raw="Active", rhs_display=""),
+            ]
+        )
+        label = expr_to_compact_label(expr)
+        assert "&" in label
+        assert "Role" in label
+        assert "Status" in label
+        assert "\n" not in label
+
+    def test_multi_predicate_or_uses_pipe(self):
+        expr = Or(
+            operands=[
+                Predicate(namespace="X", attribute="a", op=Op.equals, rhs_raw="1", rhs_display=""),
+                Predicate(namespace="X", attribute="b", op=Op.equals, rhs_raw="2", rhs_display=""),
+            ]
+        )
+        label = expr_to_compact_label(expr)
+        assert "|" in label
+
+    def test_long_label_truncated_with_ellipsis(self):
+        p = Predicate(
+            namespace="X",
+            attribute="memberOf",
+            op=Op.equals,
+            rhs_raw="CN=Tier-2-Wireless-Deny,OU=T2-Groups,OU=Tier 2,OU=Admin Groups,OU=Groups,DC=example,DC=com",
+            rhs_display="",
+        )
+        label = expr_to_compact_label(p, max_len=50)
+        assert len(label) <= 50
+        assert label.endswith("...")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_clearpass_policy_visualizer_flow.py
+++ b/tests/unit/test_clearpass_policy_visualizer_flow.py
@@ -395,6 +395,58 @@ class TestIsDenySemantics:
         assert _is_deny(["unknown_pid"], ["Update DenyList Audit"], {}) is False
 
 
+class TestShortLabelPropagation:
+    """Decision nodes must populate short_label with the compact summary so
+    diagram renderers can produce legible Mermaid for large policies.
+    """
+
+    def test_service_match_decision_has_short_label(self):
+        model = build(_minimal_raw())
+        flow = compile_service(next(iter(model.services.values())), model)
+        match_node = next(n for n in flow.nodes if n.id.endswith("__match"))
+        assert match_node.short_label
+        # short_label must be substantially shorter than label for compound conditions
+        # (label includes 3 lines per predicate; short_label is single line)
+        assert "\n" not in match_node.short_label.replace("\n", " ")[: len(match_node.short_label)]
+        assert match_node.short_label.startswith("Service Match?")
+
+    def test_enforcement_decision_short_label_is_single_line(self):
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": {
+                    "operator": "and",
+                    "displayOperator": "MATCHES_ALL",
+                    "attributes": [
+                        {"type": "Tips", "name": "Role", "operator": "EQUALS", "value": "X"},
+                        {"type": "Endpoint", "name": "Status", "operator": "EQUALS", "value": "Active"},
+                    ],
+                },
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            }
+        ]
+        model = build(_minimal_raw(enf_rules=enf_rules))
+        flow = compile_service(next(iter(model.services.values())), model)
+        enf_dec = next(n for n in flow.nodes if "__enf_rule_" in n.id)
+        # short_label is one line — no embedded newlines
+        assert "\n" not in enf_dec.short_label
+        # label is the verbose multi-line form
+        assert "\n" in enf_dec.label
+        # short_label still encodes both conditions joined with &
+        assert "&" in enf_dec.short_label
+
+    def test_non_decision_nodes_default_short_label_to_label(self):
+        """For start/process/action/end nodes, short_label defaults to label."""
+        model = build(_minimal_raw())
+        flow = compile_service(next(iter(model.services.values())), model)
+        for node in flow.nodes:
+            if node.type != "decision":
+                # These nodes don't get a compact override — default == label
+                assert node.short_label == node.label, (
+                    f"Non-decision node {node.id} ({node.type}) has short_label != label"
+                )
+
+
 class TestCompileServiceRadiusProxy:
     def test_radius_proxy_skips_auth_and_role_mapping(self):
         enf_rules = [


### PR DESCRIPTION
## Summary

Operator screenshot showed v3.1.3.2 producing the correct data but rendering as one tall narrow column with tiny text — unreadable. With ~30 decision diamonds across role-mapping + enforcement chains for a real MAC-auth + MPSK policy, Mermaid's default `flowchart TD` + the verbose multi-line `expr_to_node_label` output collapsed under the conversation's width constraint.

## Three coordinated fixes

### 1. New `expr_to_compact_label()` in `conditions.py`

Single-line summaries with short operator glyphs (`=` `≠` `~=` `∈` `&` `|`), namespace dropped, `displayValue` preferred over numeric IDs, 80-char cap with ellipsis truncation.

```
# expr_to_node_label (verbose — 3 lines per predicate, for inspector tooltips):
Authorization:[Guest Device Repository]:Device Role ID
EQUALS
21

# expr_to_compact_label (compact single-line, for diagram nodes):
Device Role ID = 21
```

### 2. `FlowNode.short_label` field

Populated by `compile_service()` for every decision node. Diagram renderers should prefer `short_label`; `label` stays around for inspector / tooltip / details content where verbosity is fine. For non-decision nodes (`start`, `process`, `action`, `end`), `short_label` defaults to `label` via `__post_init__` so existing rendering paths still work unchanged.

### 3. Skill template rewritten for legibility

- Default direction switched to `flowchart LR` (left-right). Long chains lay out horizontally instead of stacking vertically.
- Explicit Mermaid `%%{init: ...}%%` directive prescribing reasonable `nodeSpacing` / `rankSpacing`.
- Template now uses `short_label` for every node, NOT `label`.
- New **Step 3b — Sectioned rendering** REQUIRED for policies with ≥ 8 decision nodes: render service-intake / role-mapping / enforcement as three separate Mermaid blocks. Each block fits on screen, operators zoom each independently.

## Counts

- ClearPass tools: still 142
- pytest: 1328 → **1337 passed** (9 new tests)

## Files changed

- `src/.../platforms/clearpass/policy_visualizer/conditions.py` — `expr_to_compact_label()` + `_OP_SHORT` glyph map + extracted `_pick_rhs_for_display()`.
- `src/.../platforms/clearpass/policy_visualizer/flow_graph.py` — `FlowNode.short_label` field with `__post_init__` default; every decision-node construction populates it.
- `src/.../skills/clearpass-policy-walker.md` — Step 3 rewritten (`LR` default + `short_label` requirement + Mermaid init); new Step 3b on sectioned rendering for large policies.
- `tests/unit/test_clearpass_policy_visualizer_adapter.py` — `TestCompactLabel` (6 cases).
- `tests/unit/test_clearpass_policy_visualizer_flow.py` — `TestShortLabelPropagation` (3 cases).
- `pyproject.toml` — 3.1.3.2 → 3.1.3.3.
- `CHANGELOG.md` — new entry.

## Test plan

- [x] `ruff check .` ✓
- [x] `ruff format --check .` ✓
- [x] `mypy src/ --ignore-missing-imports` ✓
- [x] `pytest tests/ -q` ✓ (1337 passed, 1 skipped)
- [ ] After merge + tag + release + image rebuild: live-verify *No Wireless For You Auth Service* renders as three readable Mermaid blocks (service-intake / role-mapping / enforcement) with one-line decision labels like `Device Role ID = 21`.