### PR TITLE
v3.2.1.8: refresh Central config-model tools against updated specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.8] - 2026-05-21
+
+**Patch — refresh Central config-model tools against an updated `api-endpoints/central/config/` spec snapshot.** Re-ran the diff between the maintainer's refreshed config-model OpenAPI specs and the committed tools; 3 of 19 generated modules had drifted.
+
+### Added — Application Experience DAP family (6 tools)
+Three net-new config-object specs (`dap`, `dap-application`, `dap-sla`, tag-group *Application Experience*, full CRUD) gained tools:
+- `central_get_dap` / `central_manage_dap`
+- `central_get_dap_application` / `central_manage_dap_application`
+- `central_get_dap_sla` / `central_manage_dap_sla`
+
+### Changed — `system-info` is now a named collection
+The `system-info` spec changed from a singleton to a collection with a `/system-info/{name}` item path (full CRUD). `central_get_system_info` now accepts an optional `name` (omit → list all); `central_manage_system_info` now takes a `name`. Previously both only addressed the singleton URL, leaving named profiles unreachable.
+
+### Changed — `mesh` docstring
+`central_get_mesh` / `central_manage_mesh` (Wireless) picked up the spec's richer Mesh-profile description. Docstring-only; no signature change.
+
+These three module files were regenerated from the current specs (verified to contain no hand-edits beyond the spec-driven deltas, so regeneration is equivalent to a surgical edit). The other 16 generated modules and all 15 hand-curated types were unchanged by the spec refresh.
+
+Central: 614 → 620 underlying tools; server-wide 1916 → 1922. Updated README, docs/TOOLS.md.
+
 ## [3.2.1.7] - 2026-05-21
 
 **Patch — new tool `central_resync_device_config`.** Adds a config-resync companion to the existing config-health diagnostics (`config_health.py`). Forces Central to re-push the intended configuration to one or more devices — the standard remediation when `central_get_devices_config_health` / `central_get_device_config_issues` show a device `OUT_OF_SYNC` or with `CONFIG_PUSH_FAILURES`.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ | — |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **1037 + 2 prompts** | **614 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** | **21** |
+| **Underlying tools** | **1037 + 2 prompts** | **620 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** | **21** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1916 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1916 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -525,10 +525,10 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐│
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │ │  UXI   ││
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │ │ uxi_*  ││
-│ │ 1037   │ │614tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
+│ │ 1037   │ │620tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │ │        ││
 │                                                                                         │
-│  All 1916 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1922 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘│
 │     │          │          │          │          │          │          │          │       │
@@ -543,7 +543,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1916 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1922 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `uxi_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -607,7 +607,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (sensor/agent/group/assignment mutations) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1916 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1922 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -802,25 +802,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1916)
+### Tool Surface Looks Wrong (6 tools vs. 1922)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1916 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1916 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1922 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1916 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1922 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1916 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1916 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1922 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1916 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1922 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1916 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1916 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1922 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1916 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -716,7 +716,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (615 tools + 12 prompts)
+## Aruba Central (621 tools + 12 prompts)
 
 > **v3.1.1.0**: bulk-imported 197 net-new config-model object types (389 net-new tools across 19 new modules) from the gitignored local snapshot at `api-endpoints/central/config/`. See the **Config-Model Tools** section at the end of the Central section for the new module inventory and the `central_get_<type>` / `central_manage_<type>` naming convention. The 15 hand-curated tool pairs documented in detail below (sites, devices, alerts, security_policy, wlan_profiles, gateway_clusters, named_vlans, aliases, server_groups, config_assignments, scope, gateway_cluster_intent) keep their tuned docstrings and edge-case handling.
 
@@ -1650,7 +1650,7 @@ Five asymmetric specs emit only one of the pair (GET-only or POST-only — `cust
 
 | Module file | Tool count | x-tag-group | Object types covered |
 |---|---|---|---|
-| `application_experience.py` | 4 | Application Experience | app-bandwidth-contract, app-recog-control |
+| `application_experience.py` | 10 | Application Experience | app-bandwidth-contract, app-recog-control, dap, dap-application, dap-sla |
 | `central_nac.py` | 21 | Central NAC (full CDA surface) | cda-airpass-approval, cda-auth-profile, cda-authz-policy, cda-identity-store, cda-message-provider, cda-portal-{custom-message, default-custom-message, overrides-profile, profile, skin-profile}, cda-static-tag |
 | `config_management.py` | 4 | Config Management | config-checkpoint, persona-assignment, persona-mapping |
 | `extensions.py` | 6 | Extensions | extension-splunk, extension-vsphere, psm |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.7"
+version = "3.2.1.8"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -132,6 +132,12 @@ TOOLS = {
         "central_manage_app_bandwidth_contract",
         "central_get_app_recog_control",
         "central_manage_app_recog_control",
+        "central_get_dap",
+        "central_manage_dap",
+        "central_get_dap_application",
+        "central_manage_dap_application",
+        "central_get_dap_sla",
+        "central_manage_dap_sla",
     ],
     "central_nac": [
         "central_get_cda_airpass_approval",

--- a/src/hpe_networking_mcp/platforms/central/tools/application_experience.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/application_experience.py
@@ -148,3 +148,171 @@ async def central_manage_app_recog_control(
         device_function,
         confirmed,
     )
+
+
+# ----- dap -----
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_dap(
+    ctx: Context,
+    name: str | None = None,
+) -> dict | list | str:
+    """Get ``dap`` configurations from Central.
+
+    Dynamic application prioritization(DAP) is an application-aware QoS feature. Unlike traditional QoS methods that treat all traffic matching a classification the same, dynamic application prioritization adjusts based on each individual application’s needs. Dynamic Application Priorization automatically adjusts the advanced RF parameters such as uplink-scheduling to satisfy stringent SLAs of business-critical applications. This ensures improved user experience even in the most challenging RF conditions.
+
+    Parameters:
+        name: Specific ``dap`` identifier (OpenAPI path param: ``name``). If omitted, returns all.
+    """
+    return await _get_resource(ctx, "dap", name)
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_dap(
+    ctx: Context,
+    name: Annotated[str, Field(description="``dap`` identifier (OpenAPI path param: ``name``).")],
+    action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Payload for the ``dap`` object. "
+                "Consult the Aruba Central config-model OpenAPI schema for the "
+                "field set; use ``central_get_dap`` to "
+                "inspect an existing object for reference. "
+                "For ``delete``, ``payload`` is ignored."
+            )
+        ),
+    ],
+    scope_id: Annotated[str | None, _SCOPE_ID_FIELD] = None,
+    device_function: Annotated[str | None, _DEVICE_FUNCTION_FIELD] = None,
+    confirmed: Annotated[bool, _CONFIRMED_FIELD] = False,
+) -> dict | str:
+    """Create, update, or delete a ``dap`` configuration in Central.
+
+    Dynamic application prioritization(DAP) is an application-aware QoS feature. Unlike traditional QoS methods that treat all traffic matching a classification the same, dynamic application prioritization adjusts based on each individual application’s needs. Dynamic Application Priorization automatically adjusts the advanced RF parameters such as uplink-scheduling to satisfy stringent SLAs of business-critical applications. This ensures improved user experience even in the most challenging RF conditions.
+    """
+    return await _manage_resource(
+        ctx,
+        "dap",
+        "dap",
+        name,
+        action_type,
+        payload,
+        scope_id,
+        device_function,
+        confirmed,
+    )
+
+
+# ----- dap-application -----
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_dap_application(
+    ctx: Context,
+    name: str | None = None,
+) -> dict | list | str:
+    """Get ``dap-application`` configurations from Central.
+
+    Configure a DAP application profile is for optimizing this application. One DAP SLA profile has to be configured under the DAP application profile knob to indicate how to optimize this application. The application profile number can be up to 32.
+
+    Parameters:
+        name: Specific ``dap-application`` identifier (OpenAPI path param: ``name``). If omitted, returns all.
+    """
+    return await _get_resource(ctx, "dap-application", name)
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_dap_application(
+    ctx: Context,
+    name: Annotated[str, Field(description="``dap-application`` identifier (OpenAPI path param: ``name``).")],
+    action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Payload for the ``dap-application`` object. "
+                "Consult the Aruba Central config-model OpenAPI schema for the "
+                "field set; use ``central_get_dap_application`` to "
+                "inspect an existing object for reference. "
+                "For ``delete``, ``payload`` is ignored."
+            )
+        ),
+    ],
+    scope_id: Annotated[str | None, _SCOPE_ID_FIELD] = None,
+    device_function: Annotated[str | None, _DEVICE_FUNCTION_FIELD] = None,
+    confirmed: Annotated[bool, _CONFIRMED_FIELD] = False,
+) -> dict | str:
+    """Create, update, or delete a ``dap-application`` configuration in Central.
+
+    Configure a DAP application profile is for optimizing this application. One DAP SLA profile has to be configured under the DAP application profile knob to indicate how to optimize this application. The application profile number can be up to 32.
+    """
+    return await _manage_resource(
+        ctx,
+        "dap-application",
+        "dap-application",
+        name,
+        action_type,
+        payload,
+        scope_id,
+        device_function,
+        confirmed,
+    )
+
+
+# ----- dap-sla -----
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_dap_sla(
+    ctx: Context,
+    name: str | None = None,
+) -> dict | list | str:
+    """Get ``dap-sla`` configurations from Central.
+
+    Dynamic application prioritization(DAP) SLA profile allow to configure some SLA parameters such as latency, jitter, and so on, based on which some specific applications can be optimized. A name is a unique identifier that names an DAP SLA profile, the SLA profile numbers can be up to 32.
+
+    Parameters:
+        name: Specific ``dap-sla`` identifier (OpenAPI path param: ``name``). If omitted, returns all.
+    """
+    return await _get_resource(ctx, "dap-sla", name)
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_dap_sla(
+    ctx: Context,
+    name: Annotated[str, Field(description="``dap-sla`` identifier (OpenAPI path param: ``name``).")],
+    action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Payload for the ``dap-sla`` object. "
+                "Consult the Aruba Central config-model OpenAPI schema for the "
+                "field set; use ``central_get_dap_sla`` to "
+                "inspect an existing object for reference. "
+                "For ``delete``, ``payload`` is ignored."
+            )
+        ),
+    ],
+    scope_id: Annotated[str | None, _SCOPE_ID_FIELD] = None,
+    device_function: Annotated[str | None, _DEVICE_FUNCTION_FIELD] = None,
+    confirmed: Annotated[bool, _CONFIRMED_FIELD] = False,
+) -> dict | str:
+    """Create, update, or delete a ``dap-sla`` configuration in Central.
+
+    Dynamic application prioritization(DAP) SLA profile allow to configure some SLA parameters such as latency, jitter, and so on, based on which some specific applications can be optimized. A name is a unique identifier that names an DAP SLA profile, the SLA profile numbers can be up to 32.
+    """
+    return await _manage_resource(
+        ctx,
+        "dap-sla",
+        "dap-sla",
+        name,
+        action_type,
+        payload,
+        scope_id,
+        device_function,
+        confirmed,
+    )

--- a/src/hpe_networking_mcp/platforms/central/tools/system.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/system.py
@@ -1852,26 +1852,32 @@ async def central_manage_sysmon(
 @tool(annotations=READ_ONLY)
 async def central_get_system_info(
     ctx: Context,
+    name: str | None = None,
 ) -> dict | list | str:
-    """Get the ``system-info`` singleton configuration from Central.
+    """Get ``system-info`` configurations from Central.
 
-    System information provides key details about the Aruba device, including hardware model, software version, serial number, and operational status. This information is essential for inventory management, support, and troubleshooting. Use this API to retrieve system information for Aruba devices.
+    System information provides key details about the Aruba device, including hardware model, software version, serial number, and operational status. This information is essential for inventory management, support, and troubleshooting. Use this API to retrieve the list of System Information profiles.
+
+    Parameters:
+        name: Specific ``system-info`` identifier (OpenAPI path param: ``name``). If omitted, returns all.
     """
-    return await _get_resource(ctx, "system-info", None)
+    return await _get_resource(ctx, "system-info", name)
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
 async def central_manage_system_info(
     ctx: Context,
+    name: Annotated[str, Field(description="``system-info`` identifier (OpenAPI path param: ``name``).")],
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
     payload: Annotated[
         dict,
         Field(
             description=(
-                "Payload for the singleton ``system-info`` object. "
+                "Payload for the ``system-info`` object. "
                 "Consult the Aruba Central config-model OpenAPI schema for the "
                 "field set; use ``central_get_system_info`` to "
-                "inspect the current state. For ``delete``, ``payload`` is ignored."
+                "inspect an existing object for reference. "
+                "For ``delete``, ``payload`` is ignored."
             )
         ),
     ],
@@ -1879,15 +1885,15 @@ async def central_manage_system_info(
     device_function: Annotated[str | None, _DEVICE_FUNCTION_FIELD] = None,
     confirmed: Annotated[bool, _CONFIRMED_FIELD] = False,
 ) -> dict | str:
-    """Create, update, or delete the singleton ``system-info`` configuration in Central.
+    """Create, update, or delete a ``system-info`` configuration in Central.
 
-    System information provides key details about the Aruba device, including hardware model, software version, serial number, and operational status. This information is essential for inventory management, support, and troubleshooting. Use this API to retrieve system information for Aruba devices.
+    System information provides key details about the Aruba device, including hardware model, software version, serial number, and operational status. This information is essential for inventory management, support, and troubleshooting. Use this API to retrieve the list of System Information profiles.
     """
     return await _manage_resource(
         ctx,
         "system-info",
         "system-info",
-        None,
+        name,
         action_type,
         payload,
         scope_id,

--- a/src/hpe_networking_mcp/platforms/central/tools/wireless.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wireless.py
@@ -160,7 +160,7 @@ async def central_get_mesh(
 ) -> dict | list | str:
     """Get ``mesh`` configurations from Central.
 
-    Configuration data for Mesh network topology.
+    Configure and retrieve Mesh profiles for Aruba Access Points, enabling wireless backhaul connectivity between mesh portals and mesh points. These profiles define mesh cluster settings, band selection, topology behavior, role selection, and recovery parameters used to build and maintain the mesh network. Use this API to retrieve the list of Mesh profiles.
 
     Parameters:
         name: Specific ``mesh`` identifier (OpenAPI path param: ``name``). If omitted, returns all.
@@ -191,7 +191,7 @@ async def central_manage_mesh(
 ) -> dict | str:
     """Create, update, or delete a ``mesh`` configuration in Central.
 
-    Configuration data for Mesh network topology.
+    Configure and retrieve Mesh profiles for Aruba Access Points, enabling wireless backhaul connectivity between mesh portals and mesh points. These profiles define mesh cluster settings, band selection, topology behavior, role selection, and recovery parameters used to build and maintain the mesh network. Use this API to retrieve the list of Mesh profiles.
     """
     return await _manage_resource(
         ctx,


### PR DESCRIPTION
## Summary

Diffed the refreshed `api-endpoints/central/config/` spec snapshot against the committed config-model tools. **3 of 19 generated modules drifted**; the other 16 generated modules and all 15 hand-curated types were unchanged.

## Added — Application Experience DAP family (6 tools)

Three net-new specs (`dap`, `dap-application`, `dap-sla`; tag-group *Application Experience*; full CRUD):

| Tool pair |
|---|
| `central_get_dap` / `central_manage_dap` |
| `central_get_dap_application` / `central_manage_dap_application` |
| `central_get_dap_sla` / `central_manage_dap_sla` |

## Changed

- **`system-info` → named collection.** The spec gained `/system-info/{name}` (full CRUD). `central_get_system_info` now accepts an optional `name` (omit → list all); `central_manage_system_info` now takes `name`. Previously both only addressed the singleton URL, leaving named profiles unreachable.
- **`mesh` docstring** refreshed to the spec's richer Mesh-profile description. Docstring-only; no signature change.

The 3 module files were regenerated from the current specs (verified to contain no hand-edits beyond the spec-driven deltas, so regeneration is equivalent to a surgical edit).

## Tool count

- Central: 614 → 620
- Server-wide: 1916 → 1922

## Docs + tests

- README (comparison table + diagram), docs/TOOLS.md (counts + module table), CHANGELOG, version → 3.2.1.8.
- Full suite green: 1478 passed, 1 skipped; ruff/format/mypy clean.

## Note (separate from this PR)

Reviewed all 15 hand-curated types against their current specs: 14 match. **`policy-group`** exposes a per-entry item path (`/policy-groups/policy-group/policy-group-list/{name}`, full CRUD) that the tool doesn't wrap — it only manages at the collection level, and its docstring incorrectly claims "there is no per-name path." Flagged for a follow-up decision; not included here.