### PR TITLE
fix(central): retry_central_command raises ToolError (fix masked errors globally)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.6] - 2026-05-21
+
+**Patch — `retry_central_command` raises `ToolError`, fixing the masked-error class globally.** v3.2.1.5 fixed error visibility for the `mrt_troubleshooting` family; this generalizes it to **every** Central tool. The helper previously raised a bare `Exception` on 4xx and after exhausting retries — and a bare exception propagating through `central_invoke_tool` (which only catches `ToolError`, issue #333) or the code-mode sandbox gets reduced by `mask_error_details=True` to the useless `Error calling tool …`, leaving the AI nothing to act on.
+
+Now it raises `ToolError({"status_code", "message"})`:
+- **4xx** → the real upstream status code + body, immediately.
+- **Retry exhaustion** → the last transient code (429/5xx) when present, else `502`.
+
+`ToolError` is exempt from masking, so the real detail survives to the caller. Callers using the error-contract passthrough (`except ToolError: raise`) now get the precise upstream code; callers that only `except Exception: raise ToolError(502, …)` still preserve the message (relabelled 502) — no regression.
+
+Updated `tests/unit/test_central_retry.py` to assert the `ToolError` payloads (4xx code preserved; exhaustion keeps the last transient code). Full suite green (1476 passed, 1 skipped); ruff/mypy/bandit clean.
+
 ## [3.2.1.5] - 2026-05-21
 
 **Patch — fix the Central client-disconnect tools (broken payload contract) + make their failures diagnosable.** Surfaced from an operator transcript where the AI couldn't disconnect a wireless client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.5"
+version = "3.2.1.6"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from fastmcp.exceptions import ToolError
 from loguru import logger
 
 from hpe_networking_mcp.platforms.central.models import (
@@ -292,7 +293,12 @@ def retry_central_command(
         api_data: Request body payload (sent as JSON for POST/PUT).
         max_retries: Max retry attempts for transient errors.
 
-    Client errors (4xx) are raised immediately.
+    Raises:
+        ToolError: On client errors (4xx, immediate) and after exhausting
+            retries on transient failures. The structured payload carries the
+            real ``status_code`` + ``message`` so the error survives code-mode
+            masking (a bare ``Exception`` here gets reduced to "Error calling
+            tool …" and the AI can't self-correct).
     """
     api_params = api_params or {}
     api_data = api_data or {}
@@ -349,11 +355,15 @@ def retry_central_command(
 
         # client errors -> raise immediately
         if 400 <= code < 500:
-            raise Exception(f"Client error from central: {resp}")
+            raise ToolError({"status_code": code, "message": f"Central API error (HTTP {code}): {resp.get('msg')}"})
 
         last_response = resp
 
-    raise Exception(f"Failed after {max_retries} attempts: {last_response}")
+    last_code = (last_response or {}).get("code", 0)
+    status = last_code if isinstance(last_code, int) and 400 <= last_code < 600 else 502
+    raise ToolError(
+        {"status_code": status, "message": f"Central API unreachable after {max_retries} attempts: {last_response}"}
+    )
 
 
 def transform_to_site_data(site_raw: dict) -> SiteData:

--- a/tests/unit/test_central_retry.py
+++ b/tests/unit/test_central_retry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central.utils import (
     _retry_backoff_secs,
@@ -60,16 +61,22 @@ class TestRetryBackoff:
         assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5]
 
     @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_exhausts_retries_then_raises_without_sleeping_after_last(self, mock_sleep):
-        conn = _conn([{"code": 500, "msg": {"message": "down"}}] * 5)
-        with pytest.raises(Exception, match="Failed after 5 attempts"):
+    def test_exhausts_retries_then_raises_toolerror_without_sleeping_after_last(self, mock_sleep):
+        conn = _conn([{"code": 503, "msg": {"message": "down"}}] * 5)
+        with pytest.raises(ToolError) as exc:
             retry_central_command(conn, "GET", "network-services/v1/audits")
+        # exhaustion preserves the last transient code, not a generic 500
+        assert exc.value.args[0]["status_code"] == 503
+        assert "after 5 attempts" in exc.value.args[0]["message"]
         # 5 attempts -> sleeps after attempts 1..4 only (no sleep after the last)
         assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0, 2.0, 4.0]
 
     @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_4xx_raises_immediately_no_sleep(self, mock_sleep):
+    def test_4xx_raises_toolerror_immediately_no_sleep(self, mock_sleep):
         conn = _conn([{"code": 400, "msg": {"message": "bad"}}])
-        with pytest.raises(Exception, match="Client error"):
+        with pytest.raises(ToolError) as exc:
             retry_central_command(conn, "GET", "network-services/v1/audits")
+        # real 4xx code is preserved (not masked, not relabelled 502)
+        assert exc.value.args[0]["status_code"] == 400
+        assert "bad" in exc.value.args[0]["message"]
         mock_sleep.assert_not_called()


### PR DESCRIPTION
Follow-up to #374 (v3.2.1.5), which fixed masked errors for the `mrt_troubleshooting` disconnect family. This generalizes the fix to **every** Central tool.

## Problem
`retry_central_command` raised a bare `Exception` on a 4xx and after exhausting retries. A bare exception propagating through `central_invoke_tool` (which only catches `ToolError`, issue #333) or the code-mode sandbox gets reduced by `mask_error_details=True` to the useless `Error calling tool …` — the AI/operator can't see the real cause. This is the class of failure behind the disconnect-tool transcript.

## Change
`retry_central_command` now raises `ToolError({"status_code", "message"})`:
- **4xx** → the real upstream status code + body, immediately.
- **Retry exhaustion** → the last transient code (429/5xx) when present, else `502`.

`ToolError` is exempt from masking, so the detail survives to the caller everywhere `retry_central_command` is used.

## Compatibility
- Callers using the error-contract passthrough (`except ToolError: raise`) now get the **precise** upstream code.
- Callers that only `except Exception: raise ToolError(502, …)` still catch it (ToolError is an Exception) and **preserve the message** (relabelled 502) — no regression.
- Full suite passes unchanged (no caller test asserted the old bare-Exception messages besides the retry test itself).

## Tests
Updated `tests/unit/test_central_retry.py`: exhaustion → `ToolError` with the last transient code (503); 4xx → `ToolError` with the real `400` (not masked, not relabelled). Full suite: **1476 passed, 1 skipped**; ruff/mypy/bandit clean. Patch bump → **3.2.1.6**.

## Note (follow-up, not in scope)
Callers wrapping `retry_central_command` with only `except Exception: raise ToolError(502)` still relabel a real 4xx as 502 (message preserved). Adding the `except ToolError: raise` passthrough to those would give precise codes — opportunistic, per the error-contract migration policy.