### PR TITLE
feat(central): surface API deprecation/sunset to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.2] - 2026-05-20
+
+**Patch — surface Central API deprecation/sunset to callers.** Central signals API retirement via the standard `Deprecation` / `Sunset` response headers (RFC 8594), but the platform layer was dropping them — so neither operators nor AI clients could tell an endpoint was being retired (surfaced while testing the audit-trail tools, whose upstream is `deprecation: true`, `sunset: 2026-05-20`).
+
+- New `deprecation_notice(resp)` helper in `central/utils.py` extracts a `{deprecated, sunset, message}` notice from a response's headers (or `None`).
+- `retry_central_command` now logs a warning on any successful response carrying those headers — platform-wide coverage for every Central tool.
+- `central_get_audit_logs` / `central_get_audit_log_detail` merge the notice into their returned payload under `_deprecation`, so AI clients see the retirement notice alongside the data.
+
+Tests added to `test_central_audit_logs.py` covering the helper, payload surfacing, and the no-headers case.
+
 ## [3.2.1.1] - 2026-05-20
 
 **Patch — fix audit-logs tools calling the wrong API version.** `central_get_audit_logs` and `central_get_audit_log_detail` called `network-services/v1alpha1/audits` and `network-services/v1alpha1/audit/{id}`, but the live routes are under **`v1`**, not `v1alpha1` — the `v1alpha1` paths return a gateway `404 Route Not Found` (verified live: `v1/audits` returns 200 with the same `start-at`/`end-at` epoch-ms params; `v1alpha1/audits` 404s, while a sibling `network-services/v1alpha1` route resolves, ruling out a group/auth issue). Both tools were therefore non-functional. Fixed by changing the version segment `v1alpha1` → `v1` in both calls; request params were already correct.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.1"
+version = "3.2.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -3,7 +3,7 @@ from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
-from hpe_networking_mcp.platforms.central.utils import retry_central_command
+from hpe_networking_mcp.platforms.central.utils import deprecation_notice, retry_central_command
 
 
 @tool(annotations=READ_ONLY)
@@ -57,7 +57,11 @@ async def central_get_audit_logs(
     code = resp.get("code", 0)
     if not (200 <= code < 300):
         raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
-    return resp.get("msg", {})
+    body = resp.get("msg", {})
+    notice = deprecation_notice(resp)
+    if notice is not None and isinstance(body, dict):
+        body = {**body, "_deprecation": notice}
+    return body
 
 
 @tool(annotations=READ_ONLY)
@@ -90,4 +94,8 @@ async def central_get_audit_log_detail(
     code = resp.get("code", 0)
     if not (200 <= code < 300):
         raise ToolError({"status_code": code, "message": f"Central API error: {resp.get('msg')}"})
-    return resp.get("msg", {})
+    body = resp.get("msg", {})
+    notice = deprecation_notice(resp)
+    if notice is not None and isinstance(body, dict):
+        body = {**body, "_deprecation": notice}
+    return body

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from loguru import logger
+
 from hpe_networking_mcp.platforms.central.models import (
     Alert,
     Client,
@@ -233,6 +235,33 @@ def paginated_fetch(
     return items
 
 
+def deprecation_notice(resp: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract a structured deprecation notice from a Central response's headers.
+
+    New Central signals API retirement via the standard ``Deprecation`` and
+    ``Sunset`` response headers (RFC 8594). Returns a small notice dict when
+    either is present, else ``None``. Tools can merge the notice into their
+    returned payload so AI clients learn the endpoint is being retired.
+
+    Args:
+        resp: A response dict from ``retry_central_command`` (carries ``headers``).
+
+    Returns:
+        ``{"deprecated": True, "sunset": <str|None>, "message": <str>}`` when the
+        response is deprecated, else ``None``.
+    """
+    headers = resp.get("headers") or {}
+    deprecation = headers.get("deprecation") or headers.get("Deprecation")
+    sunset = headers.get("sunset") or headers.get("Sunset")
+    if not (deprecation or sunset):
+        return None
+    message = "This Central API endpoint is deprecated"
+    if sunset:
+        message += f" and scheduled for sunset ({sunset})"
+    message += ". Plan migration to its replacement."
+    return {"deprecated": True, "sunset": sunset, "message": message}
+
+
 def retry_central_command(
     central_conn: Any,
     api_method: str,
@@ -279,6 +308,14 @@ def retry_central_command(
         code = resp.get("code", 0)
         # success
         if 200 <= code < 300:
+            notice = deprecation_notice(resp)
+            if notice is not None:
+                logger.warning(
+                    "Central endpoint {} {} is DEPRECATED (sunset={}) — plan migration",
+                    api_method,
+                    api_path,
+                    notice.get("sunset"),
+                )
             return resp
 
         # retry on server errors or rate limiting

--- a/tests/unit/test_central_audit_logs.py
+++ b/tests/unit/test_central_audit_logs.py
@@ -57,6 +57,41 @@ class TestCentralGetAuditLogs:
         assert exc_info.value.args[0]["status_code"] == 404
 
 
+class TestDeprecationSurfacing:
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_deprecation_headers_surfaced_in_payload(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {
+            "code": 200,
+            "msg": {"audits": [], "totalCount": 0},
+            "headers": {"deprecation": "true", "sunset": "Wed, 20 May 2026 23:59:59 GMT"},
+        }
+        result = await central_get_audit_logs(_ctx(), start_at="1", end_at="2")
+
+        assert result["_deprecation"]["deprecated"] is True
+        assert result["_deprecation"]["sunset"] == "Wed, 20 May 2026 23:59:59 GMT"
+        assert "sunset" in result["_deprecation"]["message"].lower()
+        # original body preserved
+        assert result["audits"] == []
+        assert result["totalCount"] == 0
+
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_no_deprecation_key_when_headers_absent(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 200, "msg": {"audits": [], "totalCount": 0}, "headers": {}}
+        result = await central_get_audit_logs(_ctx(), start_at="1", end_at="2")
+        assert "_deprecation" not in result
+
+    def test_deprecation_notice_helper(self):
+        from hpe_networking_mcp.platforms.central.utils import deprecation_notice
+
+        assert deprecation_notice({"headers": {}}) is None
+        assert deprecation_notice({"headers": {"sunset": "X"}})["deprecated"] is True
+        assert deprecation_notice({"headers": {"deprecation": "true"}})["deprecated"] is True
+
+
 class TestCentralGetAuditLogDetail:
     @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
     async def test_uses_v1_path_with_id(self, mock_cmd):


### PR DESCRIPTION
## Summary

Central signals API retirement via the standard `Deprecation` / `Sunset` response headers (RFC 8594), but the platform layer was dropping them — so neither operators nor AI clients could tell an endpoint was being retired. Surfaced while testing the audit-trail tools, whose upstream now returns `deprecation: true` + a same-day `sunset`.

## Changes

- **`deprecation_notice(resp)`** helper in `central/utils.py` — extracts `{deprecated, sunset, message}` from a response's headers, or `None`.
- **`retry_central_command`** logs a warning on any successful response carrying those headers — platform-wide coverage for every Central tool.
- **`central_get_audit_logs` / `central_get_audit_log_detail`** merge the notice into their returned payload under `_deprecation`, so AI clients see the retirement notice alongside the data (original body keys preserved).

## Tests

`test_central_audit_logs.py` gains coverage for the helper, payload surfacing, and the no-headers (no `_deprecation` key) case. Full suite: **1459 passed, 1 skipped**; ruff/mypy clean.

Patch bump → **3.2.1.2**.

## Context

The Central audit API (`network-services/v1/audits`, fixed to `v1` in #370) is itself deprecated with a same-day sunset and no live successor on the tested tenant yet — this change makes that signal visible to callers rather than silently dropping it.