### PR TITLE
fix(central): correct client-disconnect payloads + surface masked errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.5] - 2026-05-21
+
+**Patch — fix the Central client-disconnect tools (broken payload contract) + make their failures diagnosable.** Surfaced from an operator transcript where the AI couldn't disconnect a wireless client.
+
+### Disconnect tools sent the wrong body field
+The 5 MRT disconnect tools exposed a free-form `payload` dict with a misleading hint ("typically `{mac_address}`"), but the API requires specific fields — and they differ between APs and gateways. Every call 400'd. Replaced the free-form `payload` with explicit, correctly-named params that build the exact body (live-verified against the tenant — `userMacAddress` returns HTTP 202 INITIATED):
+
+| Tool | body |
+|------|------|
+| `central_disconnect_user_by_mac_on_ap` | `{"userMacAddress": …}` |
+| `central_disconnect_user_by_network` | `{"networkName": …}` |
+| `central_disconnect_user_all_on_ap` | _(none)_ |
+| `central_disconnect_client_by_mac_on_gateway` | `{"clientMacAddress": …}` |
+| `central_disconnect_client_all_on_gateway` | _(none)_ |
+
+### The real error was masked
+`_call` (mrt_troubleshooting) let `retry_central_command`'s **bare `Exception`** propagate on a 4xx. `central_invoke_tool` only catches `ToolError` (issue #333), so the bare exception slipped through and `mask_error_details=True` reduced it to the useless `Error calling tool …` — the AI (and operator) couldn't see the underlying `400`. `_call` now raises `ToolError` with the real status + body, so `central_invoke_tool` returns a structured `{"status": "tool_error", "status_code", "message"}` and the direct-call path surfaces readable text via `SandboxErrorCatch`.
+
+### Renamed misleading tool
+`central_disconnect_client_ap` → **`central_disconnect_client_switch`** — it targets switches (`aos-s`/`cx`), not APs, and the name sent the AI down the wrong path. Updated the registration list, INSTRUCTIONS.md, and docs/TOOLS.md; error strings corrected from "from AP" → "from switch".
+
+### Docstrings corrected
+These OPERATIONAL troubleshooting tools claimed "fires elicitation" but never confirmed (and shouldn't — consistent with port/PoE bounce). Replaced with "runs immediately, no confirmation" across the file.
+
+Added `tests/unit/test_central_disconnect_tools.py` — pins each tool's exact body, the `ToolError` surfacing (400 detail + 502 wrapping), and the `_switch` rename.
+
 ## [3.2.1.4] - 2026-05-20
 
 **Patch — make `central_get_audit_logs` forgiving of the two params AI clients keep getting wrong.** Live-verified against the audit API:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1216,13 +1216,14 @@ Rule shape:
 |-----------|------|----------|-------------|
 | serial_number | str | Yes | AP serial number. |
 
-#### `central_disconnect_client_ap`
+#### `central_disconnect_client_switch`
 
-> Disconnect a specific client by MAC address from an AP.
+> Disconnect a specific client by MAC address from a switch (aos-s/cx). Targets switches, not APs — use `central_disconnect_user_by_mac_on_ap` for AP clients.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| serial_number | str | Yes | AP serial number. |
+| serial_number | str | Yes | Switch serial number. |
+| device_type | str | Yes | Switch type — "aos-s" or "cx". |
 | mac_address | str | Yes | Client MAC address. |
 
 #### `central_disconnect_client_gateway`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.4"
+version = "3.2.1.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -356,7 +356,7 @@ When asked to create a new site based on an existing site:
 - **Events**: central_get_events, central_get_events_count
 - **Audit Logs**: central_get_audit_logs, central_get_audit_log_detail
 - **Applications**: central_get_applications
-- **Troubleshooting**: central_ping, central_traceroute, central_cable_test, central_show_commands, central_disconnect_users_ssid, central_disconnect_users_ap, central_disconnect_client_ap, central_disconnect_client_gateway, central_disconnect_clients_gateway, central_port_bounce_switch, central_poe_bounce_switch, central_port_bounce_gateway, central_poe_bounce_gateway
+- **Troubleshooting**: central_ping, central_traceroute, central_cable_test, central_show_commands, central_disconnect_users_ssid, central_disconnect_users_ap, central_disconnect_client_switch, central_disconnect_client_gateway, central_disconnect_clients_gateway, central_port_bounce_switch, central_poe_bounce_switch, central_port_bounce_gateway, central_poe_bounce_gateway
 - **WLAN Profiles**: central_get_wlan_profiles, central_manage_wlan_profile
   - Use `central_get_wlan_profiles` to read WLAN SSID profile configurations from the library
   - Use `central_manage_wlan_profile` to create, update, or delete WLAN profiles — requires `ENABLE_CENTRAL_WRITE_TOOLS=true`

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -56,7 +56,7 @@ TOOLS = {
     "actions": [
         "central_disconnect_users_ssid",
         "central_disconnect_users_ap",
-        "central_disconnect_client_ap",
+        "central_disconnect_client_switch",
         "central_disconnect_client_gateway",
         "central_disconnect_clients_gateway",
         "central_port_bounce_switch",

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -114,17 +114,18 @@ async def central_disconnect_users_ap(
 
 
 @tool(annotations=OPERATIONAL)
-async def central_disconnect_client_ap(
+async def central_disconnect_client_switch(
     ctx: Context,
     serial_number: str,
     device_type: Literal["aos-s", "cx"],
     mac_address: str,
 ) -> dict | str:
     """
-    Disconnect a specific client by MAC address from a switch.
+    Disconnect a specific client by MAC address from a switch (aos-s/cx).
 
-    Use central_find_client to get the MAC address and
-    central_find_device to get the switch serial number.
+    This targets SWITCHES, not APs — for AP client disconnects use
+    central_disconnect_user_by_mac_on_ap. Use central_find_client to get the
+    MAC address and central_find_device to get the switch serial number.
 
     Parameters:
         serial_number: Switch serial number (required).
@@ -142,10 +143,10 @@ async def central_disconnect_client_ap(
             mac_address=mac_address,
         )
     except Exception as e:
-        raise ToolError({"status_code": 502, "message": f"Error disconnecting client from AP: {e}"}) from e
+        raise ToolError({"status_code": 502, "message": f"Error disconnecting client from switch: {e}"}) from e
 
     if not resp:
-        return "Disconnect client from AP returned no results."
+        return "Disconnect client from switch returned no results."
     return resp
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -421,7 +421,7 @@ async def central_disconnect_user_by_network(
     serial_number: Annotated[str, Field(description="AP serial number.")],
     network_name: Annotated[str, Field(description="Network name (SSID) to disconnect users from.")],
 ) -> dict | str:
-    """Disconnect users associated to a specific network (SSID) on an AP (operational — runs immediately, no confirmation)."""
+    """Disconnect users on a specific network/SSID on an AP (operational — runs immediately, no confirmation)."""
     return _post_action(
         ctx.lifespan_context["central_conn"],
         "aps",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -19,14 +19,15 @@ Pattern notes:
 * ``list-tasks`` per family is wrapped by one shared
   ``central_list_troubleshooting_tasks``.
 * Operational actions (reboot, halt, locate, disconnect) use the
-  ``OPERATIONAL`` annotation — they fire elicitation but are not gated
-  behind ``ENABLE_CENTRAL_WRITE_TOOLS`` (matches the existing
-  reboot / disconnect / port-bounce surface).
+  ``OPERATIONAL`` annotation — they run immediately without a confirmation
+  prompt and are not gated behind ``ENABLE_CENTRAL_WRITE_TOOLS`` (matches
+  the existing reboot / disconnect / port-bounce surface).
 """
 
 from typing import Annotated, Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
@@ -49,17 +50,25 @@ DeviceFamilySwitchGw = Literal["aos-s", "cx", "gateways"]
 
 
 def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
-    response = retry_central_command(
-        central_conn=conn,
-        api_method=method,
-        api_path=path,
-        api_params=params or {},
-        api_data=data or {},
-    )
+    try:
+        response = retry_central_command(
+            central_conn=conn,
+            api_method=method,
+            api_path=path,
+            api_params=params or {},
+            api_data=data or {},
+        )
+    except ToolError:
+        raise
+    except Exception as e:
+        # retry_central_command raises a bare Exception on 4xx/5xx; surface the
+        # real upstream detail as a ToolError so it isn't masked to a generic
+        # "Error calling tool" in code mode (the message carries the HTTP body).
+        raise ToolError({"status_code": 502, "message": f"Central troubleshooting request failed: {e}"}) from e
     code = response.get("code", 0)
     if 200 <= code < 300:
         return response.get("msg", {})
-    return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
+    raise ToolError({"status_code": code, "message": f"Central API error (HTTP {code}): {response.get('msg')}"})
 
 
 def _post_action(conn, family: str, serial: str, action: str, payload: dict | None) -> dict | str:
@@ -347,7 +356,7 @@ async def central_reboot_device(
         Field(description="Optional reboot body (vendor-specific flags). Omit for defaults."),
     ] = None,
 ) -> dict | str:
-    """Reboot a device (operational — fires elicitation). Returns a ``task_id`` to poll."""
+    """Reboot a device (operational — runs immediately, no confirmation). Returns a ``task_id`` to poll."""
     return _post_action(
         ctx.lifespan_context["central_conn"],
         device_family,
@@ -366,7 +375,7 @@ async def central_reboot_swarm(
         Field(description="Optional reboot body. Omit for defaults."),
     ] = None,
 ) -> dict | str:
-    """Reboot an entire IAP / Instant swarm (operational — fires elicitation)."""
+    """Reboot an entire IAP / Instant swarm (operational — runs immediately, no confirmation)."""
     return _post_action(ctx.lifespan_context["central_conn"], "aps", serial_number, "rebootSwarm", payload)
 
 
@@ -402,7 +411,7 @@ async def central_halt_gateway(
         Field(description="Optional halt body. Omit for defaults."),
     ] = None,
 ) -> dict | str:
-    """Halt (graceful shutdown) a gateway (operational — fires elicitation)."""
+    """Halt (graceful shutdown) a gateway (operational — runs immediately, no confirmation)."""
     return _post_action(ctx.lifespan_context["central_conn"], "gateways", serial_number, "halt", payload)
 
 
@@ -410,18 +419,15 @@ async def central_halt_gateway(
 async def central_disconnect_user_by_network(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
-    payload: Annotated[
-        dict,
-        Field(description="Network-scope disconnect body — typically ``{ssid_name}`` or per-network selector."),
-    ],
+    network_name: Annotated[str, Field(description="Network name (SSID) to disconnect users from.")],
 ) -> dict | str:
-    """Disconnect users associated to a specific network on an AP (operational — fires elicitation)."""
+    """Disconnect users associated to a specific network (SSID) on an AP (operational — runs immediately, no confirmation)."""
     return _post_action(
         ctx.lifespan_context["central_conn"],
         "aps",
         serial_number,
         "disconnectUserByNetwork",
-        payload,
+        {"networkName": network_name},
     )
 
 
@@ -429,22 +435,15 @@ async def central_disconnect_user_by_network(
 async def central_disconnect_user_by_mac_on_ap(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
-    payload: Annotated[
-        dict,
-        Field(description="Per-MAC disconnect body — typically ``{mac_address}``."),
-    ],
+    user_mac_address: Annotated[str, Field(description="MAC address of the user/client to disconnect.")],
 ) -> dict | str:
-    """Disconnect a specific user/client by MAC from an AP (operational — fires elicitation).
-
-    Use this MRT variant when the existing ``central_disconnect_client_ap``
-    pathway doesn't reach the device. Both target the same outcome.
-    """
+    """Disconnect a specific user/client by MAC address from an AP (operational — runs immediately, no confirmation)."""
     return _post_action(
         ctx.lifespan_context["central_conn"],
         "aps",
         serial_number,
         "disconnectUserByMacAddress",
-        payload,
+        {"userMacAddress": user_mac_address},
     )
 
 
@@ -452,12 +451,8 @@ async def central_disconnect_user_by_mac_on_ap(
 async def central_disconnect_user_all_on_ap(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
-    payload: Annotated[
-        dict | None,
-        Field(description="Optional body. Omit for the default disconnect-everyone behavior."),
-    ] = None,
 ) -> dict | str:
-    """Disconnect ALL users on an AP (operational — fires elicitation).
+    """Disconnect ALL users on an AP (operational — runs immediately, no confirmation).
 
     Service-affecting — every associated client gets bounced. Use only
     during planned maintenance windows.
@@ -467,7 +462,7 @@ async def central_disconnect_user_all_on_ap(
         "aps",
         serial_number,
         "disconnectUserAll",
-        payload,
+        None,
     )
 
 
@@ -475,12 +470,8 @@ async def central_disconnect_user_all_on_ap(
 async def central_disconnect_client_all_on_gateway(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
-    payload: Annotated[
-        dict | None,
-        Field(description="Optional body. Omit for the default disconnect-everyone behavior."),
-    ] = None,
 ) -> dict | str:
-    """Disconnect ALL clients terminating on a gateway (operational — fires elicitation).
+    """Disconnect ALL clients terminating on a gateway (operational — runs immediately, no confirmation).
 
     Service-affecting — every client connected through the gateway gets
     bounced. Use only during planned maintenance windows.
@@ -490,7 +481,7 @@ async def central_disconnect_client_all_on_gateway(
         "gateways",
         serial_number,
         "disconnectClientAll",
-        payload,
+        None,
     )
 
 
@@ -498,16 +489,13 @@ async def central_disconnect_client_all_on_gateway(
 async def central_disconnect_client_by_mac_on_gateway(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
-    payload: Annotated[
-        dict,
-        Field(description="Per-MAC disconnect body — typically ``{mac_address}``."),
-    ],
+    client_mac_address: Annotated[str, Field(description="MAC address of the client to disconnect.")],
 ) -> dict | str:
-    """Disconnect a specific client by MAC from a gateway (operational — fires elicitation)."""
+    """Disconnect a specific client by MAC address from a gateway (operational — runs immediately, no confirmation)."""
     return _post_action(
         ctx.lifespan_context["central_conn"],
         "gateways",
         serial_number,
         "disconnectClientByMacAddress",
-        payload,
+        {"clientMacAddress": client_mac_address},
     )

--- a/tests/unit/test_central_disconnect_tools.py
+++ b/tests/unit/test_central_disconnect_tools.py
@@ -1,0 +1,131 @@
+"""Unit tests for the Central MRT disconnect tools.
+
+Regression coverage for the payload-contract bug: the AP/gateway disconnect
+actions take specific body fields (``userMacAddress`` / ``networkName`` /
+``clientMacAddress``), but the tools previously exposed a free-form ``payload``
+dict with a misleading "{mac_address}" hint, so callers guessed wrong field
+names and got HTTP 400. These tests pin the exact body each tool sends, plus
+the ``_call`` ToolError behaviour (so upstream errors aren't masked to a
+generic "Error calling tool" in code mode).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.unit
+
+_CMD = "hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting.retry_central_command"
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestDisconnectBodies:
+    @patch(_CMD)
+    async def test_by_mac_on_ap_uses_user_mac_address(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_user_by_mac_on_ap,
+        )
+
+        mock_cmd.return_value = {"code": 202, "msg": {"status": "INITIATED"}}
+        await central_disconnect_user_by_mac_on_ap(_ctx(), serial_number="CNT123", user_mac_address="00:BD:3E:E4:8C:5D")
+        kw = mock_cmd.call_args.kwargs
+        assert kw["api_method"] == "POST"
+        assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserByMacAddress"
+        assert kw["api_data"] == {"userMacAddress": "00:BD:3E:E4:8C:5D"}
+
+    @patch(_CMD)
+    async def test_by_network_uses_network_name(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_user_by_network,
+        )
+
+        mock_cmd.return_value = {"code": 202, "msg": {}}
+        await central_disconnect_user_by_network(_ctx(), serial_number="CNT123", network_name="CORP-WIFI")
+        kw = mock_cmd.call_args.kwargs
+        assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserByNetwork"
+        assert kw["api_data"] == {"networkName": "CORP-WIFI"}
+
+    @patch(_CMD)
+    async def test_by_mac_on_gateway_uses_client_mac_address(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_client_by_mac_on_gateway,
+        )
+
+        mock_cmd.return_value = {"code": 202, "msg": {}}
+        await central_disconnect_client_by_mac_on_gateway(
+            _ctx(), serial_number="GW9", client_mac_address="aa:bb:cc:dd:ee:ff"
+        )
+        kw = mock_cmd.call_args.kwargs
+        assert kw["api_path"] == "network-troubleshooting/v1/gateways/GW9/disconnectClientByMacAddress"
+        assert kw["api_data"] == {"clientMacAddress": "aa:bb:cc:dd:ee:ff"}
+
+    @patch(_CMD)
+    async def test_all_on_ap_sends_empty_body(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_user_all_on_ap,
+        )
+
+        mock_cmd.return_value = {"code": 202, "msg": {}}
+        await central_disconnect_user_all_on_ap(_ctx(), serial_number="CNT123")
+        kw = mock_cmd.call_args.kwargs
+        assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserAll"
+        assert kw["api_data"] == {}
+
+    @patch(_CMD)
+    async def test_all_on_gateway_sends_empty_body(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_client_all_on_gateway,
+        )
+
+        mock_cmd.return_value = {"code": 202, "msg": {}}
+        await central_disconnect_client_all_on_gateway(_ctx(), serial_number="GW9")
+        kw = mock_cmd.call_args.kwargs
+        assert kw["api_path"] == "network-troubleshooting/v1/gateways/GW9/disconnectClientAll"
+        assert kw["api_data"] == {}
+
+
+class TestCallErrorSurfacing:
+    @patch(_CMD)
+    async def test_non_2xx_raises_tool_error_with_detail(self, mock_cmd):
+        """A 4xx body must surface as a ToolError carrying the real message —
+        not be masked to a generic 'Error calling tool' in code mode."""
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_user_by_mac_on_ap,
+        )
+
+        mock_cmd.return_value = {
+            "code": 400,
+            "msg": {"message": "Bad Request", "errorCode": "HPE_GL_NETWORKING_ERROR_BAD_REQUEST"},
+        }
+        with pytest.raises(ToolError) as exc:
+            await central_disconnect_user_by_mac_on_ap(_ctx(), serial_number="CNT123", user_mac_address="x")
+        assert exc.value.args[0]["status_code"] == 400
+        assert "Bad Request" in exc.value.args[0]["message"]
+
+    @patch(_CMD)
+    async def test_upstream_exception_wrapped_as_tool_error(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
+            central_disconnect_user_by_mac_on_ap,
+        )
+
+        mock_cmd.side_effect = Exception("Client error from central: {'code': 400}")
+        with pytest.raises(ToolError) as exc:
+            await central_disconnect_user_by_mac_on_ap(_ctx(), serial_number="CNT123", user_mac_address="x")
+        assert exc.value.args[0]["status_code"] == 502
+        assert "Client error from central" in exc.value.args[0]["message"]
+
+
+class TestSwitchRename:
+    def test_switch_tool_exists_and_old_name_gone(self):
+        import hpe_networking_mcp.platforms.central.tools.actions as actions
+
+        assert hasattr(actions, "central_disconnect_client_switch")
+        assert not hasattr(actions, "central_disconnect_client_ap")


### PR DESCRIPTION
From an operator transcript: the AI couldn't disconnect a wireless client. Three root causes, all fixed.

## 1. Disconnect tools sent the wrong body field
The 5 MRT disconnect tools exposed a free-form `payload` dict hinting "typically `{mac_address}`", but the API requires specific fields that **differ between APs and gateways**. Every attempt 400'd. Replaced `payload` with explicit, correctly-named params building the exact body (live-verified — `userMacAddress` → **HTTP 202 INITIATED**):

| Tool | body |
|------|------|
| `central_disconnect_user_by_mac_on_ap` | `{"userMacAddress": …}` |
| `central_disconnect_user_by_network` | `{"networkName": …}` |
| `central_disconnect_user_all_on_ap` | _(none)_ |
| `central_disconnect_client_by_mac_on_gateway` | `{"clientMacAddress": …}` |
| `central_disconnect_client_all_on_gateway` | _(none)_ |

## 2. The real error was masked (undiagnosable)
`_call` let `retry_central_command`'s **bare `Exception`** propagate on a 4xx. `central_invoke_tool` only catches `ToolError` (issue #333), so the bare exception slipped past it and `mask_error_details=True` reduced it to the useless `Error calling tool …` — neither the AI nor the operator could see the underlying `400` (I recovered it from container logs). `_call` now raises `ToolError` with the real status + body, so `central_invoke_tool` returns a structured `{"status":"tool_error","status_code","message"}` and the direct path surfaces readable text via `SandboxErrorCatch`. (`SandboxErrorCatch` itself was working as designed — it can only show what reaches it; the fix is upstream.)

## 3. Misleading tool name
`central_disconnect_client_ap` → **`central_disconnect_client_switch`** — it targets switches (`aos-s`/`cx`), not APs, and the name sent the AI down the wrong path. Updated the registration list, INSTRUCTIONS.md, docs/TOOLS.md, and the "from AP" → "from switch" error strings.

## Also
Removed the false "fires elicitation" docstrings — these OPERATIONAL troubleshooting tools run immediately with no confirmation (consistent with port/PoE bounce, per maintainer).

## Tests
New `tests/unit/test_central_disconnect_tools.py` (8) pins each tool's exact body, the `ToolError` surfacing (400 detail + 502 wrap), and the rename. Full suite: **1476 passed, 1 skipped**; ruff/mypy clean. Patch bump → **3.2.1.5**.