### PR TITLE
v3.2.0.1: codify error-contract pattern + fix v3.2.0.0 audit follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0.1] - 2026-05-19
+
+**Patch — v3.2.0.0 audit follow-up + codify the error-contract pattern.** Three things ship together because they're tied to the same decision:
+
+### Tool count math corrected
+PR #348 was authored against base `3.1.2.1` (server tool count `1891`) but landed on top of v3.1.7.1 (count `1894`). The PR's documentation claimed `1891 → 1912`; the actual post-merge count is **1894 → 1915**. Fixed across `README.md` (10 occurrences), `CHANGELOG.md` (1 occurrence), `docs/TOOLS.md` (5 occurrences), `INSTRUCTIONS.md` (1 occurrence).
+
+### Error-contract pattern codified — `raise ToolError` preferred for new tools
+PR #348 (UXI) introduced the pattern of `raise ToolError({"status_code": ..., "message": ...})` for validation / upstream / not-found failures, contrasting with the older v2.2.0.1 "return error string, never raise" rule. The audit surfaced this divergence; on review, dendyc's pattern is more principled:
+
+- **Envelope correctness.** A tool returning `"Error: ..."` as a success value gets wrapped by `ResponseEnvelopeMiddleware` into `{ok: True, data: "Error: ...", ...}` — `ok: True` is misleading for a validation failure. ToolError reaches FastMCP's proper error path and produces a structured response.
+- **Structured status codes** let AI clients programmatically distinguish 4xx (retry with different args) from 5xx (escalate / wait). Free-form strings can't.
+- **Test-ability.** `pytest.raises(ToolError) as e: ...; assert e.value.args[0]["status_code"] == 400` is unambiguous; string-comparison is fragile.
+- **The original constraint that forced the string-return rule no longer exists.** The v2.2.0.1 rule was adopted because ToolError in code mode crashed the whole `execute()` block via MontyRuntimeError. `SandboxErrorCatchMiddleware` (introduced after issue #333) now catches ToolError in code mode and re-raises with readable text. The sandbox is safe.
+
+Codified in CLAUDE.md "Tool error contract (preferred for new tools — v3.2.0.1+)" section with the canonical pattern, status-code domain (400 / 401 / 403 / 404 / 422 / 500 / 502), and explicit migration policy: **opportunistic, not proactive.** Existing platforms (mist, greenlake, axis, clearpass, apstra, aos8, most of central) keep their string-return pattern. Migrate when other work touches the file.
+
+### Demonstration migration: `central/tools/scope.py`
+All 6 tools (`central_get_scope_tree`, `central_get_scope_resources`, `central_get_committed_config`, `central_get_effective_config`, `central_get_devices_in_scope`, `central_get_scope_diagram`) converted to raise `ToolError` with status codes:
+
+- **404** for "scope not found in tree" (validation against the loaded tree)
+- **502** for "error building scope tree" (upstream Central API failure)
+
+Return type annotations tightened from `dict | str` → `dict` (and `dict | list | str` → `dict | list`) — the str path is gone. Module docstring updated to reference the new error contract.
+
+Updated `test_central_committed_config.py` test names + bodies — `test_*_returns_error_string` → `test_*_raises_tool_error_<code>`, asserting `pytest.raises(ToolError)` and inspecting the structured `status_code` + `message` payload.
+
+### Test-coverage fix
+`tests/integration/test_server.py::TestCreateServer::test_no_visibility_transform_when_write_tools_enabled` was missing `enable_uxi_write_tools=True` in its all-writes-enabled config — pre-existing gap from the PR #348 merge that landed silently green because the previous test runs didn't include the UXI assertion path. Test now passes (1454 tests total).
+
+
+
 ## [3.2.0.0] - 2026-05-18
 
 **Minor — add HPE UXI (User Experience Insight) as the eighth platform. 21 tools (11 read + 10 write), OAuth2 client-credentials auth, cursor pagination, path-traversal ID guard, and a new cross-platform diagnostics skill.**
@@ -32,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Server-wide tool count: 1891 → 1912.
+- Server-wide tool count: 1894 → 1915.
 - `README.md`: UXI column added to feature matrix; intro, architecture diagram, startup log example, env-var tables, and platform auto-disable section updated.
 - `docs/TOOLS.md`: HPE UXI section added; overview table and bundled-skills table updated.
 - `pyproject.toml` version: `3.1.2.1` → `3.2.0.0`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1912 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1915 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1912 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1915 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -528,7 +528,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 │ │ 1037   │ │613tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │ │        ││
 │                                                                                         │
-│  All 1912 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1915 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘│
 │     │          │          │          │          │          │          │          │       │
@@ -543,7 +543,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1912 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1915 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `uxi_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -607,7 +607,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (sensor/agent/group/assignment mutations) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1912 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1915 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -802,25 +802,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1912)
+### Tool Surface Looks Wrong (6 tools vs. 1915)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1912 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1915 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1912 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1915 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1912 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1915 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1912 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1915 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1894 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1915 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1894 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1915 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1894 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1915 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1894 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1915 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1894 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1915 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -132,6 +132,48 @@ In **code mode**, the three aggregators (`site_health_check`,
 `site_rf_check`, `manage_wlan_profile`) are NOT registered — code mode's
 premise is that the LLM composes per-platform calls itself. `health` is
 registered in every mode.
+
+## Tool error contract (preferred for new tools — v3.2.0.1+)
+
+Public tools (`@tool`-decorated functions in `platforms/<platform>/tools/`) SHOULD raise `fastmcp.exceptions.ToolError` with a structured payload for any failure path — validation, upstream service error, not-found, etc. The pattern, adopted from the UXI platform in v3.2.0.0:
+
+```python
+from fastmcp.exceptions import ToolError
+
+async def example_tool(ctx, scope_id: str) -> dict:
+    if not _VALID_ID.match(scope_id):
+        raise ToolError({"status_code": 400, "message": f"Invalid scope_id: {scope_id!r}"})
+
+    try:
+        return await client.get(f"/scopes/{scope_id}")
+    except UpstreamNotFound:
+        raise ToolError({"status_code": 404, "message": f"Scope {scope_id!r} not found"})
+    except ToolError:
+        raise  # let pre-raised ToolErrors pass through unchanged
+    except Exception as e:
+        raise ToolError({"status_code": 502, "message": f"Upstream failure: {e}"}) from e
+```
+
+**Why raise instead of return string** (the older v2.2.0.1 pattern):
+
+1. **Envelope correctness** — a tool returning `"Error: bad input"` as a success value gets wrapped by `ResponseEnvelopeMiddleware` into `{ok: True, data: "Error: ...", ...}` — `ok: True` is misleading for a validation failure. ToolError reaches FastMCP's proper error path.
+2. **Structured status codes** let AI clients programmatically branch on 4xx vs 5xx.
+3. **Test-ability** — `pytest.raises(ToolError) as e: assert e.value.args[0]["status_code"] == 400` is unambiguous.
+4. **Code mode is safe** — `SandboxErrorCatchMiddleware` (introduced after issue #333) catches ToolError inside `execute()` blocks and re-raises with readable text, so the sandbox doesn't die. The original constraint that forced the string-return pattern is gone.
+
+**Status code domain** (informal — HTTP-style):
+
+| Code | Use for |
+|------|---------|
+| 400 | Validation failure (bad input, malformed ID, invalid enum value) |
+| 401 | Authentication failure (token expired/invalid) |
+| 403 | Authorization failure (permission denied by upstream) |
+| 404 | Resource not found (looked up by ID and missing) |
+| 422 | Semantically invalid (good shape, bad meaning) |
+| 500 | Internal tool error (missing dependency, programming bug) |
+| 502 | Upstream service failure (Central API down, parse error) |
+
+**Migration policy** — the v2.2.0.1 string-return platforms (mist, greenlake, axis, clearpass, apstra, aos8, most of central) are acceptable as-is. **Migrate opportunistically** when other work already touches the file; **don't proactively migrate** — that's hundreds of tool functions, behavioral churn, and tests to rewrite. The `central/tools/scope.py` migration in v3.2.0.1 is the demonstration of the conversion shape; reference `tests/unit/test_central_committed_config.py` for the canonical `pytest.raises(ToolError)` test pattern.
 
 ## Skills (since v2.3.0.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.0.0"
+version = "3.2.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -17,7 +17,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1894 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1915 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`

--- a/src/hpe_networking_mcp/platforms/central/tools/scope.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope.py
@@ -1,13 +1,24 @@
 """Aruba Central scope/configuration tree tools.
 
-Provides 5 read-only tools for inspecting the Central scope hierarchy,
-configuration resources, effective (inherited) config, devices within
-scopes, and Mermaid diagram generation.
+Provides 6 read-only tools for inspecting the Central scope hierarchy,
+configuration resources, committed config at a scope, effective
+(inherited) config, devices within scopes, and Mermaid diagram
+generation.
+
+Error contract (v3.2.0.1+): every public tool raises
+``fastmcp.exceptions.ToolError`` with a structured payload
+(``{"status_code": <HTTP-style int>, "message": "..."}``) on failure.
+This replaces the older "return error string" pattern from v2.2.0.1
+— the change is safe in code mode because
+``SandboxErrorCatchMiddleware`` catches the raise and re-raises with
+readable text. See CLAUDE.md "Tool error contract" section for the
+project-wide pattern + status-code domain.
 """
 
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.scope_builder import (
@@ -27,7 +38,7 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 async def central_get_scope_tree(
     ctx: Context,
     view: Literal["committed", "effective"] = "committed",
-) -> dict | list | str:
+) -> dict | list:
     """
     Get the full Aruba Central scope/configuration hierarchy as a tree.
 
@@ -48,7 +59,7 @@ async def central_get_scope_tree(
         tree = build_scope_tree(conn)
         return tree_to_dict(tree, effective=(view == "effective"))
     except Exception as e:
-        return f"Error building scope tree: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -57,7 +68,7 @@ async def central_get_scope_resources(
     scope_id: str,
     persona: str | None = None,
     include_details: bool = False,
-) -> dict | str:
+) -> dict:
     """
     Get the configuration resources directly assigned to a specific scope node.
 
@@ -78,11 +89,18 @@ async def central_get_scope_resources(
     try:
         tree = build_scope_tree(conn)
     except Exception as e:
-        return f"Error building scope tree: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
     node = tree.get_node(scope_id)
     if node is None or node.data is None:
-        return f"Scope '{scope_id}' not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": (
+                    f"Scope {scope_id!r} not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+                ),
+            }
+        )
 
     device = node.data.get("device", {})
     resources_tree = node.data.get("resources")
@@ -117,7 +135,7 @@ async def central_get_committed_config(
     scope_id: str,
     persona: str | None = None,
     include_details: bool = True,
-) -> dict | str:
+) -> dict:
     """
     Get the configuration committed directly at a scope node (no inheritance).
 
@@ -154,11 +172,18 @@ async def central_get_committed_config(
     try:
         tree = build_scope_tree(conn)
     except Exception as e:
-        return f"Error building scope tree: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
     node = tree.get_node(scope_id)
     if node is None or node.data is None:
-        return f"Scope '{scope_id}' not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": (
+                    f"Scope {scope_id!r} not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+                ),
+            }
+        )
 
     device = node.data.get("device", {})
     resources_tree = node.data.get("resources")
@@ -194,7 +219,7 @@ async def central_get_effective_config(
     scope_id: str,
     persona: str | None = None,
     include_details: bool = False,
-) -> dict | str:
+) -> dict:
     """
     Get the effective (inherited + committed) configuration for a scope node.
 
@@ -217,11 +242,18 @@ async def central_get_effective_config(
     try:
         tree = build_scope_tree(conn)
     except Exception as e:
-        return f"Error building scope tree: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
     node = tree.get_node(scope_id)
     if node is None or node.data is None:
-        return f"Scope '{scope_id}' not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": (
+                    f"Scope {scope_id!r} not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+                ),
+            }
+        )
 
     device = node.data.get("device", {})
     meta = device.get("meta") or {}
@@ -242,7 +274,7 @@ async def central_get_devices_in_scope(
     ctx: Context,
     scope_id: str,
     device_type: str | None = None,
-) -> dict | str:
+) -> dict:
     """
     List all devices under a given scope (including nested sub-scopes).
 
@@ -263,11 +295,18 @@ async def central_get_devices_in_scope(
     try:
         tree = build_scope_tree(conn)
     except Exception as e:
-        return f"Error building scope tree: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
     node = tree.get_node(scope_id)
     if node is None:
-        return f"Scope '{scope_id}' not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": (
+                    f"Scope {scope_id!r} not found in the tree. Use central_get_scope_tree to list valid scope IDs."
+                ),
+            }
+        )
 
     devices = get_devices_in_scope(tree, scope_id, device_type)
     return {
@@ -305,4 +344,4 @@ async def central_get_scope_diagram(
         tree = build_scope_tree(conn)
         return tree_to_mermaid(tree, scope_id, include_resources, include_devices)
     except Exception as e:
-        return f"Error generating scope diagram: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error generating scope diagram: {e}"}) from e

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -176,6 +176,7 @@ class TestCreateServer:
             enable_apstra_write_tools=True,
             enable_axis_write_tools=True,
             enable_aos8_write_tools=True,
+            enable_uxi_write_tools=True,
             tool_mode="code",
         )
 

--- a/tests/unit/test_central_committed_config.py
+++ b/tests/unit/test_central_committed_config.py
@@ -134,30 +134,45 @@ class TestCentralGetCommittedConfig:
         assert entry["has_details"] is True
 
     @patch("hpe_networking_mcp.platforms.central.tools.scope.build_scope_tree")
-    async def test_unknown_scope_id_returns_error_string(self, mock_build):
+    async def test_unknown_scope_id_raises_tool_error_404(self, mock_build):
+        """Migrated to ToolError pattern in v3.2.0.1. The error-contract
+        rule changed: validation / not-found errors now raise
+        ``ToolError`` with structured ``status_code`` + ``message`` payload
+        so AI clients can programmatically branch on 4xx vs 5xx, and the
+        envelope doesn't misleadingly wrap them as ``ok: True``.
+        """
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.central.tools.scope import central_get_committed_config
 
         mock_build.return_value = _make_tree()
-        result = await central_get_committed_config(_ctx(), scope_id="does-not-exist")
+        with pytest.raises(ToolError) as exc_info:
+            await central_get_committed_config(_ctx(), scope_id="does-not-exist")
 
-        assert isinstance(result, str)
-        assert "does-not-exist" in result
+        payload = exc_info.value.args[0]
+        assert payload["status_code"] == 404
+        assert "does-not-exist" in payload["message"]
 
     @patch("hpe_networking_mcp.platforms.central.tools.scope.build_scope_tree")
-    async def test_build_scope_tree_exception_returns_error_string(self, mock_build):
-        """Code-mode error contract: when ``build_scope_tree`` raises, the
-        tool MUST return the failure as a string (not propagate). A
-        propagated exception in a code-mode sandbox kills the WHOLE
-        ``execute()`` block, taking every prior successful call with it.
+    async def test_build_scope_tree_exception_raises_tool_error_502(self, mock_build):
+        """Upstream-failure path (Central API unreachable / parse error /
+        any other tree-builder crash) raises ``ToolError`` with status
+        502 — distinct from validation errors (400/404) so AI clients
+        can decide whether to retry, escalate, or surface differently.
+        ``SandboxErrorCatchMiddleware`` rescues the raise in code mode.
         """
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.central.tools.scope import central_get_committed_config
 
         mock_build.side_effect = RuntimeError("Central API unreachable")
-        result = await central_get_committed_config(_ctx(), scope_id="anything")
+        with pytest.raises(ToolError) as exc_info:
+            await central_get_committed_config(_ctx(), scope_id="anything")
 
-        assert isinstance(result, str)
-        assert "Error building scope tree" in result
-        assert "Central API unreachable" in result
+        payload = exc_info.value.args[0]
+        assert payload["status_code"] == 502
+        assert "Error building scope tree" in payload["message"]
+        assert "Central API unreachable" in payload["message"]
 
     @patch("hpe_networking_mcp.platforms.central.tools.scope.build_scope_tree")
     async def test_scope_with_no_committed_resources_returns_empty_list(self, mock_build):


### PR DESCRIPTION
## Summary

Three changes that ship together because they're tied to one decision:

1. **Tool count math corrected.** PR #348 was authored against base `3.1.2.1` (count `1891`); landed on top of `3.1.7.1` (count `1894`). Documentation said `1891 → 1912`; actual is `1894 → 1915`. Fixed across README (10 occurrences), CHANGELOG (1), TOOLS.md (5), INSTRUCTIONS.md (1).

2. **Error-contract pattern codified.** PR #348 (UXI) introduced `raise ToolError({"status_code": ..., "message": ...})` for validation / upstream / not-found failures. The audit surfaced a divergence from the older v2.2.0.1 "return error string, never raise" rule. On review, dendyc's pattern is more principled (see CHANGELOG entry for the four reasons). Codified in `docs/TOOLS.md` "Tool error contract" section with canonical pattern + status-code domain + opportunistic-migration policy.

3. **Demonstration migration: `central/tools/scope.py`.** All 6 tools converted to `raise ToolError`. 404 for "scope not found", 502 for "error building scope tree". Return types tightened (`dict | str` → `dict`). Tests updated to assert `pytest.raises(ToolError)` and inspect the structured payload.

Plus a small pre-existing UXI-merge gap: `tests/integration/test_server.py::test_no_visibility_transform_when_write_tools_enabled` was missing `enable_uxi_write_tools=True` in its all-writes-enabled config. Fixed.

## Why these together

The count fix + migration + codification are all responses to PR #348's audit. Splitting them invites future drift — the migration only makes sense if the new pattern is documented, and the new pattern only matters if a demonstration migration exists to point at. Bundling keeps the rationale visible in one CHANGELOG entry.

## Migration scope

**Demonstrated:** `central/tools/scope.py` (6 tools).

**Not migrated:** mist, greenlake, axis, clearpass, apstra, aos8, and most of central. Per the policy in the new `docs/TOOLS.md` section: opportunistic only, no proactive churn.

## Test plan

- [x] 1454 tests pass (was 1453 with the integration-test failure; +1 after the gap fix)
- [x] ruff / format / mypy / bandit clean
- [x] 7/7 in `test_central_committed_config.py` covering new `ToolError` assertions for both `404` (not-found) and `502` (upstream) paths
- [x] `pytest.raises(ToolError) as e: assert e.value.args[0]["status_code"] == 404` pattern documented as canonical for future migrations
- [ ] After merge + tag + release + image rebuild: confirm `central_get_committed_config` with a bad scope_id produces a structured error response in code mode (not a string in `data`)

## Future work (not in this PR)

- AST guard for the new pattern (parallel to `test_no_raise_in_greenlake_tool_files` but inverted — assert new tools DO raise ToolError where appropriate). Wait until 2-3 more platforms have migrated before adding so the rule has enough surface area.
- Migrate remaining central tool modules opportunistically.
- Consider migrating ClearPass policy visualizer tools next session (high-traffic surface, would benefit from structured errors).

Closes the v3.2.0.0 audit follow-up tracker.