### PR TITLE
fix(central): retry backoff + code-mode sandbox import guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.3] - 2026-05-20
+
+**Patch — add backoff to `retry_central_command` so transient flaps don't defeat all retries.** The helper retried up to 5× on transient errors (429 / 5xx) but with **zero delay between attempts** — all 5 fired in under a second, so a brief upstream flap (e.g. the deprecated audit endpoint degrading near its sunset) failed every attempt and surfaced a 502. Now waits a capped exponential backoff between retries (0.5s → 1s → 2s → 4s, cap 5s; no wait after the final attempt), letting calls ride out short blips. Applies to every Central tool, not just audit.
+
+- New `_retry_backoff_secs(attempt)` helper; `time.sleep` between retries on both the transport-exception and 429/5xx paths.
+- 4xx still raises immediately (no retry, no sleep).
+- New `tests/unit/test_central_retry.py` covering the backoff schedule, transient-then-success, 429 retry, exhaustion-then-raise, and the 4xx fast-fail (all with `time.sleep` patched).
+
 ## [3.2.1.2] - 2026-05-20
 
 **Patch — surface Central API deprecation/sunset to callers.** Central signals API retirement via the standard `Deprecation` / `Sunset` response headers (RFC 8594), but the platform layer was dropping them — so neither operators nor AI clients could tell an endpoint was being retired (surfaced while testing the audit-trail tools, whose upstream is `deprecation: true`, `sunset: 2026-05-20`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 4xx still raises immediately (no retry, no sleep).
 - New `tests/unit/test_central_retry.py` covering the backoff schedule, transient-then-success, 429 retry, exhaustion-then-raise, and the 4xx fast-fail (all with `time.sleep` patched).
 
+**Also — code-mode sandbox guidance.** The `execute` description now warns that not every stdlib module exists in the Monty sandbox (e.g. `import collections` raises `ModuleNotFoundError`) and steers the AI to builtins (plain `dict` for counting/grouping, `set`, `sorted`, `sum`, `min`/`max`). Operator transcripts repeatedly hit this when aggregating audit data in code mode. Regression test added to `test_server_code_mode.py`.
+
 ## [3.2.1.2] - 2026-05-20
 
 **Patch — surface Central API deprecation/sunset to callers.** Central signals API retirement via the standard `Deprecation` / `Sunset` response headers (RFC 8594), but the platform layer was dropping them — so neither operators nor AI clients could tell an endpoint was being retired (surfaced while testing the audit-trail tools, whose upstream is `deprecation: true`, `sunset: 2026-05-20`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.2"
+version = "3.2.1.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -1,3 +1,4 @@
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -16,6 +17,17 @@ from hpe_networking_mcp.platforms.central.models import (
     SiteData,
     SiteMetrics,
 )
+
+# Exponential backoff for retry_central_command's transient-failure path.
+# Without a delay, all retries fire in <1s and a brief upstream flap
+# (e.g. the degrading audit endpoint near its sunset) defeats every attempt.
+_RETRY_BACKOFF_BASE_SECS = 0.5
+_RETRY_BACKOFF_CAP_SECS = 5.0
+
+
+def _retry_backoff_secs(attempt: int) -> float:
+    """Seconds to wait before the next retry (1-indexed attempt). Capped exponential."""
+    return min(_RETRY_BACKOFF_BASE_SECS * (2 ** (attempt - 1)), _RETRY_BACKOFF_CAP_SECS)
 
 
 def normalize_site_name_filter(value: str | list[str] | None) -> list[str] | None:
@@ -303,6 +315,8 @@ def retry_central_command(
                 exc,
             )
             last_response = {"code": 0, "msg": str(exc)}
+            if attempt < max_retries:
+                time.sleep(_retry_backoff_secs(attempt))
             continue
 
         code = resp.get("code", 0)
@@ -329,6 +343,8 @@ def retry_central_command(
                 max_retries,
             )
             last_response = resp
+            if attempt < max_retries:
+                time.sleep(_retry_backoff_secs(attempt))
             continue
 
         # client errors -> raise immediately

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -544,7 +544,10 @@ def _register_code_mode(mcp: FastMCP) -> None:
         "including `datetime.now()`, `time.time()`, file I/O, `os.environ`, "
         "and `subprocess`. For timestamps, accept ISO strings as parameters "
         "or hardcode literal ISO-8601 strings rather than computing them "
-        "inside the sandbox."
+        "inside the sandbox. Not every stdlib module exists in the sandbox — "
+        "e.g. `import collections` (Counter/defaultdict) raises "
+        "ModuleNotFoundError. Use builtins instead: a plain `dict` for "
+        "counting/grouping, plus `set`, `sorted`, `sum`, and `min`/`max`."
     )
 
     # Build the skills registry once and hand factories to CodeMode so the

--- a/tests/unit/test_central_retry.py
+++ b/tests/unit/test_central_retry.py
@@ -1,0 +1,75 @@
+"""Unit tests for retry_central_command's transient-failure backoff.
+
+Without backoff, all retries fire in <1s and a brief upstream flap (e.g. the
+degrading audit endpoint near its sunset) defeats every attempt. These tests
+pin the exponential backoff and the eventual-success behaviour, with
+``time.sleep`` patched so the suite stays fast.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.utils import (
+    _retry_backoff_secs,
+    retry_central_command,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _conn(responses: list[dict]) -> MagicMock:
+    """A fake pycentral conn whose .command returns the given responses in order."""
+    conn = MagicMock()
+    conn.command.side_effect = responses
+    conn.logger = MagicMock()
+    return conn
+
+
+class TestRetryBackoff:
+    def test_backoff_schedule_is_capped_exponential(self):
+        assert _retry_backoff_secs(1) == 0.5
+        assert _retry_backoff_secs(2) == 1.0
+        assert _retry_backoff_secs(3) == 2.0
+        assert _retry_backoff_secs(4) == 4.0
+        # capped at 5.0
+        assert _retry_backoff_secs(5) == 5.0
+        assert _retry_backoff_secs(10) == 5.0
+
+    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
+    def test_transient_500_then_success(self, mock_sleep):
+        conn = _conn(
+            [
+                {"code": 500, "msg": {"message": "flap"}},
+                {"code": 500, "msg": {"message": "flap"}},
+                {"code": 200, "msg": {"audits": [{"id": "x"}]}},
+            ]
+        )
+        resp = retry_central_command(conn, "GET", "network-services/v1/audits")
+        assert resp["code"] == 200
+        # rode out two flaps -> slept after attempts 1 and 2
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0]
+
+    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
+    def test_429_is_retried_with_backoff(self, mock_sleep):
+        conn = _conn([{"code": 429, "msg": {}}, {"code": 200, "msg": {"ok": True}}])
+        resp = retry_central_command(conn, "GET", "network-monitoring/v1/devices/X")
+        assert resp["code"] == 200
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5]
+
+    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
+    def test_exhausts_retries_then_raises_without_sleeping_after_last(self, mock_sleep):
+        conn = _conn([{"code": 500, "msg": {"message": "down"}}] * 5)
+        with pytest.raises(Exception, match="Failed after 5 attempts"):
+            retry_central_command(conn, "GET", "network-services/v1/audits")
+        # 5 attempts -> sleeps after attempts 1..4 only (no sleep after the last)
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0, 2.0, 4.0]
+
+    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
+    def test_4xx_raises_immediately_no_sleep(self, mock_sleep):
+        conn = _conn([{"code": 400, "msg": {"message": "bad"}}])
+        with pytest.raises(Exception, match="Client error"):
+            retry_central_command(conn, "GET", "network-services/v1/audits")
+        mock_sleep.assert_not_called()

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -59,6 +59,20 @@ def test_execute_description_names_all_platforms() -> None:
 
 
 @pytest.mark.unit
+def test_execute_description_warns_unavailable_stdlib_modules() -> None:
+    """The Monty sandbox is a Python subset — some stdlib modules aren't
+    importable (e.g. `collections`). Operator transcripts repeatedly hit
+    `ModuleNotFoundError: No module named 'collections'` in code mode, so the
+    description must warn and point at builtins instead."""
+    body = _read_execute_description_block()
+    assert "collections" in body and "ModuleNotFoundError" in body, (
+        "execute_description must warn that not every stdlib module exists in "
+        "the sandbox (e.g. `import collections` raises ModuleNotFoundError) and "
+        "steer the AI to builtins."
+    )
+
+
+@pytest.mark.unit
 def test_execute_description_steers_to_invoke_tool() -> None:
     """#328: the description must steer the LLM to `<platform>_invoke_tool`
     as the dispatch path — NOT bare-name `call_tool("mist_get_self", ...)`,


### PR DESCRIPTION
Two resilience fixes from the same operator code-mode session ("the AI keeps having issues" aggregating audit logs).

## 1. Backoff in `retry_central_command`

It retried up to 5× on transient errors (429 / 5xx) with **zero delay** — all 5 fired in <1s, so a brief upstream flap (e.g. the deprecated audit endpoint degrading near its sunset) defeated every attempt and surfaced a `502`, even though the endpoint returned 200 seconds later.

- Capped exponential backoff: **0.5s → 1s → 2s → 4s** (cap 5s), on the transport-exception and 429/5xx paths.
- No wait after the final attempt; `4xx` still raises immediately.
- Applies to every Central tool, not just audit.
- `tests/unit/test_central_retry.py` — backoff schedule, transient-then-success, 429 retry, exhaustion-then-raise, 4xx fast-fail (`time.sleep` patched).

## 2. Code-mode sandbox import guidance

The Monty sandbox is a Python *subset* — `import collections` (Counter/defaultdict) raises `ModuleNotFoundError`, which the AI hit repeatedly while aggregating audit data. The `execute` description now warns about this and steers the AI to builtins (plain `dict` for counting/grouping, `set`, `sorted`, `sum`, `min`/`max`). Regression test added to `test_server_code_mode.py`.

## Verification

Full suite: **1465 passed, 1 skipped**; ruff/mypy clean. Patch bump → **3.2.1.3**.