### PR TITLE
fix: preserve bare-string returns through response envelope (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.6.0] - 2026-05-19
 
-**Minor — ClearPass policy visualizer fix combine-algorithm mislabeling + add cross-platform Aruba role resolution (#360).** Operator's custom widget on v3.1.5.0 hardcoded "stop on match" on every role-mapping rule row even though the policy is evaluate-all (rules continue, devices accumulate multiple roles). Also: there was no way to drill into what an Aruba role actually does — `WLAN-NIGHT-NIGHT` was just a name. Both fixed.
+**Minor — ClearPass policy visualizer fix combine-algorithm mislabeling + add cross-platform Aruba role resolution (#360); response envelope no longer drops bare-string returns from invoke_tool dispatch (#362).**
+
+### Envelope bug — bare-string returns silently lost via `<platform>_invoke_tool` (#362)
+
+Operator dispatched `central_get_scope_diagram` via `central_invoke_tool` and got `{ok: True, data: None}` — the Mermaid source was silently lost. Root cause: `_payload_from_content` in the response envelope only recovered JSON-parseable text blocks (`json.loads(block.text)` raises on a Mermaid string → loop `continue`s → returns None). Affected EVERY string-returning tool dispatched through the meta-tool path, including the very common `-> dict | list | str` error-fallback case where the AI silently lost `"Error: ..."` messages.
+
+Fixed in `middleware/response_envelope.py:_payload_from_content`: two-pass recovery — first pass finds a JSON-parseable block (existing behaviour, preserves dict/list payloads), fallback returns the first non-empty text block as a raw string. Bare-string returns now survive. Unit tests pin the contract.
+
+### Operator's original v3.1.5.0 visualizer feedback (#360)
+
+Custom widget on v3.1.5.0 hardcoded "stop on match" on every role-mapping rule row even though the policy is evaluate-all (rules continue, devices accumulate multiple roles). Also: there was no way to drill into what an Aruba role actually does — `WLAN-NIGHT-NIGHT` was just a name. Both fixed.
 
 ### Combine algorithm surfaced as structured response fields
 

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -110,7 +110,7 @@ def _is_envelope_shape(value: Any) -> bool:
 
 
 def _payload_from_content(content: list | None) -> Any:
-    """Recover a tool's JSON payload from its content blocks.
+    """Recover a tool's payload from its content blocks.
 
     FastMCP leaves ``structured_content`` as ``None`` for a tool annotated
     ``-> Any`` that returns a **non-dict** value — most importantly a bare
@@ -121,16 +121,31 @@ def _payload_from_content(content: list | None) -> Any:
     text, so recover it here — otherwise the envelope's ``data`` is
     ``null`` and the AI never sees the result. See issue #327.
 
-    Returns the parsed JSON of the first JSON-parseable ``TextContent``
-    block, or ``None`` when no block parses (the envelope then falls back
-    to ``data: null`` — the pre-fix behaviour, no regression).
+    Two-pass recovery:
+
+    1. First pass — find a JSON-parseable block (preserves dict/list
+       payloads from ``-> Any`` tools that returned a non-dict, plus
+       structured returns from ``-> dict | list | str`` tools).
+    2. Fallback — if no block parses as JSON, return the first non-empty
+       text block as a raw string. This preserves bare-string returns —
+       Mermaid source from ``central_get_scope_diagram``, error fallback
+       strings from tools declared ``-> dict | list | str``, etc. — that
+       previously vanished into ``data: null`` (issue #362).
+
+    Returns ``None`` only when no text block carries any content.
     """
+    # First pass: any JSON-parseable block wins (preserves dict/list payloads).
     for block in content or []:
         if isinstance(block, TextContent) and block.text:
             try:
                 return json.loads(block.text)
             except (ValueError, TypeError):
                 continue
+    # Second pass: no JSON found. Fall back to the first non-empty text
+    # block so bare-string returns survive instead of becoming data: null.
+    for block in content or []:
+        if isinstance(block, TextContent) and block.text:
+            return block.text
     return None
 
 

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -307,19 +307,45 @@ class TestPayloadFromContent:
         payload = {"name": "mcp", "privileges": []}
         assert _payload_from_content(_text(payload)) == payload
 
-    def test_non_json_text_returns_none(self):
-        assert _payload_from_content([TextContent(type="text", text="not json")]) is None
+    def test_non_json_text_preserved_as_string(self):
+        """Issue #362 — bare-string returns (e.g. Mermaid source from
+        central_get_scope_diagram, error fallback strings from tools
+        declared `-> dict | list | str`) MUST survive the envelope wrap
+        instead of becoming ``data: null``. Pre-fix this returned None
+        and the AI silently lost the entire result."""
+        assert _payload_from_content([TextContent(type="text", text="not json")]) == "not json"
+
+    def test_mermaid_string_preserved(self):
+        """The actual scope_diagram failure case from operator #362."""
+        mermaid = "flowchart TD\n    N1((HQ))\n    N2((BRANCH-1))\n    N1 --> N2"
+        assert _payload_from_content([TextContent(type="text", text=mermaid)]) == mermaid
 
     def test_empty_or_none_content_returns_none(self):
         assert _payload_from_content([]) is None
         assert _payload_from_content(None) is None
 
+    def test_empty_text_block_returns_none(self):
+        """Empty-string text blocks shouldn't satisfy the fallback —
+        truly empty content still yields None."""
+        assert _payload_from_content([TextContent(type="text", text="")]) is None
+
     def test_first_json_parseable_block_wins(self):
+        """JSON blocks take priority over later non-JSON blocks (existing behaviour)."""
         blocks = [
             TextContent(type="text", text="not json"),
             TextContent(type="text", text=json.dumps({"recovered": True})),
         ]
         assert _payload_from_content(blocks) == {"recovered": True}
+
+    def test_first_text_used_when_no_block_parses_as_json(self):
+        """When zero blocks parse as JSON, fall back to the FIRST non-empty
+        text block — not concatenated, not later blocks. Preserves
+        single-block string returns deterministically."""
+        blocks = [
+            TextContent(type="text", text="first non-json"),
+            TextContent(type="text", text="second non-json"),
+        ]
+        assert _payload_from_content(blocks) == "first non-json"
 
 
 @pytest.mark.unit
@@ -396,17 +422,49 @@ class TestContentFallbackRecovery:
         assert result is original
 
     @pytest.mark.asyncio
-    async def test_non_json_content_still_yields_null_data(self):
-        """No regression: non-JSON text content → data: None (pre-fix behaviour)."""
+    async def test_non_json_content_preserved_as_string(self):
+        """Issue #362 — bare-string returns (e.g. Mermaid source from
+        central_get_scope_diagram, error strings from tools declared
+        `-> dict | list | str`) MUST land in `data` as the raw string
+        rather than `data: null`. Pre-fix the string was silently lost.
+        """
         middleware = ResponseEnvelopeMiddleware()
         ctx = _make_context("health")
-        original = _make_tool_result(structured=None, content=[TextContent(type="text", text="plain text, not json")])
+        original = _make_tool_result(
+            structured=None,
+            content=[TextContent(type="text", text="plain text, not json")],
+        )
         call_next = AsyncMock(return_value=original)
 
         result = await middleware.on_call_tool(ctx, call_next)
 
-        assert result.structured_content["data"] is None
+        assert result.structured_content["data"] == "plain text, not json"
         assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_dispatch_to_string_returning_tool_preserves_mermaid(self):
+        """The exact path from issue #362: `central_invoke_tool` dispatching
+        to `central_get_scope_diagram`. The underlying tool returns the
+        Mermaid source as a `str`; FastMCP doesn't populate
+        structured_content for `-> Any` meta-tools forwarding a non-dict;
+        the envelope must recover the string from content rather than
+        emitting `data: null`.
+        """
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        mermaid = "flowchart TD\n    N1((HQ))\n    N2((BRANCH-1))\n    N1 --> N2"
+        original = _make_tool_result(
+            structured=None,
+            content=[TextContent(type="text", text=mermaid)],
+        )
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["data"] == mermaid
+        assert result.structured_content["ok"] is True
+        assert result.structured_content["tool"] == "central_invoke_tool"
+        assert result.structured_content["platform"] == "central"
 
     @pytest.mark.asyncio
     async def test_structured_content_takes_precedence_over_content(self):


### PR DESCRIPTION
## Summary

Operator hit a silent data-loss bug dispatching `central_get_scope_diagram` via `central_invoke_tool` in code mode — the envelope came back with `{ok: True, data: None}` and the entire Mermaid source was dropped. Root cause: `_payload_from_content` only recovered JSON-parseable text blocks. A Mermaid string isn't valid JSON, so `json.loads` raises, the loop `continue`s every block, returns None.

Affects **every string-returning tool dispatched through the `<platform>_invoke_tool` meta-tool path**, including the very common `-> dict | list | str` error-fallback case — when one of those tools returned an `\"Error: ...\"` string, the envelope hid it.

## Fix

Two-pass recovery in `_payload_from_content`:

1. First pass — find a JSON-parseable block (preserves dict/list payloads, existing behaviour).
2. Fallback — if no block parses as JSON, return the first non-empty text block as a raw string. Bare-string returns now survive.

Closes #362

## Bundling

v3.1.6.0 (PR #361) isn't tagged yet — paused at user request to investigate this bug. CHANGELOG entry amended in place so the envelope fix ships in v3.1.6.0 rather than being split into v3.1.6.1.

## Test plan

- [x] 1389 tests pass; ruff + format + mypy + bandit clean in dev container
- [x] New unit test `test_invoke_tool_dispatch_to_string_returning_tool_preserves_mermaid` covers the exact failing path from operator's report
- [x] New unit test `test_mermaid_string_preserved` pins the simplest case
- [x] Existing `test_non_json_text_returns_none` updated → `test_non_json_text_preserved_as_string` (this was the bug, codified)
- [x] Existing `test_first_json_parseable_block_wins` stays green — JSON precedence is preserved
- [x] New `test_first_text_used_when_no_block_parses_as_json` pins fallback determinism
- [x] Live verified in dev container: replaying operator's exact `central_invoke_tool` → `central_get_scope_diagram` payload through the middleware now returns the Mermaid string in `data`
- [ ] After merge + tag + release + image rebuild: re-run operator's `central_invoke_tool` call and confirm the Mermaid string lands in `data`