### PR TITLE
fix(code-mode): MRT items-shape guidance + cable-test poll budget controls (v3.2.1.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1.11] - 2026-05-26
+
+**Patch — code-mode robustness from an operator transcript: paginated-collection guidance + cable-test budget controls.** Two unrelated failure modes surfaced in a single code-mode `execute()` session, both fixed by hardening the layer rather than the AI.
+
+**1. Paginated-collection shape (#381).** An AI iterated `result["data"]` from `central_get_switches` as if it were a list and got `AttributeError: 'str' object has no attribute 'get'`. Root cause (reproduced live): the `network-monitoring/v1/*` MRT reads return the raw API envelope, so `data` is a **dict** `{"items": [...], "next", "total", "count"}`, not the rows. Iterating a dict yields its string keys, so the next `.get(...)` blows up. The rows live at `data["items"]`. (A few older hand-curated reads such as `central_get_aps` already unwrap to a bare list — so the shape genuinely isn't uniform, which is the trap.) Added a dedicated INSTRUCTIONS.md subsection documenting the shape and a defensive `rows()` helper that handles all three conventions (bare list / inner `{"result": ...}` / paginated `{"items": ...}`). Docs-only for this half — no behavior change.
+
+**2. Cable-test poll budget (#382).** A block calling `central_cable_test` plus a second read hit `TimeoutError: time limit exceeded: 31.1s > 30s`. `central_cable_test` is fire-and-poll — pycentral's `cable_test` blocks up to `max_attempts * poll_interval` (default 5 × 5 = ~25s) of synchronous polling, nearly the whole sandbox budget on its own. Two complementary fixes:
+
+- **Configurable sandbox budget.** The code-mode `MontySandboxProvider` wall-clock limit (`max_duration_secs`) was a hardcoded `30.0` in `server.py`. It's now driven by `ServerConfig.code_sandbox_max_duration_secs`, overridable via the `CODE_SANDBOX_MAX_DURATION_SECS` env var (default 30.0; invalid / non-positive values fall back to 30.0 with a warning).
+- **Exposed poll params on `central_cable_test`.** Added `max_attempts` / `poll_interval` (validated 1-10, `status_code: 400` on out-of-range) forwarded to pycentral, so callers can fit a tighter budget. Docstring + INSTRUCTIONS.md + TOOLS.md now warn to call it in its own `execute()` block and not chain other calls after it.
+
+Tests: `test_config.py` covers the new env var (default / override / invalid fallback); new `test_central_cable_test.py` covers param validation, forwarding, and the empty-result info string. No tool-count change.
+
 ## [3.2.1.10] - 2026-05-22
 
 **Patch — make the `ToolError` contract uniform: validation guards now raise structured payloads.** A sweep found 15 validation guards across Central (12) and AOS 8 (3) still raising `ToolError("plain string")` instead of the v3.2.0.1-codified `ToolError({"status_code": 400, "message": ...})`. They weren't broken (a string still raises, and `_invoke_tool` wraps it), but a client couldn't read `status_code` off them, and CLAUDE.md states all platforms moved to the structured form. Migrated all 15:

--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
 | `ENABLE_PII_TOKENIZATION` | `false` | Tokenize sensitive fields (PSKs, RADIUS secrets, hostnames, emails, etc.) in tool responses before they reach the AI. Round-trips: AI passes tokens back into write tools and the middleware substitutes plaintext. MAC normalization is always-on regardless of this toggle. See [PII Tokenization](#pii-tokenization-v2310) above. |
 | `PII_MAX_TOKENS_PER_SESSION` | `10000` | Soft cap on the per-session keymap size. Cap-hit logs a warning and falls through with plaintext rather than erroring out the call. |
+| `CODE_SANDBOX_MAX_DURATION_SECS` | `30.0` | Wall-clock budget for a single code-mode `execute()` block. Raise it when driving poll-and-wait tools (e.g. `central_cable_test`, which blocks up to ~25s). Invalid / non-positive values fall back to `30.0`. |
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1181,13 +1181,15 @@ Rule shape:
 
 #### `central_cable_test`
 
-> Initiate a cable test on switch ports (cable status and length).
+> Initiate a cable test on switch ports (cable status and length). Fire-and-poll: blocks up to `max_attempts * poll_interval` seconds. In code mode, call it in its own `execute()` block — it can consume most of the sandbox wall-clock budget.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | serial_number | str | Yes | Switch serial number. |
 | device_type | str | Yes | `aos-s` or `cx`. |
 | ports | str | Yes | Comma-separated port list (e.g. `1/1/1,1/1/2`). |
+| max_attempts | int | No | Result-poll attempts before giving up (1-10, default 5). |
+| poll_interval | int | No | Seconds between poll attempts (1-10, default 5). |
 
 #### `central_show_commands`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.1.10"
+version = "3.2.1.11"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -163,6 +163,37 @@ When tokenization is off, tool responses contain plaintext values — your behav
 
   Tools known to use the inner wrapper as of v3.0.0.0: most `central_*` and `aos8_*` reads (e.g. `central_get_sites`, `aos8_get_ap_database`, `aos8_get_effective_config`). Tools that return the payload directly (no inner wrapper): `health`, the 4 cross-platform tools, most `mist_*` reads. When in doubt, use the fallback pattern above — it's safe for both shapes.
 
+- **Many list tools return a PAGINATED COLLECTION, not a bare list.** The Central monitoring reads bulk-imported from `network-monitoring/v1/*` in v3.1.2.0 (the `mrt_*` family — e.g. `central_get_switches`, `central_get_gateways`, and the `*_trends` / `*_radios` / `*_ports` reads) return the raw API envelope, so `result["data"]` is a **dict** `{"items": [...], "next": ..., "total": ..., "count": ...}`, NOT the list of rows. The actual rows live at `result["data"]["items"]`. (A few older hand-curated reads such as `central_get_aps` already unwrap to a bare list at `result["data"]` — which is exactly why you can't assume one shape.)
+
+  This is the single most common code-mode mistake: assuming `data` is a list and iterating it. Iterating a dict yields its **string keys** (`"items"`, `"next"`, ...), so the next `.get(...)` call raises `AttributeError: 'str' object has no attribute 'get'`:
+
+  ```python
+  # ❌ Wrong — `data` is {"items": [...], ...}; this iterates the keys, then 'items'.get(...) raises.
+  switches = await call_tool("central_invoke_tool", {"name": "central_get_switches", "params": {}})
+  home = [s for s in (switches.get("data") or []) if s.get("siteName") == "HOME"]
+  ```
+
+  ```python
+  # ✅ Correct — reach the rows at data["items"].
+  switches = await call_tool("central_invoke_tool", {"name": "central_get_switches", "params": {}})
+  rows = (switches.get("data") or {}).get("items", [])
+  home = [s for s in rows if s.get("siteName") == "HOME"]
+  result = {"home_switches": home, "total": len(home)}
+  result
+  ```
+
+  Use this one defensive helper to get the rows regardless of which shape a read returns (bare list, inner `{"result": [...]}`, or paginated `{"items": [...]}`):
+
+  ```python
+  def rows(response):
+      d = response.get("data", response)
+      if isinstance(d, dict):
+          d = d.get("result", d)            # peel inner {"result": ...} wrapper
+          if isinstance(d, dict) and "items" in d:
+              return d["items"]             # paginated collection → its rows
+      return d if isinstance(d, list) else []
+  ```
+
 ## Code-mode `execute()` patterns
 
 Two rules — both are responses to live small-local-model failure modes (Zach's OpenClaw + Qwen3 4B test report, 2026-05-07).
@@ -241,6 +272,12 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 | `asyncio.gather()` | unavailable | Use sequential `await` calls — same wall-clock cost matters less here than in production async code |
 
 **This list grows as more failures surface.** If you hit a sandbox error not listed here, file an issue with the exact error message — both the documented blocklist and the `tests/unit/test_skill_snippet_sandbox_compat.py` lint update from the same evidence.
+
+### 4. Watch the wall-clock budget with poll-and-wait tools
+
+The sandbox kills any `execute()` block that runs longer than the configured budget (default 30s; operators can raise it via `CODE_SANDBOX_MAX_DURATION_SECS`). Most reads are sub-second, but a few tools **block while polling** an upstream task and can consume most of the budget on their own. The clearest example is `central_cable_test`, which polls for results up to `max_attempts * poll_interval` seconds (default 5 × 5 = ~25s).
+
+For these tools: **call them in their own `execute()` block — don't chain other calls after them** — and lower `max_attempts` / `poll_interval` when you need a tighter budget. A block that runs `central_cable_test` plus another Central read will routinely breach the default 30s with `TimeoutError: time limit exceeded`.
 
 ---
 

--- a/src/hpe_networking_mcp/config.py
+++ b/src/hpe_networking_mcp/config.py
@@ -164,6 +164,14 @@ class ServerConfig:
     enable_pii_tokenization: bool = False
     pii_max_tokens_per_session: int = 10_000
 
+    # Code-mode sandbox wall-clock budget (v3.2.1.11). The MontySandboxProvider
+    # kills an ``execute()`` block that runs longer than this. The default 30s
+    # is comfortable for read/compose workflows, but poll-and-wait operational
+    # tools (e.g. ``central_cable_test`` blocks up to ~25s of synchronous
+    # polling) can breach it when combined with other calls in one block.
+    # Raise via ``CODE_SANDBOX_MAX_DURATION_SECS`` when driving such tools.
+    code_sandbox_max_duration_secs: float = 30.0
+
     # Platform secrets — None means platform is disabled
     mist: MistSecrets | None = None
     central: CentralSecrets | None = None
@@ -537,6 +545,18 @@ def load_config() -> ServerConfig:
         )
         pii_max_tokens = 10_000
 
+    # Code-mode sandbox wall-clock budget (CODE_SANDBOX_MAX_DURATION_SECS).
+    # Must be positive; invalid or non-positive values fall back to 30s.
+    try:
+        sandbox_max_duration = float(os.getenv("CODE_SANDBOX_MAX_DURATION_SECS", "30"))
+        if sandbox_max_duration <= 0:
+            raise ValueError("must be positive")
+    except ValueError:
+        logger.warning(
+            "Invalid CODE_SANDBOX_MAX_DURATION_SECS; defaulting to 30.0",
+        )
+        sandbox_max_duration = 30.0
+
     # Load platform credentials from Docker secrets
     mist = _load_mist()
     central = _load_central()
@@ -565,6 +585,7 @@ def load_config() -> ServerConfig:
         allowed_origins=allowed_origins,
         enable_pii_tokenization=enable_pii_tokenization,
         pii_max_tokens_per_session=pii_max_tokens,
+        code_sandbox_max_duration_secs=sandbox_max_duration,
         mist=mist,
         central=central,
         greenlake=greenlake,

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -118,6 +118,8 @@ async def central_cable_test(
     serial_number: str,
     device_type: Literal["aos-s", "cx"],
     ports: str,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
 ) -> dict | str:
     """
     Initiate a cable test on switch ports.
@@ -125,11 +127,26 @@ async def central_cable_test(
     Returns cable status and length for each port. Useful for
     diagnosing physical layer issues.
 
+    This tool is fire-and-poll: it triggers the test, then blocks while
+    polling for the result up to ``max_attempts`` times at ``poll_interval``
+    seconds apart. The worst case is roughly ``max_attempts * poll_interval``
+    seconds of blocking. In code mode this counts against the sandbox
+    wall-clock budget (default 30s, see CODE_SANDBOX_MAX_DURATION_SECS), so
+    do NOT combine this call with other tool calls in one ``execute()`` block,
+    and lower ``max_attempts`` / ``poll_interval`` if you need a tighter budget.
+
     Parameters:
         serial_number: Switch serial number (required).
         device_type: Switch type — "aos-s" or "cx" (required).
         ports: Comma-separated port list, e.g. "1/1/1,1/1/2" (required).
+        max_attempts: Result-poll attempts before giving up (1-10, default 5).
+        poll_interval: Seconds between poll attempts (1-10, default 5).
     """
+    if not 1 <= max_attempts <= 10:
+        raise ToolError({"status_code": 400, "message": f"max_attempts must be 1-10, got {max_attempts}"})
+    if not 1 <= poll_interval <= 10:
+        raise ToolError({"status_code": 400, "message": f"poll_interval must be 1-10, got {poll_interval}"})
+
     conn = ctx.lifespan_context["central_conn"]
     resolved_id = _resolve_if_switch(conn, serial_number, device_type)
     port_list = [p.strip() for p in ports.split(",")]
@@ -140,6 +157,8 @@ async def central_cable_test(
             device_type=device_type,
             serial_number=resolved_id,
             ports=port_list,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
         )
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error running cable test: {e}"}) from e

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -387,7 +387,7 @@ def create_server(config: ServerConfig) -> FastMCP:
         # Cross-platform aggregators (site_health_check, site_rf_check,
         # manage_wlan_profile) were not registered above in code mode, so
         # they don't leak into Search's catalog.
-        _register_code_mode(mcp)
+        _register_code_mode(mcp, config.code_sandbox_max_duration_secs)
 
     return mcp
 
@@ -441,7 +441,7 @@ _GET_SCHEMA_DESCRIPTION = _SKILLS_FIRST_GATE + (
 )
 
 
-def _register_code_mode(mcp: FastMCP) -> None:
+def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
     Falls back with a warning if ``pydantic-monty`` isn't installed — the
@@ -490,7 +490,7 @@ def _register_code_mode(mcp: FastMCP) -> None:
             return tool
 
     limits = ResourceLimits(
-        max_duration_secs=30.0,
+        max_duration_secs=max_duration_secs,
         max_memory=128 * 1024 * 1024,
         max_recursion_depth=50,
     )

--- a/tests/unit/test_central_cable_test.py
+++ b/tests/unit/test_central_cable_test.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``central_cable_test`` poll-budget parameters.
+
+Regression coverage for issue #382: the tool is fire-and-poll (pycentral's
+``cable_test`` blocks up to ``max_attempts * poll_interval`` seconds), which
+can breach the code-mode sandbox wall-clock budget. The tool now exposes
+``max_attempts`` / ``poll_interval`` (validated, 1-10) and forwards them to
+pycentral.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from hpe_networking_mcp.platforms.central.tools.troubleshooting import central_cable_test
+
+pytestmark = pytest.mark.unit
+
+_TS = "hpe_networking_mcp.platforms.central.tools.troubleshooting.Troubleshooting"
+_RESOLVE = "hpe_networking_mcp.platforms.central.tools.troubleshooting._resolve_if_switch"
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCableTestPolling:
+    @patch(_RESOLVE, return_value="SW1")
+    @patch(_TS)
+    async def test_defaults_forward_5_by_5(self, mock_ts, _mock_resolve):
+        mock_ts.cable_test.return_value = {"ports": []}
+        await central_cable_test(_ctx(), serial_number="SW1", device_type="cx", ports="1/1/1")
+        kw = mock_ts.cable_test.call_args.kwargs
+        assert kw["max_attempts"] == 5
+        assert kw["poll_interval"] == 5
+
+    @patch(_RESOLVE, return_value="SW1")
+    @patch(_TS)
+    async def test_custom_poll_params_forwarded(self, mock_ts, _mock_resolve):
+        mock_ts.cable_test.return_value = {"ports": []}
+        await central_cable_test(
+            _ctx(), serial_number="SW1", device_type="cx", ports="1/1/1", max_attempts=2, poll_interval=1
+        )
+        kw = mock_ts.cable_test.call_args.kwargs
+        assert kw["max_attempts"] == 2
+        assert kw["poll_interval"] == 1
+
+    @pytest.mark.parametrize("max_attempts", [0, 11, -1])
+    async def test_invalid_max_attempts_raises_400(self, max_attempts):
+        with pytest.raises(ToolError) as exc:
+            await central_cable_test(
+                _ctx(), serial_number="SW1", device_type="cx", ports="1/1/1", max_attempts=max_attempts
+            )
+        assert exc.value.args[0]["status_code"] == 400
+
+    @pytest.mark.parametrize("poll_interval", [0, 11, -1])
+    async def test_invalid_poll_interval_raises_400(self, poll_interval):
+        with pytest.raises(ToolError) as exc:
+            await central_cable_test(
+                _ctx(), serial_number="SW1", device_type="cx", ports="1/1/1", poll_interval=poll_interval
+            )
+        assert exc.value.args[0]["status_code"] == 400
+
+    @patch(_RESOLVE, return_value="SW1")
+    @patch(_TS)
+    async def test_empty_result_returns_info_string(self, mock_ts, _mock_resolve):
+        mock_ts.cable_test.return_value = None
+        result = await central_cable_test(_ctx(), serial_number="SW1", device_type="cx", ports="1/1/1")
+        assert result == "Cable test returned no results."

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -190,6 +190,22 @@ class TestLoadConfig:
         assert config.disable_elicitation is True
         assert config.debug is True
 
+    def test_code_sandbox_max_duration_defaults_to_30(self, patch_secrets_dir, monkeypatch):
+        monkeypatch.delenv("CODE_SANDBOX_MAX_DURATION_SECS", raising=False)
+        config = load_config()
+        assert config.code_sandbox_max_duration_secs == 30.0
+
+    def test_code_sandbox_max_duration_env_override(self, patch_secrets_dir, monkeypatch):
+        monkeypatch.setenv("CODE_SANDBOX_MAX_DURATION_SECS", "90")
+        config = load_config()
+        assert config.code_sandbox_max_duration_secs == 90.0
+
+    @pytest.mark.parametrize("bad_value", ["abc", "0", "-5", ""])
+    def test_code_sandbox_max_duration_invalid_falls_back_to_30(self, patch_secrets_dir, monkeypatch, bad_value):
+        monkeypatch.setenv("CODE_SANDBOX_MAX_DURATION_SECS", bad_value)
+        config = load_config()
+        assert config.code_sandbox_max_duration_secs == 30.0
+
 
 # ---------------------------------------------------------------------------
 # enabled_platforms property


### PR DESCRIPTION
## Summary

Two unrelated code-mode `execute()` failure modes surfaced in a single operator transcript. Both are fixed by hardening the layer (docs + tool params + config), not band-aiding the AI.

### 1. Paginated-collection shape — Closes #381

An AI iterated `result["data"]` from `central_get_switches` as a list and got `AttributeError: 'str' object has no attribute 'get'`. Reproduced live: the `network-monitoring/v1/*` (MRT) reads return the raw API envelope, so `data` is a **dict** `{items, next, total, count}`, not the rows. Iterating a dict yields its string keys, so the next `.get(...)` raises. Rows live at `data["items"]`.

Notably the shape **isn't uniform** — older hand-curated reads like `central_get_aps` already unwrap to a bare list, which is the trap. Added an INSTRUCTIONS.md subsection plus a defensive `rows()` helper that handles all three conventions (bare list / inner `{"result": ...}` / paginated `{"items": ...}`). Docs-only; no behavior change.

### 2. Cable-test poll budget — Closes #382

`central_cable_test` is fire-and-poll: pycentral's `cable_test` blocks up to `max_attempts * poll_interval` (default 5 × 5 = ~25s) of synchronous polling, nearly the whole sandbox budget. Chaining a second call hit `TimeoutError: 31.1s > 30s`.

- **Configurable sandbox budget**: `MontySandboxProvider`'s `max_duration_secs` (was a hardcoded `30.0` in `server.py`) now comes from `ServerConfig.code_sandbox_max_duration_secs`, overridable via `CODE_SANDBOX_MAX_DURATION_SECS` (default 30.0; invalid/non-positive → 30.0 + warning).
- **Exposed poll params**: `central_cable_test` gains validated `max_attempts` / `poll_interval` (1-10, `status_code: 400` on out-of-range), forwarded to pycentral. Docstring + INSTRUCTIONS.md + TOOLS.md warn to call it in its own `execute()` block.

## Tests
- `test_config.py`: new env var (default / override / invalid fallback)
- `test_central_cable_test.py` (new): param validation, forwarding, empty-result info string
- Full suite: **1499 passed, 1 skipped**; ruff / format / mypy clean

## Docs updated (same PR)
INSTRUCTIONS.md, CHANGELOG.md, docs/TOOLS.md, README.md (env-var table), pyproject.toml (3.2.1.10 → 3.2.1.11). No tool-count change.