### PR TITLE
v3.1.7.1: sanitize tenant names + close v3.1.7.0 doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.7.1] - 2026-05-19
+
+**Patch — v3.1.7.0 audit follow-up: sanitize tenant identifiers from shipped skill + close doc drift.** No behaviour change; clears the cleanup items the v3.1.7.0 audit surfaced before the next feature lands on top.
+
+- **Sanitize tenant-real names** from `central-scope-visualizer.md` worked examples. Replaced operator's actual site / collection / role / alias / policy names (`HOME`, `Lake House`, `EST Timezone Sites`, `PD-US`, `CST`, `US Sites`, `JA`, `AdamsLAB`, `night-night`, `apple-tv`, `login-control`, `fpp-device`, `nest-device`, `9004-US`, `635-US`, `755-US`, `BR-150`) with generic placeholders (`HQ` / `BRANCH-1` / `East Region Sites` / `Region-A..D` / `CORP-LAB` / `policy-A..D` / `role-A..C` / `model-A..E`). Industry-generic Aruba product references kept (CX-8360, CX-6300, CX-6200 model families). Per the [generic-example-names rule](../../.claude/projects/-Users-jonadams-Documents-Coding-Projects-hpe-networking-mcp/memory/feedback_generic_example_names.md), shipped artifacts must not leak tenant identity.
+- **README.md tool counts updated** — Central 613 → 614, total underlying tools 1893 → 1894 (12 occurrences across the comparison table, ASCII architecture diagram, env-var docs, and troubleshooting section).
+- **INSTRUCTIONS.md scope-tools section updated** — added `central_get_committed_config` to the inventory line + a guidance bullet explaining when to use it vs `central_get_effective_config`. Flagged `central_get_scope_diagram` as deprecated for visualization with a pointer to the new `central-scope-visualizer` skill. Total tool count bumped to 1894.
+- **docs/TOOLS.md** — new `### Scope & Configuration Hierarchy` section documenting all six scope tools (the five existing + the new `central_get_committed_config`) with one-line descriptions + parameter tables. Added rows for `clearpass-policy-walker` and `central-scope-visualizer` skills in the skill index table. Central header bumped to `(614 tools + 12 prompts)`. Tool-count references updated throughout (1893 → 1894).
+- **`test_central_committed_config.py`** — added `test_build_scope_tree_exception_returns_error_string` covering the code-mode error contract path that the audit flagged as missing (when `build_scope_tree` raises, the tool returns the failure as a string, not propagates).
+
 ## [3.1.7.0] - 2026-05-19
 
 **Minor — Central scope visualizer skill + symmetric `central_get_committed_config` tool.** Operator's first try at `central_get_scope_diagram` produced a sprawling unreadable wall — devices and device-groups all enumerated as separate circle nodes. The structured `central_get_scope_tree` output already has everything needed for the screenshot-quality visualizations operators want (per-scope resource counts, persona breakdowns, device-type rollups) — there was just no discoverable runbook telling the AI to use that path instead of the raw Mermaid string.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **1037 + 2 prompts** | **613 + 12 prompts** | **10** | **142** | **19** | **25** | **47 + 9 prompts** |
+| **Underlying tools** | **1037 + 2 prompts** | **614 + 12 prompts** | **10** | **142** | **19** | **25** | **47 + 9 prompts** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1893 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1894 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 142 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1893 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 142 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1894 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -516,10 +516,10 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐           │
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │           │
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │           │
-│ │ 1037   │ │613tools│ │10 tools│ │142 tool│ │19 tools│ │25 tools│ │47 tools│           │
+│ │ 1037   │ │614tools│ │10 tools│ │142 tool│ │19 tools│ │25 tools│ │47 tools│           │
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │           │
 │                                                                                         │
-│  All 1893 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1894 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘           │
 │     │          │          │          │          │          │          │                 │
@@ -534,7 +534,7 @@ Set `ENABLE_AOS8_WRITE_TOOLS=true` to expose the 12 AOS8 write tools (gated by e
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1893 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1894 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -596,7 +596,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis write/mutation tools (staged; commit with `axis_commit_changes`) |
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1893 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1894 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -791,25 +791,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1893)
+### Tool Surface Looks Wrong (6 tools vs. 1894)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1893 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1894 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 7 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1893 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1894 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1893 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1894 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1893 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1894 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1893 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1894 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1893 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1894 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1893 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1894 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1893 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1894 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1893 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1894 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -171,6 +171,8 @@ skills register in every mode without violating the code-mode design.
 | `morning-coffee-report` | Daily ops digest covering the last 24h: who's been in (audit logs), what's broken (active alerts), top talkers (clients/APs by load), AI insights (Mist SLE). Day-over-day delta deferred to phase 2 | v2.3.1.8 |
 | `central-scope-walker` | Aruba Central scope-tree walker — resolves a scope name / path / scope_id to its Central `scope_id` plus parent path, type, and metadata. Tiny utility skill (one paste-ready `execute` snippet) referenced by `central-scope-audit`, `change-pre-check`, `change-post-check`, `aos-migration`. Authored in response to small-local-model failures at authoring tree-recursion in the sandbox (Qwen3 4B / OpenClaw test report 2026-05-07) | v3.0.1.5 |
 | `cross-platform-rf-check` | Cross-platform site RF / channel-planning check — code-mode runbook equivalent of the `site_rf_check` tool (which is registered in `dynamic` mode only). Resolves a site on Mist + Central, pulls per-AP per-band radio state (channel, power, utilization, noise floor), aggregates channel distribution, and flags co-channel clusters / airtime pressure / elevated noise. Authored after operators hit "AI can't find site_rf_check" in code mode | v3.1.0.6 |
+| `clearpass-policy-walker` | ClearPass policy visualizer — compiles a policy service into a sectioned Mermaid flowchart (Block A intake / Block B role mapping / Block C enforcement) with combine-algorithm labels, what-if simulator, and on-demand drill into Aruba role policies via `central_get_role_with_policy` | v3.1.3.0 / v3.1.6.0 |
+| `central-scope-visualizer` | Aruba Central scope hierarchy visualizer — RF-check-style data-fetch runbook for the scope tree. Five zoom levels (top-level overview / drilled-in site / per-scope committed inspector / per-scope effective inspector / committed-vs-effective diff). Operator-output rules pin aggregate-by-default rendering, resource counts on every node, and never-expose-numeric-IDs. Replaces the deprecated `central_get_scope_diagram` Mermaid path | v3.1.7.0 |
 
 The `TEMPLATE.md` file in the skills directory is a starting point if you
 want to author a new skill — it's filtered out of the registry by name.
@@ -671,7 +673,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (613 tools + 12 prompts)
+## Aruba Central (614 tools + 12 prompts)
 
 > **v3.1.1.0**: bulk-imported 197 net-new config-model object types (389 net-new tools across 19 new modules) from the gitignored local snapshot at `api-endpoints/central/config/`. See the **Config-Model Tools** section at the end of the Central section for the new module inventory and the `central_get_<type>` / `central_manage_<type>` naming convention. The 15 hand-curated tool pairs documented in detail below (sites, devices, alerts, security_policy, wlan_profiles, gateway_clusters, named_vlans, aliases, server_groups, config_assignments, scope, gateway_cluster_intent) keep their tuned docstrings and edge-case handling.
 
@@ -1333,6 +1335,67 @@ to translate between Central's named/aliased config and Mist's inline config.
 | action_type | str | Yes | `create`, `update`, or `delete`. |
 | payload | dict | Yes | Device group payload. For create: `scopeName` required. Optional: `description`. |
 | group_id | str | No | Group ID. Required for update and delete. |
+
+### Scope & Configuration Hierarchy
+
+Six read-only tools for inspecting the Central scope hierarchy (Global → Site collections → Sites → Device collections → Devices) and the configuration committed at each level. The `central-scope-visualizer` skill orchestrates these into ready-to-render visualizations; the `central-scope-walker` skill resolves a scope name / path to its `scope_id` for downstream tool calls.
+
+#### `central_get_scope_tree`
+
+> Returns the full scope hierarchy as a nested dict. Each node carries `scope_id`, `scope_name`, `type` (`GLOBAL` / `SITE_COLLECTION` / `SITE` / `DEVICE_COLLECTION` / `DEVICE`), `persona_count`, `resource_count`, `child_scope_count`, `device_count`, per-persona `categories` breakdown, and recursive `children`. One call gives you everything needed for top-level visualizations + per-scope counts.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| view | str | No | `committed` (default — directly assigned at each scope) or `effective` (rolls up inherited resources at every descendant scope). |
+
+#### `central_get_scope_resources`
+
+> Returns the configuration resources directly assigned to a specific scope node — does NOT roll up inherited resources from parent scopes (use `central_get_effective_config` for that, or `central_get_committed_config` for the same data in a shape that diffs cleanly).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | Yes | The scope ID to look up. Get from `central_get_scope_tree`. |
+| persona | str | No | Filter (e.g. `CAMPUS_AP`, `ACCESS_SWITCH`, `BRANCH_GW`). Omit for all personas. |
+| include_details | bool | No | Include full resource configuration data (default false). |
+
+#### `central_get_committed_config` (v3.1.7.0+)
+
+> Returns resources committed AT the given scope as a flat list with persona attribution and `scope_path`. Same per-resource shape as `central_get_effective_config`'s `effective_resources` so the two views diff cleanly side-by-side when answering "what did the parent contribute vs what was added here?".
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | Yes | The scope ID. Get from `central_get_scope_tree`. |
+| persona | str | No | Filter (e.g. `CAMPUS_AP`, `ACCESS_SWITCH`). |
+| include_details | bool | No | Include full resource configuration data (default `true`). |
+
+#### `central_get_effective_config`
+
+> Walks from the given scope up to the global root, collecting all resources at each ancestor. Returns `inheritance_path` (Global → … → this scope) plus `effective_resources` — each resource grouped by name with `instances` showing where it was committed (`origin_scope_id`, `origin_scope_name`, `persona`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | Yes | The scope ID to query. |
+| persona | str | No | Filter. |
+| include_details | bool | No | Include full resource configuration data (default false). |
+
+#### `central_get_devices_in_scope`
+
+> Recursively collects all DEVICE leaves beneath the given scope. Each device dict includes `category`, `persona`, `device_type` (`AP` / `SWITCH` / `GATEWAY` / `OTHER`), `device_model`, `serial_number`, `mac_address`, `part_number`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | Yes | The scope ID to search under. |
+| device_type | str | No | Filter to one of `AP`, `SWITCH`, `GATEWAY`, `OTHER`. |
+
+#### `central_get_scope_diagram`
+
+> Generates a Mermaid `flowchart TD` string for the scope hierarchy. **Deprecated for visualization** — on real tenants the single Mermaid block sprawls horizontally into an unreadable wall and disconnects device groups into floating islands. Use the `central-scope-visualizer` skill instead, which fetches the structured tree and lets the AI render whatever diagram fits the request. Kept available as a text-mode fallback when nothing else works.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| scope_id | str | No | Optional subtree root. Omit for full tree. |
+| include_resources | bool | No | Show resource nodes via dashed edges. On large tenants this explodes the line count (180 → 2000+); leave false. |
+| include_devices | bool | No | Show device leaf nodes (default true). |
 
 ### Config Assignments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.1.7.0"
+version = "3.1.7.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1893 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1894 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
@@ -339,11 +339,12 @@ When asked to create a new site based on an existing site:
 - **Switch PoE & Trends**: central_get_switch_hardware_trends, central_get_switch_poe
   - **ALWAYS use `central_get_switch_hardware_trends` for PoE capacity/consumption data** — it returns all stack members with per-member PoE data. Do NOT use `central_get_switch_details` for PoE as it only returns the conductor's data for stacked switches.
   - Use `central_get_switch_poe` for per-port PoE wattage (which port is drawing how many watts).
-- **Scope & Configuration**: central_get_scope_tree, central_get_scope_resources, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram
+- **Scope & Configuration**: central_get_scope_tree, central_get_scope_resources, central_get_committed_config, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram
   - Use `central_get_scope_tree` to view the full scope hierarchy (Global → Collections → Sites → Devices)
-  - Use `central_get_scope_resources` to see what configuration profiles are assigned at a specific scope level
+  - Use `central_get_scope_resources` to see what configuration profiles are assigned at a specific scope level (legacy walker; `central_get_committed_config` returns the same data in a shape that diffs cleanly against `central_get_effective_config`)
+  - Use `central_get_committed_config(scope_id, persona?, include_details=True)` to see resources directly assigned AT a scope — same per-resource shape as `central_get_effective_config` for clean side-by-side diff when asking "what did the parent contribute vs what was added here?" (v3.1.7.0+)
   - Use `central_get_effective_config` to see what configuration a device inherits and from where — pass `include_details=true` for full resource configuration data
-  - Use `central_get_scope_diagram` to generate a Mermaid flowchart of the scope hierarchy — render it directly, the string is pre-built
+  - Use `central_get_scope_diagram` to generate a Mermaid flowchart of the scope hierarchy — **deprecated for visualization** (sprawls horizontally on real tenants); for visualization use the `central-scope-visualizer` skill which fetches the structured tree and lets the AI build whatever diagram fits the request
   - **Presenting scope data**: Each scope node includes `persona_count`, `resource_count`, and per-persona `categories` (e.g. policy, vlan, profile). Present as an indented hierarchy with counts at each level. Group resources by category, not as flat lists. For effective config, show the `inheritance_path` first (Global → Collection → Site), then group resources by origin scope to show what each level contributes. Use the `scope_configuration_overview` or `scope_effective_config` prompts for guided workflows.
 - **WLANs**: central_get_wlans, central_get_wlan_stats
   - Use `central_get_wlan_stats` for throughput trends (tx/rx time-series) for a specific SSID over a time window

--- a/src/hpe_networking_mcp/skills/central-scope-visualizer.md
+++ b/src/hpe_networking_mcp/skills/central-scope-visualizer.md
@@ -69,22 +69,23 @@ These constrain every response you produce inside this skill:
 
 1. **Aggregate by default, enumerate on demand.** When a scope has 4+
    sibling site-collections, show them as one aggregated node
-   ("4 Site Collections — CST · US Sites · JA · PD-US") with an
-   affordance to expand. When a site has 17 devices spanning 5 models,
-   show them grouped by type ("Switches — 8 (8360×2, 6300×2,
-   6200×2)") not as 17 individual rectangles. Enumerated walls of
-   nodes are unreadable; the operator can ask to drill in.
+   ("4 Site Collections — Region-A · Region-B · Region-C · Region-D")
+   with an affordance to expand. When a site has 17 devices spanning
+   5 models, show them grouped by type ("Switches — 8 (CX-8360×2,
+   CX-6300×2, CX-6200×2)") not as 17 individual rectangles.
+   Enumerated walls of nodes are unreadable; the operator can ask to
+   drill in.
 2. **Resource counts on every node.** Each scope's most useful single
    number is "how much config lives here?" Always include resource
    count (from `tree_to_dict`'s `resource_count`) and device count
    (`device_count`) on every visible node.
 3. **NEVER expose raw numeric scope IDs to the user.** Values like
-   `"197674198"`, `"18413656377"`, `"2611343621"` are internal
-   identifiers — operators don't recognize them. Use scope NAMES
-   (`"HOME"`, `"EST Timezone Sites"`, `"Global"`) in user-facing
-   output. When a scope has no friendly name (some intermediate
-   site-collection nodes), show its TYPE plus child counts instead
-   (e.g. "Site collection · 3 sites · 12 devices") rather than the ID.
+   `"1234567890"` or `"9876543210"` are internal identifiers —
+   operators don't recognize them. Use scope NAMES (`"HQ"`,
+   `"East Region Sites"`, `"Global"`) in user-facing output. When a
+   scope has no friendly name (some intermediate site-collection
+   nodes), show its TYPE plus child counts instead (e.g.
+   "Site collection · 3 sites · 12 devices") rather than the ID.
 4. **Color-code by node type** in the legend: Global (gray/neutral),
    Site collection (orange/green), Site (blue), Device collection
    (yellow/purple), Device (white/gray-outline). Match the legend
@@ -124,7 +125,7 @@ These constrain every response you produce inside this skill:
 | User request | Zoom level | Primary tool |
 |---|---|---|
 | "visualize the scope hierarchy" / "show me the scope tree" / "draw the Central scope" | **Top-level overview** | `central_get_scope_tree(view="committed")` |
-| "show me what's at site HQ" / "what does HOME look like" | **Drilled-in subtree** for one site | `central_get_scope_tree` + `central_get_devices_in_scope(scope_id=<site>)` |
+| "show me what's at site HQ" / "what does BRANCH-1 look like" | **Drilled-in subtree** for one site | `central_get_scope_tree` + `central_get_devices_in_scope(scope_id=<site>)` |
 | "what config is at <scope>" / "what's directly assigned here" | **Committed config at one scope** | `central_get_committed_config(scope_id=<scope>)` |
 | "what's the effective config at <scope>" / "where does <resource> come from at <scope>" | **Effective config at one scope** | `central_get_effective_config(scope_id=<scope>)` |
 | "what did the parent contribute vs what was added at <scope>" / "committed vs effective at <scope>" | **Both views — diff** | `central_get_committed_config` + `central_get_effective_config` side-by-side |
@@ -172,10 +173,10 @@ Pattern for each visible node:
 When you have 4+ sibling site-collections under Global, fold them into one node:
 
 ```
-+--------------------------------+
-|  4 Site Collections            |
-|  CST · US Sites · JA · PD-US   |   ← first ~3 names, then "..."
-+--------------------------------+
++-------------------------------------+
+|  4 Site Collections                 |
+|  Region-A · Region-B · Region-C ... |   ← first ~3 names, then "..."
++-------------------------------------+
 ```
 
 The legend goes at the **top** of the response (above the tree), not the bottom:
@@ -194,7 +195,7 @@ End the overview with a one-line offer: *"Want to drill into a specific site or 
 
 #### 3b — Drilled-in subtree for one site
 
-Goal: show one site (HOME, Lake House, etc.) with its device-type rollups underneath.
+Goal: show one site (HQ, BRANCH-1, etc.) with its device-type rollups underneath.
 
 ```python
 # Step 3b — find the site_id then get device inventory
@@ -216,7 +217,7 @@ Render the site as the root, with one child per device TYPE (not per device):
 
 ```
 +----------------------+
-|  HOME                |
+|  HQ                  |
 |  17 devices · 3 personas |
 +----------------------+
         |
@@ -225,9 +226,9 @@ Render the site as the root, with one child per device TYPE (not per device):
 +----+ +----+ +----+ +-------+
 | APs| | SW | | GW | | Bridge|
 | 4  | | 8  | | 4  | | 1     |
-| 635-US,| | 8360×2,| | 9004-US ×4 | | BR-150 |
-| 755-US×3| 6300×2, |
-+----+ | 6200×2 |
+| (model-A,| | (model-B×2,| | (model-D ×4) | | (model-E ×1)|
+| model-C×3)| model-B×2, |
++----+ | model-B×2)|
        +-------+
 ```
 
@@ -235,11 +236,11 @@ In Mermaid:
 
 ```mermaid
 flowchart TD
-    SITE["HOME<br/>17 devices · 3 personas"]
-    APS["Access Points<br/>4 (635-US, 755-US ×3)"]
-    SW["Switches<br/>8 (8360×2, 6300×2, 6200×2)"]
-    GW["Gateways<br/>4 × 9004-US"]
-    BR["Bridge<br/>1 × BR-150"]
+    SITE["HQ<br/>17 devices · 3 personas"]
+    APS["Access Points<br/>4 (model-A, model-C ×3)"]
+    SW["Switches<br/>8 (model-B×2, model-B×2, model-B×2)"]
+    GW["Gateways<br/>4 × model-D"]
+    BR["Bridge<br/>1 × model-E"]
     SITE --> APS
     SITE --> SW
     SITE --> GW
@@ -265,17 +266,17 @@ Render as labelled groups of chips per persona, with category headers
 inside each persona block. Example (one persona block):
 
 ```
-Global › EST Timezone Sites  [CAMPUS_AP]
-51 resources committed at this scope — these are inherited by HOME and Lake House
+Global › East Region Sites  [CAMPUS_AP]
+51 resources committed at this scope — these are inherited by HQ and BRANCH-1
 
 POLICIES (17)
-[apple-tv] [login-control] [printer] [domain-machine] ...
+[policy-A] [policy-B] [policy-C] [policy-D] ...
 
 ROLES (13)
-[amazon-device] [parent] [game-console] ...
+[role-A] [role-B] [role-C] ...
 
 ALIASES (7)
-[AdamsLAB] [user] [user-vlan] ...
+[CORP-LAB] [user-alias] [user-vlan] ...
 ```
 
 Always include the **inheritance flow statement** at the top: *"These N resources flow down to all sites in <site-collection>. The <site> site adds M more on top: …"* — operators need to know what's reused vs site-specific.
@@ -294,7 +295,7 @@ eff = await call_tool("central_get_effective_config", {"scope_id": scope_id})
 Render as chip-list with the origin scope visible per chip — color-code or label by origin. Example chip:
 
 ```
-[apple-tv ← Global]   [login-control ← EST Timezone Sites]   [fpp-device ← HOME]
+[policy-A ← Global]   [policy-B ← East Region Sites]   [policy-C ← HQ]
 ```
 
 #### 3e — Committed vs effective diff for one scope
@@ -375,20 +376,21 @@ Reply (rich-client variant — embed card tree; chips for legend):
            │
    ┌───────┼────────────┬──────────────┐
    │       │            │              │
-┌─────┐ ┌─────┐ ┌──────────────┐ ┌──────────────┐
-│ EST │ │PD-US│ │ 4 Site       │ │ 28 Device    │
-│Sites│ │ 14r │ │ Collections  │ │ Collections  │
-│177r │ └─────┘ │ CST · USSites│ │ (CNX, US-EST,│
-└─────┘         │ · JA · ...   │ │  PDC, ...)   │
-                └──────────────┘ └──────────────┘
+┌─────────┐ ┌──────────┐ ┌──────────────┐ ┌──────────────┐
+│  East   │ │  West    │ │ 4 Site       │ │ 28 Device    │
+│  Region │ │  Region  │ │ Collections  │ │ Collections  │
+│  177r   │ │  14r     │ │ Region-A ·   │ │ (group-1,    │
+└─────────┘ └──────────┘ │ Region-B ... │ │  group-2,    │
+                         └──────────────┘ │  group-3 ...)│
+                                          └──────────────┘
    │
-┌──────┬──────┐
-│ HOME │ Lake │
-│ 52r ·│ House│
-│ 17d  │ 12r  │
-└──────┴──────┘
+┌──────────┬──────────┐
+│   HQ     │ BRANCH-1 │
+│   52r ·  │  12r     │
+│   17d    │          │
+└──────────┴──────────┘
 
-**Walkthrough:** Global carries the lion's share of the library (399 resources, mostly platform-level: aliases, auth servers, system policies). EST Timezone Sites adds 177 resources that flow down to HOME (52 site-specific on top) and Lake House (12 site-specific). PD-US is a thin collection (14 resources). The 4 site collections at right are organizational containers with light direct config — most config lives one level up in the per-region collections.
+**Walkthrough:** Global carries the lion's share of the library (399 resources, mostly platform-level: aliases, auth servers, system policies). East Region Sites adds 177 resources that flow down to HQ (52 site-specific on top) and BRANCH-1 (12 site-specific). West Region is a thin collection (14 resources). The 4 site collections at right are organizational containers with light direct config — most config lives one level up in the per-region collections.
 
 Want to drill into a site, or see what's committed/effective at a specific scope?
 ```

--- a/tests/unit/test_central_committed_config.py
+++ b/tests/unit/test_central_committed_config.py
@@ -144,6 +144,22 @@ class TestCentralGetCommittedConfig:
         assert "does-not-exist" in result
 
     @patch("hpe_networking_mcp.platforms.central.tools.scope.build_scope_tree")
+    async def test_build_scope_tree_exception_returns_error_string(self, mock_build):
+        """Code-mode error contract: when ``build_scope_tree`` raises, the
+        tool MUST return the failure as a string (not propagate). A
+        propagated exception in a code-mode sandbox kills the WHOLE
+        ``execute()`` block, taking every prior successful call with it.
+        """
+        from hpe_networking_mcp.platforms.central.tools.scope import central_get_committed_config
+
+        mock_build.side_effect = RuntimeError("Central API unreachable")
+        result = await central_get_committed_config(_ctx(), scope_id="anything")
+
+        assert isinstance(result, str)
+        assert "Error building scope tree" in result
+        assert "Central API unreachable" in result
+
+    @patch("hpe_networking_mcp.platforms.central.tools.scope.build_scope_tree")
     async def test_scope_with_no_committed_resources_returns_empty_list(self, mock_build):
         """An intermediate scope can exist as an organizational container
         without anything directly committed. Returns an empty list rather


### PR DESCRIPTION
## Summary

Audit follow-up to v3.1.7.0 (code-reviewer subagent flagged one rule violation + three doc-parity gaps). No behaviour change. Clears the cleanup items before the UXI PR #348 lands on top so doc drift doesn't compound.

### What it fixes

1. **Tenant identity scrubbed from shipped skill.** `central-scope-visualizer.md` worked examples had operator's real site / collection / role / alias / policy names baked in (HOME, Lake House, EST Timezone Sites, PD-US, CST, US Sites, JA, AdamsLAB, night-night, apple-tv, login-control, fpp-device, nest-device, 9004-US, 635-US, 755-US, BR-150). The skill ships in the public Docker image — per the generic-example-names memory rule, that's a no-go. Replaced with generic placeholders (HQ / BRANCH-1 / East Region Sites / Region-A..D / CORP-LAB / policy-A..D / role-A..C / model-A..E). Industry-generic Aruba product references (CX-8360, CX-6300, CX-6200) kept.
2. **README.md tool counts.** Central 613 → 614, total underlying tools 1893 → 1894 (12 occurrences across the comparison table, ASCII architecture diagram, env-var docs, troubleshooting).
3. **INSTRUCTIONS.md scope-tools section.** Added `central_get_committed_config` to the inventory line + guidance bullet. Flagged `central_get_scope_diagram` as deprecated for visualization with a pointer to the new skill. Total count 1894.
4. **docs/TOOLS.md.** New `### Scope & Configuration Hierarchy` section documenting all six scope tools (filled a pre-existing gap — only param-table references existed before). Skill index gains rows for `clearpass-policy-walker` and `central-scope-visualizer`. Central header bumped to `(614 tools + 12 prompts)`.
5. **Test coverage gap.** Added `test_build_scope_tree_exception_returns_error_string` covering the code-mode error contract path for `central_get_committed_config` when the tree builder raises. Previously implicit, could regress silently.

## Test plan

- [x] 1398 tests pass (was 1397, +1 new exception-path test)
- [x] ruff / format / mypy / bandit clean
- [x] `grep -n "HOME\|Lake House\|EST Timezone\|PD-US\|AdamsLAB" src/hpe_networking_mcp/skills/central-scope-visualizer.md` returns nothing
- [x] `grep -c "1894\|614" README.md` confirms 12 updated occurrences, no stale 1893/613 left
- [ ] After merge + tag + release + image rebuild: spot-check the rendered skill output to confirm placeholders read naturally