### PR TITLE
Error-contract sweep: all platforms raise ToolError (v3.2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.0] - 2026-05-20
+
+**Minor — error-contract sweep: every platform now raises `ToolError` instead of returning error strings.** v3.2.0.1 codified the `raise ToolError({"status_code": int, "message": str})` pattern and explicitly scoped migration as *opportunistic*. This release supersedes that stance and proactively completes the migration across all remaining platforms, so the contract is now uniform server-wide. Shipped as one atomic change set (no partial state): public tools raise structured `ToolError` for failure paths (validation, upstream error, not-found), while genuine info-strings (empty-result / "No X found" / no-op) and elicitation confirmation/decline dicts are preserved as ordinary returns.
+
+Why this is safe and correct (recap from v3.2.0.1): `ResponseEnvelopeMiddleware` was wrapping returned error strings as `{ok: True, ...}` — misleading; `ToolError` reaches FastMCP's proper error path. Structured status codes let AI clients distinguish 4xx (retry) from 5xx (escalate). `SandboxErrorCatchMiddleware` catches `ToolError` inside code-mode `execute()` blocks, so the sandbox stays safe.
+
+### Status-code domain applied
+`400` validation (bad/missing/invalid input) · `404` resource looked up by ID and missing · `500` internal/programming error (e.g. unreachable `action_type` fall-through) · `502` upstream service failure. Auth/config failures keep their existing structured codes from each platform's session layer (e.g. ClearPass `get_clearpass_session` raises `503`).
+
+### Platforms migrated
+- **GreenLake** (10 sites) — validation/coerce failures → 400.
+- **Apstra** (23 sites) — upstream failures → 502 via `format_http_error`; `manage_networks` validation → 400.
+- **Axis** (23 sites) — upstream → 502; `_manage.py` shared-helper guards + `status.py` entity-type guard → 400.
+- **Central** non-scope (~77 sites) — upstream → 502; `mrt_*` validation → 400; `switch_poe`/`wlans` HTTP-code errors now raise with the real upstream `code`; switch-not-found → 404. (`central/tools/scope.py` was already migrated in v3.2.0.1.)
+- **ClearPass** (249 sites across all 36 `tools/*.py` modules) — read-tool upstream failures → 502 (each `except Exception` now has a preceding `except ToolError: raise` so the session layer's structured 503 passes through unchanged); write/manage validation guards (`Invalid action_type`, `Must be one of`, `… is required`, `Either … required`) → 400; defensive `Unhandled action_type` fall-throughs and an `Internal error:` guard → 500; source-device-not-found → 404; two `"Error:"`-prefixed strings that were actually pre-call validation guards → 400.
+
+### Pattern note — `except ToolError: raise` pass-through
+Where a tool's `try` body calls a session/helper that itself raises `ToolError` (config/auth/validation), the `except Exception → 502` handler is now preceded by `except ToolError: raise` so structured errors propagate unchanged instead of being re-wrapped as a generic 502.
+
+### Tests
+`test_clearpass_policy_visualizer_tools.py::test_requires_exactly_one_selector` updated from asserting a returned error string to `pytest.raises(ToolError)` + `status_code == 400`. Full suite green: **1453 passed, 1 skipped**; ruff / mypy / bandit clean. No tool counts changed (refactor only).
+
+
+
 ## [3.2.0.1] - 2026-05-19
 
 **Patch — v3.2.0.0 audit follow-up + codify the error-contract pattern.** Three things ship together because they're tied to the same decision:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -173,7 +173,7 @@ async def example_tool(ctx, scope_id: str) -> dict:
 | 500 | Internal tool error (missing dependency, programming bug) |
 | 502 | Upstream service failure (Central API down, parse error) |
 
-**Migration policy** — the v2.2.0.1 string-return platforms (mist, greenlake, axis, clearpass, apstra, aos8, most of central) are acceptable as-is. **Migrate opportunistically** when other work already touches the file; **don't proactively migrate** — that's hundreds of tool functions, behavioral churn, and tests to rewrite. The `central/tools/scope.py` migration in v3.2.0.1 is the demonstration of the conversion shape; reference `tests/unit/test_central_committed_config.py` for the canonical `pytest.raises(ToolError)` test pattern.
+**Status — fully migrated (v3.2.1.0).** The error-contract sweep converted every platform that had string-return error paths (greenlake, apstra, axis, central, clearpass; mist and aos8 had none) to `raise ToolError`. All tools now follow this contract — new tools MUST too. When a `try` body calls a session/helper that itself raises `ToolError`, precede `except Exception` with `except ToolError: raise` so structured errors propagate unchanged. Genuine info-strings (empty-result / "No X found" / no-op) and elicitation confirmation/decline dicts stay as ordinary returns — only failure paths raise. Reference `tests/unit/test_central_committed_config.py` for the canonical `pytest.raises(ToolError)` test pattern.
 
 ## Skills (since v2.3.0.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.0.1"
+version = "3.2.1.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -13,7 +14,7 @@ from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all racks in a blueprint.
 
     Args:
@@ -28,11 +29,12 @@ async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any] | 
             "data": items,
         }
     except Exception as e:
-        return f"Error fetching racks: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching racks: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all routing zones (security zones) in a blueprint.
 
     Args:
@@ -46,11 +48,12 @@ async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str,
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching routing zones: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching routing zones: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_system_info(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_system_info(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get systems (devices) inside a blueprint.
 
     Args:
@@ -64,4 +67,5 @@ async def apstra_get_system_info(ctx: Context, blueprint_id: str) -> dict[str, A
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching system info: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching system info: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/blueprints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -13,7 +14,7 @@ from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_blueprints(ctx: Context) -> dict[str, Any] | str:
+async def apstra_get_blueprints(ctx: Context) -> dict[str, Any]:
     """Get list of all Apstra blueprints.
 
     Returns the blueprint summary records (including id, label, design, status)
@@ -28,11 +29,12 @@ async def apstra_get_blueprints(ctx: Context) -> dict[str, Any] | str:
             "data": items,
         }
     except Exception as e:
-        return f"Error fetching blueprints: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching blueprints: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_templates(ctx: Context) -> dict[str, Any] | str:
+async def apstra_get_templates(ctx: Context) -> dict[str, Any]:
     """Get list of available design templates for blueprint creation."""
     try:
         client = await get_apstra_client()
@@ -42,4 +44,5 @@ async def apstra_get_templates(ctx: Context) -> dict[str, Any] | str:
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching templates: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching templates: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -13,7 +14,7 @@ from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get connectivity templates (endpoint policies) in a blueprint.
 
     Policies marked ``"visible": true`` can be assigned to interfaces.
@@ -29,11 +30,12 @@ async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> 
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching connectivity templates: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching connectivity templates: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_application_endpoints(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_application_endpoints(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all possible application endpoints for connectivity templates.
 
     This endpoint uses POST semantics per Apstra's API contract, returning the
@@ -51,4 +53,5 @@ async def apstra_get_application_endpoints(ctx: Context, blueprint_id: str) -> d
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching application endpoints: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching application endpoints: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.apstra import guidelines
@@ -20,7 +21,7 @@ async def apstra_deploy(
     description: str,
     staging_version: int,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Deploy a blueprint's staged configuration to the fabric.
 
     Args:
@@ -50,7 +51,8 @@ async def apstra_deploy(
             "data": response.json() if response.content else {"status": "accepted"},
         }
     except Exception as e:
-        return f"Error deploying blueprint: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error deploying blueprint: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"apstra_write_delete"})
@@ -58,7 +60,7 @@ async def apstra_delete_blueprint(
     ctx: Context,
     blueprint_id: str,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Permanently delete an Apstra blueprint.
 
     Args:
@@ -89,7 +91,8 @@ async def apstra_delete_blueprint(
             "data": body,
         }
     except Exception as e:
-        return f"Error deleting blueprint: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error deleting blueprint: {detail}"}) from e
 
 
 @tool(annotations=WRITE, tags={"apstra_write"})
@@ -98,7 +101,7 @@ async def apstra_create_datacenter_blueprint(
     blueprint_name: str,
     template_id: str,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create a new datacenter (``two_stage_l3clos``) blueprint from a template.
 
     Args:
@@ -131,7 +134,8 @@ async def apstra_create_datacenter_blueprint(
             "data": response.json(),
         }
     except Exception as e:
-        return f"Error creating datacenter blueprint: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error creating datacenter blueprint: {detail}"}) from e
 
 
 @tool(annotations=WRITE, tags={"apstra_write"})
@@ -139,7 +143,7 @@ async def apstra_create_freeform_blueprint(
     ctx: Context,
     blueprint_name: str,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create a new freeform blueprint.
 
     Args:
@@ -166,4 +170,5 @@ async def apstra_create_freeform_blueprint(
             "data": response.json(),
         }
     except Exception as e:
-        return f"Error creating freeform blueprint: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error creating freeform blueprint: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.apstra import guidelines
@@ -20,7 +21,7 @@ async def apstra_apply_ct_policies(
     blueprint_id: str,
     application_points: str | list[dict[str, Any]] | dict[str, Any],
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Apply or remove connectivity-template policies on application endpoints.
 
     Uses the ``obj-policy-batch-apply`` endpoint with ``async=full`` and PATCH.
@@ -34,7 +35,7 @@ async def apstra_apply_ct_policies(
     try:
         normalized = normalize_application_points(application_points)
     except ValueError as e:
-        return f"Invalid application_points: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid application_points: {e}"}) from e
 
     if not confirmed:
         decline = await confirm_write(
@@ -63,4 +64,5 @@ async def apstra_apply_ct_policies(
             "data": data,
         }
     except Exception as e:
-        return f"Error applying CT policies: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error applying CT policies: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.apstra import guidelines
@@ -40,7 +41,7 @@ async def apstra_create_virtual_network(
     virtual_gateway_ipv6_enabled: str | bool = False,
     ipv6_enabled: str | bool = False,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create a virtual network via Apstra's ``virtual-networks-batch`` API.
 
     Accepts flexible input shapes (JSON strings or native types) for backward
@@ -68,7 +69,7 @@ async def apstra_create_virtual_network(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if vn_type not in ("vxlan", "vlan"):
-        return f"Invalid vn_type '{vn_type}'. Must be 'vxlan' or 'vlan'."
+        raise ToolError({"status_code": 400, "message": f"Invalid vn_type '{vn_type}'. Must be 'vxlan' or 'vlan'."})
 
     if not confirmed:
         decline = await confirm_write(
@@ -85,12 +86,12 @@ async def apstra_create_virtual_network(
         ipv6_enabled_b = bool(parse_bool(ipv6_enabled))
         policy_tagged_b = parse_bool(create_policy_tagged) if create_policy_tagged is not None else None
     except ValueError as e:
-        return f"Invalid boolean parameter: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid boolean parameter: {e}"}) from e
 
     try:
         normalized_system_ids = normalize_to_string_list(system_ids)
     except ValueError as e:
-        return f"Invalid system_ids: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid system_ids: {e}"}) from e
 
     if normalized_system_ids:
         target_len = len(normalized_system_ids)
@@ -98,7 +99,7 @@ async def apstra_create_virtual_network(
             normalized_vlan_ids = normalize_to_int_list(vlan_ids, target_len) if vlan_ids is not None else None
             normalized_access = normalize_to_nested_list(access_switch_node_ids, target_len)
         except ValueError as e:
-            return f"Invalid VLAN or access-switch input: {e}"
+            raise ToolError({"status_code": 400, "message": f"Invalid VLAN or access-switch input: {e}"}) from e
     else:
         normalized_vlan_ids = None
         normalized_access = None
@@ -177,7 +178,8 @@ async def apstra_create_virtual_network(
             "data": response.json(),
         }
     except Exception as e:
-        return f"Error creating virtual network: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error creating virtual network: {detail}"}) from e
 
 
 @tool(annotations=WRITE, tags={"apstra_write"})
@@ -195,7 +197,7 @@ async def apstra_create_remote_gateway(
     holdtime_timer: int = 30,
     ttl: int = 30,
     confirmed: bool = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create a remote EVPN gateway in a blueprint.
 
     Args:
@@ -247,4 +249,5 @@ async def apstra_create_remote_gateway(
             "data": response.json(),
         }
     except Exception as e:
-        return f"Error creating remote gateway: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error creating remote gateway: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -13,7 +14,7 @@ from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get virtual networks in a blueprint, including bound systems and VLAN IDs.
 
     Args:
@@ -27,11 +28,12 @@ async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[s
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching virtual networks: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching virtual networks: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_remote_gateways(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_remote_gateways(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all remote EVPN gateways in a blueprint.
 
     Args:
@@ -45,4 +47,5 @@ async def apstra_get_remote_gateways(ctx: Context, blueprint_id: str) -> dict[st
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching remote gateways: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching remote gateways: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/apstra/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -13,7 +14,7 @@ from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get anomalies for a blueprint.
 
     Args:
@@ -27,11 +28,12 @@ async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching anomalies: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching anomalies: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get configuration diff status (staging vs active) for a blueprint.
 
     Use this after changes to confirm pending work is staged correctly before
@@ -48,11 +50,12 @@ async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, A
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching diff status: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching diff status: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
-async def apstra_get_protocol_sessions(ctx: Context, blueprint_id: str) -> dict[str, Any] | str:
+async def apstra_get_protocol_sessions(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all protocol (e.g. BGP) sessions in a blueprint.
 
     Args:
@@ -66,4 +69,5 @@ async def apstra_get_protocol_sessions(ctx: Context, blueprint_id: str) -> dict[
             "data": payload,
         }
     except Exception as e:
-        return f"Error fetching protocol sessions: {format_http_error(e) if hasattr(e, 'response') else e}"
+        detail = format_http_error(e) if hasattr(e, "response") else e
+        raise ToolError({"status_code": 502, "message": f"Error fetching protocol sessions: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -37,7 +38,7 @@ async def manage_entity(
     payload: dict | None,
     entity_id: str | None,
     confirmed: bool,
-) -> dict | str:
+) -> dict:
     """Generic create/update/delete dispatcher for Axis CRUD entities.
 
     Args:
@@ -55,11 +56,16 @@ async def manage_entity(
         string error message.
     """
     if action_type not in _VALID_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}.",
+            }
+        )
     if action_type in ("update", "delete") and not entity_id:
-        return f"entity_id is required for action '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"entity_id is required for action '{action_type}'."})
     if action_type in ("create", "update") and not payload:
-        return f"payload is required for action '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"payload is required for action '{action_type}'."})
 
     target = entity_id or "(new)"
     decline = await confirm_write(ctx, f"Axis: {action_type} {label} '{target}'. Confirm?")
@@ -75,7 +81,8 @@ async def manage_entity(
         else:
             result = await client.delete_resource(f"{base_path}/{entity_id}")
     except Exception as e:
-        return f"Error during {action_type} {label}: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error during {action_type} {label}: {detail}"}) from e
 
     response: dict[str, Any] = result if isinstance(result, dict) else {"result": result}
     response["next_step"] = _NEXT_STEP_HINT

--- a/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -22,7 +23,7 @@ async def axis_get_application_groups(
     application_group_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis application groups (tags).
 
     Args:
@@ -36,7 +37,8 @@ async def axis_get_application_groups(
             return await client.get_json(f"/Tags/{application_group_id}")
         return await client.get_paged("/Tags", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching application groups: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching application groups: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -46,7 +48,7 @@ async def axis_manage_application_group(
     payload: dict | None = None,
     application_group_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis application group (tag).
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/applications.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_applications(
     application_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis published applications.
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_applications(
             return await client.get_json(f"/Applications/{application_id}")
         return await client.get_paged("/Applications", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching applications: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching applications: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_application(
     payload: dict | None = None,
     application_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis published application.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/commit.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/commit.py
@@ -13,6 +13,7 @@ caller a clear positive response.
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.axis._registry import tool
@@ -26,7 +27,7 @@ _COMMIT_TIMEOUT = 60.0
 async def axis_commit_changes(
     ctx: Context,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Apply all staged Axis changes (POST /Commit).
 
     Every ``axis_manage_*`` write tool stages its change; this is the tool
@@ -54,4 +55,5 @@ async def axis_commit_changes(
         body = response.json() if response.content else {}
         return {"status": "committed", "status_code": response.status_code, "body": body}
     except Exception as e:
-        return f"Error committing Axis changes: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error committing Axis changes: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_connector_zones(
     connector_zone_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis connector zones (groupings of connectors).
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_connector_zones(
             return await client.get_json(f"/ConnectorZones/{connector_zone_id}")
         return await client.get_paged("/ConnectorZones", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching connector zones: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching connector zones: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_connector_zone(
     payload: dict | None = None,
     connector_zone_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis connector zone.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.axis._registry import tool
@@ -24,7 +25,7 @@ async def axis_get_connectors(
     connector_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis connectors (tunnel-endpoint devices).
 
     If ``connector_id`` is provided, returns a single connector record.
@@ -43,7 +44,8 @@ async def axis_get_connectors(
             return await client.get_json(f"/Connectors/{connector_id}")
         return await client.get_paged("/Connectors", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching connectors: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching connectors: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -53,7 +55,7 @@ async def axis_manage_connector(
     payload: dict | None = None,
     connector_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis connector.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.
@@ -80,7 +82,7 @@ async def axis_regenerate_connector(
     ctx: Context,
     connector_id: str,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Issue a fresh installation command for an existing Axis connector.
 
     Invalidates the prior install command for the same connector — anyone
@@ -105,4 +107,5 @@ async def axis_regenerate_connector(
         client = await get_axis_client()
         return await client.post_json(f"/Connectors/{connector_id}/regenerate", json_body={})
     except Exception as e:
-        return f"Error regenerating connector: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error regenerating connector: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_custom_ip_categories(
     custom_ip_category_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis custom IP categories.
 
     Customer-defined IP groupings used in policy rules. For threat-intel
@@ -35,7 +36,8 @@ async def axis_get_custom_ip_categories(
             return await client.get_json(f"/IpCategories/{custom_ip_category_id}")
         return await client.get_paged("/IpCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching custom IP categories: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching custom IP categories: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -45,7 +47,7 @@ async def axis_manage_custom_ip_category(
     payload: dict | None = None,
     custom_ip_category_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis custom IP category.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/groups.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_groups(
     group_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis groups (Atmos IdP user groups).
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_groups(
             return await client.get_json(f"/Groups/{group_id}")
         return await client.get_paged("/Groups", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching groups: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching groups: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_group(
     payload: dict | None = None,
     group_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis user group.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_ip_feed_categories(
     ip_feed_category_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis IP-feed categories.
 
     Threat-intel IP feeds maintained by Axis (vs. customer-defined feeds
@@ -35,7 +36,8 @@ async def axis_get_ip_feed_categories(
             return await client.get_json(f"/IpCategoriesFeed/{ip_feed_category_id}")
         return await client.get_paged("/IpCategoriesFeed", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching IP feed categories: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching IP feed categories: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -45,7 +47,7 @@ async def axis_manage_ip_feed_category(
     payload: dict | None = None,
     ip_feed_category_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis IP feed category.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/locations.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/locations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -22,7 +23,7 @@ async def axis_get_locations(
     location_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis locations (physical sites).
 
     Args:
@@ -36,7 +37,8 @@ async def axis_get_locations(
             return await client.get_json(f"/Locations/{location_id}")
         return await client.get_paged("/Locations", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching locations: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching locations: {detail}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -46,7 +48,7 @@ async def axis_get_sub_locations(
     sub_location_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get sub-locations nested under a parent location.
 
     Args:
@@ -65,7 +67,8 @@ async def axis_get_sub_locations(
             page_size=page_size,
         )
     except Exception as e:
-        return f"Error fetching sub-locations: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching sub-locations: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -75,7 +78,7 @@ async def axis_manage_location(
     payload: dict | None = None,
     location_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis location.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.
@@ -105,7 +108,7 @@ async def axis_manage_sub_location(
     payload: dict | None = None,
     sub_location_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis sub-location under a parent location.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_ssl_exclusions(
     ssl_exclusion_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis SSL exclusions (hosts excluded from SSL inspection).
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_ssl_exclusions(
             return await client.get_json(f"/SslExclusions/{ssl_exclusion_id}")
         return await client.get_paged("/SslExclusions", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching SSL exclusions: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching SSL exclusions: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_ssl_exclusion(
     payload: dict | None = None,
     ssl_exclusion_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis SSL exclusion.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/status.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms.axis._registry import tool
@@ -22,7 +23,7 @@ async def axis_get_status(
     ctx: Context,
     entity_type: Annotated[str, Field(description="Either 'connector' or 'tunnel'.")],
     entity_id: Annotated[str, Field(description="GUID of the connector or tunnel.")],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get runtime status for a connector or tunnel.
 
     Connector status returns rich telemetry (state, CPU/mem/disk/network,
@@ -38,9 +39,12 @@ async def axis_get_status(
     elif entity_type == "tunnel":
         path = f"/Tunnels/{entity_id}/status"
     else:
-        return f"Invalid entity_type '{entity_type}'. Must be 'connector' or 'tunnel'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid entity_type '{entity_type}'. Must be 'connector' or 'tunnel'."}
+        )
     try:
         client = await get_axis_client()
         return await client.get_json(path)
     except Exception as e:
-        return f"Error fetching {entity_type} status: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching {entity_type} status: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -23,7 +24,7 @@ async def axis_get_tunnels(
     tunnel_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis tunnels.
 
     If ``tunnel_id`` is provided, returns a single tunnel.
@@ -40,7 +41,8 @@ async def axis_get_tunnels(
             return await client.get_json(f"/Tunnels/{tunnel_id}")
         return await client.get_paged("/Tunnels", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching tunnels: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching tunnels: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -50,7 +52,7 @@ async def axis_manage_tunnel(
     payload: dict | None = None,
     tunnel_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis tunnel.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/users.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_users(
     user_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis users (Atmos IdP user records).
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_users(
             return await client.get_json(f"/Users/{user_id}")
         return await client.get_paged("/Users", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching users: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching users: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_user(
     payload: dict | None = None,
     user_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis user.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -18,7 +19,7 @@ async def axis_get_web_categories(
     web_category_id: str | None = None,
     page_number: int = 1,
     page_size: int = 50,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Get Axis web categories (URL-classification categories used in policy).
 
     Args:
@@ -32,7 +33,8 @@ async def axis_get_web_categories(
             return await client.get_json(f"/WebCategories/{web_category_id}")
         return await client.get_paged("/WebCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
-        return f"Error fetching web categories: {format_http_error(e)}"
+        detail = format_http_error(e)
+        raise ToolError({"status_code": 502, "message": f"Error fetching web categories: {detail}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"axis_write_delete"})
@@ -42,7 +44,7 @@ async def axis_manage_web_category(
     payload: dict | None = None,
     web_category_id: str | None = None,
     confirmed: bool = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete an Axis web category.
 
     Writes stage in Axis. Call ``axis_commit_changes`` to apply.

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
@@ -73,7 +74,7 @@ async def central_disconnect_users_ssid(
             network=ssid,
         )
     except Exception as e:
-        return f"Error disconnecting users from SSID: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting users from SSID: {e}"}) from e
 
     if not resp:
         return "Disconnect users from SSID returned no results."
@@ -105,7 +106,7 @@ async def central_disconnect_users_ap(
             serial_number=resolved_id,
         )
     except Exception as e:
-        return f"Error disconnecting users from AP: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting users from AP: {e}"}) from e
 
     if not resp:
         return "Disconnect users from AP returned no results."
@@ -141,7 +142,7 @@ async def central_disconnect_client_ap(
             mac_address=mac_address,
         )
     except Exception as e:
-        return f"Error disconnecting client from AP: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting client from AP: {e}"}) from e
 
     if not resp:
         return "Disconnect client from AP returned no results."
@@ -174,7 +175,7 @@ async def central_disconnect_client_gateway(
             mac_address=mac_address,
         )
     except Exception as e:
-        return f"Error disconnecting client from gateway: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting client from gateway: {e}"}) from e
 
     if not resp:
         return "Disconnect client from gateway returned no results."
@@ -203,7 +204,7 @@ async def central_disconnect_clients_gateway(
             serial_number=serial_number,
         )
     except Exception as e:
-        return f"Error disconnecting clients from gateway: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting clients from gateway: {e}"}) from e
 
     if not resp:
         return "Disconnect clients from gateway returned no results."
@@ -286,7 +287,7 @@ async def central_port_bounce_switch(
     try:
         port_info = _get_switch_ports(conn, serial_number)
     except Exception as e:
-        return f"Error checking port status: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error checking port status: {e}"}) from e
 
     safe_ports = []
     skipped = []
@@ -318,7 +319,7 @@ async def central_port_bounce_switch(
             ports=safe_ports,
         )
     except Exception as e:
-        return f"Error bouncing switch ports: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error bouncing switch ports: {e}"}) from e
 
     return {
         "bounced": safe_ports,
@@ -362,7 +363,7 @@ async def central_poe_bounce_switch(
     try:
         port_info = _get_switch_ports(conn, serial_number)
     except Exception as e:
-        return f"Error checking port status: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error checking port status: {e}"}) from e
 
     safe_ports = []
     skipped = []
@@ -398,7 +399,7 @@ async def central_poe_bounce_switch(
             ports=safe_ports,
         )
     except Exception as e:
-        return f"Error bouncing PoE on switch ports: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error bouncing PoE on switch ports: {e}"}) from e
 
     return {
         "bounced": safe_ports,
@@ -436,7 +437,7 @@ async def central_port_bounce_gateway(
             ports=port_list,
         )
     except Exception as e:
-        return f"Error bouncing gateway ports: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error bouncing gateway ports: {e}"}) from e
 
     if not resp:
         return "Port bounce returned no results."
@@ -472,7 +473,7 @@ async def central_poe_bounce_gateway(
             ports=port_list,
         )
     except Exception as e:
-        return f"Error bouncing PoE on gateway ports: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error bouncing PoE on gateway ports: {e}"}) from e
 
     if not resp:
         return "PoE bounce returned no results."

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -94,7 +95,7 @@ async def central_get_alerts(
     try:
         odata = build_odata_filter(pairs)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
     if odata:
         query_params["filter"] = odata
 

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -1,4 +1,5 @@
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -16,7 +17,7 @@ async def central_get_applications(
     client_id: str | None = None,
     filter: str | None = None,
     sort: str | None = None,
-) -> dict | str:
+) -> dict:
     """
     Get application usage data for a site within a time window.
 
@@ -58,9 +59,9 @@ async def central_get_applications(
             api_params=query_params,
         )
     except Exception as e:
-        return f"Error fetching applications: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching applications: {e}"}) from e
 
     code = resp.get("code", 0)
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
     return resp.get("msg", {})

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -1,4 +1,5 @@
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -14,7 +15,7 @@ async def central_get_audit_logs(
     sort: str | None = None,
     limit: int = 200,
     offset: int = 1,
-) -> dict | str:
+) -> dict:
     """
     Retrieve audit logs from Aruba Central within a time window.
 
@@ -51,11 +52,11 @@ async def central_get_audit_logs(
             api_params=query_params,
         )
     except Exception as e:
-        return f"Error fetching audit logs: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching audit logs: {e}"}) from e
 
     code = resp.get("code", 0)
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
     return resp.get("msg", {})
 
 
@@ -63,7 +64,7 @@ async def central_get_audit_logs(
 async def central_get_audit_log_detail(
     ctx: Context,
     id: str,
-) -> dict | str:
+) -> dict:
     """
     Get the full detail of a single audit log entry.
 
@@ -84,9 +85,9 @@ async def central_get_audit_log_detail(
             api_params={},
         )
     except Exception as e:
-        return f"Error fetching audit log detail: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching audit log detail: {e}"}) from e
 
     code = resp.get("code", 0)
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
     return resp.get("msg", {})

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring.clients import Clients
 
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -73,7 +74,7 @@ async def central_get_clients(
     try:
         filter_str = build_odata_filter(pairs)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     try:
         clients = Clients.get_all_clients(
@@ -86,7 +87,7 @@ async def central_get_clients(
             filter_str=filter_str,
         )
     except Exception as e:
-        return f"Error occurred while fetching clients: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error occurred while fetching clients: {e}"}) from e
 
     if not clients:
         return "No clients found matching the specified criteria."
@@ -117,7 +118,7 @@ async def central_find_client(
     except Exception as e:
         if MISSING_CLIENT_RESPONSE in str(e):
             return f"No client found with MAC address '{mac_address}'."
-        return f"Error occurred while fetching client details: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error occurred while fetching client details: {e}"}) from e
 
     if not result:
         return f"No client found with MAC address '{mac_address}'."

--- a/src/hpe_networking_mcp/platforms/central/tools/config_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_health.py
@@ -11,6 +11,7 @@ with sort/filter/search for spotting which devices need attention.
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -92,7 +93,12 @@ async def central_get_devices_config_health(
         ``/network-config/v1alpha1/config-health/devices`` response shape.
     """
     if search is not None and not (_SEARCH_MIN_CHARS <= len(search) <= _SEARCH_MAX_CHARS):
-        return f"Error: search must be {_SEARCH_MIN_CHARS}-{_SEARCH_MAX_CHARS} chars when supplied, got {len(search)}"
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"search must be {_SEARCH_MIN_CHARS}-{_SEARCH_MAX_CHARS} chars, got {len(search)}",
+            }
+        )
 
     api_params: dict[str, Any] = {"limit": limit, "offset": offset}
     if sort is not None:

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring import MonitoringDevices
 
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -82,7 +83,7 @@ async def central_get_devices(
     try:
         filter_str = build_odata_filter(pairs)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     # normalize site_assigned: True -> "ASSIGNED", False -> "UNASSIGNED"
     site_assigned_str: str | None = None if site_assigned is None else ("ASSIGNED" if site_assigned else "UNASSIGNED")
@@ -95,7 +96,7 @@ async def central_get_devices(
             sort=sort,
         )
     except Exception as e:
-        return f"Error fetching devices: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching devices: {e}"}) from e
 
     if not devices:
         return "No devices found matching the specified criteria."
@@ -134,16 +135,16 @@ async def central_find_device(
     try:
         filter_str = build_odata_filter(pairs)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
     try:
         device_resp = MonitoringDevices.get_device_inventory(
             central_conn=ctx.lifespan_context["central_conn"],
             filter_str=filter_str,
         )
     except Exception as e:
-        return f"Error occurred while fetching device data: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error occurred while fetching device data: {e}"}) from e
     if "items" not in device_resp:
-        return f"Unexpected API error response: {device_resp}"
+        raise ToolError({"status_code": 502, "message": f"Unexpected API error response: {device_resp}"})
 
     if len(device_resp["items"]) == 0:
         return "No device found matching the provided criteria."

--- a/src/hpe_networking_mcp/platforms/central/tools/events.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/events.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import (
@@ -63,7 +64,7 @@ async def central_get_events(
     search: str | None = None,
     limit: int = 50,
     cursor: int | None = None,
-) -> PaginatedEvents | str:
+) -> PaginatedEvents:
     """
     Retrieve events for a given context (site, device, or client) within a specified time range.
 
@@ -97,7 +98,7 @@ async def central_get_events(
     try:
         start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     query_params: dict = {
         "context-type": context_type,
@@ -121,7 +122,7 @@ async def central_get_events(
             api_params=query_params,
         )
     except Exception as e:
-        return f"Error fetching events: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching events: {e}"}) from e
 
     msg = response["msg"]
     raw_events = msg.get("events", [])  # key is "events", not "items"
@@ -141,7 +142,7 @@ async def central_get_events_count(
     time_range: TIME_RANGE = "last_1h",
     start_time: str | None = None,
     end_time: str | None = None,
-) -> EventFilters | str:
+) -> EventFilters:
     """
     Return a breakdown of event counts for a context without fetching full event details.
 
@@ -168,7 +169,7 @@ async def central_get_events_count(
     try:
         start_at, end_at = _resolve_time_window(time_range, start_time, end_time)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     response = retry_central_command(
         ctx.lifespan_context["central_conn"],

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring.aps import MonitoringAPs
 from pycentral.new_monitoring.gateways import MonitoringGateways
 
@@ -77,7 +78,7 @@ async def central_get_aps(
     try:
         filter_str = build_odata_filter(pairs)
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     try:
         kwargs: dict = {"central_conn": conn}
@@ -87,7 +88,7 @@ async def central_get_aps(
             kwargs["sort"] = sort
         aps = MonitoringAPs.get_all_aps(**kwargs)
     except Exception as e:
-        return f"Error fetching access points: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching access points: {e}"}) from e
 
     return aps or []
 
@@ -116,7 +117,7 @@ async def central_get_ap_wlans(
             serial_number=serial_number,
         )
     except Exception as e:
-        return f"Error fetching AP WLANs: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching AP WLANs: {e}"}) from e
 
     items = resp.get("items", []) if isinstance(resp, dict) else []
     if wlan_name:
@@ -150,7 +151,7 @@ async def central_get_ap_details(
             serial_number=serial_number,
         )
     except Exception as e:
-        return f"Error fetching AP details: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching AP details: {e}"}) from e
 
     if not resp:
         return f"No AP found with serial number '{serial_number}'. Verify the serial using central_find_device."
@@ -181,13 +182,13 @@ async def central_get_switch_details(
             api_path=(f"network-monitoring/v1/switches/{serial_number}"),
         )
     except Exception as e:
-        return f"Error fetching switch details: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching switch details: {e}"}) from e
 
     code = resp.get("code", 0)
     if code == 404:
         return f"No switch found with serial number '{serial_number}'. Verify the serial using central_find_device."
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
 
     result = resp.get("msg", {})
 
@@ -264,7 +265,7 @@ async def central_get_gateway_details(
             serial_number=serial_number,
         )
     except Exception as e:
-        return f"Error fetching gateway details: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching gateway details: {e}"}) from e
 
     if not resp:
         return f"No gateway found with serial number '{serial_number}'. Verify the serial using central_find_device."

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -11,6 +11,7 @@ distinct subsystem; they're collected here because they share the
 from typing import Annotated, Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -26,7 +27,7 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
+def _get(conn, path: str, params: dict | None = None) -> dict:
     response = retry_central_command(
         central_conn=conn,
         api_method="GET",
@@ -48,7 +49,7 @@ def _get(conn, path: str, params: dict | None = None) -> dict | str:
 async def central_get_fco_resp_info(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Device serial number.")],
-) -> dict | str:
+) -> dict:
     """Get FCO (Factory Cell Order) response info for one device.
 
     Returns provisioning / RMA-related metadata tied to the device's
@@ -64,7 +65,7 @@ async def central_get_fco_resp_info_all(
     ctx: Context,
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """List FCO response info across all devices in the tenant.
 
     Paginated; use for bulk audits of factory-order state.
@@ -84,7 +85,7 @@ async def central_get_asset_tags(
     filter: str | None = None,
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """List BLE asset tags detected by the tenant's APs.
 
     Asset tags are physical BLE beacons (e.g. ArubaAssetTag, Blyott)
@@ -115,7 +116,7 @@ async def central_get_asset_tag(
         str,
         Field(description="Asset-tag identifier (assigned by Central on first detection)."),
     ],
-) -> dict | str:
+) -> dict:
     """Get one BLE asset tag's full record.
 
     Returns classifications, BLE MAC, first/last seen, attached metadata,
@@ -150,7 +151,7 @@ async def central_manage_asset_tag_metadata(
             ),
         ),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Create / update / delete the descriptive metadata attached to a BLE asset tag.
 
     The metadata is the inventory record for a tracked asset — name,
@@ -161,10 +162,10 @@ async def central_manage_asset_tag_metadata(
     conn = ctx.lifespan_context["central_conn"]
     method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}
     if action_type not in method_map:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     method = method_map[action_type]
     if action_type != "delete" and not payload:
-        return f"Error: ``payload`` is required for {action_type}."
+        raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
     response = retry_central_command(
         central_conn=conn,
         api_method=method,
@@ -200,7 +201,7 @@ async def central_start_ap_ranging_scan(
             ),
         ),
     ],
-) -> dict | str:
+) -> dict:
     """Kick off an AP ranging scan.
 
     Ranging scans calibrate inter-AP distances for accurate location
@@ -226,7 +227,7 @@ async def central_get_ap_ranging_scans(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier (under ``site_id``).")],
-) -> dict | str:
+) -> dict:
     """List AP ranging scans for a floor."""
     conn = ctx.lifespan_context["central_conn"]
     return _get(
@@ -241,7 +242,7 @@ async def central_get_ap_ranging_scan(
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
     scan_id: Annotated[str, Field(description="Scan identifier.")],
-) -> dict | str:
+) -> dict:
     """Get one AP ranging scan's results / status."""
     conn = ctx.lifespan_context["central_conn"]
     return _get(
@@ -256,7 +257,7 @@ async def central_delete_ap_ranging_scan(
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
     scan_id: Annotated[str, Field(description="Scan identifier to delete.")],
-) -> dict | str:
+) -> dict:
     """Delete an AP ranging scan record. Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``."""
     conn = ctx.lifespan_context["central_conn"]
     response = retry_central_command(
@@ -281,7 +282,7 @@ async def central_get_site_device_locations(
     site_id: Annotated[str, Field(description="Site identifier.")],
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """List device locations placed at a site (across all floors)."""
     conn = ctx.lifespan_context["central_conn"]
     return _get(
@@ -296,7 +297,7 @@ async def central_get_site_device_location(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     location_id: Annotated[str, Field(description="Device-location identifier.")],
-) -> dict | str:
+) -> dict:
     """Get one device-location record."""
     conn = ctx.lifespan_context["central_conn"]
     return _get(conn, f"network-services/v1/sites/{site_id}/device-locations/{location_id}")
@@ -307,7 +308,7 @@ async def central_get_device_location(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     serial_number: Annotated[str, Field(description="Device serial number.")],
-) -> dict | str:
+) -> dict:
     """Get the placement (floor + coordinates) for a specific device at a site."""
     conn = ctx.lifespan_context["central_conn"]
     return _get(
@@ -334,12 +335,12 @@ async def central_manage_device_location(
             ),
         ),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Place / move / unplace a device on a site's floor plan."""
     conn = ctx.lifespan_context["central_conn"]
     if action_type == "set":
         if not payload:
-            return "Error: ``payload`` is required for set."
+            raise ToolError({"status_code": 400, "message": "``payload`` is required for set."})
         response = retry_central_command(
             central_conn=conn,
             api_method="POST",
@@ -353,7 +354,7 @@ async def central_manage_device_location(
             api_path=f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
         )
     else:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     code = response.get("code", 0)
     if 200 <= code < 300:
         return {
@@ -376,7 +377,7 @@ async def central_get_wifi_clients_locations(
     filter: str | None = None,
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """Get real-time locations of WiFi clients across the tenant.
 
     PII: returns client MAC + computed coordinates. MACs ride existing
@@ -396,7 +397,7 @@ async def central_get_location_analytics_trends(
     start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
     end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
     filter: str | None = None,
-) -> dict | str:
+) -> dict:
     """Get location-analytics trend data over a time window.
 
     Surfaces visitor dwell-time, footfall, and repeat-visitor analytics
@@ -417,7 +418,7 @@ async def central_get_location_analytics_trends(
 async def central_get_location_analytics_site_insights(
     ctx: Context,
     filter: str | None = None,
-) -> dict | str:
+) -> dict:
     """Get per-site location-analytics insights (summary KPIs)."""
     conn = ctx.lifespan_context["central_conn"]
     params: dict = {}

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
@@ -9,6 +9,7 @@ location-services accuracy and the floor-plan view in Central's UI.
 from typing import Annotated, Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -24,7 +25,7 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
+def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict:
     response = retry_central_command(
         central_conn=conn,
         api_method=method,
@@ -47,7 +48,7 @@ def _call(conn, method: str, path: str, params: dict | None = None, data: dict |
 async def central_get_sitemap_summary(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
-) -> dict | str:
+) -> dict:
     """Get high-level sitemap summary for a site (counts, floors, devices placed)."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{site_id}")
@@ -58,7 +59,7 @@ async def central_get_catalogue_aps(
     ctx: Context,
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """List catalogue APs — the AP models available for placement on floor plans."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(
@@ -85,7 +86,7 @@ async def central_get_sitemap_devices(
         _DeviceStatus,
         Field(description="``'deployed'``, ``'assigned'``, or ``'planned'``."),
     ],
-) -> dict | str:
+) -> dict:
     """List network devices on a site map by lifecycle status.
 
     ``planned`` = placeholders on the floor plan that haven't been
@@ -111,7 +112,7 @@ async def central_manage_sitemap_devices(
             description="Action body — typically a list of device placements with serial / floor / x / y / rotation."
         ),
     ],
-) -> dict | str:
+) -> dict:
     """Apply a device-placement lifecycle transition on a site map.
 
     | action | endpoint |
@@ -133,7 +134,7 @@ async def central_manage_sitemap_devices(
         "unplan": ("DELETE", "network-devices-planned"),
     }
     if action not in action_map:
-        return f"Error: unknown action '{action}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action '{action}'."})
     method, segment = action_map[action]
     response = retry_central_command(
         central_conn=conn,
@@ -157,7 +158,7 @@ async def central_get_floor(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
-) -> dict | str:
+) -> dict:
     """Get one floor's configuration (dimensions, scale, building, image ref)."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}")
@@ -179,12 +180,12 @@ async def central_manage_floor(
         dict | None,
         Field(description="Floor configuration body. Required for create/update; ignored for delete."),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Create / update / delete a floor under a site."""
     conn = ctx.lifespan_context["central_conn"]
     if action_type == "create":
         if not payload:
-            return "Error: ``payload`` is required for create."
+            raise ToolError({"status_code": 400, "message": "``payload`` is required for create."})
         response = retry_central_command(
             central_conn=conn,
             api_method="POST",
@@ -193,7 +194,7 @@ async def central_manage_floor(
         )
     elif action_type == "update":
         if not floor_id or not payload:
-            return "Error: ``floor_id`` and ``payload`` are required for update."
+            raise ToolError({"status_code": 400, "message": "``floor_id`` and ``payload`` are required for update."})
         response = retry_central_command(
             central_conn=conn,
             api_method="PUT",
@@ -202,14 +203,14 @@ async def central_manage_floor(
         )
     elif action_type == "delete":
         if not floor_id:
-            return "Error: ``floor_id`` is required for delete."
+            raise ToolError({"status_code": 400, "message": "``floor_id`` is required for delete."})
         response = retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}",
         )
     else:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     code = response.get("code", 0)
     if 200 <= code < 300:
         return {"status": "success", "action": action_type, "floor_id": floor_id, "data": response.get("msg", {})}
@@ -225,7 +226,7 @@ async def central_set_floor_scale(
         dict,
         Field(description="Scale calibration body — typically two anchor points + real-world distance."),
     ],
-) -> dict | str:
+) -> dict:
     """Set the physical scale calibration for a floor (drives location accuracy)."""
     conn = ctx.lifespan_context["central_conn"]
     response = retry_central_command(
@@ -245,7 +246,7 @@ async def central_get_floor_image(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
-) -> dict | str:
+) -> dict:
     """Get the floor-plan image reference / metadata."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image")
@@ -260,7 +261,7 @@ async def central_set_floor_image(
         dict,
         Field(description="Image-upload payload — typically a base64 blob or upload URL reference per Central's docs."),
     ],
-) -> dict | str:
+) -> dict:
     """Upload / replace the floor-plan image for a floor."""
     conn = ctx.lifespan_context["central_conn"]
     response = retry_central_command(
@@ -284,7 +285,7 @@ async def central_set_floor_image(
 async def central_get_buildings(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
-) -> dict | str:
+) -> dict:
     """List buildings at a site."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/buildings")
@@ -303,12 +304,12 @@ async def central_manage_building(
         dict | None,
         Field(description="Building body. Required for update; ignored for delete."),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Update or delete a building. (Create endpoint not exposed by Central MRT.)"""
     conn = ctx.lifespan_context["central_conn"]
     if action_type == "update":
         if not payload:
-            return "Error: ``payload`` is required for update."
+            raise ToolError({"status_code": 400, "message": "``payload`` is required for update."})
         response = retry_central_command(
             central_conn=conn,
             api_method="PUT",
@@ -322,7 +323,7 @@ async def central_manage_building(
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/buildings/{building_id}",
         )
     else:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     code = response.get("code", 0)
     if 200 <= code < 300:
         return {"status": "success", "action": action_type, "building_id": building_id, "data": response.get("msg", {})}
@@ -344,7 +345,7 @@ async def central_import_sitemap(
             description="Import-request body — typically references the floor-plan file(s) being imported and metadata."
         ),
     ],
-) -> dict | str:
+) -> dict:
     """Kick off a sitemap import (bulk floor-plan upload). Poll status via ``central_get_sitemap_import_status``."""
     conn = ctx.lifespan_context["central_conn"]
     response = retry_central_command(
@@ -364,7 +365,7 @@ async def central_get_sitemap_import_status(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     import_id: Annotated[str, Field(description="Import job identifier (from ``central_import_sitemap``).")],
-) -> dict | str:
+) -> dict:
     """Get the status / result of a sitemap import job."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/import/{import_id}")
@@ -376,7 +377,7 @@ async def central_get_sitemap_import_status(
 
 
 @tool(annotations=READ_ONLY)
-async def central_get_wall_types(ctx: Context) -> dict | str:
+async def central_get_wall_types(ctx: Context) -> dict:
     """List the wall types configured at the tenant level (used in floor walls)."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", "network-monitoring/v1/wall-types")
@@ -393,14 +394,14 @@ async def central_manage_wall_types(
         dict | None,
         Field(description="Wall-types body — typically a list of {name, attenuation, color, ...}. Ignored for delete."),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Create / update / delete tenant-global wall types."""
     conn = ctx.lifespan_context["central_conn"]
     method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}
     if action_type not in method_map:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
-        return f"Error: ``payload`` is required for {action_type}."
+        raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
     response = retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
@@ -423,7 +424,7 @@ async def central_get_floor_walls(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
-) -> dict | str:
+) -> dict:
     """List walls placed on a floor (used by location services for signal attenuation modeling)."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls")
@@ -442,14 +443,14 @@ async def central_manage_floor_walls(
         dict | None,
         Field(description="Wall-set body. Ignored for delete (which clears all walls on the floor)."),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Manage walls on a floor (create / update / delete the wall set)."""
     conn = ctx.lifespan_context["central_conn"]
     method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}
     if action_type not in method_map:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
-        return f"Error: ``payload`` is required for {action_type}."
+        raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
     response = retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
@@ -467,7 +468,7 @@ async def central_get_floor_zones(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
     floor_id: Annotated[str, Field(description="Floor identifier.")],
-) -> dict | str:
+) -> dict:
     """List zones placed on a floor (named polygons used for location analytics)."""
     conn = ctx.lifespan_context["central_conn"]
     return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones")
@@ -486,14 +487,14 @@ async def central_manage_floor_zones(
         dict | None,
         Field(description="Zone-set body. Ignored for delete."),
     ] = None,
-) -> dict | str:
+) -> dict:
     """Manage zones on a floor (create / update / delete the zone set)."""
     conn = ctx.lifespan_context["central_conn"]
     method_map = {"create": "POST", "update": "PUT", "delete": "DELETE"}
     if action_type not in method_map:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
-        return f"Error: ``payload`` is required for {action_type}."
+        raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
     response = retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
@@ -13,6 +13,7 @@ untrusted AI clients.
 from typing import Annotated, Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -33,7 +34,7 @@ async def central_get_webhooks(
     ctx: Context,
     limit: int = 100,
     offset: int = 0,
-) -> dict | str:
+) -> dict:
     """List configured webhooks.
 
     Returns webhook definitions (URL, event types, HMAC settings,
@@ -57,7 +58,7 @@ async def central_get_webhooks(
 async def central_get_webhook(
     ctx: Context,
     webhook_id: Annotated[str, Field(description="Webhook identifier.")],
-) -> dict | str:
+) -> dict:
     """Get one webhook's full configuration by ID."""
     conn = ctx.lifespan_context["central_conn"]
     response = retry_central_command(
@@ -104,7 +105,7 @@ async def central_manage_webhook(
             ),
         ),
     ] = False,
-) -> dict | str:
+) -> dict:
     """Create, update, or delete a webhook.
 
     Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``. Update defaults to
@@ -115,7 +116,7 @@ async def central_manage_webhook(
 
     if action_type == "create":
         if not payload:
-            return "Error: ``payload`` is required for create."
+            raise ToolError({"status_code": 400, "message": "``payload`` is required for create."})
         response = retry_central_command(
             central_conn=conn,
             api_method="POST",
@@ -124,9 +125,9 @@ async def central_manage_webhook(
         )
     elif action_type == "update":
         if not webhook_id:
-            return "Error: ``webhook_id`` is required for update."
+            raise ToolError({"status_code": 400, "message": "``webhook_id`` is required for update."})
         if not payload:
-            return "Error: ``payload`` is required for update."
+            raise ToolError({"status_code": 400, "message": "``payload`` is required for update."})
         method = "PUT" if replace_existing else "PATCH"
         response = retry_central_command(
             central_conn=conn,
@@ -136,14 +137,14 @@ async def central_manage_webhook(
         )
     elif action_type == "delete":
         if not webhook_id:
-            return "Error: ``webhook_id`` is required for delete."
+            raise ToolError({"status_code": 400, "message": "``webhook_id`` is required for delete."})
         response = retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-services/v1/webhooks/{webhook_id}",
         )
     else:
-        return f"Error: unknown action_type '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
 
     code = response.get("code", 0)
     if 200 <= code < 300:
@@ -155,7 +156,7 @@ async def central_manage_webhook(
 async def central_rotate_webhook_hmac_key(
     ctx: Context,
     webhook_id: Annotated[str, Field(description="Webhook identifier to rotate.")],
-) -> dict | str:
+) -> dict:
     """Rotate the HMAC signing key for a webhook.
 
     After rotation, the old key stops signing future deliveries.

--- a/src/hpe_networking_mcp/platforms/central/tools/stats.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/stats.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring.aps import MonitoringAPs
 from pycentral.new_monitoring.gateways import MonitoringGateways
 
@@ -42,7 +43,7 @@ async def central_get_ap_stats(
     try:
         resp = MonitoringAPs.get_ap_stats(**kwargs)
     except Exception as e:
-        return f"Error fetching AP stats: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching AP stats: {e}"}) from e
 
     if not resp:
         return f"No stats found for AP '{serial_number}'. Verify the serial using central_find_device."
@@ -91,7 +92,7 @@ async def central_get_ap_utilization(
     try:
         resp = method_map[metric](**kwargs)
     except Exception as e:
-        return f"Error fetching AP {metric} utilization: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching AP {metric} utilization: {e}"}) from e
 
     if not resp:
         return f"No {metric} utilization data for AP '{serial_number}'. Verify the serial using central_find_device."
@@ -132,7 +133,7 @@ async def central_get_gateway_stats(
     try:
         resp = MonitoringGateways.get_gateway_stats(**kwargs)
     except Exception as e:
-        return f"Error fetching gateway stats: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching gateway stats: {e}"}) from e
 
     if not resp:
         return f"No stats found for gateway '{serial_number}'. Verify the serial using central_find_device."
@@ -180,7 +181,7 @@ async def central_get_gateway_utilization(
     try:
         resp = method_map[metric](**kwargs)
     except Exception as e:
-        return f"Error fetching gateway {metric} utilization: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching gateway {metric} utilization: {e}"}) from e
 
     if not resp:
         return (
@@ -223,7 +224,7 @@ async def central_get_gateway_wan_availability(
     try:
         resp = MonitoringGateways.get_gateway_wan_availability(**kwargs)
     except Exception as e:
-        return f"Error fetching gateway WAN availability: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching gateway WAN availability: {e}"}) from e
 
     if not resp:
         return f"No WAN availability data for gateway '{serial_number}'. Verify the serial using central_find_device."
@@ -254,7 +255,7 @@ async def central_get_tunnel_health(
             serial_number=serial_number,
         )
     except Exception as e:
-        return f"Error fetching tunnel health: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching tunnel health: {e}"}) from e
 
     if not resp:
         return f"No tunnel health data for gateway '{serial_number}'. Verify the serial using central_find_device."

--- a/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
@@ -1,6 +1,7 @@
 """Central tools for switch PoE and hardware trends."""
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -11,7 +12,7 @@ from hpe_networking_mcp.platforms.central.utils import retry_central_command
 async def central_get_switch_hardware_trends(
     ctx: Context,
     serial_number: str,
-) -> dict | str:
+) -> dict:
     """
     Get time-series hardware trends for a switch including PoE
     capacity, PoE consumption, CPU, memory, temperature, and
@@ -36,13 +37,18 @@ async def central_get_switch_hardware_trends(
             api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
         )
     except Exception as e:
-        return f"Error fetching hardware trends: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching hardware trends: {e}"}) from e
 
     code = resp.get("code", 0)
     if code == 404:
-        return f"Switch '{serial_number}' not found. For stacked switches, use the conductor serial or stack ID."
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": f"Switch '{serial_number}' not found. For a stack, use the conductor serial / stack ID.",
+            }
+        )
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
 
     msg = resp.get("msg", {})
     data = msg.get("response", msg)
@@ -98,7 +104,7 @@ async def central_get_switch_poe(
     ctx: Context,
     serial_number: str,
     limit: int = 100,
-) -> dict | str:
+) -> dict:
     """
     Get per-port PoE data for a switch showing power drawn
     on each interface.
@@ -121,13 +127,13 @@ async def central_get_switch_poe(
             api_params={"limit": limit},
         )
     except Exception as e:
-        return f"Error fetching port PoE data: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching port PoE data: {e}"}) from e
 
     code = resp.get("code", 0)
     if code == 404:
-        return f"Switch '{serial_number}' not found."
+        raise ToolError({"status_code": 404, "message": f"Switch '{serial_number}' not found."})
     if not (200 <= code < 300):
-        return f"Central API error (HTTP {code}): {resp.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
 
     msg = resp.get("msg", {})
     data = msg.get("response", msg)

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -63,7 +64,7 @@ async def central_ping(
     try:
         resp = method_map[device_type](**kwargs)
     except Exception as e:
-        return f"Error running ping test: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error running ping test: {e}"}) from e
 
     if not resp:
         return "Ping test returned no results."
@@ -104,7 +105,7 @@ async def central_traceroute(
             destination=destination,
         )
     except Exception as e:
-        return f"Error running traceroute test: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error running traceroute test: {e}"}) from e
 
     if not resp:
         return "Traceroute test returned no results."
@@ -141,7 +142,7 @@ async def central_cable_test(
             ports=port_list,
         )
     except Exception as e:
-        return f"Error running cable test: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error running cable test: {e}"}) from e
 
     if not resp:
         return "Cable test returned no results."
@@ -178,7 +179,7 @@ async def central_show_commands(
             commands=command_list,
         )
     except Exception as e:
-        return f"Error running show commands: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error running show commands: {e}"}) from e
 
     if not resp:
         return "Show commands returned no results."

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring.aps import MonitoringAPs
 
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -49,7 +50,7 @@ async def central_get_wlans(
 
         resp = MonitoringAPs.get_wlans(**kwargs)
     except Exception as e:
-        return f"Error fetching WLANs: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching WLANs: {e}"}) from e
 
     if isinstance(resp, dict):
         items = resp.get("items", [])
@@ -101,11 +102,11 @@ async def central_get_wlan_stats(
             api_params={"filter": f"timestamp gt {start_at} and timestamp lt {end_at}"},
         )
     except Exception as e:
-        return f"Error fetching WLAN statistics: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching WLAN statistics: {e}"}) from e
 
     code = response.get("code", 0)
     if not (200 <= code < 300):
-        return f"Error fetching WLAN stats (HTTP {code}): {response.get('msg')}"
+        raise ToolError({"status_code": code, "message": f"Error fetching WLAN stats: {response.get('msg')}"})
 
     # Flatten the graph structure into a list of samples
     msg = response.get("msg", {})

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -27,8 +28,10 @@ async def clearpass_get_audit_logs(
 
         client = await get_clearpass_session(ApiLogs)
         return client.get_login_audit_by_name(name=username)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching audit logs: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching audit logs: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -59,8 +62,10 @@ async def clearpass_get_system_events(
         client = await get_clearpass_session(ApiLogs)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/system-event" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching system events: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching system events: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -98,8 +103,10 @@ async def clearpass_get_insight_alerts(
             return client.get_alert_by_name(name=name)
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return clearpass_get(client, "/alert" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching insight alerts: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching insight alerts: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -137,8 +144,10 @@ async def clearpass_get_insight_reports(
             return client.get_report_by_name(name=name)
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return clearpass_get(client, "/report" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching insight reports: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching insight reports: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -177,6 +186,13 @@ async def clearpass_get_endpoint_insights(
                 from_time=from_time,
                 to_time=to_time,
             )
-        return "Error: at least one parameter (mac, ip, ip_range, or from_time+to_time) is required."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": "Error: at least one parameter (mac, ip, ip_range, or from_time+to_time) is required.",
+            }
+        )
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching endpoint insights: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching endpoint insights: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -51,8 +52,10 @@ async def clearpass_get_auth_sources(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/auth-source" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching auth sources: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching auth sources: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -73,8 +76,10 @@ async def clearpass_get_auth_source_status(
 
         client = await get_clearpass_session(ApiPolicyElements)
         return client.get_auth_source_by_auth_source_id(auth_source_id=auth_source_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching auth source status: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching auth source status: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -101,8 +106,10 @@ async def clearpass_test_auth_source(
             "note": "Actual connectivity testing (LDAP bind, AD join check) "
             "requires ClearPass server-side capabilities.",
         }
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching auth source for testing: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching auth source for testing: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -146,5 +153,7 @@ async def clearpass_get_auth_methods(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/auth-method" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching auth methods: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching auth methods: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -15,6 +15,7 @@ See: https://developer.arubanetworks.com/cppm/reference (Certificate Authority)
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -62,8 +63,10 @@ async def clearpass_get_certificates(
             return clearpass_get(client, f"/certificate/{certificate_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/certificate" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching CA certificates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching CA certificates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -107,5 +110,7 @@ async def clearpass_get_onboard_devices(
             return clearpass_get(client, f"/onboard/device/{onboard_device_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/onboard/device" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching onboard devices: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching onboard devices: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -49,8 +50,10 @@ async def clearpass_get_trust_list(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/cert-trust-list" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching trust list: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching trust list: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -83,8 +86,10 @@ async def clearpass_get_client_certificates(
             return client.get_client_cert_by_client_cert_id(client_cert_id=client_cert_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/client-cert" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching client certificates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching client certificates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -117,8 +122,10 @@ async def clearpass_get_server_certificates(
                 service_name=service_name,
             )
         return clearpass_get(client, "/server-cert")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching server certificates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching server certificates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -151,8 +158,10 @@ async def clearpass_get_service_certificates(
             return client.get_service_cert_by_service_cert_id(service_cert_id=service_cert_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/service-cert" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching service certificates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching service certificates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -191,5 +200,7 @@ async def clearpass_get_revocation_list(
             return clearpass_get(client, f"/revocation-list/{revocation_list_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/revocation-list" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching revocation lists: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching revocation lists: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -10,6 +10,7 @@ See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility)
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -54,8 +55,10 @@ async def clearpass_get_onguard_activity(
             return clearpass_get(client, f"/onguard-activity/mac/{mac}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/onguard-activity" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching OnGuard activity: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching OnGuard activity: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -95,8 +98,10 @@ async def clearpass_get_fingerprint_dictionary(
             return clearpass_get(client, f"/fingerprint/{fingerprint_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/fingerprint" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching fingerprint dictionary: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching fingerprint dictionary: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -136,8 +141,10 @@ async def clearpass_get_network_scan(
             return clearpass_get(client, f"/config/network-scan/{scan_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/config/network-scan" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching network scans: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching network scans: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -164,5 +171,7 @@ async def clearpass_get_onguard_settings(
         client = await get_clearpass_session(ApiEndpointVisibility)
         path = "/onguard/global-settings" if global_settings else "/onguard/settings"
         return clearpass_get(client, path)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching OnGuard settings: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching OnGuard settings: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -59,8 +60,10 @@ async def clearpass_get_endpoints(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/endpoint" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching endpoints: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching endpoints: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -81,5 +84,7 @@ async def clearpass_get_endpoint_profiler(
 
         client = await get_clearpass_session(ApiEndpointVisibility)
         return client.get_device_profiler_device_fingerprint_by_mac_or_ip(mac_or_ip=mac_or_ip)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching endpoint profiler data: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching endpoint profiler data: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -54,8 +55,10 @@ async def clearpass_get_enforcement_policies(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/enforcement-policy" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching enforcement policies: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching enforcement policies: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -102,8 +105,10 @@ async def clearpass_get_enforcement_profiles(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/enforcement-profile" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching enforcement profiles: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching enforcement profiles: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -40,8 +41,10 @@ async def clearpass_get_pass_templates(
             return client.get_template_pass_by_id(id=template_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/template/pass" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching pass templates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching pass templates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -74,8 +77,10 @@ async def clearpass_get_print_templates(
             return client.get_template_print_by_id(id=template_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/template/print" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching print templates: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching print templates: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -112,8 +117,10 @@ async def clearpass_get_weblogin_pages(
             return client.get_weblogin_page_name_by_page_name(page_name=page_name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/weblogin" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching web login pages: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching web login pages: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -130,8 +137,10 @@ async def clearpass_get_guest_auth_settings(
 
         client = await get_clearpass_session(ApiGuestConfiguration)
         return client.get_guest_authentication()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching guest authentication settings: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching guest authentication settings: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -148,5 +157,7 @@ async def clearpass_get_guest_manager_settings(
 
         client = await get_clearpass_session(ApiGuestConfiguration)
         return client.get_guestmanager()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching guest manager settings: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching guest manager settings: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -51,5 +52,7 @@ async def clearpass_get_guest_users(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/guest" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching guest users: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching guest users: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -40,8 +41,10 @@ async def clearpass_get_api_clients(
             return client.get_api_client_by_client_id(client_id=client_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/api-client" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching API clients: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching API clients: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -79,8 +82,10 @@ async def clearpass_get_local_users(
             return client.get_local_user_user_id_by_user_id(user_id=user_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/local-user" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching local users: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching local users: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -119,8 +124,10 @@ async def clearpass_get_static_host_lists(
             return client.get_static_host_list_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/static-host-list" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching static host lists: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching static host lists: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -157,8 +164,10 @@ async def clearpass_get_devices(
             return client.get_device_mac_by_macaddr(macaddr=macaddr)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/device" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching devices: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching devices: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -193,8 +202,10 @@ async def clearpass_get_deny_listed_users(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/deny-listed-users" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching deny-listed users: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching deny-listed users: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -239,5 +250,7 @@ async def clearpass_get_external_accounts(
             return clearpass_get(client, f"/external-account/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/external-account" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching external accounts: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching external accounts: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -45,8 +46,10 @@ async def clearpass_get_extensions(
             return client.get_extension_instance_by_id(id=extension_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/extension/instance" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching extensions: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching extensions: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -79,8 +82,10 @@ async def clearpass_get_syslog_targets(
             return client.get_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/syslog-target" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching syslog targets: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching syslog targets: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -115,8 +120,10 @@ async def clearpass_get_syslog_export_filters(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/syslog-export-filter" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching syslog export filters: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching syslog export filters: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -149,8 +156,10 @@ async def clearpass_get_event_sources(
             return client.get_event_sources_by_event_sources_id(event_sources_id=event_sources_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/event-sources" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching event sources: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching event sources: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -185,8 +194,10 @@ async def clearpass_get_context_servers(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/context-server-action" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching context server actions: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching context server actions: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -221,8 +232,10 @@ async def clearpass_get_endpoint_context_servers(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/endpoint-context-server" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching endpoint context servers: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching endpoint context servers: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -250,5 +263,7 @@ async def clearpass_get_extension_log(
         if tail is not None:
             path += f"?tail={tail}"
         return clearpass_get(client, path)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching extension log: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching extension log: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -34,8 +35,10 @@ async def clearpass_get_access_controls(
                 resource_name=resource_name,
             )
         return client.get_server_access_control_by_server_uuid(server_uuid=server_uuid)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching access controls: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching access controls: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -63,8 +66,10 @@ async def clearpass_get_ad_domains(
                 netbios_name=netbios_name,
             )
         return client.get_ad_domain_by_server_uuid(server_uuid=server_uuid)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching AD domains: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching AD domains: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -90,8 +95,10 @@ async def clearpass_get_server_version(
             "cppm_version": client.get_cppm_version(),
             "server_version": client.get_server_version(),
         }
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching server version: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching server version: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -107,8 +114,10 @@ async def clearpass_get_fips_status(
 
         client = await get_clearpass_session(ApiLocalServerConfiguration)
         return client.get_server_fips()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching FIPS status: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching FIPS status: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -136,8 +145,10 @@ async def clearpass_get_server_services(
                 service_name=service_name,
             )
         return client.get_server_service_by_server_uuid(server_uuid=server_uuid)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching server services: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching server services: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -158,8 +169,10 @@ async def clearpass_get_server_snmp(
 
         client = await get_clearpass_session(ApiLocalServerConfiguration)
         return client.get_server_snmp_by_server_uuid(server_uuid=server_uuid)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching server SNMP config: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching server SNMP config: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -187,5 +200,7 @@ async def clearpass_get_cluster_servers(
 
         client = await get_clearpass_session(ApiLocalServerConfiguration)
         return client.get_cluster_server()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching cluster servers: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching cluster servers: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -50,7 +51,12 @@ async def clearpass_manage_insight_alert(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _ALERT_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_ALERT_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_ALERT_ACTIONS)}.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} insight alert", alert_id)
@@ -62,8 +68,10 @@ async def clearpass_manage_insight_alert(
 
         client = await get_clearpass_session(ApiInsight)
         return _execute_alert_action(client, action_type, payload, alert_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing insight alert: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing insight alert: {e}"}) from e
 
 
 def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str | None) -> dict | str:
@@ -81,7 +89,7 @@ def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str
     if action_type == "create":
         return client._send_request("/alert", "post", query=payload)
     if not alert_id:
-        return "alert_id is required for this action."
+        raise ToolError({"status_code": 400, "message": "alert_id is required for this action."})
     if action_type == "update":
         return client._send_request(f"/alert/{alert_id}", "patch", query=payload)
     if action_type == "delete":
@@ -94,7 +102,7 @@ def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str
         return client._send_request(f"/alert/{alert_id}/mute", "patch", query={})
     if action_type == "unmute":
         return client._send_request(f"/alert/{alert_id}/unmute", "patch", query={})
-    return f"Unhandled action_type: {action_type}"
+    raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -120,7 +128,12 @@ async def clearpass_manage_insight_report(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _REPORT_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_REPORT_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_REPORT_ACTIONS)}.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} insight report", report_id)
@@ -132,8 +145,10 @@ async def clearpass_manage_insight_report(
 
         client = await get_clearpass_session(ApiInsight)
         return _execute_report_action(client, action_type, payload, report_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing insight report: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing insight report: {e}"}) from e
 
 
 def _execute_report_action(client, action_type: str, payload: dict, report_id: str | None) -> dict | str:
@@ -151,7 +166,7 @@ def _execute_report_action(client, action_type: str, payload: dict, report_id: s
     if action_type == "create":
         return client._send_request("/report", "post", query=payload)
     if not report_id:
-        return "report_id is required for this action."
+        raise ToolError({"status_code": 400, "message": "report_id is required for this action."})
     if action_type == "delete":
         return client.delete_report_by_id(id=report_id)
     if action_type == "enable":
@@ -160,7 +175,7 @@ def _execute_report_action(client, action_type: str, payload: dict, report_id: s
         return client.update_report_by_id_disable(id=report_id)
     if action_type == "run":
         return client.new_report_by_id_run(id=report_id)
-    return f"Unhandled action_type: {action_type}"
+    raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -187,7 +202,9 @@ async def clearpass_create_system_event(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if level not in ("INFO", "WARN", "ERROR"):
-        return f"Invalid level '{level}'. Must be 'INFO', 'WARN', or 'ERROR'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid level '{level}'. Must be 'INFO', 'WARN', or 'ERROR'."}
+        )
 
     if not confirmed:
         decline = await _confirm_write(ctx, "create system event", f"{source}/{action}")
@@ -206,5 +223,7 @@ async def clearpass_create_system_event(
             "description": description,
         }
         return client._send_request("/system-event", "post", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error creating system event: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error creating system event: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -62,7 +63,12 @@ async def clearpass_manage_auth_source(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _SOURCE_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_SOURCE_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_SOURCE_ACTIONS)}.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} auth source", auth_source_id or name)
@@ -74,8 +80,10 @@ async def clearpass_manage_auth_source(
 
         client = await get_clearpass_session(ApiPolicyElements)
         return _execute_auth_source_action(client, action_type, payload, auth_source_id, name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing auth source: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing auth source: {e}"}) from e
 
 
 def _execute_auth_source_action(
@@ -97,7 +105,7 @@ def _execute_auth_source_action(
         return client._send_request("/auth-source", "post", query=payload)
 
     if not auth_source_id and not name:
-        return "Either auth_source_id or name is required for this action."
+        raise ToolError({"status_code": 400, "message": "Either auth_source_id or name is required for this action."})
 
     if action_type == "delete":
         if auth_source_id:
@@ -132,7 +140,12 @@ async def clearpass_manage_auth_method(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} auth method", auth_method_id or name)
@@ -147,7 +160,9 @@ async def clearpass_manage_auth_method(
         if action_type == "create":
             return client._send_request("/auth-method", "post", query=payload)
         if not auth_method_id and not name:
-            return "Either auth_method_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either auth_method_id or name is required for update/delete."}
+            )
         if action_type == "update":
             if auth_method_id:
                 return client._send_request(f"/auth-method/{auth_method_id}", "patch", query=payload)
@@ -156,5 +171,7 @@ async def clearpass_manage_auth_method(
         if auth_method_id:
             return client.delete_auth_method_by_auth_method_id(auth_method_id=auth_method_id)
         return client.delete_auth_method_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing auth method: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing auth method: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -87,9 +88,14 @@ async def clearpass_manage_certificate_authority(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _CA_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CA_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CA_ACTIONS)}.",
+            }
+        )
     if action_type in ("sign", "revoke", "reject", "export", "delete") and not certificate_id:
-        return f"certificate_id is required for action '{action_type}'."
+        raise ToolError({"status_code": 400, "message": f"certificate_id is required for action '{action_type}'."})
 
     decline = await confirm_write(ctx, f"ClearPass CA: {action_type} certificate {certificate_id or '(new)'}. Confirm?")
     if decline:
@@ -110,8 +116,10 @@ async def clearpass_manage_certificate_authority(
             return client._send_request(f"/certificate/{certificate_id}", "delete")
         # sign / revoke / reject / export
         return client._send_request(f"/certificate/{certificate_id}/{action_type}", "post", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing CA certificate ({action_type}): {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing CA certificate ({action_type}): {e}"}) from e
 
 
 _ONBOARD_ACTIONS = ("update", "delete")
@@ -149,9 +157,11 @@ async def clearpass_manage_onboard_device(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _ONBOARD_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."}
+        )
     if action_type == "update" and not payload:
-        return "payload is required for action 'update'."
+        raise ToolError({"status_code": 400, "message": "payload is required for action 'update'."})
 
     decline = await confirm_write(
         ctx,
@@ -169,5 +179,7 @@ async def clearpass_manage_onboard_device(
             return client._send_request(path, "delete")
         body: Any = payload if payload is not None else {}
         return client._send_request(path, "patch", query=body)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing onboard device ({action_type}): {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing onboard device ({action_type}): {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -78,7 +79,12 @@ async def clearpass_manage_certificate(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _CERT_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CERT_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CERT_ACTIONS)}.",
+            }
+        )
 
     if not confirmed:
         identifier = cert_id or server_uuid or "certificate"
@@ -91,8 +97,10 @@ async def clearpass_manage_certificate(
 
         client = await get_clearpass_session(ApiCertificateAuthority)
         return _execute_cert_action(client, action_type, payload, cert_id, server_uuid, service_name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing certificate: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing certificate: {e}"}) from e
 
 
 def _execute_cert_action(
@@ -121,22 +129,27 @@ def _execute_cert_action(
 
     if action_type == "delete_trust_list":
         if not cert_id:
-            return "cert_id is required for delete_trust_list."
+            raise ToolError({"status_code": 400, "message": "cert_id is required for delete_trust_list."})
         return client.delete_cert_trust_list_by_cert_trust_list_id(cert_trust_list_id=cert_id)
 
     if action_type == "delete_client_cert":
         if not cert_id:
-            return "cert_id is required for delete_client_cert."
+            raise ToolError({"status_code": 400, "message": "cert_id is required for delete_client_cert."})
         return client.delete_client_cert_by_client_cert_id(client_cert_id=cert_id)
 
     if action_type in ("enable_server_cert", "disable_server_cert"):
         if not server_uuid or not service_name:
-            return "server_uuid and service_name are required for enable/disable_server_cert."
+            raise ToolError(
+                {
+                    "status_code": 400,
+                    "message": "server_uuid and service_name are required for enable/disable_server_cert.",
+                }
+            )
         action = "enable" if action_type == "enable_server_cert" else "disable"
         path = f"/server-cert/name/{server_uuid}/{service_name}/{action}"
         return client._send_request(path, "patch", query={})
 
-    return f"Unhandled action_type: {action_type}"
+    raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -173,5 +186,7 @@ async def clearpass_create_csr(
 
         client = await get_clearpass_session(ApiCertificateAuthority)
         return client._send_request("/certificate/csr", "post", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error creating CSR: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error creating CSR: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -39,7 +40,12 @@ async def clearpass_manage_endpoint(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         identifier = endpoint_id or mac_address or "unknown"
@@ -56,7 +62,9 @@ async def clearpass_manage_endpoint(
             return client._send_request("/endpoint", "post", query=payload)
 
         if not endpoint_id and not mac_address:
-            return "Either endpoint_id or mac_address is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either endpoint_id or mac_address is required for update/delete."}
+            )
 
         if action_type == "update":
             if endpoint_id:
@@ -67,5 +75,7 @@ async def clearpass_manage_endpoint(
         if endpoint_id:
             return client.delete_endpoint_by_endpoint_id(endpoint_id=endpoint_id)
         return client.delete_endpoint_mac_address_by_mac_address(mac_address=mac_address)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing endpoint: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing endpoint: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -46,7 +47,12 @@ async def clearpass_manage_enforcement_policy(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} enforcement policy", policy_id or name)
@@ -61,7 +67,7 @@ async def clearpass_manage_enforcement_policy(
         if action_type == "create":
             return client._send_request("/enforcement-policy", "post", query=payload)
         if not policy_id and not name:
-            return "Either policy_id or name is required for update/delete."
+            raise ToolError({"status_code": 400, "message": "Either policy_id or name is required for update/delete."})
         if action_type == "update":
             if policy_id:
                 return client._send_request(f"/enforcement-policy/{policy_id}", "patch", query=payload)
@@ -70,8 +76,10 @@ async def clearpass_manage_enforcement_policy(
         if policy_id:
             return client.delete_enforcement_policy_by_enforcement_policy_id(enforcement_policy_id=policy_id)
         return client.delete_enforcement_policy_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing enforcement policy: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing enforcement policy: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -96,7 +104,12 @@ async def clearpass_manage_enforcement_profile(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} enforcement profile", profile_id or name)
@@ -111,7 +124,7 @@ async def clearpass_manage_enforcement_profile(
         if action_type == "create":
             return client._send_request("/enforcement-profile", "post", query=payload)
         if not profile_id and not name:
-            return "Either profile_id or name is required for update/delete."
+            raise ToolError({"status_code": 400, "message": "Either profile_id or name is required for update/delete."})
         if action_type == "update":
             if profile_id:
                 return client._send_request(f"/enforcement-profile/{profile_id}", "patch", query=payload)
@@ -120,5 +133,7 @@ async def clearpass_manage_enforcement_profile(
         if profile_id:
             return client.delete_enforcement_profile_by_enforcement_profile_id(enforcement_profile_id=profile_id)
         return client.delete_enforcement_profile_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing enforcement profile: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing enforcement profile: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -44,7 +45,12 @@ async def clearpass_manage_pass_template(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "replace", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} pass template", template_id)
@@ -59,14 +65,16 @@ async def clearpass_manage_pass_template(
         if action_type == "create":
             return client._send_request("/template/pass", "post", query=payload)
         if not template_id:
-            return "template_id is required for update/replace/delete."
+            raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
             return client._send_request(f"/template/pass/{template_id}", "patch", query=payload)
         if action_type == "replace":
             return client._send_request(f"/template/pass/{template_id}", "put", query=payload)
         return client.delete_template_pass_by_id(id=template_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing pass template: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing pass template: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -88,7 +96,12 @@ async def clearpass_manage_print_template(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "replace", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} print template", template_id)
@@ -103,14 +116,16 @@ async def clearpass_manage_print_template(
         if action_type == "create":
             return client._send_request("/template/print", "post", query=payload)
         if not template_id:
-            return "template_id is required for update/replace/delete."
+            raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
             return client._send_request(f"/template/print/{template_id}", "patch", query=payload)
         if action_type == "replace":
             return client._send_request(f"/template/print/{template_id}", "put", query=payload)
         return client.delete_template_print_by_id(id=template_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing print template: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing print template: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -134,7 +149,12 @@ async def clearpass_manage_weblogin_page(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "replace", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} weblogin page", page_id or page_name)
@@ -149,7 +169,9 @@ async def clearpass_manage_weblogin_page(
         if action_type == "create":
             return client._send_request("/weblogin", "post", query=payload)
         if not page_id and not page_name:
-            return "Either page_id or page_name is required for update/replace/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either page_id or page_name is required for update/replace/delete."}
+            )
         if action_type == "delete":
             if page_id:
                 return client.delete_weblogin_by_id(id=page_id)
@@ -158,8 +180,10 @@ async def clearpass_manage_weblogin_page(
         path_suffix = f"/{page_id}" if page_id else f"/page-name/{page_name}"
         method = "patch" if action_type == "update" else "put"
         return client._send_request(f"/weblogin{path_suffix}", method, query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing weblogin page: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing weblogin page: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -177,7 +201,12 @@ async def clearpass_manage_guest_settings(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if setting_type not in ("authentication", "manager"):
-        return f"Invalid setting_type '{setting_type}'. Must be 'authentication' or 'manager'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid setting_type '{setting_type}'. Must be 'authentication' or 'manager'.",
+            }
+        )
 
     if not confirmed:
         decline = await _confirm_write(ctx, f"update guest {setting_type} settings", setting_type)
@@ -192,5 +221,7 @@ async def clearpass_manage_guest_settings(
         if setting_type == "authentication":
             return client._send_request("/guest/authentication", "patch", query=payload)
         return client._send_request("/guestmanager", "patch", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing guest settings: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing guest settings: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -43,7 +44,12 @@ async def clearpass_manage_guest_user(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, action_type, guest_id or username)
@@ -58,7 +64,9 @@ async def clearpass_manage_guest_user(
         if action_type == "create":
             return client._send_request("/guest", "post", query=payload)
         if not guest_id and not username:
-            return "Either guest_id or username is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either guest_id or username is required for update/delete."}
+            )
         if action_type == "update":
             if guest_id:
                 return client._send_request(f"/guest/{guest_id}", "patch", query=payload)
@@ -67,8 +75,10 @@ async def clearpass_manage_guest_user(
         if guest_id:
             return client.delete_guest_by_guest_id(guest_id=guest_id)
         return client.delete_guest_username_by_username(username=username)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing guest user: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing guest user: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -86,7 +96,9 @@ async def clearpass_send_guest_credentials(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if delivery_method not in ("sms", "email"):
-        return f"Invalid delivery_method '{delivery_method}'. Must be 'sms' or 'email'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid delivery_method '{delivery_method}'. Must be 'sms' or 'email'."}
+        )
 
     if not confirmed:
         decline = await _confirm_write(ctx, f"send credentials via {delivery_method}", guest_id)
@@ -98,8 +110,10 @@ async def clearpass_send_guest_credentials(
 
         client = await get_clearpass_session(ApiGuestActions)
         return client._send_request(f"/guest/{guest_id}/send-{delivery_method}", "post", query={})
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error sending guest credentials: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error sending guest credentials: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -117,7 +131,9 @@ async def clearpass_generate_guest_pass(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if pass_type not in ("digital", "receipt"):
-        return f"Invalid pass_type '{pass_type}'. Must be 'digital' or 'receipt'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid pass_type '{pass_type}'. Must be 'digital' or 'receipt'."}
+        )
 
     if not confirmed:
         decline = await _confirm_write(ctx, f"generate {pass_type} pass", guest_id)
@@ -130,8 +146,10 @@ async def clearpass_generate_guest_pass(
         client = await get_clearpass_session(ApiGuestActions)
         endpoint = "pass" if pass_type == "digital" else "receipt"  # nosec B105 — API path, not a password
         return client._send_request(f"/guest/{guest_id}/{endpoint}", "post", query={})
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error generating guest pass: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error generating guest pass: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -149,7 +167,7 @@ async def clearpass_process_sponsor_action(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action not in ("approve", "reject"):
-        return f"Invalid action '{action}'. Must be 'approve' or 'reject'."
+        raise ToolError({"status_code": 400, "message": f"Invalid action '{action}'. Must be 'approve' or 'reject'."})
 
     if not confirmed:
         decline = await _confirm_write(ctx, f"sponsor {action}", guest_id)
@@ -161,5 +179,7 @@ async def clearpass_process_sponsor_action(
 
         client = await get_clearpass_session(ApiGuestActions)
         return client._send_request(f"/guest/{guest_id}/sponsor/{action}", "post", query={})
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error processing sponsor action: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error processing sponsor action: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -43,7 +44,12 @@ async def clearpass_manage_api_client(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "API client", client_id, confirmed)
     if decline:
         return decline
@@ -54,12 +60,14 @@ async def clearpass_manage_api_client(
         if action_type == "create":
             return client._send_request("/api-client", "post", query=payload)
         if not client_id:
-            return "client_id is required for update/delete."
+            raise ToolError({"status_code": 400, "message": "client_id is required for update/delete."})
         if action_type == "update":
             return client._send_request(f"/api-client/{client_id}", "patch", query=payload)
         return client.delete_api_client_by_client_id(client_id=client_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing API client: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing API client: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -81,7 +89,12 @@ async def clearpass_manage_local_user(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "local user", local_user_id or user_id, confirmed)
     if decline:
         return decline
@@ -92,15 +105,19 @@ async def clearpass_manage_local_user(
         if action_type == "create":
             return client._send_request("/local-user", "post", query=payload)
         if not local_user_id and not user_id:
-            return "Either local_user_id or user_id is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either local_user_id or user_id is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/local-user/{local_user_id}" if local_user_id else f"/local-user/user-id/{user_id}"
             return client._send_request(path, "patch", query=payload)
         if local_user_id:
             return client.delete_local_user_by_local_user_id(local_user_id=local_user_id)
         return client.delete_local_user_user_id_by_user_id(user_id=user_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing local user: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing local user: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -124,7 +141,12 @@ async def clearpass_manage_static_host_list(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "static host list", static_host_list_id or name, confirmed)
     if decline:
         return decline
@@ -135,7 +157,9 @@ async def clearpass_manage_static_host_list(
         if action_type == "create":
             return client._send_request("/static-host-list", "post", query=payload)
         if not static_host_list_id and not name:
-            return "Either static_host_list_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either static_host_list_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/static-host-list/{static_host_list_id}" if static_host_list_id else f"/static-host-list/name/{name}"
@@ -144,8 +168,10 @@ async def clearpass_manage_static_host_list(
         if static_host_list_id:
             return client.delete_static_host_list_by_static_host_list_id(static_host_list_id=static_host_list_id)
         return client.delete_static_host_list_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing static host list: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing static host list: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -167,7 +193,12 @@ async def clearpass_manage_device(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "device", device_id or macaddr, confirmed)
     if decline:
         return decline
@@ -178,15 +209,19 @@ async def clearpass_manage_device(
         if action_type == "create":
             return client._send_request("/device", "post", query=payload)
         if not device_id and not macaddr:
-            return "Either device_id or macaddr is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either device_id or macaddr is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/device/{device_id}" if device_id else f"/device/mac/{macaddr}"
             return client._send_request(path, "patch", query=payload)
         if device_id:
             return client.delete_device_by_device_id(device_id=device_id)
         return client.delete_device_mac_by_macaddr(macaddr=macaddr)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing device: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing device: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -206,7 +241,9 @@ async def clearpass_manage_deny_listed_user(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create' or 'delete'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'create' or 'delete'."}
+        )
     decline = await _confirm_write(ctx, action_type, "deny-listed user", deny_listed_users_id, confirmed)
     if decline:
         return decline
@@ -217,7 +254,9 @@ async def clearpass_manage_deny_listed_user(
         if action_type == "create":
             return client._send_request("/deny-listed-users", "post", query=payload)
         if not deny_listed_users_id:
-            return "deny_listed_users_id is required for delete."
+            raise ToolError({"status_code": 400, "message": "deny_listed_users_id is required for delete."})
         return client.delete_deny_listed_users_by_deny_listed_users_id(deny_listed_users_id=deny_listed_users_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing deny-listed user: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing deny-listed user: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -42,7 +43,9 @@ async def clearpass_manage_extension(
     """
     valid = ("start", "stop", "restart", "delete")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "extension", extension_id, confirmed)
     if decline:
         return decline
@@ -57,8 +60,10 @@ async def clearpass_manage_extension(
         if action_type == "restart":
             return client.new_extension_instance_by_id_restart(id=extension_id)
         return client.delete_extension_instance_by_id(id=extension_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing extension: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing extension: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -80,7 +85,12 @@ async def clearpass_manage_syslog_target(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "syslog target", syslog_target_id or name, confirmed)
     if decline:
         return decline
@@ -91,15 +101,19 @@ async def clearpass_manage_syslog_target(
         if action_type == "create":
             return client._send_request("/syslog-target", "post", query=payload)
         if not syslog_target_id and not name:
-            return "Either syslog_target_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either syslog_target_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/syslog-target/{syslog_target_id}" if syslog_target_id else f"/syslog-target/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if syslog_target_id:
             return client.delete_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
         return client._send_request(f"/syslog-target/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing syslog target: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing syslog target: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -123,7 +137,12 @@ async def clearpass_manage_syslog_export_filter(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "syslog export filter", syslog_export_filter_id or name, confirmed)
     if decline:
         return decline
@@ -134,7 +153,9 @@ async def clearpass_manage_syslog_export_filter(
         if action_type == "create":
             return client._send_request("/syslog-export-filter", "post", query=payload)
         if not syslog_export_filter_id and not name:
-            return "Either syslog_export_filter_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either syslog_export_filter_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/syslog-export-filter/{syslog_export_filter_id}"
@@ -147,8 +168,10 @@ async def clearpass_manage_syslog_export_filter(
                 syslog_export_filter_id=syslog_export_filter_id
             )
         return client._send_request(f"/syslog-export-filter/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing syslog export filter: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing syslog export filter: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -173,7 +196,9 @@ async def clearpass_manage_endpoint_context_server(
     """
     valid = ("create", "update", "delete", "trigger_poll")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(
         ctx, action_type, "endpoint context server", endpoint_context_server_id or name, confirmed
     )
@@ -186,7 +211,7 @@ async def clearpass_manage_endpoint_context_server(
         if action_type == "create":
             return client._send_request("/endpoint-context-server", "post", query=payload)
         if not endpoint_context_server_id and not name:
-            return "Either endpoint_context_server_id or name is required."
+            raise ToolError({"status_code": 400, "message": "Either endpoint_context_server_id or name is required."})
         if action_type == "update":
             path = (
                 f"/endpoint-context-server/{endpoint_context_server_id}"
@@ -195,7 +220,9 @@ async def clearpass_manage_endpoint_context_server(
             )
             return client._send_request(path, "patch", query=payload)
         if not endpoint_context_server_id:
-            return "endpoint_context_server_id is required for delete/trigger_poll."
+            raise ToolError(
+                {"status_code": 400, "message": "endpoint_context_server_id is required for delete/trigger_poll."}
+            )
         if action_type == "trigger_poll":
             return client.update_endpoint_context_server_by_endpoint_context_server_id_trigger_poll(
                 endpoint_context_server_id=endpoint_context_server_id
@@ -203,5 +230,7 @@ async def clearpass_manage_endpoint_context_server(
         return client.delete_endpoint_context_server_by_endpoint_context_server_id(
             endpoint_context_server_id=endpoint_context_server_id
         )
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing endpoint context server: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing endpoint context server: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -45,7 +46,9 @@ async def clearpass_manage_access_control(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."}
+        )
     decline = await _confirm_write(ctx, action_type, "access control", f"{server_uuid}/{resource_name}", confirmed)
     if decline:
         return decline
@@ -58,8 +61,10 @@ async def clearpass_manage_access_control(
         return client.delete_server_access_control_by_server_uuid_resource_name(
             server_uuid=server_uuid, resource_name=resource_name
         )
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing access control: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing access control: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -84,7 +89,9 @@ async def clearpass_manage_ad_domain(
     """
     valid = ("join", "leave", "configure_password_servers")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "AD domain", server_uuid, confirmed)
     if decline:
         return decline
@@ -97,12 +104,14 @@ async def clearpass_manage_ad_domain(
         if action_type == "leave":
             return client._send_request(f"/ad-domain/{server_uuid}/leave", "put", query=payload)
         if not netbios_name:
-            return "netbios_name is required for configure_password_servers."
+            raise ToolError({"status_code": 400, "message": "netbios_name is required for configure_password_servers."})
         return client._send_request(
             f"/ad-domain/{server_uuid}/netbios-name/{netbios_name}/password-servers", "patch", query=payload
         )
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing AD domain: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing AD domain: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -127,8 +136,10 @@ async def clearpass_manage_cluster_server(
 
         client = await get_clearpass_session(ApiLocalServerConfiguration)
         return client._send_request(f"/cluster/server/{server_uuid}", "patch", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing cluster server: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing cluster server: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -148,7 +159,9 @@ async def clearpass_manage_server_service(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("start", "stop"):
-        return f"Invalid action_type '{action_type}'. Must be 'start' or 'stop'."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'start' or 'stop'."}
+        )
     decline = await _confirm_write(ctx, action_type, "server service", f"{service_name}@{server_uuid}", confirmed)
     if decline:
         return decline
@@ -163,8 +176,10 @@ async def clearpass_manage_server_service(
         return client.update_server_service_by_server_uuid_service_name_stop(
             server_uuid=server_uuid, service_name=service_name
         )
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing server service: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing server service: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -222,5 +237,7 @@ async def clearpass_manage_service_params(
         client = await get_clearpass_session(ApiLocalServerConfiguration)
         path = f"/server/{server_uuid}/service/{service_id}"
         return client._send_request(path, "patch", query=param_values)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error editing service params: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error editing service params: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -92,7 +93,12 @@ async def clearpass_manage_network_device(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in _VALID_ACTIONS:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_action(ctx, action_type, device_id, name)
@@ -104,8 +110,10 @@ async def clearpass_manage_network_device(
 
         client = await get_clearpass_session(ApiPolicyElements)
         return await _execute_device_action(client, action_type, payload, device_id, name, source_device_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing network device: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing network device: {e}"}) from e
 
 
 async def _execute_device_action(
@@ -129,10 +137,10 @@ async def _execute_device_action(
 
     if action_type == "clone":
         if not source_device_id:
-            return "source_device_id is required for clone action."
+            raise ToolError({"status_code": 400, "message": "source_device_id is required for clone action."})
         source = client.get_network_device_by_network_device_id(network_device_id=source_device_id)
         if not isinstance(source, dict):
-            return f"Failed to retrieve source device {source_device_id}."
+            raise ToolError({"status_code": 404, "message": f"Failed to retrieve source device {source_device_id}."})
         source.pop("id", None)
         source.update(payload)
         return client._send_request("/network-device", "post", query=source)
@@ -141,7 +149,7 @@ async def _execute_device_action(
     if not resolved_id and action_type == "delete" and name:
         return client.delete_network_device_name_by_name(name=name)
     if not resolved_id:
-        return "Either device_id or name is required for this action."
+        raise ToolError({"status_code": 400, "message": "Either device_id or name is required for this action."})
 
     if action_type == "update":
         return client._send_request(f"/network-device/{resolved_id}", "patch", query=payload)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -46,7 +47,9 @@ async def clearpass_manage_service(
     """
     valid = ("create", "update", "delete", "enable", "disable")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "service", config_service_id or name, confirmed)
     if decline:
         return decline
@@ -57,24 +60,26 @@ async def clearpass_manage_service(
         if action_type == "create":
             return client._send_request("/config/service", "post", query=payload)
         if not config_service_id and not name:
-            return "Either config_service_id or name is required."
+            raise ToolError({"status_code": 400, "message": "Either config_service_id or name is required."})
         if action_type == "update":
             path = f"/config/service/{config_service_id}" if config_service_id else f"/config/service/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if action_type == "enable":
             if not config_service_id:
-                return "config_service_id is required for enable."
+                raise ToolError({"status_code": 400, "message": "config_service_id is required for enable."})
             return client.update_config_service_by_config_service_id_enable(config_service_id=config_service_id)
         if action_type == "disable":
             if not config_service_id:
-                return "config_service_id is required for disable."
+                raise ToolError({"status_code": 400, "message": "config_service_id is required for disable."})
             return client.update_config_service_by_config_service_id_disable(config_service_id=config_service_id)
         # delete
         if config_service_id:
             return client.delete_config_service_by_config_service_id(config_service_id=config_service_id)
         return client.delete_config_service_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing service: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing service: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -98,7 +103,12 @@ async def clearpass_manage_device_group(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "device group", network_device_group_id or name, confirmed)
     if decline:
         return decline
@@ -109,7 +119,9 @@ async def clearpass_manage_device_group(
         if action_type == "create":
             return client._send_request("/network-device-group", "post", query=payload)
         if not network_device_group_id and not name:
-            return "Either network_device_group_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either network_device_group_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/network-device-group/{network_device_group_id}"
@@ -122,8 +134,10 @@ async def clearpass_manage_device_group(
                 network_device_group_id=network_device_group_id
             )
         return client.delete_network_device_group_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing device group: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing device group: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -147,7 +161,12 @@ async def clearpass_manage_posture_policy(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "posture policy", posture_policy_id or name, confirmed)
     if decline:
         return decline
@@ -158,15 +177,19 @@ async def clearpass_manage_posture_policy(
         if action_type == "create":
             return client._send_request("/posture-policy", "post", query=payload)
         if not posture_policy_id and not name:
-            return "Either posture_policy_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either posture_policy_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/posture-policy/{posture_policy_id}" if posture_policy_id else f"/posture-policy/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if posture_policy_id:
             return client.delete_posture_policy_by_posture_policy_id(posture_policy_id=posture_policy_id)
         return client.delete_posture_policy_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing posture policy: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing posture policy: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -188,7 +211,12 @@ async def clearpass_manage_proxy_target(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "proxy target", proxy_target_id or name, confirmed)
     if decline:
         return decline
@@ -199,15 +227,19 @@ async def clearpass_manage_proxy_target(
         if action_type == "create":
             return client._send_request("/proxy-target", "post", query=payload)
         if not proxy_target_id and not name:
-            return "Either proxy_target_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either proxy_target_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/proxy-target/{proxy_target_id}" if proxy_target_id else f"/proxy-target/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if proxy_target_id:
             return client.delete_proxy_target_by_proxy_target_id(proxy_target_id=proxy_target_id)
         return client.delete_proxy_target_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing proxy target: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing proxy target: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -232,7 +264,9 @@ async def clearpass_manage_radius_dictionary(
     """
     valid = ("create", "update", "delete", "enable", "disable")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "RADIUS dictionary", radius_dictionary_id or name, confirmed)
     if decline:
         return decline
@@ -243,7 +277,7 @@ async def clearpass_manage_radius_dictionary(
         if action_type == "create":
             return client._send_request("/radius-dictionary", "post", query=payload)
         if not radius_dictionary_id and not name:
-            return "Either radius_dictionary_id or name is required."
+            raise ToolError({"status_code": 400, "message": "Either radius_dictionary_id or name is required."})
         if action_type == "update":
             path = (
                 f"/radius-dictionary/{radius_dictionary_id}"
@@ -253,13 +287,13 @@ async def clearpass_manage_radius_dictionary(
             return client._send_request(path, "patch", query=payload)
         if action_type == "enable":
             if not radius_dictionary_id:
-                return "radius_dictionary_id is required for enable."
+                raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for enable."})
             return client.update_radius_dictionary_by_radius_dictionary_id_enable(
                 radius_dictionary_id=radius_dictionary_id
             )
         if action_type == "disable":
             if not radius_dictionary_id:
-                return "radius_dictionary_id is required for disable."
+                raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for disable."})
             return client.update_radius_dictionary_by_radius_dictionary_id_disable(
                 radius_dictionary_id=radius_dictionary_id
             )
@@ -267,8 +301,10 @@ async def clearpass_manage_radius_dictionary(
         if radius_dictionary_id:
             return client._send_request(f"/radius-dictionary/{radius_dictionary_id}", "delete")
         return client._send_request(f"/radius-dictionary/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing RADIUS dictionary: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing RADIUS dictionary: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -292,7 +328,12 @@ async def clearpass_manage_tacacs_dictionary(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "TACACS dictionary", tacacs_dictionary_id or name, confirmed)
     if decline:
         return decline
@@ -303,7 +344,9 @@ async def clearpass_manage_tacacs_dictionary(
         if action_type == "create":
             return client._send_request("/tacacs-dictionary", "post", query=payload)
         if not tacacs_dictionary_id and not name:
-            return "Either tacacs_dictionary_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either tacacs_dictionary_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/tacacs-dictionary/{tacacs_dictionary_id}"
@@ -314,8 +357,10 @@ async def clearpass_manage_tacacs_dictionary(
         if tacacs_dictionary_id:
             return client._send_request(f"/tacacs-dictionary/{tacacs_dictionary_id}", "delete")
         return client._send_request(f"/tacacs-dictionary/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing TACACS dictionary: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing TACACS dictionary: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -339,7 +384,12 @@ async def clearpass_manage_application_dictionary(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(
         ctx, action_type, "application dictionary", application_dictionary_id or name, confirmed
     )
@@ -352,7 +402,12 @@ async def clearpass_manage_application_dictionary(
         if action_type == "create":
             return client._send_request("/application-dictionary", "post", query=payload)
         if not application_dictionary_id and not name:
-            return "Either application_dictionary_id or name is required for update/delete."
+            raise ToolError(
+                {
+                    "status_code": 400,
+                    "message": "Either application_dictionary_id or name is required for update/delete.",
+                }
+            )
         if action_type == "update":
             path = (
                 f"/application-dictionary/{application_dictionary_id}"
@@ -363,5 +418,7 @@ async def clearpass_manage_application_dictionary(
         if application_dictionary_id:
             return client._send_request(f"/application-dictionary/{application_dictionary_id}", "delete")
         return client._send_request(f"/application-dictionary/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing application dictionary: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing application dictionary: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -47,7 +48,12 @@ async def clearpass_manage_role(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} role", role_id or name)
@@ -62,7 +68,7 @@ async def clearpass_manage_role(
         if action_type == "create":
             return client._send_request("/role", "post", query=payload)
         if not role_id and not name:
-            return "Either role_id or name is required for update/delete."
+            raise ToolError({"status_code": 400, "message": "Either role_id or name is required for update/delete."})
         if action_type == "update":
             if role_id:
                 return client._send_request(f"/role/{role_id}", "patch", query=payload)
@@ -71,8 +77,10 @@ async def clearpass_manage_role(
         if role_id:
             return client.delete_role_by_role_id(role_id=role_id)
         return client.delete_role_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing role: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing role: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -97,7 +105,12 @@ async def clearpass_manage_role_mapping(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     if action_type != "create" and not confirmed:
         decline = await _confirm_write(ctx, f"{action_type} role mapping", role_mapping_id or name)
@@ -112,7 +125,9 @@ async def clearpass_manage_role_mapping(
         if action_type == "create":
             return client._send_request("/role-mapping", "post", query=payload)
         if not role_mapping_id and not name:
-            return "Either role_mapping_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either role_mapping_id or name is required for update/delete."}
+            )
         if action_type == "update":
             if role_mapping_id:
                 return client._send_request(f"/role-mapping/{role_mapping_id}", "patch", query=payload)
@@ -121,5 +136,7 @@ async def clearpass_manage_role_mapping(
         if role_mapping_id:
             return client.delete_role_mapping_by_role_mapping_id(role_mapping_id=role_mapping_id)
         return client.delete_role_mapping_name_by_name(name=name)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing role mapping: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing role mapping: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -37,7 +38,12 @@ async def clearpass_manage_admin_user(
 ) -> dict | str:
     """Create, update, or delete a ClearPass admin user."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "admin user", admin_user_id or name, confirmed)
     if decline:
         return decline
@@ -48,15 +54,19 @@ async def clearpass_manage_admin_user(
         if action_type == "create":
             return client._send_request("/admin-user", "post", query=payload)
         if not admin_user_id and not name:
-            return "Either admin_user_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either admin_user_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/admin-user/{admin_user_id}" if admin_user_id else f"/admin-user/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if admin_user_id:
             return client.delete_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
         return client._send_request(f"/admin-user/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing admin user: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing admin user: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -70,7 +80,12 @@ async def clearpass_manage_admin_privilege(
 ) -> dict | str:
     """Create, update, or delete a ClearPass admin privilege."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "admin privilege", admin_privilege_id or name, confirmed)
     if decline:
         return decline
@@ -81,15 +96,19 @@ async def clearpass_manage_admin_privilege(
         if action_type == "create":
             return client._send_request("/admin-privilege", "post", query=payload)
         if not admin_privilege_id and not name:
-            return "Either admin_privilege_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either admin_privilege_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/admin-privilege/{admin_privilege_id}" if admin_privilege_id else f"/admin-privilege/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if admin_privilege_id:
             return client.delete_admin_privilege_by_admin_privilege_id(admin_privilege_id=admin_privilege_id)
         return client._send_request(f"/admin-privilege/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing admin privilege: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing admin privilege: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -105,7 +124,12 @@ async def clearpass_manage_operator_profile(
 ) -> dict | str:
     """Create, update, or delete a ClearPass operator profile."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "operator profile", operator_profile_id or name, confirmed)
     if decline:
         return decline
@@ -116,7 +140,9 @@ async def clearpass_manage_operator_profile(
         if action_type == "create":
             return client._send_request("/operator-profile", "post", query=payload)
         if not operator_profile_id and not name:
-            return "Either operator_profile_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either operator_profile_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/operator-profile/{operator_profile_id}" if operator_profile_id else f"/operator-profile/name/{name}"
@@ -125,8 +151,10 @@ async def clearpass_manage_operator_profile(
         if operator_profile_id:
             return client.delete_operator_profile_by_operator_profile_id(operator_profile_id=operator_profile_id)
         return client._send_request(f"/operator-profile/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing operator profile: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing operator profile: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -142,7 +170,9 @@ async def clearpass_manage_license(
     """Create, delete, or activate a ClearPass application license."""
     valid = ("create", "delete", "activate_online", "activate_offline")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "license", license_id, confirmed)
     if decline:
         return decline
@@ -153,14 +183,16 @@ async def clearpass_manage_license(
         if action_type == "create":
             return client._send_request("/application-license", "post", query=payload)
         if not license_id:
-            return "license_id is required for delete/activate operations."
+            raise ToolError({"status_code": 400, "message": "license_id is required for delete/activate operations."})
         if action_type == "delete":
             return client.delete_application_license_by_license_id(license_id=license_id)
         if action_type == "activate_online":
             return client.update_application_license_activate_online_by_license_id(license_id=license_id)
         return client.update_application_license_activate_offline_by_license_id(license_id=license_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing license: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing license: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -178,8 +210,10 @@ async def clearpass_manage_cluster_params(
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         return client._send_request("/cluster/parameters", "patch", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing cluster parameters: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing cluster parameters: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -192,7 +226,9 @@ async def clearpass_manage_password_policy(
     """Update ClearPass admin or local user password policy."""
     valid = ("update_admin", "update_local")
     if action_type not in valid:
-        return f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
+        )
     decline = await _confirm_write(ctx, action_type, "password policy", action_type, confirmed)
     if decline:
         return decline
@@ -202,8 +238,10 @@ async def clearpass_manage_password_policy(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         path = "/admin-user/password-policy" if action_type == "update_admin" else "/local-user/password-policy"
         return client._send_request(path, "patch", query=payload)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing password policy: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing password policy: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -217,7 +255,12 @@ async def clearpass_manage_attribute(
 ) -> dict | str:
     """Create, update, or delete a ClearPass attribute."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "attribute", attribute_id or name, confirmed)
     if decline:
         return decline
@@ -228,15 +271,19 @@ async def clearpass_manage_attribute(
         if action_type == "create":
             return client._send_request("/attribute", "post", query=payload)
         if not attribute_id and not name:
-            return "Either attribute_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either attribute_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/attribute/{attribute_id}" if attribute_id else f"/attribute/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if attribute_id:
             return client.delete_attribute_by_attribute_id(attribute_id=attribute_id)
         return client._send_request(f"/attribute/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing attribute: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing attribute: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -250,7 +297,12 @@ async def clearpass_manage_data_filter(
 ) -> dict | str:
     """Create, update, or delete a ClearPass data filter."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "data filter", data_filter_id or name, confirmed)
     if decline:
         return decline
@@ -261,15 +313,19 @@ async def clearpass_manage_data_filter(
         if action_type == "create":
             return client._send_request("/data-filter", "post", query=payload)
         if not data_filter_id and not name:
-            return "Either data_filter_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either data_filter_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = f"/data-filter/{data_filter_id}" if data_filter_id else f"/data-filter/name/{name}"
             return client._send_request(path, "patch", query=payload)
         if data_filter_id:
             return client.delete_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
         return client._send_request(f"/data-filter/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing data filter: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing data filter: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -285,7 +341,12 @@ async def clearpass_manage_file_backup_server(
 ) -> dict | str:
     """Create, update, or delete a ClearPass file backup server."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "file backup server", file_backup_server_id or name, confirmed)
     if decline:
         return decline
@@ -296,7 +357,9 @@ async def clearpass_manage_file_backup_server(
         if action_type == "create":
             return client._send_request("/file-backup-server", "post", query=payload)
         if not file_backup_server_id and not name:
-            return "Either file_backup_server_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either file_backup_server_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/file-backup-server/{file_backup_server_id}"
@@ -309,8 +372,10 @@ async def clearpass_manage_file_backup_server(
                 file_backup_server_id=file_backup_server_id
             )
         return client._send_request(f"/file-backup-server/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing file backup server: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing file backup server: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -322,7 +387,12 @@ async def clearpass_manage_messaging_setup(
 ) -> dict | str:
     """Create, update, or delete the ClearPass messaging setup."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "messaging setup", "global", confirmed)
     if decline:
         return decline
@@ -335,8 +405,10 @@ async def clearpass_manage_messaging_setup(
         if action_type == "update":
             return client._send_request("/messaging-setup", "patch", query=payload)
         return client.delete_messaging_setup()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing messaging setup: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing messaging setup: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -352,7 +424,12 @@ async def clearpass_manage_snmp_trap_receiver(
 ) -> dict | str:
     """Create, update, or delete a ClearPass SNMP trap receiver."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "SNMP trap receiver", snmp_trap_receiver_id or name, confirmed)
     if decline:
         return decline
@@ -363,7 +440,9 @@ async def clearpass_manage_snmp_trap_receiver(
         if action_type == "create":
             return client._send_request("/snmp-trap-receiver", "post", query=payload)
         if not snmp_trap_receiver_id and not name:
-            return "Either snmp_trap_receiver_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either snmp_trap_receiver_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/snmp-trap-receiver/{snmp_trap_receiver_id}"
@@ -376,8 +455,10 @@ async def clearpass_manage_snmp_trap_receiver(
                 snmp_trap_receiver_id=snmp_trap_receiver_id
             )
         return client._send_request(f"/snmp-trap-receiver/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing SNMP trap receiver: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing SNMP trap receiver: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -393,7 +474,12 @@ async def clearpass_manage_policy_manager_zone(
 ) -> dict | str:
     """Create, update, or delete a ClearPass policy manager zone."""
     if action_type not in ("create", "update", "delete"):
-        return f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     decline = await _confirm_write(ctx, action_type, "policy manager zone", policy_manager_zones_id or name, confirmed)
     if decline:
         return decline
@@ -404,7 +490,9 @@ async def clearpass_manage_policy_manager_zone(
         if action_type == "create":
             return client._send_request("/server/policy-manager-zones", "post", query=payload)
         if not policy_manager_zones_id and not name:
-            return "Either policy_manager_zones_id or name is required for update/delete."
+            raise ToolError(
+                {"status_code": 400, "message": "Either policy_manager_zones_id or name is required for update/delete."}
+            )
         if action_type == "update":
             path = (
                 f"/server/policy-manager-zones/{policy_manager_zones_id}"
@@ -417,5 +505,7 @@ async def clearpass_manage_policy_manager_zone(
                 policy_manager_zones_id=policy_manager_zones_id
             )
         return client._send_request(f"/server/policy-manager-zones/name/{name}", "delete")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error managing policy manager zone: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error managing policy manager zone: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
@@ -56,11 +57,18 @@ async def clearpass_disconnect_session(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if target_type not in _VALID_TARGETS:
-        return f"Invalid target_type '{target_type}'. Must be one of: {', '.join(_VALID_TARGETS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid target_type '{target_type}'. Must be one of: {', '.join(_VALID_TARGETS)}.",
+            }
+        )
     if target_type != "bulk" and not target_value:
-        return f"target_value is required when target_type is '{target_type}'."
+        raise ToolError(
+            {"status_code": 400, "message": f"target_value is required when target_type is '{target_type}'."}
+        )
     if target_type == "bulk" and not filter:
-        return "filter is required when target_type is 'bulk'."
+        raise ToolError({"status_code": 400, "message": "filter is required when target_type is 'bulk'."})
 
     if not confirmed:
         decline = await _confirm_session_action(ctx, "disconnect", target_type, target_value)
@@ -80,8 +88,10 @@ async def clearpass_disconnect_session(
         filter_map = {"username": "username", "mac": "mac_address", "ip": "framedipaddress"}
         query = {filter_map[target_type]: target_value}
         return client._send_request("/session/disconnect", "post", query=query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error disconnecting session: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting session: {e}"}) from e
 
 
 @tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
@@ -117,11 +127,18 @@ async def clearpass_perform_coa(
         confirmed: Set true after user confirms. Skips re-prompting.
     """
     if target_type not in _VALID_TARGETS:
-        return f"Invalid target_type '{target_type}'. Must be one of: {', '.join(_VALID_TARGETS)}."
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid target_type '{target_type}'. Must be one of: {', '.join(_VALID_TARGETS)}.",
+            }
+        )
     if target_type != "bulk" and not target_value:
-        return f"target_value is required when target_type is '{target_type}'."
+        raise ToolError(
+            {"status_code": 400, "message": f"target_value is required when target_type is '{target_type}'."}
+        )
     if target_type == "bulk" and not filter:
-        return "filter is required when target_type is 'bulk'."
+        raise ToolError({"status_code": 400, "message": "filter is required when target_type is 'bulk'."})
 
     if not confirmed:
         decline = await _confirm_session_action(ctx, "CoA", target_type, target_value)
@@ -141,5 +158,7 @@ async def clearpass_perform_coa(
         filter_map = {"username": "username", "mac": "mac_address", "ip": "framedipaddress"}
         query = {filter_map[target_type]: target_value}
         return client._send_request("/session/reauthorize", "post", query=query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error performing CoA: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error performing CoA: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -44,8 +45,10 @@ async def clearpass_get_network_devices(
             return client.get_network_device_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/network-device" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching network devices: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching network devices: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -66,8 +69,10 @@ async def clearpass_get_network_device_stats(
 
         client = await get_clearpass_session(ApiPolicyElements)
         return client.get_network_device_by_network_device_id(network_device_id=device_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching network device stats: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching network device stats: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -93,8 +98,10 @@ async def clearpass_test_device_connectivity(
             "device": result,
             "note": "Actual connectivity testing requires ClearPass server-side capabilities.",
         }
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching device for connectivity review: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching device for connectivity review: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -127,5 +134,7 @@ async def clearpass_validate_device_config(
             "device": device,
             "validation_issues": issues if issues else "No issues found",
         }
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error validating device config: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error validating device config: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -44,8 +45,10 @@ async def clearpass_get_services(
             return client.get_config_service_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/config/service" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching services: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching services: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -82,8 +85,10 @@ async def clearpass_get_posture_policies(
             return client.get_posture_policy_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/posture-policy" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching posture policies: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching posture policies: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -122,8 +127,10 @@ async def clearpass_get_device_groups(
             return client.get_network_device_group_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/network-device-group" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching device groups: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching device groups: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -160,8 +167,10 @@ async def clearpass_get_proxy_targets(
             return client.get_proxy_target_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/proxy-target" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching proxy targets: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching proxy targets: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -200,8 +209,10 @@ async def clearpass_get_radius_dictionaries(
             return client.get_radius_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/radius-dictionary" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching RADIUS dictionaries: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching RADIUS dictionaries: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -240,8 +251,10 @@ async def clearpass_get_tacacs_dictionaries(
             return client.get_tacacs_service_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/tacacs-service-dictionary" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching TACACS+ dictionaries: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching TACACS+ dictionaries: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -280,8 +293,10 @@ async def clearpass_get_application_dictionaries(
             return client.get_application_dictionary_name_by_name(name=name)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/application-dictionary" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching application dictionaries: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching application dictionaries: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -325,5 +340,9 @@ async def clearpass_get_radius_dynamic_authorization_template(
             return clearpass_get(client, f"/radius-dynamic-authorization-template/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/radius-dynamic-authorization-template" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching RADIUS dynamic authorization templates: {e}"
+        raise ToolError(
+            {"status_code": 502, "message": f"Error fetching RADIUS dynamic authorization templates: {e}"}
+        ) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
@@ -21,6 +21,7 @@ from dataclasses import asdict
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -105,8 +106,10 @@ async def clearpass_list_policy_services(
             }
             for s in items
         ]
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error listing policy services: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error listing policy services: {e}"}) from e
 
 
 def _resolve_service_name(
@@ -253,7 +256,7 @@ async def clearpass_compile_policy_flow(
         "available_services": [<name>, ...], "available_count": <int>}``.
     """
     if (service_id is None) == (service_name is None):
-        return "Error: provide exactly one of service_id or service_name"
+        raise ToolError({"status_code": 400, "message": "Error: provide exactly one of service_id or service_name"})
 
     try:
         from pyclearpass.api_enforcementprofile import ApiEnforcementProfile
@@ -298,7 +301,13 @@ async def clearpass_compile_policy_flow(
         model = build(raw)
         target = next((s for s in model.services.values() if s.name == target_name), None)
         if target is None:
-            return f"Internal error: service '{target_name}' resolved from REST but not present in compiled model"
+            raise ToolError(
+                {
+                    "status_code": 500,
+                    "message": f"Internal error: service '{target_name}' resolved from REST "
+                    "but not present in compiled model",
+                }
+            )
 
         flow = compile_service(target, model, simulated_attributes=simulated_attributes)
 
@@ -327,5 +336,7 @@ async def clearpass_compile_policy_flow(
         if flow.simulation is not None:
             result["simulation"] = asdict(flow.simulation)
         return result
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error compiling policy flow: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error compiling policy flow: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -51,8 +52,10 @@ async def clearpass_get_roles(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/role" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching roles: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching roles: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -99,5 +102,7 @@ async def clearpass_get_role_mappings(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/role-mapping" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching role mappings: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching role mappings: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -40,8 +41,10 @@ async def clearpass_get_admin_users(
             return client.get_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/admin-user" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching admin users: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching admin users: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -76,8 +79,10 @@ async def clearpass_get_admin_privileges(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/admin-privilege" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching admin privileges: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching admin privileges: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -105,8 +110,10 @@ async def clearpass_get_operator_profiles(
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/operator-profile" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching operator profiles: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching operator profiles: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -129,8 +136,10 @@ async def clearpass_get_licenses(
         if license_id:
             return client.get_application_license_by_license_id(license_id=license_id)
         return client.get_application_license_summary()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching licenses: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching licenses: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -147,8 +156,10 @@ async def clearpass_get_cluster_params(
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         return client.get_cluster_parameters()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching cluster parameters: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching cluster parameters: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -169,8 +180,10 @@ async def clearpass_get_password_policies(
             "admin_password_policy": admin_policy,
             "local_user_password_policy": local_user_policy,
         }
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching password policies: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching password policies: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -203,8 +216,10 @@ async def clearpass_get_attributes(
             return client.get_attribute_by_attribute_id(attribute_id=attribute_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/attribute" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching attributes: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching attributes: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -237,8 +252,10 @@ async def clearpass_get_data_filters(
             return client.get_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/data-filter" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching data filters: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching data filters: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -273,8 +290,10 @@ async def clearpass_get_file_backup_servers(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/file-backup-server" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching file backup servers: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching file backup servers: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -291,8 +310,10 @@ async def clearpass_get_messaging_setup(
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         return client.get_messaging_setup()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching messaging setup: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching messaging setup: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -327,8 +348,10 @@ async def clearpass_get_snmp_trap_receivers(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/snmp-trap-receiver" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching SNMP trap receivers: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching SNMP trap receivers: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -363,8 +386,10 @@ async def clearpass_get_policy_manager_zones(
             )
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return clearpass_get(client, "/server/policy-manager-zones" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching Policy Manager zones: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching Policy Manager zones: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -381,5 +406,7 @@ async def clearpass_get_oauth_privileges(
 
         client = await get_clearpass_session(ApiGlobalServerConfiguration)
         return clearpass_get(client, "/oauth/all-privileges")
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching OAuth privileges: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching OAuth privileges: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -47,8 +48,10 @@ async def clearpass_get_sessions(
         ]
         query = "?" + "&".join(p for p in params if p)
         return clearpass_get(client, "/session" + query)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching sessions: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching sessions: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -69,8 +72,10 @@ async def clearpass_get_session_action_status(
 
         client = await get_clearpass_session(ApiSessionControl)
         return client.get_session_action_by_action_id(action_id=action_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching session action status: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching session action status: {e}"}) from e
 
 
 @tool(annotations=READ_ONLY)
@@ -91,5 +96,7 @@ async def clearpass_get_reauth_profiles(
 
         client = await get_clearpass_session(ApiSessionControl)
         return client.get_session_by_id_reauthorize(id=session_id)
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error fetching reauthorization profiles: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error fetching reauthorization profiles: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
@@ -29,5 +30,7 @@ async def clearpass_generate_random_password(
         if type == "mpsk":
             return client.get_random_mpsk()
         return client.get_random_password()
+    except ToolError:
+        raise
     except Exception as e:
-        return f"Error generating random password: {e}"
+        raise ToolError({"status_code": 502, "message": f"Error generating random password: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
@@ -104,7 +105,7 @@ async def greenlake_get_audit_logs(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve audit logs from HPE GreenLake."""
     logger.debug("greenlake_get_audit_logs called")
 
@@ -121,7 +122,7 @@ async def greenlake_get_audit_logs(
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid parameter: {e}"}) from e
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -156,12 +157,12 @@ async def greenlake_get_audit_log_details(
             description=("ID of the audit log record whose ``hasDetails`` value is ``true``."),
         ),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve detailed information for a single audit log entry."""
     logger.debug("greenlake_get_audit_log_details called, id={}", id)
 
     if not id or not id.strip():
-        return "Error: id is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
@@ -112,7 +113,7 @@ async def greenlake_get_devices(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """List devices in the GreenLake workspace."""
     logger.debug("greenlake_get_devices called")
 
@@ -131,7 +132,7 @@ async def greenlake_get_devices(
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid parameter: {e}"}) from e
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -168,12 +169,12 @@ async def greenlake_get_device_by_id(
         str,
         Field(description="The resource ID of the device."),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve details for a single device."""
     logger.debug("greenlake_get_device_by_id called, id={}", id)
 
     if not id or not id.strip():
-        return "Error: id is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
@@ -113,7 +114,7 @@ async def greenlake_get_subscriptions(
             description="Zero-based offset for pagination.",
         ),
     ] = None,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """List subscriptions in the GreenLake workspace."""
     logger.debug("greenlake_get_subscriptions called")
 
@@ -132,7 +133,7 @@ async def greenlake_get_subscriptions(
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid parameter: {e}"}) from e
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -169,12 +170,12 @@ async def greenlake_get_subscription_details(
         str,
         Field(description="The unique identifier of the subscription."),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve detailed information for a single subscription."""
     logger.debug("greenlake_get_subscription_details called, id={}", id)
 
     if not id or not id.strip():
-        return "Error: id is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
@@ -89,7 +90,7 @@ async def greenlake_get_users(
             description=("Pagination offset (number of pages to skip)."),
         ),
     ] = None,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """List users in the GreenLake workspace."""
     logger.debug("greenlake_get_users called")
 
@@ -102,7 +103,7 @@ async def greenlake_get_users(
         if offset is not None:
             params["offset"] = _coerce_int(offset, "offset")
     except ValueError as e:
-        return f"Error: {e}"
+        raise ToolError({"status_code": 400, "message": f"Invalid parameter: {e}"}) from e
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -137,12 +138,12 @@ async def greenlake_get_user_details(
             description=("The unique identifier of the user. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve detailed information for a single user."""
     logger.debug("greenlake_get_user_details called, id={}", id)
 
     if not id or not id.strip():
-        return "Error: id is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
@@ -44,7 +45,7 @@ async def greenlake_get_workspace(
             description=("The unique identifier of the workspace. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve basic information for a single workspace."""
     logger.debug(
         "greenlake_get_workspace called, workspaceId={}",
@@ -52,7 +53,7 @@ async def greenlake_get_workspace(
     )
 
     if not workspaceId or not workspaceId.strip():
-        return "Error: workspaceId is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "workspaceId is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]
@@ -87,7 +88,7 @@ async def greenlake_get_workspace_details(
             description=("The unique identifier of the workspace. Example: 7600415a-8876-5722-9f3c-b0fd11112283"),
         ),
     ],
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Retrieve detailed workspace information (contact info)."""
     logger.debug(
         "greenlake_get_workspace_details called, workspaceId={}",
@@ -95,7 +96,7 @@ async def greenlake_get_workspace_details(
     )
 
     if not workspaceId or not workspaceId.strip():
-        return "Error: workspaceId is required and cannot be empty"
+        raise ToolError({"status_code": 400, "message": "workspaceId is required and cannot be empty"})
 
     token_manager = ctx.lifespan_context["greenlake_token_manager"]
     config = ctx.lifespan_context["config"]

--- a/tests/integration/test_wlans_live.py
+++ b/tests/integration/test_wlans_live.py
@@ -1,6 +1,7 @@
 """Integration tests for WLAN tools against live Central API."""
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central.tools.wlans import (
     central_get_wlan_stats,
@@ -50,12 +51,19 @@ async def test_get_wlan_stats_custom_time_window(live_ctx):
     if not wlan_name:
         pytest.skip("WLAN has no name")
 
-    result = await central_get_wlan_stats(
-        live_ctx,
-        wlan_name=wlan_name,
-        start_time="2026-04-14T00:00:00.000Z",
-        end_time="2026-04-14T23:59:59.999Z",
-    )
+    try:
+        result = await central_get_wlan_stats(
+            live_ctx,
+            wlan_name=wlan_name,
+            start_time="2026-04-14T00:00:00.000Z",
+            end_time="2026-04-14T23:59:59.999Z",
+        )
+    except ToolError:
+        # v3.2.1.0: a non-2xx from the live API (e.g. the requested
+        # historical window has aged out of retention) now raises
+        # ToolError rather than returning an error string. That's a
+        # valid outcome for this live call.
+        return
     assert isinstance(result, (list, str))
 
 

--- a/tests/unit/test_central_config_health.py
+++ b/tests/unit/test_central_config_health.py
@@ -105,14 +105,19 @@ class TestCentralGetDevicesConfigHealth:
 
     @pytest.mark.parametrize("bad_search", ["", "ab", "x" * 129, "x" * 500])
     async def test_search_length_rejected(self, bad_search):
-        """Search must be 3-128 chars per upstream OpenAPI."""
+        """Search must be 3-128 chars per upstream OpenAPI. v3.2.1.0:
+        validation failures raise ToolError(400) instead of returning a
+        string."""
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.central.tools.config_health import (
             central_get_devices_config_health,
         )
 
-        result = await central_get_devices_config_health(_ctx(), search=bad_search)
-        assert isinstance(result, str)
-        assert "search must be 3-128 chars" in result
+        with pytest.raises(ToolError) as exc_info:
+            await central_get_devices_config_health(_ctx(), search=bad_search)
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "search must be 3-128 chars" in exc_info.value.args[0]["message"]
 
     @pytest.mark.parametrize("good_search", ["foo", "x" * 3, "x" * 128, "abc switch"])
     @patch("hpe_networking_mcp.platforms.central.tools.config_health.retry_central_command")

--- a/tests/unit/test_central_monitoring.py
+++ b/tests/unit/test_central_monitoring.py
@@ -47,10 +47,15 @@ class TestCentralGetApsEmptyContract:
         assert await central_get_aps(_ctx()) == sample
 
     @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
-    async def test_sdk_exception_returns_error_string(self, mock_get_all):
+    async def test_sdk_exception_raises_tool_error(self, mock_get_all):
+        """v3.2.1.0: SDK exceptions now raise ToolError(502) instead of
+        returning an error string."""
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
 
         mock_get_all.side_effect = RuntimeError("auth failed")
-        result = await central_get_aps(_ctx())
-        assert isinstance(result, str)
-        assert "auth failed" in result
+        with pytest.raises(ToolError) as exc_info:
+            await central_get_aps(_ctx())
+        assert exc_info.value.args[0]["status_code"] == 502
+        assert "auth failed" in exc_info.value.args[0]["message"]

--- a/tests/unit/test_clearpass_policy_visualizer_tools.py
+++ b/tests/unit/test_clearpass_policy_visualizer_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 pytestmark = pytest.mark.unit
 
@@ -94,14 +95,16 @@ class TestCompilePolicyFlowValidation:
         )
 
         # Neither
-        result = await clearpass_compile_policy_flow(_ctx())
-        assert isinstance(result, str)
-        assert "exactly one" in result.lower()
+        with pytest.raises(ToolError) as exc_info:
+            await clearpass_compile_policy_flow(_ctx())
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "exactly one" in exc_info.value.args[0]["message"].lower()
 
         # Both
-        result = await clearpass_compile_policy_flow(_ctx(), service_id=1, service_name="X")
-        assert isinstance(result, str)
-        assert "exactly one" in result.lower()
+        with pytest.raises(ToolError) as exc_info:
+            await clearpass_compile_policy_flow(_ctx(), service_id=1, service_name="X")
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "exactly one" in exc_info.value.args[0]["message"].lower()
 
 
 class TestResolveServiceName:

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -261,88 +261,61 @@ class TestCodeModeRegistrationHook:
 
 @pytest.mark.unit
 class TestCodeModeErrorReturns:
-    """Regression coverage for the issue #202 fix.
+    """Error-contract coverage — REVISED for the v3.2.1.0 sweep.
 
-    In code mode, a tool function that raises propagates as ``MontyRuntimeError``
-    and crashes the AI's whole ``execute()`` call — even a ``try/except`` inside
-    the sandbox can't catch it. Tools must therefore RETURN errors as a string
-    or dict, not raise. These tests assert the contract for the affected
-    surface so a future edit can't silently regress.
+    The original issue #202 rule ("tools must RETURN error strings, never
+    raise") was reversed: `SandboxErrorCatchMiddleware` (post-#333) now
+    catches `ToolError` inside the code-mode sandbox and re-raises with
+    readable text, so the sandbox no longer dies. The preferred pattern is
+    to `raise ToolError({"status_code": ..., "message": ...})`. These tests
+    assert the migrated GreenLake surface raises structured ToolErrors.
 
-    See ``CHANGELOG.md`` and issue #202 for the full root-cause writeup.
+    See CHANGELOG.md [3.2.0.1] / [3.2.1.0] and docs/TOOLS.md "Tool error
+    contract" for the full writeup.
     """
 
     @pytest.mark.asyncio
-    async def test_greenlake_get_user_details_empty_id_returns_string(self):
-        """Empty-string id returns an error string instead of raising.
+    async def test_greenlake_get_user_details_empty_id_raises_tool_error(self):
+        """Empty-string id raises ToolError(400) instead of returning a string.
         The registry shim (with ``_registry.mcp = None`` at import time in
         tests) returns the raw function, so ``ctx`` can be ``None`` for the
-        early-return path that never touches it.
+        early-validation path that never touches it.
         """
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.greenlake.tools.users import (
             greenlake_get_user_details,
         )
 
-        result = await greenlake_get_user_details(None, id="")  # type: ignore[arg-type]
-        assert isinstance(result, str)
-        assert result.startswith("Error:")
+        with pytest.raises(ToolError) as exc_info:
+            await greenlake_get_user_details(None, id="")  # type: ignore[arg-type]
+        assert exc_info.value.args[0]["status_code"] == 400
 
     @pytest.mark.asyncio
-    async def test_greenlake_get_workspace_empty_returns_string(self):
+    async def test_greenlake_get_workspace_empty_raises_tool_error(self):
+        from fastmcp.exceptions import ToolError
+
         from hpe_networking_mcp.platforms.greenlake.tools.workspaces import (
             greenlake_get_workspace,
         )
 
-        result = await greenlake_get_workspace(None, workspaceId="")  # type: ignore[arg-type]
-        assert isinstance(result, str)
-        assert result.startswith("Error:")
+        with pytest.raises(ToolError) as exc_info:
+            await greenlake_get_workspace(None, workspaceId="")  # type: ignore[arg-type]
+        assert exc_info.value.args[0]["status_code"] == 400
 
     def test_greenlake_users_coerce_int_still_raises_for_helper_callers(self):
-        """``_coerce_int`` itself remains a raising helper — only the public
-        tool entry that calls it is required to be code-mode-safe (via try/
-        except wrapping the param-build block). Pinning this so we don't
-        accidentally rewrite the helper to return error sentinels and
-        silently break unrelated callers.
+        """``_coerce_int`` remains a raising helper — its ValueError is caught
+        by the public tool entry's param-build try/except and re-raised as a
+        ToolError(400). Pinning this so we don't accidentally rewrite the
+        helper to return error sentinels and silently break callers.
         """
         from hpe_networking_mcp.platforms.greenlake.tools.users import _coerce_int
 
         with pytest.raises(ValueError):
             _coerce_int("abc", "limit")
 
-    # NOTE (v3.1.0.0, issue #304): the original ``test_mist_mac_to_device_id_*``
-    # and ``test_mist_get_configuration_object_schema_*`` test methods were
-    # removed alongside the Mist tools they tested. The spec-driven Mist
-    # tool generation no longer has those hand-coded modules — coverage
-    # for generator output sits in ``test_mist_spec_driven.py`` (added in
-    # v3.1.0.0) instead of per-tool unit assertions.
-
-    def test_no_raise_in_greenlake_tool_files(self):
-        """Static guard: every public tool function in ``greenlake/tools/*.py``
-        must return errors as strings (or dicts), not raise. This catches a
-        future edit that re-introduces the bug.
-
-        Helper functions (names starting with ``_``) are exempt — they may
-        raise as long as their callers wrap the call.
-        """
-        import ast
-        from pathlib import Path
-
-        tools_dir = (
-            Path(__file__).parent.parent.parent / "src" / "hpe_networking_mcp" / "platforms" / "greenlake" / "tools"
-        )
-        offenders: list[str] = []
-        for py_file in tools_dir.glob("*.py"):
-            if py_file.name == "__init__.py":
-                continue
-            tree = ast.parse(py_file.read_text())
-            for node in ast.walk(tree):
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    # Skip helpers — names starting with ``_``.
-                    if node.name.startswith("_"):
-                        continue
-                    for inner in ast.walk(node):
-                        if isinstance(inner, ast.Raise):
-                            offenders.append(f"{py_file.name}::{node.name}:{inner.lineno}")
-        assert not offenders, (
-            f"Public GreenLake tool functions must not raise — code mode crashes the sandbox. Offenders: {offenders}"
-        )
+    # NOTE (v3.2.1.0): the old ``test_no_raise_in_greenlake_tool_files`` AST
+    # guard was removed — it enforced the obsolete no-raise rule. GreenLake
+    # tools now raise ToolError per the codified contract. An inverse guard
+    # (assert tools DO raise ToolError) is deferred until 2-3 more platforms
+    # migrate so it has enough surface area to be worth maintaining.


### PR DESCRIPTION
## Summary

Completes the proactive error-contract sweep started in v3.2.0.1. Every platform that returned free-form error strings now raises `ToolError({"status_code": int, "message": str})` for failure paths, so the contract is uniform server-wide.

v3.2.0.1 codified the pattern but scoped migration as *opportunistic*. This PR supersedes that and finishes the job in one atomic change set (no partial state), per the agreed plan.

### Why
- **Envelope correctness** — a returned `"Error: ..."` string was wrapped by `ResponseEnvelopeMiddleware` as `{ok: True, data: "Error: ...", ...}`; `ok: True` is misleading for a failure. `ToolError` reaches FastMCP's proper error path.
- **Structured status codes** let AI clients branch on 4xx (retry) vs 5xx (escalate).
- **Code mode safe** — `SandboxErrorCatchMiddleware` catches `ToolError` inside `execute()` blocks and re-raises with readable text.

### Status-code domain
`400` validation · `404` resource looked up by ID and missing · `500` internal/programming error · `502` upstream service failure. Auth/config failures keep each platform's existing structured session-layer codes (e.g. ClearPass session → `503`).

### Platforms migrated
| Platform | Sites | Notes |
|----------|-------|-------|
| GreenLake | 10 | validation/coerce → 400 |
| Apstra | 23 | upstream → 502 via `format_http_error`; manage validation → 400 |
| Axis | 23 | upstream → 502; shared-helper + entity-type guards → 400 |
| Central (non-scope) | ~77 | upstream → 502; mrt_* validation → 400; switch/wlan errors raise real upstream code; not-found → 404 (scope.py already done in v3.2.0.1) |
| ClearPass | 249 | all 36 tool modules; reads → 502 with `except ToolError: raise` pass-through; validation → 400; defensive fall-throughs → 500; source-not-found → 404 |

Mist and AOS8 had no string-return error paths — nothing to migrate.

### Pattern note
Where a tool's `try` body calls a session/helper that itself raises `ToolError`, the `except Exception → 502` handler is preceded by `except ToolError: raise` so structured errors propagate unchanged instead of being re-wrapped.

### Tests / docs
- Updated tests that asserted the old string-return behavior to `pytest.raises(ToolError)` + structured `status_code`.
- Genuine info-strings (empty-result / "No X found" / no-op) and elicitation confirm/decline dicts left as ordinary returns.
- Version → **3.2.1.0**; CHANGELOG + `docs/TOOLS.md` policy section updated. No tool counts changed (refactor only).

### Verification
Full suite green — **1453 passed, 1 skipped**; ruff / mypy / bandit clean (run in Docker).