### PR TITLE
v3.2.1.9: add per-entry policy-group tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.9] - 2026-05-21
+
+**Patch — add per-entry policy-group tools.** Follow-up to the v3.2.1.8 spec review, which found the `policy-group` spec exposes a per-entry item path (`/policy-groups/policy-group/policy-group-list/{name}`, full CRUD) that the hand-curated tools didn't wrap — they only managed at the collection level, and a docstring incorrectly claimed "there is no per-name path."
+
+Added (2 tools):
+- `central_get_policy_group_entry(name)` — fetch a single policy-group-list entry by name.
+- `central_manage_policy_group_entry(name, action_type, payload, …)` — create/update/delete a single entry without rewriting the whole evaluation order. Gated by `ENABLE_CENTRAL_WRITE_TOOLS=true` + chat confirmation on non-create actions (same as the collection-level tool).
+
+The existing `central_get_policy_groups` / `central_manage_policy_group` (collection-level, wholesale replace) are unchanged except for corrected docstrings that now cross-reference the per-entry tools. Both delegate to the shared `_get_resource` / `_manage_resource` helpers, which build the nested item path from `api_base="policy-groups/policy-group/policy-group-list"`.
+
+Central: 620 → 622 underlying tools; server-wide 1922 → 1924. Updated README, docs/TOOLS.md; added `tests/unit/test_central_policy_group_entry.py`.
+
 ## [3.2.1.8] - 2026-05-21
 
 **Patch — refresh Central config-model tools against an updated `api-endpoints/central/config/` spec snapshot.** Re-ran the diff between the maintainer's refreshed config-model OpenAPI specs and the committed tools; 3 of 19 generated modules had drifted.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ | — |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **1037 + 2 prompts** | **620 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** | **21** |
+| **Underlying tools** | **1037 + 2 prompts** | **622 + 12 prompts** | **10** | **140** | **19** | **25** | **47 + 9 prompts** | **21** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -525,10 +525,10 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐│
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │ │  UXI   ││
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │ │ uxi_*  ││
-│ │ 1037   │ │620tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
+│ │ 1037   │ │622tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │ │        ││
 │                                                                                         │
-│  All 1922 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1924 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘│
 │     │          │          │          │          │          │          │          │       │
@@ -543,7 +543,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1922 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1924 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `uxi_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -607,7 +607,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (sensor/agent/group/assignment mutations) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1922 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1924 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -802,25 +802,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1922)
+### Tool Surface Looks Wrong (6 tools vs. 1924)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1922 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1922 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1924 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1922 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1924 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1922 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1924 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1922 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1924 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1922 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1924 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1922 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -716,7 +716,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (621 tools + 12 prompts)
+## Aruba Central (623 tools + 12 prompts)
 
 > **v3.1.1.0**: bulk-imported 197 net-new config-model object types (389 net-new tools across 19 new modules) from the gitignored local snapshot at `api-endpoints/central/config/`. See the **Config-Model Tools** section at the end of the Central section for the new module inventory and the `central_get_<type>` / `central_manage_<type>` naming convention. The 15 hand-curated tool pairs documented in detail below (sites, devices, alerts, security_policy, wlan_profiles, gateway_clusters, named_vlans, aliases, server_groups, config_assignments, scope, gateway_cluster_intent) keep their tuned docstrings and edge-case handling.
 
@@ -1516,7 +1516,11 @@ and optional `scope_id` + `device_function` for local (scoped) objects.
 
 #### `central_get_policy_groups` / `central_manage_policy_group`
 
-> Policy groups — define the evaluation sequence for all firewall policies. Collection-level resource (no per-name path).
+> Policy groups — define the evaluation sequence for all firewall policies. Collection-level: `central_manage_policy_group` replaces the entire evaluation order wholesale. API: `network-config/v1alpha1/policy-groups`.
+
+#### `central_get_policy_group_entry` / `central_manage_policy_group_entry`
+
+> Per-entry counterparts to the collection tools above — get or create/update/delete a single policy-group-list entry by name without rewriting the whole list. Manage tool gated by `ENABLE_CENTRAL_WRITE_TOOLS=true`. API: `network-config/v1alpha1/policy-groups/policy-group/policy-group-list/{name}`.
 
 #### `central_get_role_gpids` / `central_manage_role_gpid`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.8"
+version = "3.2.1.9"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -99,6 +99,8 @@ TOOLS = {
     "security_policy_ext": [
         "central_get_policy_groups",
         "central_manage_policy_group",
+        "central_get_policy_group_entry",
+        "central_manage_policy_group_entry",
         "central_get_role_gpids",
         "central_manage_role_gpid",
     ],

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
@@ -45,8 +45,8 @@ async def central_get_policy_groups(
 
     Policy groups define the evaluation sequence for all firewall
     policies. They control the order in which policies are applied
-    to traffic. This is a global configuration — there is no
-    per-name lookup.
+    to traffic. This returns the whole collection; to fetch a single
+    entry by name use ``central_get_policy_group_entry``.
     """
     return await _get_resource(ctx, "policy-groups", None)
 
@@ -77,9 +77,10 @@ async def central_manage_policy_group(
 ) -> dict | str:
     """Create, update, or delete the policy group configuration.
 
-    Unlike other resources, policy-groups operate at the collection
-    level — there is no per-name path. The payload defines the entire
-    policy evaluation order.
+    This operates at the collection level — the payload defines the
+    entire policy evaluation order, replacing it wholesale. To edit a
+    single entry by name without rewriting the whole list, use
+    ``central_manage_policy_group_entry`` instead.
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
@@ -134,6 +135,65 @@ async def central_manage_policy_group(
         return {"status": "success", "action": action_type, "data": response.get("msg", {})}
 
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_policy_group_entry(
+    ctx: Context,
+    name: Annotated[str, Field(description="Name of the policy-group-list entry to fetch.")],
+) -> dict | list | str:
+    """Get a single policy-group-list entry by name from Central.
+
+    Targeted, per-entry counterpart to ``central_get_policy_groups``
+    (which returns the whole collection). Wraps the
+    ``/policy-groups/policy-group/policy-group-list/{name}`` item path —
+    use this to inspect one entry's position/description without
+    pulling the entire evaluation order.
+
+    Parameters:
+        name: The policy-group-list entry name.
+    """
+    return await _get_resource(ctx, "policy-groups/policy-group/policy-group-list", name)
+
+
+@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+async def central_manage_policy_group_entry(
+    ctx: Context,
+    name: Annotated[str, Field(description="Name of the policy-group-list entry to create/update/delete.")],
+    action_type: Annotated[str, Field(description="'create', 'update', or 'delete'.")],
+    payload: Annotated[
+        dict,
+        Field(
+            description=(
+                "Policy-group-list entry payload. Key fields: name, "
+                "position (evaluation order), description. Use "
+                "central_get_policy_group_entry to inspect an existing "
+                "entry for reference. For 'delete', payload is ignored."
+            )
+        ),
+    ],
+    scope_id: Annotated[str | None, _SCOPE_ID_FIELD] = None,
+    device_function: Annotated[str | None, _DEVICE_FUNCTION_FIELD] = None,
+    confirmed: Annotated[bool, _CONFIRMED_FIELD] = False,
+) -> dict | str:
+    """Create, update, or delete a single policy-group-list entry by name.
+
+    Targeted, per-entry counterpart to ``central_manage_policy_group``
+    (which replaces the whole collection). Wraps the
+    ``/policy-groups/policy-group/policy-group-list/{name}`` item path so
+    one entry can be edited without rewriting the entire evaluation order.
+    """
+    return await _manage_resource(
+        ctx,
+        "policy-groups/policy-group/policy-group-list",
+        "policy-group entry",
+        name,
+        action_type,
+        payload,
+        scope_id,
+        device_function,
+        confirmed,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_central_policy_group_entry.py
+++ b/tests/unit/test_central_policy_group_entry.py
@@ -1,0 +1,83 @@
+"""Unit tests for the per-entry policy-group tools (v3.2.1.9).
+
+``central_get_policy_group_entry`` / ``central_manage_policy_group_entry``
+wrap the nested item path
+``network-config/v1alpha1/policy-groups/policy-group/policy-group-list/{name}``
+via the shared ``_get_resource`` / ``_manage_resource`` helpers in
+``security_policy.py`` — so the mock target is ``retry_central_command``
+at that helper module's import site.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ITEM_PATH = "network-config/v1alpha1/policy-groups/policy-group/policy-group-list/web-rules"
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestGetPolicyGroupEntry:
+    @patch("hpe_networking_mcp.platforms.central.tools.security_policy.retry_central_command")
+    async def test_builds_nested_item_path(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.security_policy_ext import (
+            central_get_policy_group_entry,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {"name": "web-rules", "position": 1}}
+        result = await central_get_policy_group_entry(_ctx(), name="web-rules")
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == _ITEM_PATH
+        assert result == {"name": "web-rules", "position": 1}
+
+
+class TestManagePolicyGroupEntry:
+    @patch("hpe_networking_mcp.platforms.central.tools.security_policy.retry_central_command")
+    async def test_create_posts_to_nested_item_path(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.security_policy_ext import (
+            central_manage_policy_group_entry,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {}}
+        # action_type="create" does not trigger elicitation.
+        await central_manage_policy_group_entry(
+            _ctx(),
+            name="web-rules",
+            action_type="create",
+            payload={"name": "web-rules", "position": 1},
+        )
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "POST"
+        assert kwargs["api_path"] == _ITEM_PATH
+        assert kwargs["api_data"] == {"name": "web-rules", "position": 1}
+
+    @patch("hpe_networking_mcp.platforms.central.tools.security_policy.retry_central_command")
+    async def test_delete_uses_delete_method(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.security_policy_ext import (
+            central_manage_policy_group_entry,
+        )
+
+        mock_cmd.return_value = {"code": 200, "msg": {}}
+        # confirmed=True bypasses the elicitation prompt for non-create actions.
+        await central_manage_policy_group_entry(
+            _ctx(),
+            name="web-rules",
+            action_type="delete",
+            payload={},
+            confirmed=True,
+        )
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "DELETE"
+        assert kwargs["api_path"] == _ITEM_PATH


### PR DESCRIPTION
## Summary

Follow-up to the v3.2.1.8 spec review (#377). That review found the `policy-group` spec exposes a per-entry item path the hand-curated tools didn't wrap — they only managed at the collection level, and a docstring wrongly claimed *"there is no per-name path."* This adds per-entry coverage.

> **Stacked on #377.** Base is `feature/central-config-spec-refresh`, so this diff shows only the policy-group changes. **Merge #377 first**, then this (I'll rebase onto `main` if needed).

## Added (2 tools)

- `central_get_policy_group_entry(name)` — fetch a single policy-group-list entry by name.
- `central_manage_policy_group_entry(name, action_type, payload, …)` — create/update/delete a single entry without rewriting the whole evaluation order. Gated by `ENABLE_CENTRAL_WRITE_TOOLS=true` + chat confirmation on non-create actions.

Both delegate to the shared `_get_resource` / `_manage_resource` helpers, which build the nested item path `network-config/v1alpha1/policy-groups/policy-group/policy-group-list/{name}` from `api_base="policy-groups/policy-group/policy-group-list"`.

## Unchanged (except docstrings)

`central_get_policy_groups` / `central_manage_policy_group` (collection-level, wholesale replace) keep their behavior; their docstrings were corrected to cross-reference the new per-entry tools instead of claiming no per-name path exists.

## Tool count

- Central: 620 → 622
- Server-wide: 1922 → 1924

## Docs + tests

- docs/TOOLS.md (Roles & Policy section + counts), README, CHANGELOG, version → 3.2.1.9.
- New `tests/unit/test_central_policy_group_entry.py` (GET path, create→POST, delete→DELETE). Full suite green: 1481 passed, 1 skipped; ruff/format/mypy clean.