### PR TITLE
v3.1.4.1: fix ClearPass policy visualizer Mermaid newline bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4.1] - 2026-05-18
+
+**Patch — fix ClearPass policy visualizer Mermaid render failures on large policies (#356).** Operator hit `Parse error … got NODE_STRING` rendering the sectioned Block B / Block C output from v3.1.3.3+. Action / process / end nodes set `label` with literal `\n` (e.g. `"Set Role:\nNest Dweller"`, `"Access: DENY\n(implicit)"`, `"Default:\n..."`) and never set `short_label` explicitly, so `FlowNode.__post_init__` defaulted `short_label = label` — newlines and all. When the AI substituted that into a Mermaid `[/.../]` shape, the literal newline broke Mermaid's per-line shape parser.
+
+### Engine fix
+
+`FlowNode.__post_init__` now collapses any embedded whitespace runs (newlines + tabs + multi-spaces) in `short_label` to single spaces. The single-line invariant is now guaranteed for every node, regardless of node type or which compile_service branch emitted it. `label` keeps its multi-line form for inspector tooltips — only the diagram-facing `short_label` is normalized.
+
+Added a hard unit invariant test: every node returned by `compile_service` across a fixture exercising all node-emitter branches (start, decision, action, process, end variants, defaults, implicit deny) must have a single-line `short_label`.
+
+### Skill template hardened
+
+`clearpass-policy-walker.md` Step 3 readability rules now make two previously-implicit requirements explicit:
+
+- **One node per source line. One edge per source line.** Mermaid's parser doesn't span lines for shapes — `A[/x/] B(((y)))` on one line throws the parse error. Even with edges, declare nodes on their own lines first.
+- **Always wrap node label text in double quotes.** ClearPass conditions contain `:`, `=`, `+`, `&`, `|`, `'` etc. that Mermaid's bare-label parser treats as syntax; the compact-label engine emits `&` between AND predicates which MUST stay inside quotes or Mermaid reads it as its own node-list separator.
+
+The template Mermaid example shows the quoted form: `<id>{"<short_label>"}` instead of `<id>{<short_label>}`.
+
 ## [3.1.4.0] - 2026-05-18
 
 **Minor — ClearPass policy visualizer gains a what-if simulator. Pass a `simulated_attributes` context (roles, endpoint status, time, visitor name, etc.) and the tool evaluates every rule's predicates against it, returning per-decision-node `simulation_match` flags + a top-level `SimulationOutcome` describing the matched rules, resulting roles, applied profiles, and access decision.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.4.0"
+version = "3.1.4.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
@@ -62,6 +62,12 @@ class FlowNode:
     def __post_init__(self) -> None:
         if not self.short_label:
             self.short_label = self.label
+        # short_label must be single-line — Mermaid node shapes (rhombus,
+        # parallelogram, etc.) can't span source lines. A literal newline
+        # inside a shape like `A0[/Set Role:\nNest Dweller/]` breaks the
+        # parser. Collapse any embedded whitespace runs to single spaces.
+        if "\n" in self.short_label or "\t" in self.short_label:
+            self.short_label = " ".join(self.short_label.split())
 
 
 @dataclass

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -192,7 +192,26 @@ services = await call_tool("clearpass_list_policy_services", {"limit": 100})
    namespace) suitable for inspector tooltips; `short_label` is a
    compact single-line summary suitable for the diagram. With many
    rules, `label` produces dense unreadable diamonds.
-3. **For large policies (≥ 8 decision nodes total), split the
+3. **One node per source line. One edge per source line. Never
+   concatenate them.** Mermaid's parser does NOT span source lines
+   for node shapes — every declaration must end with a real newline
+   (or `;`). Writing `A[/x/] B(((y)))` on one line throws a `got
+   NODE_STRING` parse error. Even if two nodes are connected by an
+   edge, prefer to declare nodes on their own lines first, then list
+   edges:
+   ```
+   A0[/Set Role: Kid/]
+   END0(((Access: ALLOW)))
+   A0 --> END0
+   ```
+4. **Always wrap node label text in double quotes.** ClearPass
+   conditions contain `:`, `=`, `+`, `(`, `)`, `&`, `|`, `'`, and
+   other chars that Mermaid's bare-label parser treats as syntax.
+   Quoted labels (`A0{"Tips:Role = 'Kid' & Endpoint:Status =
+   'Known'"}`) parse safely. The compact-label engine emits `&` as
+   the AND separator between predicates — that MUST stay inside
+   quotes or Mermaid will read it as its own node-list separator.
+5. **For large policies (≥ 8 decision nodes total), split the
    rendering into 2–3 separate Mermaid blocks** instead of one giant
    diagram. See "Step 3b — Sectioned rendering" below.
 
@@ -202,17 +221,17 @@ Mermaid template (single-block version, fine for small policies):
 flowchart LR
     %%{init: {'flowchart': {'nodeSpacing': 30, 'rankSpacing': 50, 'curve': 'basis'}}}%%
 
-    %% --- nodes (use short_label, NOT label) ---
-    %% For each node in flow.nodes, emit ONE line:
-    %%   start        →  <id>([short_label])
-    %%   process      →  <id>[short_label]
-    %%   decision     →  <id>{short_label}
-    %%   action       →  <id>[/short_label/]
-    %%   end (allow)  →  <id>(((short_label)))
-    %%   end (deny)   →  <id>(((short_label))):::deny
-    %%   end (skip)   →  <id>(((short_label))):::skip
+    %% --- nodes (use short_label, NOT label; ALWAYS wrap text in double quotes) ---
+    %% For each node in flow.nodes, emit ONE line — never two nodes inline:
+    %%   start        →  <id>(["<short_label>"])
+    %%   process      →  <id>["<short_label>"]
+    %%   decision     →  <id>{"<short_label>"}
+    %%   action       →  <id>[/"<short_label>"/]
+    %%   end (allow)  →  <id>((("<short_label>")))
+    %%   end (deny)   →  <id>((("<short_label>"))):::deny
+    %%   end (skip)   →  <id>((("<short_label>"))):::skip
 
-    %% --- edges ---
+    %% --- edges (one per line) ---
     %% For each edge in flow.edges:
     %%   ""        →  from --> to
     %%   YES       →  from -->|YES| to

--- a/tests/unit/test_clearpass_policy_visualizer_flow.py
+++ b/tests/unit/test_clearpass_policy_visualizer_flow.py
@@ -435,16 +435,61 @@ class TestShortLabelPropagation:
         # short_label still encodes both conditions joined with &
         assert "&" in enf_dec.short_label
 
-    def test_non_decision_nodes_default_short_label_to_label(self):
-        """For start/process/action/end nodes, short_label defaults to label."""
+    def test_non_decision_nodes_default_short_label_to_label_single_line(self):
+        """For start/process/action/end nodes, short_label defaults to label
+        with embedded newlines collapsed to spaces — Mermaid node shapes
+        can't span source lines (issue #356).
+        """
         model = build(_minimal_raw())
         flow = compile_service(next(iter(model.services.values())), model)
         for node in flow.nodes:
             if node.type != "decision":
-                # These nodes don't get a compact override — default == label
-                assert node.short_label == node.label, (
-                    f"Non-decision node {node.id} ({node.type}) has short_label != label"
+                expected = " ".join(node.label.split())
+                assert node.short_label == expected, (
+                    f"Non-decision node {node.id} ({node.type}): "
+                    f"short_label={node.short_label!r} != collapsed label {expected!r}"
                 )
+
+    def test_short_label_is_always_single_line_across_all_nodes(self):
+        """Hard invariant: every node's short_label must be single-line for
+        ALL node types and ALL emitter branches — Mermaid renders break
+        when a literal newline lands inside a node shape (issue #356).
+
+        Use a fixture that exercises every label-emitting branch in
+        compile_service: start, service-match decision, no-match end,
+        auth process, auth-fail end, role-mapping rule decision + Set
+        Role action + default role action, enforcement rule decision +
+        ApplyProfiles action + ALLOW/DENY end + implicit_deny end.
+        """
+        rm_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("UserA"),
+                "results": [{"name": "Set Role", "displayValue": "Kid"}],
+            },
+            {
+                "index": 1,
+                "expression": _single_predicate("UserB"),
+                "results": [{"name": "Set Role", "displayValue": "Nest Dweller"}],
+            },
+        ]
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("Kid"),
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            },
+        ]
+        model = build(
+            _minimal_raw(
+                rm_rules=rm_rules,
+                rm_default="Guest",
+                enf_rules=enf_rules,
+            )
+        )
+        flow = compile_service(next(iter(model.services.values())), model)
+        offenders = [(n.id, n.type, n.short_label) for n in flow.nodes if "\n" in n.short_label]
+        assert offenders == [], f"short_label must never contain a newline. Offenders: {offenders}"
 
 
 class TestCompileServiceRadiusProxy:


### PR DESCRIPTION
## Summary

- **Engine fix**: `FlowNode.__post_init__` now collapses embedded whitespace runs in `short_label` to single spaces. Action / process / end nodes had `label` with literal `\n` (e.g. `"Set Role:\nNest Dweller"`, `"Access: DENY\n(implicit)"`, `"Default:\n..."`) and never set `short_label` explicitly, so the default `short_label = label` carried those newlines into Mermaid `[/.../]` / `{...}` shapes — which can't span source lines. Operator hit `Parse error … got NODE_STRING` rendering Block B / Block C from large policies.
- **Skill template hardened**: explicit one-node-per-line + always-quote-labels rules. The compact-label engine emits `&` between AND predicates, which MUST stay inside quotes or Mermaid reads it as its own node-list separator.
- **Hard invariant test**: every node returned by `compile_service` across a fixture exercising all node-emitter branches must have a single-line `short_label`.

Closes #356

## Test plan

- [x] `ruff check` + `ruff format --check` + `mypy src/` + `pytest tests/ -q` all clean in dev container (1366 passed, 1 skipped)
- [x] New test `test_short_label_is_always_single_line_across_all_nodes` exercises start / decision / action / process / end variants + defaults + implicit deny — asserts zero offenders with `\n` in `short_label`
- [x] Updated existing `test_non_decision_nodes_default_short_label_to_label_single_line` to verify `short_label == " ".join(label.split())` for non-decision nodes (was previously `short_label == label`)
- [ ] After merge + tag + release + image rebuild: live-verify the rendered Mermaid against *No Wireless For You Auth Service* — should no longer throw `Parse error … got NODE_STRING` on Block B / Block C