### PR TITLE
fix(central): forgiving audit-logs params (offset clamp + ISO time docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.4] - 2026-05-20
+
+**Patch — make `central_get_audit_logs` forgiving of the two params AI clients keep getting wrong.** Live-verified against the audit API:
+
+- **`offset=0` returns HTTP 500.** Pagination is 1-based (`offset=1` → page 1, `offset=2` → page 2); `offset=0` is invalid and 500s. AI clients naturally pass `offset=0`, which was a direct cause of the audit-log failures. The tool now clamps `offset` to `>= 1`.
+- **The time params accept ISO 8601, not just epoch ms.** The old docstring said "epoch milliseconds," which pushed clients to *compute* epoch ms (and `datetime.now()` is blocked in the code-mode sandbox). The API accepts ISO 8601 directly (verified), and the tool forwards the value verbatim — so the fix is documentation: `start_at`/`end_at` now documented as "ISO 8601 (e.g. `2026-02-19T00:00:00Z`) or epoch milliseconds." This also aligns with the code-mode sandbox guidance to hardcode literal ISO-8601 strings.
+- `limit` is now clamped to the documented `1..200` range.
+
+Tests added to `test_central_audit_logs.py`: offset-zero clamped to 1, limit capped at 200, ISO timestamps forwarded unchanged.
+
 ## [3.2.1.3] - 2026-05-20
 
 **Patch — add backoff to `retry_central_command` so transient flaps don't defeat all retries.** The helper retried up to 5× on transient errors (429 / 5xx) but with **zero delay between attempts** — all 5 fired in under a second, so a brief upstream flap (e.g. the deprecated audit endpoint degrading near its sunset) failed every attempt and surfaced a 502. Now waits a capped exponential backoff between retries (0.5s → 1s → 2s → 4s, cap 5s; no wait after the final attempt), letting calls ride out short blips. Applies to every Central tool, not just audit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.3"
+version = "3.2.1.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -24,14 +24,22 @@ async def central_get_audit_logs(
     who changed what and when.
 
     Parameters:
-        start_at: Start of the time window in epoch milliseconds (required).
-        end_at: End of the time window in epoch milliseconds (required).
+        start_at: Start of the time window. Accepts an ISO 8601 timestamp
+            (e.g. "2026-02-19T00:00:00Z") or epoch milliseconds. Required.
+        end_at: End of the time window, same formats as start_at. Required.
         filter: OData filter expression to narrow results.
         sort: Sort order for results (e.g. "+timestamp" or "-timestamp").
-        limit: Number of records per page (default 200, max 200).
-        offset: Page number starting at 1 (default 1).
+        limit: Records per page (default 200; clamped to 1..200).
+        offset: 1-based page number (default 1). offset=2 is the second page,
+            etc. The API returns HTTP 500 for offset 0, so values < 1 are
+            clamped to 1.
     """
     conn = ctx.lifespan_context["central_conn"]
+
+    # The audit API paginates by 1-based page number and returns a 500 for
+    # offset 0, so clamp it; limit is capped at the documented max of 200.
+    offset = max(1, offset)
+    limit = max(1, min(limit, 200))
 
     query_params: dict = {
         "start-at": start_at,

--- a/tests/unit/test_central_audit_logs.py
+++ b/tests/unit/test_central_audit_logs.py
@@ -57,6 +57,37 @@ class TestCentralGetAuditLogs:
         assert exc_info.value.args[0]["status_code"] == 404
 
 
+class TestParamClamping:
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_offset_zero_clamped_to_one(self, mock_cmd):
+        """offset=0 makes the audit API return HTTP 500 — clamp it to 1 so the
+        AI's natural 'start at zero' doesn't fail."""
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 200, "msg": {"audits": []}}
+        await central_get_audit_logs(_ctx(), start_at="1", end_at="2", offset=0)
+        assert mock_cmd.call_args.kwargs["api_params"]["offset"] == 1
+
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_limit_capped_at_200(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 200, "msg": {"audits": []}}
+        await central_get_audit_logs(_ctx(), start_at="1", end_at="2", limit=1000)
+        assert mock_cmd.call_args.kwargs["api_params"]["limit"] == 200
+
+    @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
+    async def test_iso_timestamps_pass_through_unchanged(self, mock_cmd):
+        """The API accepts ISO 8601 directly; the tool must forward it verbatim."""
+        from hpe_networking_mcp.platforms.central.tools.audit_logs import central_get_audit_logs
+
+        mock_cmd.return_value = {"code": 200, "msg": {"audits": []}}
+        await central_get_audit_logs(_ctx(), start_at="2026-02-19T00:00:00Z", end_at="2026-05-20T23:59:59Z")
+        params = mock_cmd.call_args.kwargs["api_params"]
+        assert params["start-at"] == "2026-02-19T00:00:00Z"
+        assert params["end-at"] == "2026-05-20T23:59:59Z"
+
+
 class TestDeprecationSurfacing:
     @patch("hpe_networking_mcp.platforms.central.tools.audit_logs.retry_central_command")
     async def test_deprecation_headers_surfaced_in_payload(self, mock_cmd):


### PR DESCRIPTION
## Summary

`central_get_audit_logs` had two params AI clients kept getting wrong, both verified live against the audit API.

### `offset=0` → HTTP 500
Pagination is **1-based**: `offset=1` → page 1, `offset=2` → page 2. `offset=0` is invalid and the API returns a `500`. AI clients naturally pass `offset: 0`, which was a **direct cause** of the repeated audit-log failures (separate from the transient flap fixed in #372). The tool now **clamps `offset` to `>= 1`**.

### Time params accept ISO 8601 — not just epoch ms
The old docstring said "epoch milliseconds," which pushed clients to *compute* epoch ms — and `datetime.now()` is blocked in the code-mode sandbox, so that computation tended to go wrong ("doing the wrong time"). The API accepts **ISO 8601 directly** (verified: `2026-02-19T00:00:00Z` → 200), and the tool forwards the value verbatim. So `start_at`/`end_at` are now documented as **"ISO 8601 (e.g. `2026-02-19T00:00:00Z`) or epoch milliseconds"** — which also matches the code-mode sandbox guidance to hardcode literal ISO strings.

### `limit` clamped to 1..200
Enforces the documented max instead of forwarding oversized values.

## Tests
`test_central_audit_logs.py`: offset-zero → 1, limit 1000 → 200, ISO timestamps forwarded unchanged. Full suite: **1468 passed, 1 skipped**; ruff/mypy clean. Patch bump → **3.2.1.4**.