### PR TITLE
v3.2.1.10: structured ToolError payloads for all validation guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.10] - 2026-05-22
+
+**Patch — make the `ToolError` contract uniform: validation guards now raise structured payloads.** A sweep found 15 validation guards across Central (12) and AOS 8 (3) still raising `ToolError("plain string")` instead of the v3.2.0.1-codified `ToolError({"status_code": 400, "message": ...})`. They weren't broken (a string still raises, and `_invoke_tool` wraps it), but a client couldn't read `status_code` off them, and CLAUDE.md states all platforms moved to the structured form. Migrated all 15:
+
+- **Central (12):** `configuration.py` (×3: resource-id/collection-id/siteIds guards), `roles.py`, `gateway_clusters.py`, `gateway_cluster_intent.py`, `config_assignments.py` (×2: action_type + device_function), `security_policy.py` (the shared `_manage_resource` helper — covers every `central_manage_*` security-policy tool), `security_policy_ext.py`, `wlan_profiles.py` (×2: action_type + opmode).
+- **AOS 8 (3):** `writes.py` (the shared `_post_managed_object` body: action_type + identifier guards, plus the AAA server_type guard).
+
+All are input-validation failures → `status_code: 400`. No behavior change beyond the payload shape (the human-readable message text is preserved). `_invoke_tool` already handled both forms, so no caller breaks; skills/prompts reference tool names only, not the error shape. The `sandbox_error_catch.py` middleware string-raise is intentional (human-readable code-mode display) and left as-is.
+
+Updated `tests/unit/test_central_gateway_clusters.py` to assert the structured payload; added `tests/unit/test_central_aos8_toolerror_contract.py` locking the two shared helpers. Full suite green (1484 passed, 1 skipped); ruff/format/mypy clean.
+
+> Note: one more site of the same class exists in **Mist** (`_client.py` org_id guard), left out of this patch because the cleanup was scoped to Central + AOS 8.
+
 ## [3.2.1.9] - 2026-05-21
 
 **Patch — add per-entry policy-group tools.** Follow-up to the v3.2.1.8 spec review, which found the `policy-group` spec exposes a per-entry item path (`/policy-groups/policy-group/policy-group-list/{name}`, full CRUD) that the hand-curated tools didn't wrap — they only managed at the collection level, and a docstring incorrectly claimed "there is no per-name path."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.9"
+version = "3.2.1.10"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
@@ -58,9 +58,14 @@ async def _post_managed_object(
 ) -> dict[str, Any] | str:
     """Shared body for the 9 manage_X tools (WRITE-01..09)."""
     if action_type not in _ACTION_MAP:
-        raise ToolError(f"Invalid action_type {action_type!r}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type {action_type!r}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
     if not payload.get(identifier_field):
-        raise ToolError(f"payload must include {identifier_field!r}.")
+        raise ToolError({"status_code": 400, "message": f"payload must include {identifier_field!r}."})
 
     action = _ACTION_MAP[action_type]
     identifier = payload[identifier_field]
@@ -237,7 +242,12 @@ async def aos8_manage_aaa_server(
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
     """
     if server_type not in _AAA_SERVER_OBJECT_BY_TYPE:
-        raise ToolError(f"Invalid server_type {server_type!r}. Must be 'radius', 'tacacs', 'ldap', or 'internal'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid server_type {server_type!r}. Must be 'radius', 'tacacs', 'ldap', or 'internal'.",
+            }
+        )
     object_name = _AAA_SERVER_OBJECT_BY_TYPE[server_type]
     return await _post_managed_object(
         ctx=ctx,

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -181,11 +181,19 @@ async def central_manage_config_assignment(
     target scope (Global, site collection, or site) by name.
     """
     if action_type not in ("assign", "remove"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'assign' or 'remove'.")
+        raise ToolError(
+            {"status_code": 400, "message": f"Invalid action_type: {action_type}. Must be 'assign' or 'remove'."}
+        )
 
     if device_function not in VALID_DEVICE_FUNCTIONS:
         raise ToolError(
-            f"Invalid device_function: {device_function}. Valid values: {', '.join(sorted(VALID_DEVICE_FUNCTIONS))}"
+            {
+                "status_code": 400,
+                "message": (
+                    f"Invalid device_function: {device_function}. "
+                    f"Valid values: {', '.join(sorted(VALID_DEVICE_FUNCTIONS))}"
+                ),
+            }
         )
 
     conn = ctx.lifespan_context["central_conn"]

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -276,7 +276,7 @@ async def _execute_config_action(
     - DELETE: DELETE to {path}/bulk, body is {"items": [{"id": "..."}]}
     """
     if action_type in (ActionType.UPDATE, ActionType.DELETE) and not resource_id:
-        raise ToolError(f"Resource ID is required for {action_type.value} operations.")
+        raise ToolError({"status_code": 400, "message": f"Resource ID is required for {action_type.value} operations."})
 
     action_wording = {
         ActionType.CREATE: "create a new",
@@ -367,11 +367,11 @@ async def _execute_collection_site_action(
         payload: Must contain 'siteIds' list.
     """
     if not collection_id:
-        raise ToolError("collection_id is required for add_sites/remove_sites.")
+        raise ToolError({"status_code": 400, "message": "collection_id is required for add_sites/remove_sites."})
 
     site_ids = payload.get("siteIds", [])
     if not site_ids:
-        raise ToolError("payload must contain 'siteIds' list.")
+        raise ToolError({"status_code": 400, "message": "payload must contain 'siteIds' list."})
 
     conn = ctx.lifespan_context["central_conn"]
 

--- a/src/hpe_networking_mcp/platforms/central/tools/gateway_cluster_intent.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/gateway_cluster_intent.py
@@ -160,7 +160,12 @@ async def central_manage_gateway_cluster_intent_profile(
     realized cluster profiles manually via central_manage_gateway_cluster.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     api_path = f"network-config/v1alpha1/gw-cluster-intent-config/{name}"
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}

--- a/src/hpe_networking_mcp/platforms/central/tools/gateway_clusters.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/gateway_clusters.py
@@ -166,7 +166,12 @@ async def central_manage_gateway_cluster(
     Manual clusters are created here directly with explicit member gateways.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     api_path = f"network-config/v1alpha1/gateway-clusters/{name}"
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -213,7 +213,12 @@ async def central_manage_role(
     assign it to a scope if needed.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     api_path = f"network-config/v1alpha1/roles/{name}"
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -60,7 +60,12 @@ async def _manage_resource(
     ``firmware-compliance``) can use the same helper.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}
     api_method = method_map[action_type]

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy_ext.py
@@ -83,7 +83,12 @@ async def central_manage_policy_group(
     ``central_manage_policy_group_entry`` instead.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}
     api_method = method_map[action_type]

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -144,7 +144,12 @@ async def central_manage_wlan_profile(
     the payload will be dropped from the stored profile.
     """
     if action_type not in ("create", "update", "delete"):
-        raise ToolError(f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.")
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": f"Invalid action_type: {action_type}. Must be 'create', 'update', or 'delete'.",
+            }
+        )
 
     # Validate opmode on create/update to catch cross-platform translation errors
     if action_type in ("create", "update") and "opmode" in payload:
@@ -175,11 +180,16 @@ async def central_manage_wlan_profile(
         opmode = payload["opmode"]
         if opmode not in valid_opmodes:
             raise ToolError(
-                f"Invalid opmode '{opmode}'. "
-                "If you are syncing a WLAN from Mist, use the "
-                "sync_wlans_mist_to_central prompt instead of calling this "
-                "tool directly — it handles opmode translation automatically. "
-                f"Valid opmodes: {', '.join(sorted(valid_opmodes))}"
+                {
+                    "status_code": 400,
+                    "message": (
+                        f"Invalid opmode '{opmode}'. "
+                        "If you are syncing a WLAN from Mist, use the "
+                        "sync_wlans_mist_to_central prompt instead of calling this "
+                        "tool directly — it handles opmode translation automatically. "
+                        f"Valid opmodes: {', '.join(sorted(valid_opmodes))}"
+                    ),
+                }
             )
 
     api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}"

--- a/tests/unit/test_central_aos8_toolerror_contract.py
+++ b/tests/unit/test_central_aos8_toolerror_contract.py
@@ -1,0 +1,78 @@
+"""Contract tests: validation guards raise structured ToolError payloads (v3.2.1.10).
+
+These lock the two most-shared write helpers — Central's ``_manage_resource``
+(used by every ``central_manage_*`` security-policy tool) and AOS 8's
+``_post_managed_object`` body — to the structured
+``ToolError({"status_code": 400, "message": ...})`` form rather than a plain
+string. Both guards fire before any upstream client call, so a bare context
+mock is enough.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCentralManageResourceContract:
+    async def test_bad_action_type_raises_structured_400(self):
+        from hpe_networking_mcp.platforms.central.tools.security_policy import (
+            central_manage_net_group,
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await central_manage_net_group(
+                _ctx(),
+                name="x",
+                action_type="bogus",
+                payload={},
+                scope_id=None,
+                device_function=None,
+                confirmed=True,
+            )
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "Invalid action_type" in exc_info.value.args[0]["message"]
+
+
+class TestAos8WritesContract:
+    async def test_bad_action_type_raises_structured_400(self):
+        from hpe_networking_mcp.platforms.aos8.tools.writes import (
+            aos8_manage_ssid_profile,
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await aos8_manage_ssid_profile(
+                _ctx(),
+                config_path="/md",
+                action_type="bogus",
+                payload={"profile-name": "x"},
+                confirmed=True,
+            )
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "Invalid action_type" in exc_info.value.args[0]["message"]
+
+    async def test_missing_identifier_raises_structured_400(self):
+        from hpe_networking_mcp.platforms.aos8.tools.writes import (
+            aos8_manage_ssid_profile,
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await aos8_manage_ssid_profile(
+                _ctx(),
+                config_path="/md",
+                action_type="create",
+                payload={},  # missing 'profile-name'
+                confirmed=True,
+            )
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "profile-name" in exc_info.value.args[0]["message"]

--- a/tests/unit/test_central_gateway_clusters.py
+++ b/tests/unit/test_central_gateway_clusters.py
@@ -171,7 +171,7 @@ class TestManageGwClusterIntentProfile:
             central_manage_gateway_cluster_intent_profile,
         )
 
-        with pytest.raises(ToolError, match="Invalid action_type"):
+        with pytest.raises(ToolError) as exc_info:
             await central_manage_gateway_cluster_intent_profile(
                 _ctx(),
                 name="x",
@@ -181,6 +181,9 @@ class TestManageGwClusterIntentProfile:
                 device_function=None,
                 confirmed=True,
             )
+        # v3.2.1.10: validation errors carry the structured {status_code, message} payload.
+        assert exc_info.value.args[0]["status_code"] == 400
+        assert "Invalid action_type" in exc_info.value.args[0]["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the `ToolError` contract uniform. A sweep found **15 validation guards** across Central (12) and AOS 8 (3) still raising `ToolError("plain string")` instead of the v3.2.0.1-codified `ToolError({"status_code": 400, "message": ...})`. They weren't broken (a string still raises, and `_invoke_tool` wraps it), but a client couldn't read `status_code` off them, and CLAUDE.md states all platforms moved to the structured form.

## Sites migrated (all → `status_code: 400`)

**Central (12):**
- `configuration.py` ×3 (resource-id, collection-id, siteIds guards)
- `roles.py`, `gateway_clusters.py`, `gateway_cluster_intent.py`
- `config_assignments.py` ×2 (action_type + device_function)
- `security_policy.py` — the shared `_manage_resource` helper (covers **every** `central_manage_*` security-policy tool)
- `security_policy_ext.py`
- `wlan_profiles.py` ×2 (action_type + opmode)

**AOS 8 (3):**
- `writes.py` — the shared `_post_managed_object` body (action_type + identifier guards) + the AAA `server_type` guard

## Impact analysis (verified — no breakage)

- **`_invoke_tool`** already branches on `isinstance(payload, dict)`, so string payloads were wrapped and dict payloads spread — changing string→dict just moves these into the richer branch. No caller breaks.
- **`SandboxErrorCatch`** (code mode) handles `ToolError` generically; dict is already the norm post-sweep.
- **Skills / prompts** reference tool *names* only, never the validation-error shape.
- **Tests:** one existing test (`test_central_gateway_clusters.py`) updated to assert the structured payload; added `test_central_aos8_toolerror_contract.py` locking the two shared helpers.

The `sandbox_error_catch.py` middleware string-raise is intentional (human-readable code-mode display) and left as-is.

## Not included

The same class exists once more in **Mist** (`_client.py` org_id guard) — left out because this cleanup was scoped to Central + AOS 8. Easy follow-up if you want full uniformity.

## Tests

Full suite green: **1484 passed, 1 skipped**; ruff/format/mypy clean. No tool-count change (version → 3.2.1.10).