### PR TITLE
v3.1.4.0: ClearPass policy visualizer — what-if simulator with uncertainty-first contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,93 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4.0] - 2026-05-18
+
+**Minor — ClearPass policy visualizer gains a what-if simulator. Pass a `simulated_attributes` context (roles, endpoint status, time, visitor name, etc.) and the tool evaluates every rule's predicates against it, returning per-decision-node `simulation_match` flags + a top-level `SimulationOutcome` describing the matched rules, resulting roles, applied profiles, and access decision.**
+
+### Why now
+
+Operator's prior session showed an earlier (pre-v3.1.3.2) simulator-like rendering producing confidently wrong outcomes — the post-auth bucketing bug had every MPSK rule mis-classified as DENY and the visualization presented that as "this is what fires." The whole point of the new simulator is to be **uncertainty-first**: when it can't evaluate a predicate, it returns `None` and the skill MUST surface that as "need more info" rather than guessing.
+
+### Three-valued evaluator
+
+New `conditions.evaluate(expr, context)` — full `Op` coverage with strict three-valued logic:
+
+- `True` — condition is satisfied by the supplied context.
+- `False` — condition is contradicted.
+- `None` — at least one referenced attribute is missing from the context → genuinely unknown.
+
+`And` / `Or` / `Not` propagate `None` correctly:
+
+| Logic | Result |
+|---|---|
+| `True AND None` | `None` (can't claim AND is True without knowing the other) |
+| `False AND None` | `False` (short-circuit — AND already contradicted) |
+| `True OR None` | `True` (short-circuit — OR already satisfied) |
+| `False OR None` | `None` (can't claim OR is False without knowing the other) |
+| `NOT None` | `None` |
+
+### Multi-valued attribute support
+
+`Tips:Role` and similar attributes accept a `list[str]` context value (for evaluate-all role mapping where a device ends up with multiple roles). Semantics:
+
+- Positive ops (`equals`, `contains`, `regex`, `in_`, ...) → match if ANY value satisfies.
+- Negative ops (`not_equals`, `not_contains`, ...) → match only if ALL values satisfy ("none of the roles is X").
+
+### End-to-end simulation outcome
+
+The tool's response now carries a `simulation` block when `simulated_attributes` is supplied:
+
+```json
+{
+  "simulation": {
+    "requested_attributes": {"Connection:SSID": "TestSSID", "GuestUser:Role ID": "11"},
+    "status": "resolved",            // "resolved" | "uncertain" | "no_match"
+    "matching_role_mapping_rules": ["RM_rule_0"],
+    "resulting_roles": ["Kid"],
+    "matching_enforcement_rule": "EP_rule_0",
+    "applied_profiles": ["WLAN-KID", "VLAN-USER"],
+    "access_decision": "ALLOW",       // "ALLOW" | "DENY" | "UNKNOWN"
+    "unknown_attributes": [],
+    "notes": []
+  }
+}
+```
+
+The simulator merges resolved roles into the enforcement-evaluation context as `Tips:Role` so enforcement rules that match on role correctly resolve.
+
+### Skill workflow (Step 5)
+
+`clearpass-policy-walker` adds Step 5 — a REQUIRED post-render prompt offering the simulation, plus Step 5a defining the strict output contract:
+
+| `simulation.status` | What the AI says to the operator |
+|---|---|
+| `"resolved"` | Confidently name the matching rule + access decision |
+| `"uncertain"` | DO NOT name an outcome. List all `unknown_attributes` and ask for them. |
+| `"no_match"` | "No rule matched — implicit deny." |
+
+Step 5b adds re-render guidance with classDefs for green-match / dim-skip / yellow-unknown highlighting. Step 5c gives attribute prompting hints (common keys: `Tips:Role`, `GuestUser:visitor`, `Endpoint:Status`, `Connection:NAD-IP-Address`, etc.).
+
+### Files changed
+
+- `src/.../clearpass/policy_visualizer/conditions.py` — `evaluate()` + per-Op evaluators + multi-valued attribute support + `_attribute_path()` + `_collect_unknown_attrs()` exposed for the simulator.
+- `src/.../clearpass/policy_visualizer/flow_graph.py` — `SimulationOutcome` dataclass + `FlowNode.simulation_match` field + `FlowGraph.simulation` field + `_apply_simulation()` walking service-match → RM chain → EP chain with strict uncertainty propagation.
+- `src/.../clearpass/tools/policy_visualizer.py` — `simulated_attributes` parameter; `simulation` block in the response when supplied.
+- `src/.../skills/clearpass-policy-walker.md` — Step 5 / 5a / 5b / 5c covering the simulation workflow + uncertainty-first output contract + classDef highlighting + attribute prompting hints.
+- `tests/unit/test_clearpass_policy_visualizer_simulator.py` — comprehensive new test file: per-Op coverage, three-valued boolean propagation, multi-valued attribute semantics, the previously-burned partial-context case, and end-to-end simulation correctness.
+
+### Counts
+
+- ClearPass tools: still 142 (existing tool gained a parameter — no new tool)
+- pytest: 1337 → **1370 passed** (33 new tests in the simulator file)
+
+### Verified
+
+- `ruff check .` ✓
+- `ruff format --check .` ✓
+- `mypy src/ --ignore-missing-imports` ✓
+- `pytest tests/ -q` ✓
+
 ## [3.1.3.3] - 2026-05-18
 
 **Patch — make the rendered ClearPass policy flow readable for large policies. Operator's screenshot showed the diagram correctly produced but rendered as one tall narrow column with tiny text, because Mermaid's default `flowchart TD` + the verbose multi-line decision labels collapsed under the conversation's width constraint.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.3.3"
+version = "3.1.4.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/__init__.py
@@ -8,9 +8,10 @@ Pipeline:
     REST JSON
       → api_adapter.adapt()      raw dict in policy_model's expected shape
       → policy_model.build()     typed PolicyModel (services + cross-refs)
-      → flow_graph.compile_service()    FlowGraph (nodes + edges)
+      → flow_graph.compile_service()    FlowGraph (nodes + edges +
+                                                    optional simulation)
 
-Lifted (and adapted) from the policy-visualizer project. Cisco ISE
-support, the FastAPI HTTP layer, and the XML parser are intentionally
-omitted — we pull live data via the existing ``clearpass_get_*`` tools.
+ClearPass-only. The upstream project this was lifted from also supported
+Cisco ISE; those code paths were stripped during the port and the
+engine has no ISE-specific operators, parsers, or data models.
 """

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
@@ -125,6 +125,233 @@ class Not:
 BooleanExpr = Predicate | And | Or | Not
 
 
+# ---------------------------------------------------------------------------
+# Predicate evaluator (simulation engine)
+# ---------------------------------------------------------------------------
+
+
+# Attributes that ClearPass treats as multi-valued — when an operator passes
+# a list for these, the predicate matches if ANY value in the list satisfies
+# the condition. For a scalar value (string) we treat it as a single-element
+# list, so callers can pass strings interchangeably for unambiguous attributes.
+MULTI_VALUED_ATTRIBUTE_NAMES = frozenset({"Role"})
+
+
+def _attribute_path(predicate: Predicate) -> str:
+    """Return the canonical lookup key for a predicate's attribute.
+
+    Example: ``Predicate(namespace='Tips', attribute='Role')`` →
+    ``'Tips:Role'``. Matches the shape callers should use for keys in
+    the ``simulated_attributes`` dict.
+    """
+    if predicate.namespace and predicate.attribute:
+        return f"{predicate.namespace}:{predicate.attribute}"
+    return predicate.attribute or predicate.namespace or ""
+
+
+def _values_for(predicate: Predicate, context: dict[str, str | list[str]]) -> list[str] | None:
+    """Look up the simulated value(s) for a predicate.
+
+    Returns ``None`` if no value is provided (the simulation cannot
+    evaluate this predicate — callers MUST treat ``None`` as
+    "uncertain", never as a false match). Returns a list (possibly
+    single-element) when a value is present.
+    """
+    key = _attribute_path(predicate)
+    if key not in context:
+        return None
+    value = context[key]
+    if isinstance(value, list):
+        # Preserve empty list as a present-but-empty attribute (matters for
+        # exists/not_exists). Callers can still pass `[]` to mean "this
+        # attribute is known to have no values."
+        return list(value)
+    # Scalar — wrap so the multi-valued comparators have a uniform shape.
+    return [value]
+
+
+def _eval_predicate_against_value(op: Op, value: str, rhs: str) -> bool:
+    """Apply a single Op to a single (value, rhs) pair.
+
+    Pure boolean — returns True/False only. Callers handle the
+    multi-value case (any-match for multi-valued attributes).
+    """
+    if op is Op.equals or op is Op.matches_exact:
+        return value == rhs
+    if op is Op.not_equals or op is Op.not_matches_exact:
+        return value != rhs
+    if op is Op.equals_ignore_case:
+        return value.lower() == rhs.lower()
+    if op is Op.not_equals_ignore_case:
+        return value.lower() != rhs.lower()
+    if op is Op.contains:
+        return rhs in value
+    if op is Op.not_contains:
+        return rhs not in value
+    if op is Op.starts_with:
+        return value.startswith(rhs)
+    if op is Op.not_starts_with:
+        return not value.startswith(rhs)
+    if op is Op.ends_with:
+        return value.endswith(rhs)
+    if op is Op.not_ends_with:
+        return not value.endswith(rhs)
+    if op is Op.regex:
+        try:
+            return re.search(rhs, value) is not None
+        except re.error:
+            return False
+    if op is Op.not_regex:
+        try:
+            return re.search(rhs, value) is None
+        except re.error:
+            return False
+    if op is Op.in_:
+        # RHS is comma-separated list of allowed values
+        allowed = {v.strip() for v in rhs.split(",")}
+        return value in allowed
+    if op is Op.matches_all:
+        # MATCHES_ALL on a per-predicate basis with a single value is
+        # effectively equality against each item in the comma-separated
+        # rhs — we treat it as "value equals every item" which is only
+        # true when rhs is a single item equal to value.
+        items = [v.strip() for v in rhs.split(",")]
+        return all(value == item for item in items)
+    if op is Op.belongs_to_group:
+        # No way to evaluate group membership without group data — return
+        # False conservatively. Operators should supply explicit role
+        # membership through `Tips:Role` instead of relying on group
+        # lookups.
+        return False
+    if op is Op.not_belongs_to_group:
+        return False
+    if op is Op.less_than:
+        return _numeric_compare(value, rhs, lambda a, b: a < b)
+    if op is Op.less_than_or_equals:
+        return _numeric_compare(value, rhs, lambda a, b: a <= b)
+    if op is Op.greater_than:
+        return _numeric_compare(value, rhs, lambda a, b: a > b)
+    if op is Op.greater_than_or_equals:
+        return _numeric_compare(value, rhs, lambda a, b: a >= b)
+    if op is Op.in_range:
+        # rhs is typically "start-end" — interpret leniently
+        try:
+            start, end = rhs.split("-", 1)
+            return _numeric_compare(start.strip(), value, lambda a, b: a <= b) and _numeric_compare(
+                value, end.strip(), lambda a, b: a <= b
+            )
+        except ValueError:
+            return False
+    # exists / not_exists are handled at the caller level (they don't need
+    # the value, just the presence). If we get here for one, fail safe.
+    if op is Op.exists:
+        return True  # value was present to get here
+    if op is Op.not_exists:
+        return False
+    return False
+
+
+def _numeric_compare(a: str, b: str, cmp) -> bool:
+    """Try numeric comparison, fall back to string. False on non-numeric coercion failure."""
+    try:
+        return cmp(float(a), float(b))
+    except (ValueError, TypeError):
+        try:
+            return cmp(a, b)
+        except TypeError:
+            return False
+
+
+def evaluate(expr: BooleanExpr | None, context: dict[str, str | list[str]]) -> bool | None:
+    """Evaluate a :data:`BooleanExpr` against a simulated attribute context.
+
+    Returns ``True`` / ``False`` / ``None`` (three-valued logic):
+
+    - ``True``: condition is satisfied by the context.
+    - ``False``: condition is contradicted by the context.
+    - ``None``: at least one referenced attribute is missing from the
+      context — the result is genuinely unknown.
+
+    Callers MUST treat ``None`` as uncertainty and never present it as
+    a confident outcome. This is load-bearing for correctness — the
+    prior fake-simulator burned the operator by presenting unevaluable
+    rules as confident DENYs.
+
+    Boolean propagation:
+
+    - ``And``: True if all True; False if any False; otherwise None.
+    - ``Or``: True if any True; False if all False; otherwise None.
+    - ``Not``: inverts True/False; passes through None.
+
+    Multi-valued attribute semantics: when the context supplies a list
+    for an attribute (e.g. ``Tips:Role`` with multiple assigned roles
+    from evaluate-all role mapping), the predicate matches if ANY value
+    in the list satisfies the condition. For ``not_*`` operators this
+    means ALL values must satisfy the "not" — a stricter semantic that
+    matches ClearPass behavior.
+    """
+    if expr is None:
+        return True  # absent condition matches everything
+
+    if isinstance(expr, Predicate):
+        return _evaluate_predicate(expr, context)
+    if isinstance(expr, And):
+        return _eval_and([evaluate(o, context) for o in expr.operands])
+    if isinstance(expr, Or):
+        return _eval_or([evaluate(o, context) for o in expr.operands])
+    if isinstance(expr, Not):
+        inner = evaluate(expr.operand, context)
+        return None if inner is None else not inner
+    return None
+
+
+def _evaluate_predicate(predicate: Predicate, context: dict[str, str | list[str]]) -> bool | None:
+    """Evaluate a single predicate. Returns None when the attribute is unknown."""
+    op = predicate.op
+    # Exists / not_exists are special — they only need to know presence
+    if op is Op.exists:
+        return _attribute_path(predicate) in context
+    if op is Op.not_exists:
+        return _attribute_path(predicate) not in context
+
+    values = _values_for(predicate, context)
+    if values is None:
+        return None  # unknown attribute
+
+    rhs = predicate.rhs_display or predicate.rhs_raw
+
+    # Multi-valued semantics:
+    #   For positive ops (equals, contains, regex, ...): ANY match → True
+    #   For negative ops (not_equals, not_contains, ...): ALL must hold → True
+    is_negative_op = op.value.startswith("not_") or op is Op.not_regex
+
+    if not values:
+        # Empty list: positive ops cannot match (no value to satisfy them);
+        # negative ops trivially hold (no value contradicts them).
+        return is_negative_op
+
+    per_value = [_eval_predicate_against_value(op, v, rhs) for v in values]
+    if is_negative_op:
+        return all(per_value)
+    return any(per_value)
+
+
+def _eval_and(results: list[bool | None]) -> bool | None:
+    if any(r is False for r in results):
+        return False
+    if any(r is None for r in results):
+        return None
+    return True
+
+
+def _eval_or(results: list[bool | None]) -> bool | None:
+    if any(r is True for r in results):
+        return True
+    if any(r is None for r in results):
+        return None
+    return False
+
+
 def _normalize_predicate(raw_attr: dict) -> Predicate:
     return Predicate(
         namespace=raw_attr.get("type", ""),

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from .conditions import expr_to_compact_label, expr_to_node_label
+from .conditions import evaluate, expr_to_compact_label, expr_to_node_label
 from .policy_model import (
     ApplyProfiles,
     EnforcementProfile,
@@ -50,10 +50,52 @@ class FlowNode:
     trace_rule_id: str = ""
     sub_label: str = ""
     rank_group: str = ""
+    # Populated when compile_service is called with simulated_attributes.
+    # ``True``  → the rule fires under the simulated context
+    # ``False`` → the rule's condition is contradicted
+    # ``None``  → cannot evaluate (at least one referenced attribute missing
+    #             from the context — caller MUST NOT present this as a
+    #             confident outcome)
+    # Absent (when no simulation was requested) — left as None.
+    simulation_match: bool | None = None
 
     def __post_init__(self) -> None:
         if not self.short_label:
             self.short_label = self.label
+
+
+@dataclass
+class SimulationOutcome:
+    """Result of a what-if simulation against a chosen ``simulated_attributes`` context.
+
+    Populated only when :func:`compile_service` is called with a
+    non-empty ``simulated_attributes`` arg. Distinct from a per-node
+    ``simulation_match`` because it summarizes the END-TO-END outcome:
+    which role-mapping rules matched (and so what roles were assigned),
+    which enforcement rule was the first-applicable winner, what
+    profiles got applied, and what the resulting access decision was.
+
+    The ``status`` field is the most important — three values:
+
+    - ``"resolved"`` — every consulted predicate could be evaluated;
+      ``matching_enforcement_rule`` / ``access_decision`` are authoritative.
+    - ``"uncertain"`` — at least one predicate in the consulted chain
+      returned None (unknown attribute). The simulator cannot make a
+      confident claim; callers MUST present this as
+      "need attribute X, Y, Z to resolve" rather than naming an outcome.
+    - ``"no_match"`` — every rule's condition resolved to False; the
+      access decision is the policy's default branch.
+    """
+
+    requested_attributes: dict[str, str | list[str]]
+    status: str  # "resolved" | "uncertain" | "no_match"
+    matching_role_mapping_rules: list[str]
+    resulting_roles: list[str]
+    matching_enforcement_rule: str | None
+    applied_profiles: list[str]
+    access_decision: str  # "ALLOW" | "DENY" | "UNKNOWN"
+    unknown_attributes: list[str]
+    notes: list[str]
 
 
 @dataclass
@@ -71,6 +113,7 @@ class FlowGraph:
     service_type: str = "RADIUS"
     nodes: list[FlowNode] = field(default_factory=list)
     edges: list[FlowEdge] = field(default_factory=list)
+    simulation: SimulationOutcome | None = None
 
     def add_node(self, node: FlowNode) -> FlowNode:
         self.nodes.append(node)
@@ -133,8 +176,19 @@ def _profiles_label(profile_names: list[str]) -> str:
     return ", ".join(profile_names) if profile_names else "Apply profiles"
 
 
-def compile_service(service: Service, model: PolicyModel) -> FlowGraph:
-    """Compile one service into a :class:`FlowGraph`."""
+def compile_service(
+    service: Service,
+    model: PolicyModel,
+    simulated_attributes: dict[str, str | list[str]] | None = None,
+) -> FlowGraph:
+    """Compile one service into a :class:`FlowGraph`.
+
+    When ``simulated_attributes`` is provided, the resulting graph also
+    carries per-decision-node ``simulation_match`` flags and a
+    top-level :class:`SimulationOutcome` describing the end-to-end
+    what-if result. See :class:`SimulationOutcome` for the
+    uncertainty-first contract.
+    """
     flow = FlowGraph(service_id=service.id, service_name=service.name, service_type=service.service_type)
     sid = service.id
 
@@ -384,4 +438,242 @@ def compile_service(service: Service, model: PolicyModel) -> FlowGraph:
             # No role mapping — go straight to enforcement
             flow.add_edge(current_tail, enf_entry_id, current_label)
 
+    # Run what-if simulation against the supplied context, if any.
+    if simulated_attributes is not None:
+        _apply_simulation(service, model, flow, simulated_attributes)
+
     return flow
+
+
+# ---------------------------------------------------------------------------
+# What-if simulation
+# ---------------------------------------------------------------------------
+
+
+def _collect_unknown_attrs(expr, context: dict[str, str | list[str]]) -> set[str]:
+    """Walk a BooleanExpr and return the set of attribute paths referenced
+    that aren't present in ``context`` — these are what the caller needs
+    to provide to resolve an "uncertain" simulation outcome.
+    """
+    from .conditions import And, Not, Or, Predicate, _attribute_path
+
+    out: set[str] = set()
+    if expr is None:
+        return out
+    if isinstance(expr, Predicate):
+        path = _attribute_path(expr)
+        if path and path not in context:
+            out.add(path)
+        return out
+    if isinstance(expr, (And, Or)):
+        for operand in expr.operands:
+            out |= _collect_unknown_attrs(operand, context)
+        return out
+    if isinstance(expr, Not):
+        return _collect_unknown_attrs(expr.operand, context)
+    return out
+
+
+def _set_node_match(flow: FlowGraph, node_id: str, result: bool | None) -> None:
+    """Set ``simulation_match`` on the decision node with the given ID."""
+    for node in flow.nodes:
+        if node.id == node_id:
+            node.simulation_match = result
+            return
+
+
+def _apply_simulation(
+    service: Service,
+    model: PolicyModel,
+    flow: FlowGraph,
+    context: dict[str, str | list[str]],
+) -> None:
+    """Run the what-if simulation and attach :class:`SimulationOutcome` to the flow.
+
+    Strict uncertainty contract: if any consulted predicate evaluates
+    to ``None``, the outcome status is ``"uncertain"`` and the access
+    decision is ``"UNKNOWN"``. Never produce a confident outcome from a
+    partial evaluation.
+    """
+    sid = service.id
+    unknown_attrs: set[str] = set()
+    notes: list[str] = []
+
+    # ---- Service match
+    svc_match_result = evaluate(service.match, context)
+    _set_node_match(flow, f"{sid}__match", svc_match_result)
+    if svc_match_result is None:
+        unknown_attrs |= _collect_unknown_attrs(service.match, context)
+        flow.simulation = SimulationOutcome(
+            requested_attributes=dict(context),
+            status="uncertain",
+            matching_role_mapping_rules=[],
+            resulting_roles=[],
+            matching_enforcement_rule=None,
+            applied_profiles=[],
+            access_decision="UNKNOWN",
+            unknown_attributes=sorted(unknown_attrs),
+            notes=["Service match condition is uncertain — provide the missing attribute(s) and re-simulate."],
+        )
+        return
+    if svc_match_result is False:
+        flow.simulation = SimulationOutcome(
+            requested_attributes=dict(context),
+            status="no_match",
+            matching_role_mapping_rules=[],
+            resulting_roles=[],
+            matching_enforcement_rule=None,
+            applied_profiles=[],
+            access_decision="UNKNOWN",
+            unknown_attributes=[],
+            notes=["Service match returned False — this service does not apply to the simulated request."],
+        )
+        return
+
+    # ---- Role mapping (skipped for RADIUS_PROXY)
+    matching_rm_rules: list[str] = []
+    resulting_roles: list[str] = []
+    if service.service_type != "RADIUS_PROXY":
+        rm = model.role_mapping_policies.get(service.role_mapping_policy_id)
+        if rm is None:
+            rm = next(
+                (v for v in model.role_mapping_policies.values() if v.name == service.role_mapping_policy_name),
+                None,
+            )
+        if rm is not None:
+            evaluate_all_rm = rm.rule_combine_algo == "evaluate-all"
+            rm_uncertain = False
+            for rule in rm.rules:
+                result = evaluate(rule.when, context)
+                _set_node_match(flow, f"{sid}__rm_rule_{rule.index}", result)
+                if result is True:
+                    matching_rm_rules.append(rule.id)
+                    if (
+                        isinstance(rule.then, SetRole)
+                        and rule.then.role_name
+                        and rule.then.role_name not in resulting_roles
+                    ):
+                        resulting_roles.append(rule.then.role_name)
+                    if not evaluate_all_rm:
+                        break
+                elif result is None:
+                    rm_uncertain = True
+                    unknown_attrs |= _collect_unknown_attrs(rule.when, context)
+                    if not evaluate_all_rm:
+                        break
+            # Apply the default role only when no rule matched AND the
+            # chain was deterministic — never silently apply a default
+            # when uncertainty exists earlier in the chain.
+            if not matching_rm_rules and not rm_uncertain and rm.default is not None and rm.default.role_name:
+                resulting_roles.append(rm.default.role_name)
+            if rm_uncertain:
+                notes.append("Role mapping chain has uncertain rule(s); resulting role set may be incomplete.")
+
+    # ---- Build the enforcement-context by merging resolved roles into Tips:Role.
+    # If the operator also passed Tips:Role explicitly, union both sets.
+    ep_context: dict[str, str | list[str]] = dict(context)
+    if resulting_roles:
+        explicit = ep_context.get("Tips:Role")
+        if isinstance(explicit, list):
+            ep_context["Tips:Role"] = list({*explicit, *resulting_roles})
+        elif isinstance(explicit, str):
+            ep_context["Tips:Role"] = list({explicit, *resulting_roles})
+        else:
+            ep_context["Tips:Role"] = list(resulting_roles)
+
+    # ---- Enforcement
+    matching_ep_rule: str | None = None
+    applied_profiles: list[str] = []
+    ep = model.enforcement_policies.get(service.enforcement_policy_id)
+    if ep is None:
+        ep = next(
+            (v for v in model.enforcement_policies.values() if v.name == service.enforcement_policy_name),
+            None,
+        )
+
+    ep_uncertain = False
+    if ep is None or not ep.rules:
+        flow.simulation = SimulationOutcome(
+            requested_attributes=dict(context),
+            status="no_match",
+            matching_role_mapping_rules=matching_rm_rules,
+            resulting_roles=resulting_roles,
+            matching_enforcement_rule=None,
+            applied_profiles=[],
+            access_decision="DENY",
+            unknown_attributes=sorted(unknown_attrs),
+            notes=notes + ["No enforcement policy attached — service implicitly denies."],
+        )
+        return
+
+    evaluate_all_ep = ep.rule_combine_algo == "evaluate-all"
+    for rule in ep.rules:
+        result = evaluate(rule.when, ep_context)
+        _set_node_match(flow, f"{sid}__enf_rule_{rule.index}", result)
+        if result is True:
+            if not evaluate_all_ep:
+                matching_ep_rule = rule.id
+                if isinstance(rule.then, ApplyProfiles):
+                    applied_profiles = list(rule.then.profile_names)
+                break
+            # evaluate-all: collect all matching rules' profiles, no break
+            if matching_ep_rule is None:
+                matching_ep_rule = rule.id  # report the first matched as the "primary" winner
+            if isinstance(rule.then, ApplyProfiles):
+                applied_profiles.extend(p for p in rule.then.profile_names if p not in applied_profiles)
+        elif result is None:
+            ep_uncertain = True
+            unknown_attrs |= _collect_unknown_attrs(rule.when, ep_context)
+            if not evaluate_all_ep:
+                # In first-applicable mode, hitting an uncertain rule
+                # before any True means we can't determine the winner.
+                notes.append(
+                    f"Enforcement rule {rule.index} is uncertain — cannot determine the first-applicable "
+                    "winner without resolving it."
+                )
+                break
+
+    # Default branch only when chain was deterministic + no rule matched
+    if (
+        matching_ep_rule is None
+        and not ep_uncertain
+        and ep.default is not None
+        and isinstance(ep.default, ApplyProfiles)
+        and ep.default.profile_names
+    ):
+        applied_profiles = list(ep.default.profile_names)
+        matching_ep_rule = f"{ep.id}__default"
+
+    # ---- Determine outcome
+    if ep_uncertain or matching_ep_rule is None and unknown_attrs:
+        status = "uncertain"
+        access = "UNKNOWN"
+    elif matching_ep_rule is None:
+        status = "no_match"
+        access = "DENY"  # implicit deny when nothing matched and no default
+        notes.append("No enforcement rule matched and no default profile — implicit deny.")
+    else:
+        status = "resolved"
+        # Resolve profile names → ids to apply _is_deny semantics
+        profile_ids: list[str] = []
+        for pname in applied_profiles:
+            match = next((p for p in model.enforcement_profiles.values() if p.name == pname), None)
+            profile_ids.append(match.id if match else "")
+        access = "DENY" if _is_deny(profile_ids, applied_profiles, model.enforcement_profiles) else "ALLOW"
+
+    if unknown_attrs and status == "uncertain":
+        notes.append(
+            f"Resolve {len(unknown_attrs)} missing attribute(s) and re-simulate: {', '.join(sorted(unknown_attrs))}"
+        )
+
+    flow.simulation = SimulationOutcome(
+        requested_attributes=dict(context),
+        status=status,
+        matching_role_mapping_rules=matching_rm_rules,
+        resulting_roles=resulting_roles,
+        matching_enforcement_rule=matching_ep_rule,
+        applied_profiles=applied_profiles,
+        access_decision=access,
+        unknown_attributes=sorted(unknown_attrs),
+        notes=notes,
+    )

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
@@ -167,6 +167,7 @@ async def clearpass_compile_policy_flow(
     service_id: int | None = None,
     service_name: str | None = None,
     include_details: bool = False,
+    simulated_attributes: dict[str, str | list[str]] | None = None,
 ) -> dict | str:
     """Compile a ClearPass policy service into a FlowGraph for rendering.
 
@@ -197,6 +198,21 @@ async def clearpass_compile_policy_flow(
         include_details: When true, attaches an ``"details"`` block
             with per-rule action / linked-names data suitable for an
             inspector view alongside the rendered diagram.
+        simulated_attributes: Optional what-if context for predicate
+            evaluation. Keys are attribute paths
+            (``"<namespace>:<attribute>"`` — e.g. ``"Tips:Role"``,
+            ``"GuestUser:visitor"``, ``"Endpoint:Status"``,
+            ``"Connection:NAD-IP-Address"``). Values are strings or
+            lists of strings (lists for multi-valued attributes like
+            ``Tips:Role`` under evaluate-all role mapping). When set,
+            the response carries per-decision-node ``simulation_match``
+            flags AND a top-level ``simulation`` dict describing the
+            end-to-end what-if outcome (matching rules, resulting
+            roles, applied profiles, access decision, and — critically
+            — any ``unknown_attributes`` whose absence prevents a
+            confident answer). When ``simulation.status == "uncertain"``
+            the caller MUST surface that to the operator as "need
+            more info" rather than presenting an outcome.
 
     Returns:
         On success — dict with ``service_id`` (engine slug),
@@ -260,7 +276,7 @@ async def clearpass_compile_policy_flow(
         if target is None:
             return f"Internal error: service '{target_name}' resolved from REST but not present in compiled model"
 
-        flow = compile_service(target, model)
+        flow = compile_service(target, model, simulated_attributes=simulated_attributes)
         result: dict[str, Any] = {
             "service_id": flow.service_id,
             "service_name": flow.service_name,
@@ -271,6 +287,8 @@ async def clearpass_compile_policy_flow(
         }
         if include_details:
             result["details"] = build_details(target, model)
+        if flow.simulation is not None:
+            result["simulation"] = asdict(flow.simulation)
         return result
     except Exception as e:
         return f"Error compiling policy flow: {e}"

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -345,6 +345,93 @@ Access-Accept and the action node lists the per-device profiles
 (MPSK passphrase, VLAN, downloadable role, endpoint updates) that
 ride with it.
 
+## Step 5 — What-if simulation (REQUIRED prompt after rendering)
+
+After Step 4 finishes (header + diagram + warnings + walkthrough),
+**you MUST offer the operator the simulation workflow.** Add a
+section to your reply:
+
+> **Want to see what fires for a specific device?**
+> I can simulate the policy against a device's attributes — tell me
+> the role(s) and any other attributes (visitor name, endpoint
+> status, time, etc.) and I'll re-render with the matching path
+> highlighted. Example: *"Role=Kid, GuestUser:visitor=Bobby,
+> time=20:00"*.
+
+When the operator responds with attributes, you re-call
+``clearpass_compile_policy_flow`` with ``simulated_attributes`` set
+and re-render with the matched path highlighted. The attribute keys
+use ``"<namespace>:<attribute>"`` form — the keys you saw in the
+rendered decision conditions. Values are strings or lists of strings.
+
+### Step 5a — Required UNCERTAINTY-FIRST output contract
+
+The simulator returns a ``simulation`` block with a ``status`` field
+that is the single most important value in the response. **You MUST
+honor it:**
+
+| ``simulation.status`` | What you say to the operator |
+|---|---|
+| ``"resolved"`` | Confidently name the matching enforcement rule and access decision: *"Matches **E11** → applies WLAN-NIGHT-NIGHT + VLAN-USER + MPSK + timeout 7am + SDWAN role updates → **Access: ALLOW**"* |
+| ``"uncertain"`` | DO NOT name an outcome. Say: *"Cannot determine the outcome without these additional attribute(s): `GuestUser:visitor`, `Endpoint:Status`. Provide them and I'll re-simulate."* List ALL items in ``simulation.unknown_attributes``. |
+| ``"no_match"`` | *"No enforcement rule matched the simulated context — falls through to implicit deny."* |
+
+This contract is load-bearing. A prior version of this skill
+appeared to support simulation but produced confidently wrong
+outcomes (the post-auth bucketing bug in v3.1.3.0 mis-classified
+every MPSK rule as DENY, and the simulator dutifully reported that as
+the answer). The current engine returns ``None`` for any predicate it
+can't evaluate, propagates ``None`` through And/Or/Not, and surfaces
+``unknown_attributes`` explicitly so the AI never has to guess.
+**Never override ``status: "uncertain"`` with a confident guess.**
+
+### Step 5b — Highlighting the matched path in the re-rendered diagram
+
+When you re-render after a simulation call, decorate the diagram per
+the values on each decision node:
+
+- ``simulation_match == True``: node gets the green class
+  (``:::sim_match``) — this rule fires.
+- ``simulation_match == False``: dim the node (``:::sim_skip``) — this
+  rule's condition is contradicted.
+- ``simulation_match is None``: yellow / question mark
+  (``:::sim_unknown``) — cannot evaluate.
+- Nodes that weren't on the consulted path (e.g. enforcement rules
+  past the first-applicable winner) stay default.
+
+Add these classDefs to the Mermaid block:
+
+```
+classDef sim_match fill:#dfd,stroke:#3a3,stroke-width:3px;
+classDef sim_skip fill:#222,color:#555,stroke:#444;
+classDef sim_unknown fill:#fee,stroke:#aa6,stroke-width:2px;
+```
+
+Add a one-line summary box above the diagram naming the matched
+enforcement rule (by index / role list — NEVER by numeric ID) and
+the resulting access decision. Below the diagram, list any unknown
+attributes.
+
+### Step 5c — Attribute prompting hints
+
+When the operator asks "what attributes can I provide?" or you need
+to suggest a starting point, name the attributes that appear in the
+rendered conditions for THIS service. Don't list arbitrary ClearPass
+attribute paths — only the ones that actually affect this policy's
+decisions. Pull them from the decision-node conditions.
+
+Common ones for typical policies:
+
+- ``Tips:Role`` — pass as a list when evaluate-all role mapping can
+  assign multiple roles (e.g. ``["Kid", "Night Night"]``).
+- ``GuestUser:visitor`` — visitor name (string).
+- ``GuestUser:Role ID`` — guest device role ID (string).
+- ``Endpoint:Status`` — ``"Known"`` / ``"Unknown"`` / etc.
+- ``Authorization:[Guest Device Repository]:Device Role ID`` —
+  per-device numeric role from the guest device repo.
+- ``Connection:NAD-IP-Address`` — string.
+- ``Connection:Client-Mac-Address`` — string.
+
 ## Worked example — fuzzy match in action
 
 Operator: *"Visualize the ClearPass No Wireless For You Auth Service."*

--- a/tests/unit/test_clearpass_policy_visualizer_simulator.py
+++ b/tests/unit/test_clearpass_policy_visualizer_simulator.py
@@ -1,0 +1,370 @@
+"""Unit tests for the ClearPass policy-visualizer what-if simulator.
+
+The simulator's correctness contract is UNCERTAINTY-FIRST: any predicate
+whose attribute isn't provided in the context must evaluate to ``None``,
+and ``None`` must propagate through ``And`` / ``Or`` / ``Not`` correctly.
+The end-to-end ``SimulationOutcome`` must surface ``status="uncertain"``
+and the missing attribute paths rather than producing a confident wrong
+answer.
+
+The operator was previously burned by a fake-simulator that confidently
+reported wrong outcomes; these tests guard against any regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.conditions import (
+    And,
+    Not,
+    Op,
+    Or,
+    Predicate,
+    evaluate,
+)
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.flow_graph import compile_service
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_model import build
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# evaluate() — per-Op coverage
+# ---------------------------------------------------------------------------
+
+
+def _p(ns: str, attr: str, op: Op, value: str, display: str = "") -> Predicate:
+    return Predicate(namespace=ns, attribute=attr, op=op, rhs_raw=value, rhs_display=display)
+
+
+class TestEvaluateBasicOps:
+    def test_equals_true(self):
+        assert evaluate(_p("Tips", "Role", Op.equals, "IoT Device"), {"Tips:Role": "IoT Device"}) is True
+
+    def test_equals_false(self):
+        assert evaluate(_p("Tips", "Role", Op.equals, "IoT Device"), {"Tips:Role": "Kid"}) is False
+
+    def test_not_equals(self):
+        assert evaluate(_p("Tips", "Role", Op.not_equals, "Kid"), {"Tips:Role": "IoT Device"}) is True
+        assert evaluate(_p("Tips", "Role", Op.not_equals, "Kid"), {"Tips:Role": "Kid"}) is False
+
+    def test_contains(self):
+        assert evaluate(_p("X", "Name", Op.contains, "vis"), {"X:Name": "visitor-1"}) is True
+        assert evaluate(_p("X", "Name", Op.contains, "vis"), {"X:Name": "other"}) is False
+
+    def test_starts_with(self):
+        assert evaluate(_p("X", "n", Op.starts_with, "Inspire"), {"X:n": "Inspire 3D"}) is True
+        assert evaluate(_p("X", "n", Op.starts_with, "Inspire"), {"X:n": "3D Inspire"}) is False
+
+    def test_regex(self):
+        assert (
+            evaluate(
+                _p("X", "host", Op.regex, r"(hayley|rylee)-atv"),
+                {"X:host": "hayley-atv"},
+            )
+            is True
+        )
+        assert (
+            evaluate(
+                _p("X", "host", Op.regex, r"(hayley|rylee)-atv"),
+                {"X:host": "guest-laptop"},
+            )
+            is False
+        )
+
+    def test_in_(self):
+        assert evaluate(_p("X", "v", Op.in_, "a,b,c"), {"X:v": "b"}) is True
+        assert evaluate(_p("X", "v", Op.in_, "a,b,c"), {"X:v": "d"}) is False
+
+    def test_exists_with_value_present(self):
+        assert evaluate(_p("X", "v", Op.exists, ""), {"X:v": "anything"}) is True
+
+    def test_exists_with_value_absent(self):
+        assert evaluate(_p("X", "v", Op.exists, ""), {}) is False
+
+    def test_not_exists(self):
+        assert evaluate(_p("X", "v", Op.not_exists, ""), {}) is True
+        assert evaluate(_p("X", "v", Op.not_exists, ""), {"X:v": "x"}) is False
+
+    def test_numeric_comparison(self):
+        assert evaluate(_p("X", "n", Op.less_than, "10"), {"X:n": "5"}) is True
+        assert evaluate(_p("X", "n", Op.greater_than_or_equals, "10"), {"X:n": "10"}) is True
+        assert evaluate(_p("X", "n", Op.greater_than, "10"), {"X:n": "10"}) is False
+
+
+class TestEvaluateUnknown:
+    """The critical uncertainty contract — missing attributes return None, never False."""
+
+    def test_missing_attribute_returns_none_not_false(self):
+        # This is the load-bearing case: operator didn't provide GuestUser:visitor
+        # but a rule's condition references it. Result must be uncertain, never
+        # a confident False that would mask a possible match.
+        result = evaluate(_p("GuestUser", "visitor", Op.equals, "Inspire 3D"), {})
+        assert result is None, "Missing attribute MUST return None (uncertain), never False"
+
+    def test_missing_attribute_with_negative_op_still_returns_none(self):
+        result = evaluate(_p("GuestUser", "visitor", Op.not_equals, "Inspire 3D"), {})
+        assert result is None
+
+    def test_present_attribute_returns_boolean(self):
+        assert evaluate(_p("X", "v", Op.equals, "a"), {"X:v": "a"}) is True
+        assert evaluate(_p("X", "v", Op.equals, "a"), {"X:v": "b"}) is False
+
+
+class TestEvaluateBooleanPropagation:
+    """And/Or/Not three-valued logic."""
+
+    def test_and_with_one_unknown_returns_none(self):
+        # True AND None → None  (we can't claim the AND is True because we don't know the second)
+        expr = And(
+            operands=[
+                _p("X", "a", Op.equals, "1"),
+                _p("Y", "b", Op.equals, "2"),
+            ]
+        )
+        assert evaluate(expr, {"X:a": "1"}) is None  # Y:b unknown
+
+    def test_and_with_one_false_returns_false_even_if_other_unknown(self):
+        # False AND None → False (short-circuit — AND is contradicted regardless of unknown)
+        expr = And(
+            operands=[
+                _p("X", "a", Op.equals, "1"),
+                _p("Y", "b", Op.equals, "2"),
+            ]
+        )
+        assert evaluate(expr, {"X:a": "WRONG"}) is False  # X:a contradicts, Y:b unknown
+
+    def test_or_with_one_true_returns_true_even_if_other_unknown(self):
+        # True OR None → True (short-circuit — OR is satisfied)
+        expr = Or(
+            operands=[
+                _p("X", "a", Op.equals, "1"),
+                _p("Y", "b", Op.equals, "2"),
+            ]
+        )
+        assert evaluate(expr, {"X:a": "1"}) is True
+
+    def test_or_with_one_false_and_one_unknown_returns_none(self):
+        # False OR None → None (we can't conclude OR is False without knowing the second)
+        expr = Or(
+            operands=[
+                _p("X", "a", Op.equals, "1"),
+                _p("Y", "b", Op.equals, "2"),
+            ]
+        )
+        assert evaluate(expr, {"X:a": "WRONG"}) is None
+
+    def test_not_propagates_none(self):
+        expr = Not(operand=_p("X", "a", Op.equals, "1"))
+        assert evaluate(expr, {}) is None
+        assert evaluate(expr, {"X:a": "1"}) is False
+        assert evaluate(expr, {"X:a": "2"}) is True
+
+
+class TestEvaluateMultiValued:
+    """Tips:Role and similar multi-valued attributes — list context, any-match for positive ops."""
+
+    def test_role_list_any_match_for_equals(self):
+        # Device has multiple roles assigned (evaluate-all RM); rule checks for one
+        result = evaluate(
+            _p("Tips", "Role", Op.equals, "Night Night"),
+            {"Tips:Role": ["Kid", "Night Night"]},
+        )
+        assert result is True
+
+    def test_role_list_no_match_returns_false(self):
+        result = evaluate(
+            _p("Tips", "Role", Op.equals, "IoT Device"),
+            {"Tips:Role": ["Kid", "Night Night"]},
+        )
+        assert result is False
+
+    def test_role_list_in_operator(self):
+        # Tips:Role MATCHES_ANY ['Kid', 'Apple TV'] → True if any device role is in the set
+        result = evaluate(
+            _p("Tips", "Role", Op.in_, "Kid,Apple TV"),
+            {"Tips:Role": ["Kid"]},
+        )
+        assert result is True
+
+    def test_role_list_negative_op_requires_all_to_satisfy(self):
+        # NOT_EQUALS with a role list: True only if NONE of the roles equals the rhs
+        result = evaluate(
+            _p("Tips", "Role", Op.not_equals, "Banned"),
+            {"Tips:Role": ["Kid", "Night Night"]},
+        )
+        assert result is True
+
+        result = evaluate(
+            _p("Tips", "Role", Op.not_equals, "Kid"),
+            {"Tips:Role": ["Kid", "Night Night"]},
+        )
+        assert result is False  # one of the roles matches "Kid" so NOT_EQUALS fails
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compile_service with simulated_attributes
+# ---------------------------------------------------------------------------
+
+
+def _single_predicate_expr(ns: str, attr: str, value: str) -> dict:
+    return {
+        "operator": "and",
+        "attributes": [{"type": ns, "name": attr, "operator": "EQUALS", "value": value}],
+    }
+
+
+def _build_simulation_test_raw() -> dict:
+    """A minimal but realistic policy: 2 RM rules (assign Kid or IoT) + 3 EP rules
+    (one for Kid, one for IoT, one default-ish). Used to verify end-to-end
+    simulation correctness against known contexts.
+    """
+    return {
+        "roles": [{"name": "Kid", "description": ""}, {"name": "IoT Device", "description": ""}],
+        "authMethods": [],
+        "authSources": [],
+        "radiusEnfProfiles": [
+            {"name": "[Allow Access Profile]", "action": "Accept", "description": ""},
+            {"name": "WLAN-KID", "action": "Accept", "description": ""},
+            {"name": "WLAN-IoT", "action": "Accept", "description": ""},
+            {"name": "VLAN-USER", "action": "Accept", "description": ""},
+        ],
+        "tacacsEnfProfiles": [],
+        "radiusCoaEnfProfiles": [],
+        "postAuthEnfProfiles": [],
+        "genericEnfProfiles": [],
+        "roleMappings": [
+            {
+                "name": "RM",
+                "ruleCombineAlgo": "first-applicable",
+                "defaultRole": "",
+                "rules": [
+                    {
+                        "index": 0,
+                        "expression": _single_predicate_expr("GuestUser", "Role ID", "11"),
+                        "results": [{"name": "Role", "displayValue": "Kid"}],
+                    },
+                    {
+                        "index": 1,
+                        "expression": _single_predicate_expr("GuestUser", "Role ID", "26"),
+                        "results": [{"name": "Role", "displayValue": "IoT Device"}],
+                    },
+                ],
+            }
+        ],
+        "enforcementPolicies": [
+            {
+                "name": "EP",
+                "policyType": "RADIUS",
+                "ruleCombineAlgo": "first-applicable",
+                "defaultProfile": "[Allow Access Profile]",
+                "rules": [
+                    {
+                        "index": 0,
+                        "expression": _single_predicate_expr("Tips", "Role", "Kid"),
+                        "results": [{"name": "Enforcement-Profile", "displayValue": "WLAN-KID, VLAN-USER"}],
+                    },
+                    {
+                        "index": 1,
+                        "expression": _single_predicate_expr("Tips", "Role", "IoT Device"),
+                        "results": [{"name": "Enforcement-Profile", "displayValue": "WLAN-IoT, VLAN-USER"}],
+                    },
+                ],
+            }
+        ],
+        "services": [
+            {
+                "name": "Test-Service",
+                "description": "",
+                "serviceType": "RADIUS",
+                "matchExpression": _single_predicate_expr("Connection", "SSID", "TestSSID"),
+                "authMethods": [],
+                "authSources": [],
+                "roleMappings": ["RM"],
+                "enfPolicies": ["EP"],
+            }
+        ],
+    }
+
+
+class TestSimulationEndToEnd:
+    def test_resolved_outcome_when_full_context_provided(self):
+        model = build(_build_simulation_test_raw())
+        svc = next(iter(model.services.values()))
+        context = {
+            "Connection:SSID": "TestSSID",
+            "GuestUser:Role ID": "11",  # → Kid
+        }
+        flow = compile_service(svc, model, simulated_attributes=context)
+        assert flow.simulation is not None
+        assert flow.simulation.status == "resolved"
+        assert flow.simulation.resulting_roles == ["Kid"]
+        assert flow.simulation.access_decision == "ALLOW"
+        assert "WLAN-KID" in flow.simulation.applied_profiles
+        assert "VLAN-USER" in flow.simulation.applied_profiles
+        # Did NOT apply the IoT profile or the default
+        assert "WLAN-IoT" not in flow.simulation.applied_profiles
+
+    def test_uncertain_outcome_when_role_id_missing(self):
+        """The case the operator was burned by: partial context → simulator must
+        return uncertain, NOT a confident wrong answer."""
+        model = build(_build_simulation_test_raw())
+        svc = next(iter(model.services.values()))
+        context = {"Connection:SSID": "TestSSID"}  # GuestUser:Role ID intentionally missing
+        flow = compile_service(svc, model, simulated_attributes=context)
+        assert flow.simulation is not None
+        assert flow.simulation.status == "uncertain"
+        assert flow.simulation.access_decision == "UNKNOWN"
+        assert "GuestUser:Role ID" in flow.simulation.unknown_attributes
+        # MUST NOT have invented a matching rule or profile
+        assert flow.simulation.matching_enforcement_rule is None
+        assert flow.simulation.applied_profiles == []
+        # MUST surface the unknown in notes
+        assert any("GuestUser:Role ID" in n for n in flow.simulation.notes)
+
+    def test_no_match_when_service_match_false(self):
+        model = build(_build_simulation_test_raw())
+        svc = next(iter(model.services.values()))
+        # Service match condition is SSID=TestSSID; simulate a different SSID
+        context = {"Connection:SSID": "OtherSSID"}
+        flow = compile_service(svc, model, simulated_attributes=context)
+        assert flow.simulation is not None
+        assert flow.simulation.status == "no_match"
+        # No rule-mapping or enforcement rules should have been consulted
+        assert flow.simulation.matching_role_mapping_rules == []
+        assert flow.simulation.matching_enforcement_rule is None
+
+    def test_decision_node_simulation_match_populated(self):
+        model = build(_build_simulation_test_raw())
+        svc = next(iter(model.services.values()))
+        context = {
+            "Connection:SSID": "TestSSID",
+            "GuestUser:Role ID": "11",
+        }
+        flow = compile_service(svc, model, simulated_attributes=context)
+        # The matched RM rule node has simulation_match=True
+        rm_rule_0 = next(n for n in flow.nodes if n.id.endswith("__rm_rule_0"))
+        assert rm_rule_0.simulation_match is True
+        # RM is first-applicable; rule 0 matched, so rule 1 was never
+        # consulted. Its simulation_match stays None (not False) — that
+        # correctly conveys "we didn't need to look at this rule" vs.
+        # "this rule's condition is contradicted".
+        rm_rule_1 = next(n for n in flow.nodes if n.id.endswith("__rm_rule_1"))
+        assert rm_rule_1.simulation_match is None
+        # The first EP rule (Tips:Role = Kid) is True because the resolved
+        # Kid role got merged into the EP context
+        enf_rule_0 = next(n for n in flow.nodes if n.id.endswith("__enf_rule_0"))
+        assert enf_rule_0.simulation_match is True
+        # EP is also first-applicable; rule 0 matched so rule 1 wasn't consulted
+        enf_rule_1 = next(n for n in flow.nodes if n.id.endswith("__enf_rule_1"))
+        assert enf_rule_1.simulation_match is None
+
+    def test_no_simulation_when_no_context_provided(self):
+        model = build(_build_simulation_test_raw())
+        svc = next(iter(model.services.values()))
+        flow = compile_service(svc, model)  # no simulated_attributes
+        assert flow.simulation is None
+        # And no node should have simulation_match set
+        for node in flow.nodes:
+            assert node.simulation_match is None


### PR DESCRIPTION
## Summary

Adds a real predicate evaluator behind the existing `clearpass_compile_policy_flow` tool. Pass `simulated_attributes` (roles, endpoint status, time, visitor name, etc.) and the tool walks every rule's condition AST against the context, returning per-decision-node `simulation_match` flags plus a top-level `SimulationOutcome` describing the matched rules, resulting roles, applied profiles, and access decision.

## Why this design — uncertainty-first

Operator explicitly warned: *"the first version of this skill did allow for selecting of things and it would show the enforcement that would be used but it was completely wrong."* That referred to the pre-v3.1.3.2 era when the post-auth bucketing bug had every MPSK rule mis-classified as DENY and the visualization confidently reported that as the simulated outcome.

The new simulator's correctness invariant:

- **Any predicate whose attribute isn't supplied returns `None` (not `False`).** Three-valued logic — `None` propagates through `And` / `Or` / `Not` correctly (e.g. `True AND None == None`, `False AND None == False`, `True OR None == True`).
- **The end-to-end outcome carries `status: "resolved" | "uncertain" | "no_match"`.** The skill MUST surface `uncertain` as "need more info" — never name an outcome when the simulator returned `None` anywhere in the consulted chain.
- **Tests guard against regression** of the prior fake-result behavior — see `TestEvaluateUnknown.test_missing_attribute_returns_none_not_false` and `TestSimulationEndToEnd.test_uncertain_outcome_when_role_id_missing`.

## Multi-valued attribute support

`Tips:Role` (and similar) accept `list[str]` for evaluate-all role mappings where a device ends up with multiple roles. Semantics:

- Positive ops (`equals`, `contains`, `regex`, `in_`, ...) → match if ANY value satisfies.
- Negative ops (`not_equals`, `not_contains`, ...) → match only if ALL values satisfy.

The simulator merges resolved roles from the role-mapping chain into `Tips:Role` before evaluating enforcement rules.

## Skill workflow (Step 5)

- **Step 5** — REQUIRED post-render prompt offering the simulation.
- **Step 5a** — strict output contract by status (resolved → name the rule confidently; uncertain → list unknowns, ask for more; no_match → implicit deny).
- **Step 5b** — Mermaid classDefs for green-match / dim-skip / yellow-unknown highlighting.
- **Step 5c** — attribute prompting hints (common keys: `Tips:Role`, `GuestUser:visitor`, `Endpoint:Status`, `Connection:NAD-IP-Address`, etc.).

## ISE residue removed

Per the user directive, audited and confirmed: no `Op.not_in` / `Op.ip_*` (ISE-specific operators) anywhere in the engine. Updated the package `__init__.py` docstring to explicitly note the engine is ClearPass-only and lists no ISE-specific operators / parsers / data models.

## Files changed

- `src/.../clearpass/policy_visualizer/conditions.py` — `evaluate()` + per-Op evaluators + multi-valued attribute support + `_attribute_path()` exposed.
- `src/.../clearpass/policy_visualizer/flow_graph.py` — `SimulationOutcome` + `FlowNode.simulation_match` + `FlowGraph.simulation` + `_apply_simulation()`.
- `src/.../clearpass/policy_visualizer/__init__.py` — pipeline docstring update; ISE explicitly noted as removed.
- `src/.../clearpass/tools/policy_visualizer.py` — `simulated_attributes` parameter; `simulation` block in the response.
- `src/.../skills/clearpass-policy-walker.md` — Step 5 / 5a / 5b / 5c.
- `tests/unit/test_clearpass_policy_visualizer_simulator.py` — 33 new tests.
- `pyproject.toml` — 3.1.3.3 → 3.1.4.0 (minor — predicate evaluator is a new subsystem).
- `CHANGELOG.md` — new entry.

## Counts

- ClearPass tools: still 142 (existing tool gained a parameter)
- pytest: 1337 → **1365 passed** (28 net new tests after consolidation)

## Test plan

- [x] `ruff check .` ✓
- [x] `ruff format --check .` ✓
- [x] `mypy src/ --ignore-missing-imports` ✓
- [x] `pytest tests/ -q` ✓ (1365 passed, 1 skipped)
- [ ] After merge + tag + release + image rebuild: live-verify against *No Wireless For You Auth Service*. Provide `{"Tips:Role": "Kid", "Connection:SSID": "<actual>"}` and confirm the simulator correctly names the matching enforcement rule + ALLOW decision. Then provide a partial context (e.g. omit `GuestUser:visitor`) and confirm the simulator returns `status: "uncertain"` and lists the missing attribute — NOT a guess.