### PR TITLE
Drop vestigial health() pre-flight from single-platform skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3.2] - 2026-05-26
+
+**Patch — drop the vestigial `health()` pre-flight from single-platform skills.** Six skills opened with a "confirm reachable" `health()` step that added a tool call without changing behavior — the first real call (a config read/write) surfaces unreachability just as well, and the health result wasn't used. Removed it from the single-platform read/write skills: `central-qos-policy`, `central-scope-audit`, `mist-scope-audit`, `central-scope-walker`, `central-scope-visualizer` (step list renumbered 0→4), `clearpass-policy-walker` — trimmed both the prerequisite/step text and the `health` entry in each `tools:` list.
+
+**Kept** where `health()` is load-bearing — i.e. multi-platform skills where one upfront probe genuinely gates which platform branches run / drives the verdict, or where health is the point: `infrastructure-health-check`, `morning-coffee-report`, `uxi-cross-platform-diagnostics`, `aos-migration`, `change-pre-check`, `change-post-check`, `cross-platform-rf-check`, `wlan-sync-validation`. Skills-only change; no tool-count change.
+
 ## [3.2.3.1] - 2026-05-26
 
 **Patch — harden the `central-qos-policy` skill with live-verified payload shapes + surface string-format hints in the distiller (#390).** A live end-to-end rebuild of a real switch QoS config (8 traffic classes / 764 rules + a `POLICY_QOS` marker + VLAN-interface bind) exposed that the v3.2.2.0 skill carried **guessed** payload shapes that the API accepts with `200` but silently drops. Replaced them with the exact, read-back-verified shapes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.3.1"
+version = "3.2.3.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/central-qos-policy.md
+++ b/src/hpe_networking_mcp/skills/central-qos-policy.md
@@ -26,7 +26,6 @@ description: |
 platforms: [central]
 tags: [central, qos, dscp, switch, cx, aos-s, policy, config-model, write]
 tools:
-  - health
   - central_get_scope_tree
   - central_list_tools
   - central_get_tool_schema
@@ -99,7 +98,7 @@ interface vlan 2
 
 ## Prerequisites
 
-- `health(platform="central")` reachable; `ENABLE_CENTRAL_WRITE_TOOLS` on.
+- `ENABLE_CENTRAL_WRITE_TOOLS` on (else build + show payloads only, don't write). The first `central_get_tool_schema` / create call surfaces any reachability problem — no separate health pre-flight needed.
 - **Library scope** unless told otherwise: omit `scope_id` (build everything
   shared). For a scoped object pass `scope_id` + `device_function`.
 - Switch OS is CX in the verified shapes below (`count`, `subnet-address`,

--- a/src/hpe_networking_mcp/skills/central-scope-audit.md
+++ b/src/hpe_networking_mcp/skills/central-scope-audit.md
@@ -15,7 +15,7 @@ description: |
   Policy Design + Policy Deploy).
 platforms: [central]
 tags: [central, audit, configuration, scope, drift-detection, vsg]
-tools: [health, central_get_scope_tree, central_get_scope_resources, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram, central_get_config_assignments, central_get_wlan_profiles, central_get_wlans, central_get_roles, central_get_role_acls, central_get_role_gpids, central_get_policies, central_get_policy_groups, central_get_object_groups, central_get_net_services, central_get_net_groups, central_get_aliases, central_get_server_groups, central_get_named_vlans, central_get_devices, central_get_aps, central_get_sites]
+tools: [central_get_scope_tree, central_get_scope_resources, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram, central_get_config_assignments, central_get_wlan_profiles, central_get_wlans, central_get_roles, central_get_role_acls, central_get_role_gpids, central_get_policies, central_get_policy_groups, central_get_object_groups, central_get_net_services, central_get_net_groups, central_get_aliases, central_get_server_groups, central_get_named_vlans, central_get_devices, central_get_aps, central_get_sites]
 ---
 
 # Aruba Central VSG-anchored configuration scope audit
@@ -36,7 +36,6 @@ appropriate `central_manage_*` tools after reviewing.
 
 ## Prerequisites
 
-- Central must be reachable (`health(platform="central")` first).
 - Operator picks an audit scope: **org-wide** (default), a specific
   **site collection**, or a specific **site**. Org-wide for a large
   deployment can produce 100+ findings — confirm with the operator
@@ -53,10 +52,9 @@ compares it to its VSG-recommended scope AND VSG-recommended values,
 and adds findings to the running report. Steps that depend on earlier
 output (e.g., role-policy linkage) are flagged.
 
-### Step 0 — Reachability + scope-tree snapshot
+### Step 0 — Scope-tree snapshot
 
 **Tools (in order):**
-- `health(platform="central")` — confirm reachable.
 - `central_get_scope_tree(view="committed")` — what's directly assigned at each scope.
 - `central_get_scope_tree(view="effective")` — full inherited+committed view.
 

--- a/src/hpe_networking_mcp/skills/central-scope-visualizer.md
+++ b/src/hpe_networking_mcp/skills/central-scope-visualizer.md
@@ -41,7 +41,7 @@ description: |
   **Read-only.** Does not mutate any Central config.
 platforms: [central]
 tags: [central, scope, hierarchy, visualization, audit, diagram]
-tools: [health, central_get_scope_tree, central_get_scope_resources, central_get_committed_config, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram]
+tools: [central_get_scope_tree, central_get_scope_resources, central_get_committed_config, central_get_effective_config, central_get_devices_in_scope, central_get_scope_diagram]
 ---
 
 # Aruba Central scope hierarchy visualizer
@@ -100,11 +100,9 @@ These constrain every response you produce inside this skill:
 
 ## Prerequisites
 
-- Central reachable: `health(platform="central")` first (skip if you
-  already ran it earlier in the same session).
 - The operator has indicated what they want to see (full tree / one
   site / committed vs effective / etc.). When the request is
-  ambiguous, default to the top-level overview (Step 2) and offer to
+  ambiguous, default to the top-level overview (Step 1) and offer to
   drill in.
 
 ## Response shapes
@@ -132,14 +130,7 @@ These constrain every response you produce inside this skill:
 
 Default when the request is ambiguous: top-level overview with an offer to drill in.
 
-### Step 1 — Confirm reachability
-
-**Tool:** `health(platform="central")`
-**Why:** Every other step depends on Central being reachable; this is a 1-call sanity check.
-**Expected:** `status: ok`.
-**If anomaly:** Surface the error and stop — no fallback to other platforms (this is Central-only).
-
-### Step 2 — Fetch the structured tree (always)
+### Step 1 — Fetch the structured tree (always)
 
 **Tool:** `central_get_scope_tree(view="committed")`
 **Why:** This is the foundation. It returns the **whole hierarchy** with per-scope `resource_count`, `device_count`, `persona_count`, `child_scope_count`, and per-persona `categories` breakdown. One call gives you everything needed for the top-level overview AND the data for any drilled-in view.
@@ -150,7 +141,7 @@ Default when the request is ambiguous: top-level overview with an offer to drill
 - `view="committed"` (default) — what's directly assigned at each scope. Use this for the structural overview.
 - `view="effective"` — adds inherited resources at every descendant scope. Use this when the operator's question is about what's actually applied at the leaves (a SITE scope's `resources` includes everything that flows down from Global + its site-collection ancestors).
 
-### Step 3 — Render the requested zoom level
+### Step 2 — Render the requested zoom level
 
 Pick the template that matches Step 0's zoom level.
 
@@ -198,7 +189,7 @@ End the overview with a one-line offer: *"Want to drill into a specific site or 
 Goal: show one site (HQ, BRANCH-1, etc.) with its device-type rollups underneath.
 
 ```python
-# Step 3b — find the site_id then get device inventory
+# Step 2b — find the site_id then get device inventory
 tree_resp = await call_tool("central_get_scope_tree", {"view": "committed"})
 # walk the tree to find the named site → grab its scope_id
 # ... (paste central-scope-walker snippet to do the name-to-id resolution)
@@ -254,7 +245,7 @@ grouped by persona, with category sub-grouping (Policies, Roles,
 Aliases, etc.).
 
 ```python
-# Step 3c — committed config at one scope
+# Step 2c — committed config at one scope
 cfg = await call_tool("central_get_committed_config", {"scope_id": scope_id})
 # Group by persona → category → resource name for chip rendering
 # Personas: CAMPUS_AP, ACCESS_SWITCH, BRANCH_GW, MOBILITY_GW, etc.
@@ -320,7 +311,7 @@ Inherited from ancestors (N resources)
   From EST Sites: [chip ← EST Sites] [chip ← EST Sites]
 ```
 
-### Step 4 — Walkthrough beneath the diagram
+### Step 3 — Walkthrough beneath the diagram
 
 Below every visualization, add a short (3-6 sentence) walkthrough in plain English:
 
@@ -330,7 +321,7 @@ Below every visualization, add a short (3-6 sentence) walkthrough in plain Engli
 
 Reference scope names (not IDs). Operators will use the walkthrough to know what to ask next.
 
-### Step 5 — Always offer the next zoom level
+### Step 4 — Always offer the next zoom level
 
 End every response with a one-line affordance:
 
@@ -344,12 +335,10 @@ Operator: *"Visualize the Central scope hierarchy."*
 
 ```python
 # Step 1
-health_resp = await call_tool("health", {"platform": "central"})
-# Step 2
 tree_resp = await call_tool("central_get_scope_tree", {"view": "committed"})
 tree = tree_resp.get("data", {})
 
-# Step 3a — top-level overview
+# Step 2a — top-level overview
 # Walk the tree's root + direct children. Aggregate device groups.
 root = tree
 collections = []

--- a/src/hpe_networking_mcp/skills/central-scope-walker.md
+++ b/src/hpe_networking_mcp/skills/central-scope-walker.md
@@ -37,8 +37,6 @@ to pin a name to an ID before running downstream operations.
 
 ## Prerequisites
 
-- Central reachable: `health(platform="central")` first (skip if you
-  already ran it earlier in the same session).
 - The operator has provided either:
   - an exact / partial scope name (`"HQ"`, `"dallas-hq"`), OR
   - a path (`"USE/dallas-hq"`, `"Global/USE/dallas-hq/floor-3"`), OR

--- a/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
+++ b/src/hpe_networking_mcp/skills/clearpass-policy-walker.md
@@ -45,7 +45,7 @@ description: |
   **Read-only.**
 platforms: [clearpass, central]
 tags: [clearpass, central, policy, visualization, audit]
-tools: [health, clearpass_list_policy_services, clearpass_compile_policy_flow, central_get_role_with_policy]
+tools: [clearpass_list_policy_services, clearpass_compile_policy_flow, central_get_role_with_policy]
 ---
 
 # ClearPass policy visualizer
@@ -90,8 +90,6 @@ These constrain every response you produce inside this skill:
 
 ## Prerequisites
 
-- ClearPass reachable: `health(platform="clearpass")` first (skip if
-  you already ran it earlier in the same session).
 - The operator has named the target service (use it directly — the
   compile tool does fuzzy matching), OR is asking generally
   ("show me a service" / "pick one to visualize") — in which case

--- a/src/hpe_networking_mcp/skills/mist-scope-audit.md
+++ b/src/hpe_networking_mcp/skills/mist-scope-audit.md
@@ -20,7 +20,7 @@ description: |
   Wired & Wireless Network Deployment Guide.
 platforms: [mist]
 tags: [mist, audit, configuration, scope, drift-detection, vsg]
-tools: [health, mist_get_self, mist_list_org_templates, mist_list_org_wlans, mist_list_site_wlans, mist_list_org_rf_templates, mist_list_org_network_templates, mist_list_org_site_templates, mist_list_org_site_groups, mist_list_org_sites, mist_list_org_device_profiles, mist_list_org_psks, mist_list_org_device_upgrades, mist_get_site_setting, mist_get_org_settings]
+tools: [mist_get_self, mist_list_org_templates, mist_list_org_wlans, mist_list_site_wlans, mist_list_org_rf_templates, mist_list_org_network_templates, mist_list_org_site_templates, mist_list_org_site_groups, mist_list_org_sites, mist_list_org_device_profiles, mist_list_org_psks, mist_list_org_device_upgrades, mist_get_site_setting, mist_get_org_settings]
 ---
 
 # Juniper Mist comprehensive configuration scope audit
@@ -57,7 +57,6 @@ catalog returns name + parameter schema for every match.
 
 ## Prerequisites
 
-- Mist must be reachable (`health(platform="mist")` first).
 - Operator picks an audit scope: **org-wide** (default), a specific
   **site group**, or a specific **site**.
 - For orgs with 50+ sites, the per-site WLAN inspection in step 5 is
@@ -69,11 +68,10 @@ catalog returns name + parameter schema for every match.
 Run the steps in order. Each step pulls a slice of the catalog and
 adds findings to the running report.
 
-### Step 0 — Reachability + org_id
+### Step 0 — Resolve org_id
 
 **Tools (in order):**
-- `health(platform="mist")` — confirm reachable.
-- `mist_get_self()` — get `org_id` from the returned `privileges[].org_id` field. (The v3.1.0.0 refactor dropped the old `action_type=` polyglot parameter — `mist_get_self()` is now a single-shape call.)
+- `mist_get_self()` — get `org_id` from the returned `privileges[].org_id` field. (Also surfaces any reachability problem on the first real call — no separate health pre-flight needed.) (The v3.1.0.0 refactor dropped the old `action_type=` polyglot parameter — `mist_get_self()` is now a single-shape call.)
 
 **Why:** every later call needs `org_id`. If the user has access to
 multiple orgs, ask which one to audit.


### PR DESCRIPTION
Follow-up from the QoS-skill review: several skills opened with a `health()` "confirm reachable" step that added a tool call without changing behavior — the first real config read/write surfaces unreachability just as well, and the health result was never used.

## Rule applied
- **Trim** where `health()` is a vestigial preamble in a **single-platform** read/write skill.
- **Keep** where it's load-bearing — a **multi-platform** skill where one upfront probe gates which platform branches run / drives the verdict, or where health *is* the point.

## Trimmed (6)
`central-qos-policy`, `central-scope-audit`, `mist-scope-audit`, `central-scope-walker`, `central-scope-visualizer` (step list renumbered 0→4, including the worked-example code), `clearpass-policy-walker`. Removed the prerequisite/step text **and** the `health` entry in each `tools:` list.

## Kept (load-bearing)
`infrastructure-health-check`, `morning-coffee-report`, `uxi-cross-platform-diagnostics`, `aos-migration`, `change-pre-check`, `change-post-check`, `cross-platform-rf-check`, `wlan-sync-validation`.

Skills-only (markdown) + version `3.2.3.2`. Full suite 1528 passed, 1 skipped; ruff/format clean; skill-tool-reference + skill-validation tests green.