### PR TITLE
v3.1.5.0: pre-render ClearPass policy visualizer Mermaid server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.5.0] - 2026-05-18
+
+**Minor — ClearPass policy visualizer now pre-renders Mermaid server-side (#358).** `clearpass_compile_policy_flow` adds a `mermaid` field to the response with three ready-to-paste sectioned blocks. The skill embeds them verbatim — no more AI-side diagram assembly.
+
+### Why now
+
+v3.1.4.1's engine fix guaranteed `short_label` is single-line, but the operator's next test still hit `Parse error … got NODE_STRING` on Block B + Block C — the AI was inlining two node declarations on the same source line in its own assembly pass (`N{"…21"} RA0[/"Set Role…/]` with no edge between them). The skill template's "one declaration per line" rule wasn't enough — AI clients reliably miscompose multi-line Mermaid source. Pre-rendering server-side eliminates the entire failure mode.
+
+### New `format_mermaid()` helper
+
+`policy_visualizer/mermaid_render.py` converts a compiled `FlowGraph` into the structured output:
+
+```json
+{
+  "mermaid": {
+    "sections": [
+      {"title": "Block A — Service intake (start → match → auth)", "code": "flowchart LR\n…"},
+      {"title": "Block B — Role mapping", "code": "flowchart LR\n…"},
+      {"title": "Block C — Enforcement (decision → access)", "code": "flowchart LR\n…"}
+    ],
+    "simulated": false
+  }
+}
+```
+
+Each `code` is a complete `flowchart LR` block. Every node declaration on its own line. Every label wrapped in double quotes. Internal double quotes demoted to single quotes; `<` `>` HTML-escaped. classDefs (`deny` / `skip` — and `sim_match` / `sim_skip` / `sim_unknown` when a simulation was requested) injected per block. Cross-section edges rendered as labeled stub nodes ("→ Block C") so each block stays self-contained.
+
+Sections with no nodes are omitted (RADIUS_PROXY services skip Block B entirely, for instance).
+
+### Skill template rewritten
+
+`clearpass-policy-walker.md` Step 3 + Step 5b now say "embed `result['mermaid']['sections']` verbatim — do NOT re-assemble." The old per-shape syntax cheat-sheet is gone; AI clients don't need it anymore.
+
+### Backwards-compat
+
+`nodes` / `edges` arrays remain in the response for inspector tooling that needs the raw structure. The `mermaid` field is purely additive.
+
 ## [3.1.4.1] - 2026-05-18
 
 **Patch — fix ClearPass policy visualizer Mermaid render failures on large policies (#356).** Operator hit `Parse error … got NODE_STRING` rendering the sectioned Block B / Block C output from v3.1.3.3+. Action / process / end nodes set `label` with literal `\n` (e.g. `"Set Role:\nNest Dweller"`, `"Access: DENY\n(implicit)"`, `"Default:\n..."`) and never set `short_label` explicitly, so `FlowNode.__post_init__` defaulted `short_label = label` — newlines and all. When the AI substituted that into a Mermaid `[/.../]` shape, the literal newline broke Mermaid's per-line shape parser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.4.1"
+version = "3.1.5.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
@@ -47,13 +47,15 @@ _NODE_SHAPE: dict[str, tuple[str, str]] = {
 
 # Edge label → Mermaid arrow syntax. CONTINUE uses a dotted line to
 # visually distinguish evaluate-all chaining from first-applicable
-# fall-through.
+# fall-through. The "PASS" key is the auth → role-mapping edge label
+# (authentication passed) — bandit B105 misreads it as a hardcoded
+# credential, suppress on the offending line.
 _EDGE_FORMAT: dict[str, str] = {
     "": "{f} --> {t}",
     "YES": "{f} -->|YES| {t}",
     "NO": "{f} -->|NO| {t}",
     "FAIL": "{f} -->|FAIL| {t}",
-    "PASS": "{f} -->|PASS| {t}",
+    "PASS": "{f} -->|PASS| {t}",  # nosec B105 — Mermaid edge label, not a credential
     "CONTINUE": "{f} -. CONTINUE .-> {t}",
 }
 

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
@@ -1,0 +1,244 @@
+"""Mermaid renderer for :class:`FlowGraph` objects.
+
+The compiled :class:`~.flow_graph.FlowGraph` is platform-neutral (nodes
++ edges + optional simulation result). This module converts it into
+ready-to-paste Mermaid source so the AI client doesn't have to assemble
+declarations on its own — historically the AI inlines multiple node
+declarations on a single source line, which Mermaid's per-line shape
+parser refuses to parse. By emitting the source server-side we eliminate
+that whole class of bug (issue #356).
+
+Output shape:
+
+    {
+        "sections": [
+            {"title": "Block A — Service intake", "code": "flowchart LR\\n..."},
+            {"title": "Block B — Role mapping (...)", "code": "flowchart LR\\n..."},
+            {"title": "Block C — Enforcement (...)", "code": "flowchart LR\\n..."},
+        ],
+        "simulated": bool,
+    }
+
+Each ``code`` is a complete Mermaid block ready to embed in a
+`````mermaid ... ````` fence. Every node is on its own line,
+every edge is on its own line, every label is wrapped in double quotes,
+internal double quotes in labels are demoted to single quotes.
+
+Sections are always three (A / B / C) for consistency. Blocks are
+omitted only when they contain no nodes (e.g. RADIUS_PROXY skips
+role-mapping entirely).
+"""
+
+from __future__ import annotations
+
+from .flow_graph import FlowEdge, FlowGraph, FlowNode
+
+# Each node type maps to (open, close) Mermaid shape delimiters. Labels
+# always go inside double quotes inside the shape — Mermaid's bare-label
+# parser stumbles on ":" "=" "+" "&" "|" "'" "(" ")" which are common in
+# ClearPass condition predicates.
+_NODE_SHAPE: dict[str, tuple[str, str]] = {
+    "start": ("([", "])"),
+    "process": ("[", "]"),
+    "decision": ("{", "}"),
+    "action": ("[/", "/]"),
+    "end": ("(((", ")))"),
+}
+
+# Edge label → Mermaid arrow syntax. CONTINUE uses a dotted line to
+# visually distinguish evaluate-all chaining from first-applicable
+# fall-through.
+_EDGE_FORMAT: dict[str, str] = {
+    "": "{f} --> {t}",
+    "YES": "{f} -->|YES| {t}",
+    "NO": "{f} -->|NO| {t}",
+    "FAIL": "{f} -->|FAIL| {t}",
+    "PASS": "{f} -->|PASS| {t}",
+    "CONTINUE": "{f} -. CONTINUE .-> {t}",
+}
+
+# classDefs emitted in every block. The first three are the styling for
+# end-node ALLOW/DENY/skip; the second three are for simulation
+# highlighting (only emitted when flow.simulation is non-None).
+_BASE_CLASSDEFS = (
+    "classDef deny fill:#fee,stroke:#c33,stroke-width:2px;",
+    "classDef skip fill:#eee,stroke:#999,stroke-width:1px;",
+)
+_SIM_CLASSDEFS = (
+    "classDef sim_match fill:#dfd,stroke:#3a3,stroke-width:3px;",
+    "classDef sim_skip fill:#222,color:#555,stroke:#444;",
+    "classDef sim_unknown fill:#ffd,stroke:#aa6,stroke-width:2px;",
+)
+
+
+def _escape_label(text: str) -> str:
+    """Sanitize a label for safe embedding in a Mermaid double-quoted label.
+
+    Demotes internal double-quotes to single quotes (Mermaid's label
+    quote syntax is `"..."` — embedded `"` would close the quote early)
+    and HTML-escapes the `<` `>` chars that Mermaid would otherwise
+    interpret as HTML tags.
+    """
+    return text.replace('"', "'").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _node_classes(node: FlowNode, simulated: bool) -> list[str]:
+    """Pick the visual classes that apply to a given node.
+
+    Order of priority for end nodes (only one class wins): the
+    simulation class if a simulation context was supplied, else the
+    deny/skip class. Non-end / non-decision nodes get no class.
+    Simulation classes only apply to decision nodes.
+    """
+    classes: list[str] = []
+    if simulated and node.type == "decision":
+        if node.simulation_match is True:
+            classes.append("sim_match")
+        elif node.simulation_match is False:
+            classes.append("sim_skip")
+        elif node.simulation_match is None:
+            # Only mark unknown if the simulator actually consulted this
+            # node — `None` is also the initial value before simulation.
+            # We can't tell from a single node, so we leave it default
+            # rather than yellow-flag every node in a non-simulated graph.
+            pass
+    if node.type == "end":
+        s = node.short_label
+        if "DENY" in s or "Auth Failed" in s:
+            classes.append("deny")
+        elif s.startswith("Skip"):
+            classes.append("skip")
+    return classes
+
+
+def _format_node_line(node: FlowNode, simulated: bool) -> str:
+    """Format one node declaration on its own source line."""
+    open_, close = _NODE_SHAPE.get(node.type, ("[", "]"))
+    label = _escape_label(node.short_label)
+    line = f'    {node.id}{open_}"{label}"{close}'
+    classes = _node_classes(node, simulated)
+    if classes:
+        # Mermaid only supports one ::: class per node; pick the
+        # highest-priority one — sim styles win over deny/skip.
+        line += ":::" + classes[0]
+    return line
+
+
+def _format_edge_line(edge: FlowEdge) -> str:
+    tmpl = _EDGE_FORMAT.get(edge.label, "{f} --> {t}")
+    return "    " + tmpl.format(f=edge.from_id, t=edge.to_id)
+
+
+def _section_for_id(node_id: str, sid: str) -> str:
+    """Bucket a node ID into section A (intake), B (role mapping), or C (enforcement)."""
+    suffix = node_id[len(sid) + 2 :] if node_id.startswith(f"{sid}__") else node_id
+    if suffix in ("start", "match", "no_match", "auth", "auth_fail"):
+        return "A"
+    if suffix.startswith("rm_") or suffix == "no_role":
+        return "B"
+    if suffix.startswith("enf_"):
+        return "C"
+    return "A"
+
+
+def _render_block(
+    title: str,
+    nodes: list[FlowNode],
+    edges: list[FlowEdge],
+    simulated: bool,
+    cross_section_targets: dict[str, str] | None = None,
+) -> str:
+    """Render one section as a complete Mermaid block.
+
+    ``cross_section_targets`` maps node IDs that live in other sections
+    to a stub label like "→ Block C" — these get rendered as plain
+    rectangle stubs at the destination of cross-section edges so the
+    reader sees where the flow continues.
+    """
+    lines: list[str] = ["flowchart LR"]
+    lines.append("    %%{init: {'flowchart': {'nodeSpacing': 30, 'rankSpacing': 50, 'curve': 'basis'}}}%%")
+    lines.append("")
+    lines.append("    %% --- nodes ---")
+    for node in nodes:
+        lines.append(_format_node_line(node, simulated))
+
+    # Emit any cross-section stub nodes (one per target ID)
+    cross_section_targets = cross_section_targets or {}
+    for stub_id, stub_label in cross_section_targets.items():
+        safe = _escape_label(stub_label)
+        lines.append(f'    {stub_id}["{safe}"]')
+
+    lines.append("")
+    lines.append("    %% --- edges ---")
+    for edge in edges:
+        lines.append(_format_edge_line(edge))
+
+    lines.append("")
+    for cd in _BASE_CLASSDEFS:
+        lines.append(f"    {cd}")
+    if simulated:
+        for cd in _SIM_CLASSDEFS:
+            lines.append(f"    {cd}")
+
+    return "\n".join(lines)
+
+
+def format_mermaid(flow: FlowGraph) -> dict:
+    """Render a :class:`FlowGraph` as three Mermaid section blocks.
+
+    Returns the dict shape documented at the top of this module. Every
+    declaration is emitted on its own source line and every label is
+    wrapped in double quotes so Mermaid's per-line parser can't trip on
+    AI assembly errors.
+
+    Empty sections are omitted from the result — RADIUS_PROXY services
+    skip role mapping entirely, for instance, and policies without an
+    attached EP skip enforcement.
+    """
+    simulated = flow.simulation is not None
+    sid = flow.service_id
+
+    # Bucket nodes by section
+    nodes_by_section: dict[str, list[FlowNode]] = {"A": [], "B": [], "C": []}
+    section_of: dict[str, str] = {}
+    for node in flow.nodes:
+        sect = _section_for_id(node.id, sid)
+        nodes_by_section[sect].append(node)
+        section_of[node.id] = sect
+
+    # Bucket edges by their FROM section; cross-section edges produce a stub
+    edges_by_section: dict[str, list[FlowEdge]] = {"A": [], "B": [], "C": []}
+    stubs_by_section: dict[str, dict[str, str]] = {"A": {}, "B": {}, "C": {}}
+    for edge in flow.edges:
+        src_sect = section_of.get(edge.from_id, "A")
+        dst_sect = section_of.get(edge.to_id, "A")
+        if src_sect == dst_sect:
+            edges_by_section[src_sect].append(edge)
+            continue
+        # Cross-section: rewrite the destination to a stub at the source section
+        stub_id = f"__stub_to_{dst_sect}_{edge.to_id}"
+        stubs_by_section[src_sect][stub_id] = f"→ Block {dst_sect}"
+        edges_by_section[src_sect].append(
+            FlowEdge(from_id=edge.from_id, to_id=stub_id, label=edge.label, reason=edge.reason)
+        )
+
+    section_titles = {
+        "A": "Block A — Service intake (start → match → auth)",
+        "B": "Block B — Role mapping",
+        "C": "Block C — Enforcement (decision → access)",
+    }
+
+    sections: list[dict[str, str]] = []
+    for key in ("A", "B", "C"):
+        if not nodes_by_section[key]:
+            continue
+        code = _render_block(
+            section_titles[key],
+            nodes_by_section[key],
+            edges_by_section[key],
+            simulated,
+            cross_section_targets=stubs_by_section[key],
+        )
+        sections.append({"title": section_titles[key], "code": code})
+
+    return {"sections": sections, "simulated": simulated}

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
@@ -26,6 +26,7 @@ from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.api_adapter import adapt
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.flow_graph import compile_service
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.mermaid_render import format_mermaid
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_details import build_details
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_model import build
 from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
@@ -217,9 +218,22 @@ async def clearpass_compile_policy_flow(
     Returns:
         On success — dict with ``service_id`` (engine slug),
         ``service_name`` (the exact resolved name), ``service_type``,
-        ``nodes``, ``edges``, ``warnings``, and optionally ``details``.
-        Edge labels are one of ``""``, ``YES``, ``NO``, ``FAIL``,
-        ``PASS``, ``CONTINUE``.
+        ``nodes``, ``edges``, ``mermaid``, ``warnings``, and optionally
+        ``details``. Edge labels are one of ``""``, ``YES``, ``NO``,
+        ``FAIL``, ``PASS``, ``CONTINUE``.
+
+        The ``mermaid`` field carries ready-to-paste Mermaid source as
+        ``{"sections": [{"title": ..., "code": ...}, ...],
+        "simulated": bool}``. Each ``code`` is a complete
+        ``flowchart LR`` block — embed it verbatim in a Mermaid code
+        fence. **Do not re-assemble the diagram from the ``nodes`` /
+        ``edges`` arrays** — historically AI clients inline two node
+        declarations on a single source line, which Mermaid's per-line
+        shape parser refuses (issue #356, #358). The pre-rendered
+        ``mermaid.sections`` output eliminates that failure mode by
+        producing one node-per-line, quoted-label output server-side.
+        The ``nodes`` / ``edges`` arrays remain for inspector / tooling
+        use cases that need the raw structure.
 
         On ambiguous match — ``{"status": "ambiguous", "query": ...,
         "candidates": [<name>, ...]}`` — caller should re-prompt with a
@@ -283,6 +297,7 @@ async def clearpass_compile_policy_flow(
             "service_type": flow.service_type,
             "nodes": [asdict(n) for n in flow.nodes],
             "edges": [asdict(e) for e in flow.edges],
+            "mermaid": format_mermaid(flow),
             "warnings": list(model.warnings),
         }
         if include_details:

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -178,120 +178,75 @@ services = await call_tool("clearpass_list_policy_services", {"limit": 100})
 # Present names + type + enabled. DO NOT include the numeric id in your reply.
 ```
 
-### Step 3 — Render the FlowGraph as Mermaid
+### Step 3 — Embed the pre-rendered Mermaid sections from the response
 
-**Critical readability rules (read first):**
+**Use the ``mermaid`` field on the response directly. Do NOT
+re-assemble the diagram from ``nodes`` / ``edges``.** The engine
+pre-renders ready-to-paste Mermaid server-side specifically to
+eliminate AI-side assembly errors — previously the AI would inline two
+node declarations on the same source line, which throws Mermaid's
+``Parse error … got NODE_STRING`` (issues #356, #358). Pre-rendering
+sidesteps that whole failure mode.
 
-1. **Use `flowchart LR` (left-right)**, not `TD`. Role-mapping and
-   enforcement chains often have 12+ rules each — `TD` produces a
-   tall narrow column that the client shrinks to fit width, making
-   every label tiny and unreadable. `LR` lays the chain out
-   horizontally with reasonable node spacing.
-2. **Use `short_label` for every node, NOT `label`.** Each FlowNode
-   carries both: `label` is verbose (3 lines per predicate, full
-   namespace) suitable for inspector tooltips; `short_label` is a
-   compact single-line summary suitable for the diagram. With many
-   rules, `label` produces dense unreadable diamonds.
-3. **One node per source line. One edge per source line. Never
-   concatenate them.** Mermaid's parser does NOT span source lines
-   for node shapes — every declaration must end with a real newline
-   (or `;`). Writing `A[/x/] B(((y)))` on one line throws a `got
-   NODE_STRING` parse error. Even if two nodes are connected by an
-   edge, prefer to declare nodes on their own lines first, then list
-   edges:
-   ```
-   A0[/Set Role: Kid/]
-   END0(((Access: ALLOW)))
-   A0 --> END0
-   ```
-4. **Always wrap node label text in double quotes.** ClearPass
-   conditions contain `:`, `=`, `+`, `(`, `)`, `&`, `|`, `'`, and
-   other chars that Mermaid's bare-label parser treats as syntax.
-   Quoted labels (`A0{"Tips:Role = 'Kid' & Endpoint:Status =
-   'Known'"}`) parse safely. The compact-label engine emits `&` as
-   the AND separator between predicates — that MUST stay inside
-   quotes or Mermaid will read it as its own node-list separator.
-5. **For large policies (≥ 8 decision nodes total), split the
-   rendering into 2–3 separate Mermaid blocks** instead of one giant
-   diagram. See "Step 3b — Sectioned rendering" below.
+The response carries:
 
-Mermaid template (single-block version, fine for small policies):
+```python
+result["mermaid"] = {
+    "sections": [
+        {"title": "Block A — Service intake (start → match → auth)", "code": "flowchart LR\n..."},
+        {"title": "Block B — Role mapping", "code": "flowchart LR\n..."},
+        {"title": "Block C — Enforcement (decision → access)", "code": "flowchart LR\n..."},
+    ],
+    "simulated": False,  # or True when a simulation was requested
+}
+```
+
+For each entry in ``result["mermaid"]["sections"]``, emit a section
+header (the ``title``) and a fenced Mermaid block containing the
+``code`` verbatim:
+
+````markdown
+## Block A — Service intake (start → match → auth)
 
 ```mermaid
 flowchart LR
-    %%{init: {'flowchart': {'nodeSpacing': 30, 'rankSpacing': 50, 'curve': 'basis'}}}%%
-
-    %% --- nodes (use short_label, NOT label; ALWAYS wrap text in double quotes) ---
-    %% For each node in flow.nodes, emit ONE line — never two nodes inline:
-    %%   start        →  <id>(["<short_label>"])
-    %%   process      →  <id>["<short_label>"]
-    %%   decision     →  <id>{"<short_label>"}
-    %%   action       →  <id>[/"<short_label>"/]
-    %%   end (allow)  →  <id>((("<short_label>")))
-    %%   end (deny)   →  <id>((("<short_label>"))):::deny
-    %%   end (skip)   →  <id>((("<short_label>"))):::skip
-
-    %% --- edges (one per line) ---
-    %% For each edge in flow.edges:
-    %%   ""        →  from --> to
-    %%   YES       →  from -->|YES| to
-    %%   NO        →  from -->|NO| to
-    %%   FAIL      →  from -->|FAIL| to
-    %%   PASS      →  from -->|PASS| to
-    %%   CONTINUE  →  from -. CONTINUE .-> to
-
-    %% --- classes ---
-    classDef deny fill:#fee,stroke:#c33,stroke-width:2px;
-    classDef skip fill:#eee,stroke:#999,stroke-width:1px;
+    ...
 ```
 
-End-node classification rules (for `:::deny` / `:::skip`):
+## Block B — Role mapping
 
-- `:::deny` if the `short_label` starts with `Access: DENY` or contains
-  `Auth Failed`.
-- `:::skip` if the `short_label` starts with `Skip` (the
-  service-no-match branch).
-- No class (default styling) for `Access: ALLOW` and any non-end node.
-
-### Step 3b — Sectioned rendering (REQUIRED for ≥ 8 decision nodes)
-
-When the policy is large, ONE Mermaid block becomes unreadable even
-with `LR` + `short_label`. Split into:
-
-**Block A — Service intake** (start + service-match + auth + auth-fail):
-
-```
-nodes with id matching <sid>__start, <sid>__match, <sid>__no_match,
-<sid>__auth, <sid>__auth_fail
-plus edges between them
+```mermaid
+flowchart LR
+    ...
 ```
 
-**Block B — Role mapping** (the `rm_chain` rank_group):
+## Block C — Enforcement (decision → access)
 
+```mermaid
+flowchart LR
+    ...
 ```
-nodes with id matching <sid>__rm_rule_*, <sid>__rm_action_*, <sid>__rm_default,
-<sid>__no_role
-plus edges between them
-end this block with a "→ enforcement" placeholder edge to a stub node
-```
+````
 
-**Block C — Enforcement** (the `enf_chain` rank_group):
+Constraints when copying the code:
 
-```
-nodes with id matching <sid>__enf_rule_*, <sid>__enf_action_*, <sid>__enf_end_*,
-<sid>__enf_default_action, <sid>__enf_default_end, <sid>__enf_implicit_deny,
-<sid>__enf_no_policy
-plus edges between them
-start this block with a stub node receiving from "← from role mapping"
-```
+- Paste each ``code`` verbatim — preserve every newline. Do NOT
+  collapse whitespace, re-flow, or "tidy up" the syntax. The engine
+  emits one node per line, one edge per line, with labels safely
+  quoted; touching it re-introduces the parser bug.
+- Do not edit node labels or add classDefs of your own — the engine
+  already includes ``classDef deny`` / ``classDef skip`` (and the sim
+  classes when ``simulated`` is true).
+- Sections with no nodes (e.g. RADIUS_PROXY skips role mapping
+  entirely) are omitted from the list — just iterate what's there.
 
-Each block gets its own `flowchart LR` + init directive. Operators can
-zoom each section independently. Below the three blocks, add a
-one-sentence connection note: *"All role-mapping outcomes converge to
-the enforcement chain in Block C."*
+If your client supports it, render each section as its own code fence
+so the user can zoom them independently. If your client renders all
+fences sequentially that's fine too — they'll appear stacked.
 
-When in doubt about sizing: if the policy has more than 8 total
-decision nodes across role-mapping + enforcement, split.
+After the three blocks, add a one-sentence connection note: *"All
+role-mapping outcomes (Block B) converge to the enforcement chain in
+Block C."*
 
 ### Step 4 — Output format
 
@@ -406,30 +361,24 @@ can't evaluate, propagates ``None`` through And/Or/Not, and surfaces
 
 ### Step 5b — Highlighting the matched path in the re-rendered diagram
 
-When you re-render after a simulation call, decorate the diagram per
-the values on each decision node:
+The engine handles all simulation styling server-side. When you re-call
+``clearpass_compile_policy_flow`` with ``simulated_attributes``, the
+response's ``mermaid.sections`` already has:
 
-- ``simulation_match == True``: node gets the green class
-  (``:::sim_match``) — this rule fires.
-- ``simulation_match == False``: dim the node (``:::sim_skip``) — this
-  rule's condition is contradicted.
-- ``simulation_match is None``: yellow / question mark
-  (``:::sim_unknown``) — cannot evaluate.
-- Nodes that weren't on the consulted path (e.g. enforcement rules
-  past the first-applicable winner) stay default.
+- The green ``:::sim_match`` class applied to decision nodes whose rule
+  fires under the simulated context.
+- The dimmed ``:::sim_skip`` class applied to decision nodes whose
+  condition is contradicted.
+- The classDefs (``sim_match`` / ``sim_skip`` / ``sim_unknown``)
+  injected into every block.
 
-Add these classDefs to the Mermaid block:
+You don't need to add any styling yourself — just embed the
+``code`` verbatim per Step 3 and the highlighting appears.
 
-```
-classDef sim_match fill:#dfd,stroke:#3a3,stroke-width:3px;
-classDef sim_skip fill:#222,color:#555,stroke:#444;
-classDef sim_unknown fill:#fee,stroke:#aa6,stroke-width:2px;
-```
-
-Add a one-line summary box above the diagram naming the matched
-enforcement rule (by index / role list — NEVER by numeric ID) and
-the resulting access decision. Below the diagram, list any unknown
-attributes.
+Above the diagrams (between the summary header and Block A), add a
+one-line outcome banner naming the matched enforcement rule (by index
+/ role list — NEVER by numeric ID) and the resulting access decision.
+Below Block C, list any ``simulation.unknown_attributes``.
 
 ### Step 5c — Attribute prompting hints
 

--- a/tests/unit/test_clearpass_policy_visualizer_mermaid.py
+++ b/tests/unit/test_clearpass_policy_visualizer_mermaid.py
@@ -1,0 +1,237 @@
+"""Unit tests for the ClearPass policy-visualizer Mermaid renderer.
+
+The renderer's whole purpose is to be defensive against AI assembly
+errors: every node declaration on its own line, every edge on its own
+line, every label safely quoted. These tests pin the structural
+invariants that protect against #356 / #358 recurring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.flow_graph import compile_service
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.mermaid_render import (
+    _escape_label,
+    format_mermaid,
+)
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_model import build
+
+pytestmark = pytest.mark.unit
+
+
+def _single_predicate(value: str = "x") -> dict:
+    return {
+        "operator": "and",
+        "displayOperator": "MATCHES_ALL",
+        "attributes": [{"type": "Tips", "name": "Role", "operator": "EQUALS", "value": value}],
+    }
+
+
+def _minimal_raw(
+    *,
+    rm_rules: list[dict] | None = None,
+    rm_default: str = "",
+    rm_combine: str = "first-applicable",
+    enf_rules: list[dict] | None = None,
+    enf_default: str = "",
+    enf_combine: str = "first-applicable",
+    service_type: str = "RADIUS",
+) -> dict:
+    return {
+        "roles": [{"name": "[Employee]", "description": ""}],
+        "authMethods": [],
+        "authSources": [],
+        "radiusEnfProfiles": [
+            {"name": "[Allow Access Profile]", "action": "Accept", "description": ""},
+            {"name": "[Deny Access Profile]", "action": "Reject", "description": ""},
+        ],
+        "tacacsEnfProfiles": [],
+        "radiusCoaEnfProfiles": [],
+        "postAuthEnfProfiles": [],
+        "genericEnfProfiles": [],
+        "roleMappings": [
+            {
+                "name": "RM-Test",
+                "ruleCombineAlgo": rm_combine,
+                "defaultRole": rm_default,
+                "rules": rm_rules or [],
+            }
+        ],
+        "enforcementPolicies": [
+            {
+                "name": "EP-Test",
+                "policyType": "RADIUS",
+                "ruleCombineAlgo": enf_combine,
+                "defaultProfile": enf_default,
+                "rules": enf_rules or [],
+            }
+        ],
+        "services": [
+            {
+                "name": "SVC-Test",
+                "description": "",
+                "serviceType": service_type,
+                "matchExpression": _single_predicate("AirGroup"),
+                "authMethods": [],
+                "authSources": [],
+                "roleMappings": ["RM-Test"],
+                "enfPolicies": ["EP-Test"],
+            }
+        ],
+    }
+
+
+def _compile_minimal(simulate: dict | None = None):
+    rm_rules = [
+        {
+            "index": 0,
+            "expression": _single_predicate("UserA"),
+            "results": [{"name": "Set Role", "displayValue": "Kid"}],
+        },
+        {
+            "index": 1,
+            "expression": _single_predicate("UserB"),
+            "results": [{"name": "Set Role", "displayValue": "Nest Dweller"}],
+        },
+    ]
+    enf_rules = [
+        {
+            "index": 0,
+            "expression": _single_predicate("Kid"),
+            "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+        },
+    ]
+    model = build(_minimal_raw(rm_rules=rm_rules, rm_default="Guest", enf_rules=enf_rules))
+    service = next(iter(model.services.values()))
+    return compile_service(service, model, simulated_attributes=simulate)
+
+
+class TestEscapeLabel:
+    def test_demotes_double_quotes_to_single(self):
+        assert _escape_label('Role = "Admin"') == "Role = 'Admin'"
+
+    def test_html_escapes_angle_brackets(self):
+        # `<` would otherwise be interpreted as the start of an HTML tag
+        assert _escape_label("Score >= 5") == "Score &gt;= 5"
+        assert _escape_label("a<b") == "a&lt;b"
+
+    def test_leaves_other_punctuation_alone(self):
+        # `&`, `|`, `=`, `:`, `+`, `(`, `)`, `'` all stay inside double-quoted Mermaid labels
+        assert _escape_label("Role = 'Kid' & Status = 'Known'") == "Role = 'Kid' & Status = 'Known'"
+
+
+class TestStructuralInvariants:
+    def test_returns_three_sections_in_order(self):
+        flow = _compile_minimal()
+        result = format_mermaid(flow)
+        titles = [s["title"] for s in result["sections"]]
+        assert titles == [
+            "Block A — Service intake (start → match → auth)",
+            "Block B — Role mapping",
+            "Block C — Enforcement (decision → access)",
+        ]
+        assert result["simulated"] is False
+
+    def test_each_node_declaration_on_its_own_line(self):
+        """Pin the cardinal rule from #356 / #358: at most one node
+        declaration per source line. Detect a declaration as an
+        identifier immediately followed by a shape opener.
+        """
+        import re
+
+        # Identifier followed by a Mermaid shape opener (parens/brackets/braces).
+        # Use longest-first alternation so `[/` wins over `[`.
+        decl_re = re.compile(r"[A-Za-z_][\w]*(\[/|\(\(\(|\(\[|\{|\[|\()")
+        flow = _compile_minimal()
+        result = format_mermaid(flow)
+        for section in result["sections"]:
+            for line in section["code"].split("\n"):
+                stripped = line.lstrip()
+                if not stripped or stripped.startswith(("%%", "flowchart", "classDef")):
+                    continue
+                if "-->" in stripped or "-.->" in stripped:
+                    continue  # edges are allowed to reference multiple node ids
+                matches = decl_re.findall(stripped)
+                assert len(matches) <= 1, f"Two node decls on one line: {line!r}"
+
+    def test_every_label_wrapped_in_double_quotes(self):
+        flow = _compile_minimal()
+        result = format_mermaid(flow)
+        # Every node line opens a shape and has `"..."` inside
+        for section in result["sections"]:
+            for line in section["code"].split("\n"):
+                stripped = line.lstrip()
+                if "{" not in stripped and "[/" not in stripped and "[" not in stripped and "([" not in stripped:
+                    continue
+                if stripped.startswith("%%") or stripped.startswith("classDef"):
+                    continue
+                if "-->" in stripped or "-.->" in stripped:
+                    continue
+                # Node lines: must have a quoted label region
+                assert '"' in stripped, f"Node line without quoted label: {line!r}"
+
+    def test_no_literal_newlines_inside_shapes(self):
+        """The cardinal rule from #356: no `\\n` between a shape's opener and closer."""
+        flow = _compile_minimal()
+        result = format_mermaid(flow)
+        # Whole-document property: no shape opener is followed by `\n` before its closer
+        for section in result["sections"]:
+            code = section["code"]
+            # Walk every `{`, `[`, `(` and check the matching close is on the same line
+            for line in code.split("\n"):
+                # If a shape opens on this line, it must close on this line
+                if any(o in line for o in ("{", "[", "(")):
+                    pass  # presence checked above; here we just confirm no orphaned shape openers
+                # A line ending in an unclosed `{`, `[/`, or `((` would mean the next line
+                # is the close. Assert that doesn't happen.
+                for opener, closer in [("{", "}"), ("[/", "/]"), ("(((", ")))"), ("([", "])"), ("[", "]")]:
+                    if opener in line and closer not in line:
+                        pytest.fail(f"Unclosed shape on line: {line!r}")
+
+    def test_radius_proxy_omits_role_mapping_block(self):
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("X"),
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            }
+        ]
+        model = build(_minimal_raw(enf_rules=enf_rules, service_type="RADIUS_PROXY"))
+        service = next(iter(model.services.values()))
+        flow = compile_service(service, model)
+        result = format_mermaid(flow)
+        titles = [s["title"] for s in result["sections"]]
+        assert "Block B — Role mapping" not in titles
+
+
+class TestSimulationStyling:
+    def test_simulated_flag_set_when_simulation_present(self):
+        flow = _compile_minimal(simulate={"Tips:Role": ["UserA", "Kid"]})
+        result = format_mermaid(flow)
+        assert result["simulated"] is True
+
+    def test_sim_classdefs_injected_when_simulated(self):
+        flow = _compile_minimal(simulate={"Tips:Role": ["UserA", "Kid"]})
+        result = format_mermaid(flow)
+        combined = "\n".join(s["code"] for s in result["sections"])
+        assert "classDef sim_match" in combined
+        assert "classDef sim_skip" in combined
+        assert "classDef sim_unknown" in combined
+
+    def test_sim_classdefs_omitted_when_not_simulated(self):
+        flow = _compile_minimal()
+        result = format_mermaid(flow)
+        combined = "\n".join(s["code"] for s in result["sections"])
+        assert "classDef sim_match" not in combined
+        assert "classDef sim_skip" not in combined
+
+    def test_matching_decision_node_gets_sim_match_class(self):
+        # Pass both roles so service-match (Tips:Role=AirGroup) AND
+        # rule 0 (Tips:Role=UserA) both evaluate True. Multi-valued
+        # Tips:Role: positive ops match if ANY value satisfies.
+        flow = _compile_minimal(simulate={"Tips:Role": ["AirGroup", "UserA"]})
+        result = format_mermaid(flow)
+        # Block B holds the role-mapping decision lines
+        block_b = next(s for s in result["sections"] if "Role mapping" in s["title"])
+        assert ":::sim_match" in block_b["code"]


### PR DESCRIPTION
## Summary

- **New `format_mermaid()` helper** ([mermaid_render.py](src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py)) converts a compiled `FlowGraph` into structured ready-to-paste Mermaid sections (Block A intake / Block B role mapping / Block C enforcement). Every declaration on its own line, labels quoted, `<` `>` HTML-escaped, classDefs (including sim styling) injected, cross-section edges rendered as labeled stub nodes.
- **Tool response gains `mermaid` field** — `clearpass_compile_policy_flow` returns `{"sections": [{title, code}, ...], "simulated": bool}` alongside the existing `nodes` / `edges` arrays.
- **Skill template rewritten** to embed `result['mermaid']['sections']` verbatim and explicitly forbid re-assembly. The old per-shape syntax cheat-sheet is gone — AI clients don't need it anymore.

Closes #358 (and prevents recurrence of #356).

## Why now

v3.1.4.1's engine fix guaranteed `short_label` is single-line, but the operator's next test still hit `Parse error … got NODE_STRING` on Block B + Block C — the AI was inlining two node declarations on the same source line in its own assembly pass despite the skill template's "one declaration per line" rule. AI-side Mermaid assembly is reliably broken on policies with many decision/action nodes. Pre-rendering server-side eliminates the whole failure mode.

## Test plan

- [x] 12 new mermaid renderer tests covering: label escaping (quotes, `<`/`>`), section ordering, one-decl-per-line invariant (regex-based), every label quoted, no unclosed shapes, RADIUS_PROXY omits Block B, simulation classDefs injected/omitted correctly, matching decision node gets `:::sim_match`
- [x] Full suite: 1378 passed, 1 skipped (was 1366 before)
- [x] `ruff check` + `ruff format --check` + `mypy src/` clean
- [ ] After merge + tag + release + image rebuild: live-verify against *No Wireless For You Auth Service* — should render Block A / B / C without `Parse error … got NODE_STRING`, with classDef styling applied