### PR TITLE
fix(central): audit-logs tools call v1, not v1alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.1] - 2026-05-20
+
+**Patch — fix audit-logs tools calling the wrong API version.** `central_get_audit_logs` and `central_get_audit_log_detail` called `network-services/v1alpha1/audits` and `network-services/v1alpha1/audit/{id}`, but the live routes are under **`v1`**, not `v1alpha1` — the `v1alpha1` paths return a gateway `404 Route Not Found` (verified live: `v1/audits` returns 200 with the same `start-at`/`end-at` epoch-ms params; `v1alpha1/audits` 404s, while a sibling `network-services/v1alpha1` route resolves, ruling out a group/auth issue). Both tools were therefore non-functional. Fixed by changing the version segment `v1alpha1` → `v1` in both calls; request params were already correct.
+
+Added `tests/unit/test_central_audit_logs.py` — regression coverage asserting both tools hit the `network-services/v1/...` path (would have caught the wrong version) plus param pass-through and the `ToolError` non-2xx path.
+
 ## [3.2.1.0] - 2026-05-20
 
 **Minor — error-contract sweep: every platform now raises `ToolError` instead of returning error strings.** v3.2.0.1 codified the `raise ToolError({"status_code": int, "message": str})` pattern and explicitly scoped migration as *opportunistic*. This release supersedes that stance and proactively completes the migration across all remaining platforms, so the contract is now uniform server-wide. Shipped as one atomic change set (no partial state): public tools raise structured `ToolError` for failure paths (validation, upstream error, not-found), while genuine info-strings (empty-result / "No X found" / no-op) and elicitation confirmation/decline dicts are preserved as ordinary returns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.0"
+version = "3.2.1.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -48,7 +48,7 @@ async def central_get_audit_logs(
         resp = retry_central_command(
             conn,
             api_method="GET",
-            api_path="network-services/v1alpha1/audits",
+            api_path="network-services/v1/audits",
             api_params=query_params,
         )
     except Exception as e:
@@ -81,7 +81,7 @@ async def central_get_audit_log_detail(
         resp = retry_central_command(
             conn,
             api_method="GET",
-            api_path=f"network-services/v1alpha1/audit/{id}",
+            api_path=f"network-services/v1/audit/{id}",
             api_params={},
         )
     except Exception as e:

--- a/tests/unit/test_central_audit_logs.py
+++ b/tests/unit/test_central_audit_logs.py
@@ -1,0 +1,71 @@
+"""Unit tests for central audit-logs tools.
+
+Regression coverage for the API-version fix: the live audit-trail routes are
+``network-services/v1/audits`` and ``network-services/v1/audit/{id}`` — the
+tools previously called the ``v1alpha1`` variant, which gateway-404s. Mocks
+``retry_central_command`` at the import site (the only thing the wrappers call
+besides ``ctx.lifespan_context["central_conn"]``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCentralGetAuditLogs:
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_uses_v1_path_and_passes_params(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 200, "msg": {"audits": [{"auditId": "x"}], "totalCount": 1}}
+        result = await central_get_audit_logs(
+            _ctx(), start_at="1779214249441", end_at="1779300649441", filter="action eq 'Cleared'", sort="-timestamp"
+        )
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        # The bug was v1alpha1; the live route is v1.
+        assert kwargs["api_path"] == "network-services/v1/audits"
+        assert kwargs["api_params"] == {
+            "start-at": "1779214249441",
+            "end-at": "1779300649441",
+            "limit": 200,
+            "offset": 1,
+            "filter": "action eq 'Cleared'",
+            "sort": "-timestamp",
+        }
+        assert result == {"audits": [{"auditId": "x"}], "totalCount": 1}
+
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_non_2xx_raises_tool_error(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 404, "msg": {"message": "404 Route Not Found"}}
+        with pytest.raises(ToolError) as exc_info:
+            await central_get_audit_logs(_ctx(), start_at="1", end_at="2")
+        assert exc_info.value.args[0]["status_code"] == 404
+
+
+class TestCentralGetAuditLogDetail:
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_uses_v1_path_with_id(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_log_detail
+
+        mock_cmd.return_value = {"code": 200, "msg": {"auditId": "abc-123", "action": "Cleared"}}
+        result = await central_get_audit_log_detail(_ctx(), id="abc-123")
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == "network-services/v1/audit/abc-123"
+        assert result == {"auditId": "abc-123", "action": "Cleared"}


### PR DESCRIPTION
## Summary

`central_get_audit_logs` and `central_get_audit_log_detail` called the **`v1alpha1`** audit routes, but the live New Central audit-trail API is under **`v1`**. The `v1alpha1` paths return a gateway `404 Route Not Found`, so both tools were non-functional.

- `network-services/v1alpha1/audits` → `network-services/v1/audits`
- `network-services/v1alpha1/audit/{id}` → `network-services/v1/audit/{id}`

Request params (`start-at`/`end-at` epoch-ms, `limit`, `offset`, optional `filter`/`sort`) were already correct — only the version segment was wrong.

## Verification (live)

- `network-services/v1/audits` + epoch-ms `start-at`/`end-at` → **200** with `{audits, totalCount, pageInfo}`.
- `network-services/v1alpha1/audits` (same params) → **404 Route Not Found**.
- Control `network-services/v1alpha1/wids-monitored-aps` → **200** in the same run, ruling out a group/version/auth problem — the `audits` resource specifically isn't served under `v1alpha1`.
- `network-services/v1/audit/{id}` → 200; `v1alpha1/audit/{id}` → 404.

Audit-trail records are tenant-scoped admin-action metadata; no key/secret/identity leakage in the sampled responses.

## Tests

New `tests/unit/test_central_audit_logs.py` asserts both tools hit the `network-services/v1/...` path (would have caught the wrong version), param pass-through, and the `ToolError` non-2xx path. Full suite: **1456 passed, 1 skipped**; ruff/mypy/bandit clean.

Patch bump → **3.2.1.1**.