### PR TITLE
v3.1.6.0: fix combine-algo mislabeling + add Aruba role resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.6.0] - 2026-05-19
+
+**Minor — ClearPass policy visualizer fix combine-algorithm mislabeling + add cross-platform Aruba role resolution (#360).** Operator's custom widget on v3.1.5.0 hardcoded "stop on match" on every role-mapping rule row even though the policy is evaluate-all (rules continue, devices accumulate multiple roles). Also: there was no way to drill into what an Aruba role actually does — `WLAN-NIGHT-NIGHT` was just a name. Both fixed.
+
+### Combine algorithm surfaced as structured response fields
+
+`clearpass_compile_policy_flow` returns two new top-level fields:
+
+- `role_mapping_combine` — `"first-applicable"` / `"evaluate-all"` / `None`
+- `enforcement_combine` — same domain
+
+Mermaid section titles now include the combine algorithm: *"Block B — Role mapping (evaluate-all — rules continue, multiple actions accumulate)"* / *"Block C — Enforcement (first-applicable — first matching rule wins)"*. AI clients building custom widgets must label rule rows from these fields, not hardcode.
+
+### Enforcement profile attributes surfaced
+
+`EnforcementProfile` model + adapter extended to carry the raw `attributes` list (RADIUS / TACACS attribute pushes — e.g. `Aruba-User-Role: night-night`, `Aruba-Named-User-Vlan: iot`, `Session-Timeout: 28800`). Available in `details.profile_attributes[<profile name>].attributes` when `include_details=True`. Operators (and the new Central role resolver) can now see what each profile actually pushes — names like `WLAN-NIGHT-NIGHT` are no longer opaque.
+
+### New Central tool: `central_get_role_with_policy`
+
+Bundles two endpoints in one call:
+
+- `GET /network-config/v1alpha1/roles/{name}` — role config (VLAN, session params, classification settings)
+- `GET /network-config/v1alpha1/policies/{name}` — security policy named after the role (firewall rules with per-rule `condition` + `action`)
+
+Response shape: `{name, role: {...}|None, policy: {...}|None, not_found: [...], errors: [...]}`. Either resource being absent is reported in `not_found` (informational — many shared roles are skeletal, many roles have no separately-named policy). Per-endpoint exceptions go in `errors` and don't abort the other fetch.
+
+Use case: when ClearPass enforcement profile pushes `Aruba-User-Role: night-night`, the AI calls `central_get_role_with_policy(name="night-night")` to surface what that role actually grants/denies (e.g. deny SOCIAL-NETWORKING, deny netflix, deny hulu, etc.).
+
+### Skill template updated
+
+`clearpass-policy-walker.md` gets:
+
+- Step 4b-2 — honor the combine algorithms; never hardcode "stop on match" on evaluate-all role-mapping.
+- Step 4d — call `central_get_role_with_policy` when operator asks about role detail. Cheap (~2 GETs per role) but call only for roles the operator actually asks about.
+
 ## [3.1.5.0] - 2026-05-18
 
 **Minor — ClearPass policy visualizer now pre-renders Mermaid server-side (#358).** `clearpass_compile_policy_flow` adds a `mermaid` field to the response with three ready-to-paste sectioned blocks. The skill embeds them verbatim — no more AI-side diagram assembly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.5.0"
+version = "3.1.6.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -80,6 +80,7 @@ TOOLS = {
     ],
     "roles": [
         "central_get_roles",
+        "central_get_role_with_policy",
         "central_manage_role",
     ],
     "security_policy": [

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -59,6 +59,86 @@ async def central_get_roles(
     return response.get("msg", {})
 
 
+@tool(annotations=READ_ONLY)
+async def central_get_role_with_policy(
+    ctx: Context,
+    name: str,
+) -> dict | str:
+    """
+    Get a Central role's config bundled with its access policy.
+
+    Pairs the two endpoints operators most often need together when
+    asking "what does this role actually do?":
+
+    - ``GET /network-config/v1alpha1/roles/{name}`` — the role definition
+      (VLAN, session params, classification settings, etc.). Often
+      skeletal (just ``{name, description}``) when the role's only
+      purpose is to be referenced as a source in a security policy.
+    - ``GET /network-config/v1alpha1/policies/{name}`` — the security
+      policy named after the role. Contains the actual firewall rules
+      that fire when a client carries this role: per-rule
+      ``condition`` (rule-type, services, source/destination) and
+      ``action`` (ALLOW / DENY / log / etc.).
+
+    Use this from the ClearPass policy visualizer: when an enforcement
+    profile pushes ``Aruba-User-Role: night-night``, call this with
+    ``name="night-night"`` to surface what access that role actually
+    grants/denies.
+
+    Parameters:
+        name: Role name as it appears in Central (case-sensitive in the
+            REST path). Matches the value pushed by ClearPass via the
+            ``Aruba-User-Role`` RADIUS attribute.
+
+    Returns:
+        Dict with keys:
+        - ``name`` — the queried role name.
+        - ``role`` — the role config dict, or ``None`` if not found.
+        - ``policy`` — the security policy dict, or ``None`` if no
+          policy named after the role exists.
+        - ``not_found`` — list of which endpoints returned empty
+          (``["role"]``, ``["policy"]``, ``["role", "policy"]``, or
+          ``[]`` when both resolved).
+        - ``errors`` — list of error messages for endpoints that
+          errored (non-2xx, network failure). Empty on full success.
+
+        Either resource being absent is NOT an error — many shared
+        roles are skeletal and many roles have no separate policy.
+        Surface ``not_found`` to the operator as informational.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+
+    result: dict = {
+        "name": name,
+        "role": None,
+        "policy": None,
+        "not_found": [],
+        "errors": [],
+    }
+
+    for endpoint_label, api_path in (
+        ("role", f"network-config/v1alpha1/roles/{name}"),
+        ("policy", f"network-config/v1alpha1/policies/{name}"),
+    ):
+        try:
+            response = retry_central_command(
+                central_conn=conn,
+                api_method="GET",
+                api_path=api_path,
+            )
+            body = response.get("msg")
+            # Central returns 200 + empty dict for "not present" on these
+            # endpoints — treat that as not_found rather than a real result.
+            if isinstance(body, dict) and body:
+                result[endpoint_label] = body
+            else:
+                result["not_found"].append(endpoint_label)
+        except Exception as e:
+            result["errors"].append(f"{endpoint_label} ({api_path}): {e}")
+
+    return result
+
+
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_role(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/api_adapter.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/api_adapter.py
@@ -145,11 +145,18 @@ def _bucket_for_profile(profile: dict) -> str:
 
 
 def _normalize_profile(profile: dict) -> dict:
-    """Slim a REST enforcement profile to the keys the builder reads."""
+    """Slim a REST enforcement profile to the keys the builder reads.
+
+    Includes the ``attributes`` list (RADIUS / TACACS attribute pushes)
+    so downstream consumers can see what the profile actually does —
+    e.g. ``Aruba-User-Role = night-night`` tells the cross-platform
+    Central role resolver to fetch the role's access policy.
+    """
     return {
         "name": profile.get("name", ""),
         "action": profile.get("action", ""),
         "description": profile.get("description", ""),
+        "attributes": profile.get("attributes") or [],
     }
 
 

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/mermaid_render.py
@@ -185,13 +185,24 @@ def _render_block(
     return "\n".join(lines)
 
 
-def format_mermaid(flow: FlowGraph) -> dict:
+def format_mermaid(
+    flow: FlowGraph,
+    *,
+    role_mapping_combine: str | None = None,
+    enforcement_combine: str | None = None,
+) -> dict:
     """Render a :class:`FlowGraph` as three Mermaid section blocks.
 
     Returns the dict shape documented at the top of this module. Every
     declaration is emitted on its own source line and every label is
     wrapped in double quotes so Mermaid's per-line parser can't trip on
     AI assembly errors.
+
+    When ``role_mapping_combine`` / ``enforcement_combine`` are provided
+    (one of ``"first-applicable"`` / ``"evaluate-all"``), the
+    corresponding section title is suffixed with the combine algorithm
+    so AI clients building custom widgets can label rule rows correctly
+    without inferring from CONTINUE edges.
 
     Empty sections are omitted from the result — RADIUS_PROXY services
     skip role mapping entirely, for instance, and policies without an
@@ -224,10 +235,17 @@ def format_mermaid(flow: FlowGraph) -> dict:
             FlowEdge(from_id=edge.from_id, to_id=stub_id, label=edge.label, reason=edge.reason)
         )
 
+    def _combine_suffix(combine: str | None) -> str:
+        if combine == "evaluate-all":
+            return " (evaluate-all — rules continue, multiple actions accumulate)"
+        if combine == "first-applicable":
+            return " (first-applicable — first matching rule wins)"
+        return ""
+
     section_titles = {
         "A": "Block A — Service intake (start → match → auth)",
-        "B": "Block B — Role mapping",
-        "C": "Block C — Enforcement (decision → access)",
+        "B": "Block B — Role mapping" + _combine_suffix(role_mapping_combine),
+        "C": "Block C — Enforcement (decision → access)" + _combine_suffix(enforcement_combine),
     }
 
     sections: list[dict[str, str]] = []

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_details.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_details.py
@@ -67,7 +67,14 @@ def _build_rule_index(role_mapping_rules: list[dict], enforcement_rules: list[di
 
 
 def build_details(service: Service, model: PolicyModel) -> dict:
-    """Serialize a service + its referenced policies into an inspector dict."""
+    """Serialize a service + its referenced policies into an inspector dict.
+
+    Includes a ``profile_attributes`` block that maps every enforcement
+    profile referenced by THIS service to its raw RADIUS / TACACS
+    attribute pushes. This is what tells the operator (or the
+    cross-platform Central role resolver) what each profile actually
+    DOES — names like ``WLAN-NIGHT-NIGHT`` are otherwise opaque.
+    """
     from .policy_model import ApplyProfiles, SetRole
 
     service_context = {
@@ -143,11 +150,38 @@ def build_details(service: Service, model: PolicyModel) -> dict:
         linked_names=[],
     )
 
+    # Profile attributes — every profile referenced by THIS service's
+    # enforcement rules (rule actions + default). Maps name → list of
+    # raw attribute dicts so the AI can show what each profile pushes
+    # (Aruba-User-Role, Aruba-Named-User-Vlan, Session-Timeout, etc.)
+    # without re-fetching the enforcement-profile collection.
+    referenced_profile_names: set[str] = set()
+    if enf_policy:
+        for rule in enf_policy.rules:
+            if isinstance(rule.then, ApplyProfiles):
+                referenced_profile_names.update(rule.then.profile_names)
+        if isinstance(enf_policy.default, ApplyProfiles):
+            referenced_profile_names.update(enf_policy.default.profile_names)
+
+    name_to_profile = {p.name: p for p in model.enforcement_profiles.values()}
+    profile_attributes: dict[str, dict] = {}
+    for pname in referenced_profile_names:
+        profile = name_to_profile.get(pname)
+        if profile is None:
+            continue
+        profile_attributes[pname] = {
+            "profile_type": profile.profile_type,
+            "action": profile.action,
+            "description": profile.description,
+            "attributes": list(profile.attributes),
+        }
+
     return {
         "service_context": service_context,
         "authen_rules": [],
         "role_mapping_rules": role_mapping_rules,
         "enforcement_rules": enforcement_rules,
+        "profile_attributes": profile_attributes,
         "warnings": list(model.warnings),
         "rule_index": rule_index,
     }

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_model.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_model.py
@@ -135,6 +135,12 @@ class EnforcementProfile:
     profile_type: str
     action: str = ""
     description: str = ""
+    # Raw RADIUS / TACACS attributes the profile pushes. Each entry is
+    # ``{"type": "Radius:Aruba", "name": "Aruba-User-Role", "value":
+    # "night-night"}`` shape (ClearPass REST format). Surfaces what the
+    # profile actually DOES — operators (and the cross-platform Central
+    # role resolver) walk these to find role / VLAN assignments.
+    attributes: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -221,6 +227,7 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             profile_type=profile_type,
             action=action,
             description=rp.get("description", ""),
+            attributes=list(rp.get("attributes") or []),
         )
     for pp in raw.get("postAuthEnfProfiles", []):
         pid = _stable_id(pp["name"])
@@ -229,6 +236,7 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             name=pp["name"],
             profile_type="post_auth",
             description=pp.get("description", ""),
+            attributes=list(pp.get("attributes") or []),
         )
     for tp in raw.get("tacacsEnfProfiles", []):
         pid = _stable_id(tp["name"])
@@ -239,6 +247,7 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             profile_type="tacacs_accept" if action == "accept" else "tacacs_other",
             action=action,
             description=tp.get("description", ""),
+            attributes=list(tp.get("attributes") or []),
         )
     for cp in raw.get("radiusCoaEnfProfiles", []):
         pid = _stable_id(cp["name"])
@@ -248,6 +257,7 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             profile_type="radius_coa",
             action=cp.get("action", "").lower(),
             description=cp.get("description", ""),
+            attributes=list(cp.get("attributes") or []),
         )
     for gp in raw.get("genericEnfProfiles", []):
         pid = _stable_id(gp["name"])
@@ -258,6 +268,7 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             profile_type="generic_accept" if action == "accept" else "generic_reject",
             action=action,
             description=gp.get("description", ""),
+            attributes=list(gp.get("attributes") or []),
         )
     profile_by_name = {v.name: v for v in model.enforcement_profiles.values()}
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
@@ -218,9 +218,19 @@ async def clearpass_compile_policy_flow(
     Returns:
         On success — dict with ``service_id`` (engine slug),
         ``service_name`` (the exact resolved name), ``service_type``,
-        ``nodes``, ``edges``, ``mermaid``, ``warnings``, and optionally
-        ``details``. Edge labels are one of ``""``, ``YES``, ``NO``,
-        ``FAIL``, ``PASS``, ``CONTINUE``.
+        ``role_mapping_combine`` (``"first-applicable"`` /
+        ``"evaluate-all"`` / ``None``), ``enforcement_combine`` (same
+        domain), ``nodes``, ``edges``, ``mermaid``, ``warnings``, and
+        optionally ``details``. Edge labels are one of ``""``, ``YES``,
+        ``NO``, ``FAIL``, ``PASS``, ``CONTINUE``.
+
+        ``role_mapping_combine`` / ``enforcement_combine`` are the rule
+        combine algorithms surfaced from the model. Evaluate-all role
+        mapping means a device can accumulate multiple roles in one
+        pass (rules continue on match); first-applicable enforcement
+        means the first matching rule wins. Use these to label rule
+        rows correctly in custom UIs — don't hardcode "stop on match"
+        (issue #360).
 
         The ``mermaid`` field carries ready-to-paste Mermaid source as
         ``{"sections": [{"title": ..., "code": ...}, ...],
@@ -291,13 +301,25 @@ async def clearpass_compile_policy_flow(
             return f"Internal error: service '{target_name}' resolved from REST but not present in compiled model"
 
         flow = compile_service(target, model, simulated_attributes=simulated_attributes)
+
+        # Surface the rule-combine algorithms so callers building custom
+        # UIs don't have to infer from CONTINUE edges. None when the
+        # service doesn't reference a corresponding policy (e.g.
+        # RADIUS_PROXY services have no role mapping).
+        rm_policy = model.role_mapping_policies.get(target.role_mapping_policy_id)
+        rm_combine = rm_policy.rule_combine_algo if rm_policy is not None else None
+        ep_policy = model.enforcement_policies.get(target.enforcement_policy_id)
+        ep_combine = ep_policy.rule_combine_algo if ep_policy is not None else None
+
         result: dict[str, Any] = {
             "service_id": flow.service_id,
             "service_name": flow.service_name,
             "service_type": flow.service_type,
+            "role_mapping_combine": rm_combine,
+            "enforcement_combine": ep_combine,
             "nodes": [asdict(n) for n in flow.nodes],
             "edges": [asdict(e) for e in flow.edges],
-            "mermaid": format_mermaid(flow),
+            "mermaid": format_mermaid(flow, role_mapping_combine=rm_combine, enforcement_combine=ep_combine),
             "warnings": list(model.warnings),
         }
         if include_details:

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -43,9 +43,9 @@ description: |
   role-mapping policies, enforcement policies + profiles, roles, auth
   methods, and auth sources to assemble the full picture.
   **Read-only.**
-platforms: [clearpass]
-tags: [clearpass, policy, visualization, audit]
-tools: [health, clearpass_list_policy_services, clearpass_compile_policy_flow]
+platforms: [clearpass, central]
+tags: [clearpass, central, policy, visualization, audit]
+tools: [health, clearpass_list_policy_services, clearpass_compile_policy_flow, central_get_role_with_policy]
 ---
 
 # ClearPass policy visualizer
@@ -295,6 +295,66 @@ out in the walkthrough**:
 > ``[Guest Device Repository]`` authorization source as a per-device
 > attribute. Same applies to "Endpoint=Oculus" in rule 5 (endpoint
 > attribute, not a role).
+
+### Step 4b-2 — Honor the rule-combine algorithms (NEVER hardcode "stop on match")
+
+The response carries two top-level fields you MUST use when labelling
+rule rows in any UI (custom widget or otherwise):
+
+- ``role_mapping_combine`` — one of ``"first-applicable"`` /
+  ``"evaluate-all"`` / ``None``.
+- ``enforcement_combine`` — same domain.
+
+The mermaid section titles already include the combine algorithm —
+when emitting your own rule list (e.g. expandable cards per rule),
+label them accordingly:
+
+- ``evaluate-all`` → "**continue on match**" (rules continue, device
+  can accumulate multiple roles or actions).
+- ``first-applicable`` → "**stop on match**" (first matching rule wins).
+- ``None`` → don't apply a combine label (service has no policy of
+  that kind).
+
+Hardcoding "stop on match" on an evaluate-all role-mapping policy is a
+bug (issue #360). A common ClearPass shape is **evaluate-all role
+mapping + first-applicable enforcement** — read the response fields,
+don't assume.
+
+### Step 4d — Drilling into Aruba role definitions (cross-platform)
+
+When the operator wants to see what an Aruba role actually does
+(beyond the name), call ``central_get_role_with_policy(name=<role>)``.
+You'll know which roles to look up because enforcement profiles push
+them via the ``Aruba-User-Role`` attribute — visible in
+``details.profile_attributes[<profile name>].attributes[]``. Common
+examples:
+
+- Profile ``WLAN-NIGHT-NIGHT`` has ``Aruba-User-Role = "night-night"``
+- Profile ``WLAN-NEST-DEVICE`` has ``Aruba-User-Role = "nest-device"``
+
+Call shape:
+
+```python
+detail = await call_tool("central_get_role_with_policy", {"name": "night-night"})
+# Returns: {name, role: {...}|None, policy: {...}|None, not_found: [...], errors: [...]}
+```
+
+Surface in your reply as an additional inspector block (mirror the
+role-mapping / enforcement section style). The ``policy.security-
+policy.policy-rule[]`` array has the firewall rules — each rule's
+``condition`` (rule-type, services with app-category / application,
+source/destination) and ``action`` (``ACTION_ALLOW`` /
+``ACTION_DENY``) are what determines what traffic the role can do.
+
+Many roles are **skeletal** (just ``{name, description}``) — that's
+fine. Many roles **have no separate security policy** —
+``not_found: ["policy"]`` is informational, not an error. Say so:
+"*The night-night role is referenced as a source in the 'AP default'
+policy but has no policy named after itself.*"
+
+Prefetch is cheap (~2 GETs per role), but call only for roles the
+operator actually asks about — don't blast Central for every profile
+referenced in a 15-rule enforcement chain.
 
 ### Step 4c — When rules apply multiple profiles (MAC auth + MPSK shape)
 

--- a/tests/unit/test_central_role_with_policy.py
+++ b/tests/unit/test_central_role_with_policy.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``central_get_role_with_policy``.
+
+Pins the bundled-fetch behavior introduced in v3.1.6.0 — the tool
+issues two GETs (/roles/{name} + /policies/{name}) and surfaces both
+results together, gracefully reporting which endpoints came back
+empty (a common case: many shared roles are skeletal, many roles have
+no separately-named security policy).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    ctx.get_state = AsyncMock(return_value="prompt")
+    return ctx
+
+
+def _ok(msg: object | None = None) -> dict:
+    return {"code": 200, "msg": msg if msg is not None else {}}
+
+
+class TestCentralGetRoleWithPolicy:
+    @patch("hpe_networking_mcp.platforms.central.tools.roles.retry_central_command")
+    async def test_issues_two_gets_to_role_and_policy_endpoints(self, mock_retry):
+        from hpe_networking_mcp.platforms.central.tools.roles import central_get_role_with_policy
+
+        mock_retry.side_effect = [
+            _ok({"name": "night-night", "description": "Restricted"}),
+            _ok({"name": "night-night", "type": "POLICY_TYPE_SECURITY", "security-policy": {}}),
+        ]
+
+        result = await central_get_role_with_policy(_ctx(), name="night-night")
+
+        assert mock_retry.call_count == 2
+        paths = [c.kwargs["api_path"] for c in mock_retry.call_args_list]
+        assert paths == [
+            "network-config/v1alpha1/roles/night-night",
+            "network-config/v1alpha1/policies/night-night",
+        ]
+        assert all(c.kwargs["api_method"] == "GET" for c in mock_retry.call_args_list)
+        assert result["name"] == "night-night"
+        assert result["role"]["description"] == "Restricted"
+        assert result["policy"]["type"] == "POLICY_TYPE_SECURITY"
+        assert result["not_found"] == []
+        assert result["errors"] == []
+
+    @patch("hpe_networking_mcp.platforms.central.tools.roles.retry_central_command")
+    async def test_missing_policy_reported_in_not_found_not_errors(self, mock_retry):
+        from hpe_networking_mcp.platforms.central.tools.roles import central_get_role_with_policy
+
+        # role exists; policy returns 200 with empty body (Central convention for "not present")
+        mock_retry.side_effect = [
+            _ok({"name": "ADAMS-MPSK", "description": "ADAMS-MPSK"}),
+            _ok({}),
+        ]
+        result = await central_get_role_with_policy(_ctx(), name="ADAMS-MPSK")
+
+        assert result["role"] is not None
+        assert result["policy"] is None
+        assert result["not_found"] == ["policy"]
+        assert result["errors"] == []
+
+    @patch("hpe_networking_mcp.platforms.central.tools.roles.retry_central_command")
+    async def test_both_missing_reports_both_not_found(self, mock_retry):
+        from hpe_networking_mcp.platforms.central.tools.roles import central_get_role_with_policy
+
+        mock_retry.side_effect = [_ok({}), _ok({})]
+        result = await central_get_role_with_policy(_ctx(), name="nonexistent")
+
+        assert result["role"] is None
+        assert result["policy"] is None
+        assert result["not_found"] == ["role", "policy"]
+        assert result["errors"] == []
+
+    @patch("hpe_networking_mcp.platforms.central.tools.roles.retry_central_command")
+    async def test_role_error_doesnt_block_policy_fetch(self, mock_retry):
+        """A failure on one endpoint must not abort the other — the
+        operator gets whatever data is available plus an errors note.
+        """
+        from hpe_networking_mcp.platforms.central.tools.roles import central_get_role_with_policy
+
+        mock_retry.side_effect = [
+            Exception("Client error from central: 500 internal error"),
+            _ok({"name": "night-night", "security-policy": {"policy-rule": [{"position": 1}]}}),
+        ]
+        result = await central_get_role_with_policy(_ctx(), name="night-night")
+
+        assert result["role"] is None
+        assert result["policy"] is not None
+        assert result["policy"]["security-policy"]["policy-rule"] == [{"position": 1}]
+        assert len(result["errors"]) == 1
+        assert "role" in result["errors"][0]
+        assert result["not_found"] == []  # not "not found", explicitly errored

--- a/tests/unit/test_clearpass_policy_visualizer_flow.py
+++ b/tests/unit/test_clearpass_policy_visualizer_flow.py
@@ -514,6 +514,68 @@ class TestCompileServiceRadiusProxy:
 # ---------------------------------------------------------------------------
 
 
+class TestEnforcementProfileAttributes:
+    """RADIUS / TACACS attribute pushes on enforcement profiles are
+    surfaced through the model (issue #360 — operators want to see
+    what each profile actually does, e.g. Aruba-User-Role pushes).
+    """
+
+    def test_profile_attributes_flow_from_raw_to_model(self):
+        raw = _minimal_raw()
+        # Inject a RADIUS profile with attribute push (overrides defaults)
+        raw["radiusEnfProfiles"] = [
+            {
+                "name": "WLAN-NIGHT-NIGHT",
+                "action": "Accept",
+                "description": "",
+                "attributes": [{"type": "Radius:Aruba", "name": "Aruba-User-Role", "value": "night-night"}],
+            }
+        ]
+        model = build(raw)
+        profile = next(p for p in model.enforcement_profiles.values() if p.name == "WLAN-NIGHT-NIGHT")
+        assert profile.attributes == [{"type": "Radius:Aruba", "name": "Aruba-User-Role", "value": "night-night"}]
+
+    def test_profile_attributes_default_empty_list(self):
+        model = build(_minimal_raw())
+        # The default [Allow Access Profile] fixture has no attributes — should be []
+        allow = next(p for p in model.enforcement_profiles.values() if p.name == "[Allow Access Profile]")
+        assert allow.attributes == []
+
+    def test_details_profile_attributes_block_includes_referenced_profiles_only(self):
+        # Build a fixture where ONE referenced + ONE unreferenced profile exist;
+        # only the referenced one should appear in details.profile_attributes.
+        raw = _minimal_raw(
+            enf_rules=[
+                {
+                    "index": 0,
+                    "expression": _single_predicate("X"),
+                    "results": [{"name": "Enforcement-Profile", "displayValue": "WLAN-NIGHT-NIGHT"}],
+                }
+            ]
+        )
+        raw["radiusEnfProfiles"] = [
+            {
+                "name": "WLAN-NIGHT-NIGHT",
+                "action": "Accept",
+                "attributes": [{"type": "Radius:Aruba", "name": "Aruba-User-Role", "value": "night-night"}],
+            },
+            {
+                "name": "WLAN-UNUSED",
+                "action": "Accept",
+                "attributes": [{"type": "Radius:Aruba", "name": "Aruba-User-Role", "value": "some-other-role"}],
+            },
+        ]
+        model = build(raw)
+        svc = next(iter(model.services.values()))
+        details = build_details(svc, model)
+        assert "profile_attributes" in details
+        assert "WLAN-NIGHT-NIGHT" in details["profile_attributes"]
+        assert "WLAN-UNUSED" not in details["profile_attributes"]
+        assert details["profile_attributes"]["WLAN-NIGHT-NIGHT"]["attributes"] == [
+            {"type": "Radius:Aruba", "name": "Aruba-User-Role", "value": "night-night"}
+        ]
+
+
 class TestBuildDetails:
     def test_details_contains_service_context_and_rules(self):
         rm_rules = [

--- a/tests/unit/test_clearpass_policy_visualizer_tools.py
+++ b/tests/unit/test_clearpass_policy_visualizer_tools.py
@@ -363,3 +363,13 @@ class TestCompilePolicyFlowFanout:
         assert len(result["edges"]) > 0
         # ALLOW end node should be present (single enf rule resolves to Allow Access Profile)
         assert any("ALLOW" in n["label"] for n in result["nodes"] if n["type"] == "end")
+        # Combine algorithms surfaced as top-level fields (issue #360)
+        assert "role_mapping_combine" in result
+        assert "enforcement_combine" in result
+        # This fixture has no role mapping → None; first-applicable enf → "first-applicable"
+        assert result["role_mapping_combine"] is None
+        assert result["enforcement_combine"] == "first-applicable"
+        # Section titles in mermaid output include the combine algorithm so
+        # AI clients building custom widgets don't hardcode "stop on match"
+        enf_block = next(s for s in result["mermaid"]["sections"] if "Enforcement" in s["title"])
+        assert "first-applicable" in enf_block["title"]


### PR DESCRIPTION
## Summary

Operator's custom widget on v3.1.5.0 hardcoded "stop on match" on every role-mapping rule row even though the policy is evaluate-all (rules continue, devices accumulate multiple roles). Also: no way to drill into what an Aruba role actually does — `WLAN-NIGHT-NIGHT` was just an opaque name. Both fixed.

- **Surface combine algorithms as structured fields.** New top-level response fields `role_mapping_combine` + `enforcement_combine`. Mermaid section titles include the algorithm: *"Block B — Role mapping (evaluate-all — rules continue, multiple actions accumulate)"*.
- **Surface enforcement profile attributes.** Extended `EnforcementProfile` model + adapter with `attributes` (RADIUS pushes like `Aruba-User-Role: night-night`). Available in `details.profile_attributes[<name>].attributes`.
- **New Central tool `central_get_role_with_policy(name)`** — bundles `/roles/{name}` + `/policies/{name}` so the AI can drill into role detail on demand. Returns `{role, policy, not_found, errors}` shape. Gracefully handles skeletal roles + missing policies.
- **Skill template updated** to honor the new fields (Step 4b-2 + Step 4d).

Closes #360

## Live verification (operator's tenant)

| Role | Result |
|---|---|
| `night-night` | role + policy both populated; policy has 10 deny rules (SOCIAL-NETWORKING, netflix, hulu, etc.) |
| `ADAMS-MPSK` | role populated, policy empty → `not_found=['policy']` |
| `nonexistent-role-xyz` | both empty → `not_found=['role','policy']`; no errors |

## Test plan

- [x] 1385 tests pass (up from 1378), ruff + format + mypy + bandit clean
- [x] New test class `TestEnforcementProfileAttributes` (3 tests) — attributes flow from raw → model, default empty list, `details.profile_attributes` includes only referenced profiles
- [x] New test file `test_central_role_with_policy.py` (4 tests) — issues two GETs to right endpoints, missing policy reported in not_found, both-missing case, role-error doesn't block policy fetch
- [x] Extended `test_end_to_end_compiles_a_minimal_service` to assert `role_mapping_combine` / `enforcement_combine` + mermaid title includes combine algo
- [x] `central_get_role_with_policy` added to `TOOLS["roles"]` so registry-population test stays green
- [ ] After merge + tag + release + image rebuild: live-verify the *No Wireless For You Auth Service* widget shows "continue on match" for Block B + correctly looks up `night-night` role detail when asked