### PR TITLE
v3.2.3.5: central_show_commands accepts 'aps' (AP show commands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3.5] - 2026-05-29
+
+**Patch — `central_show_commands` now accepts `aps` (executes AP show commands).** An operator investigating AI-derived AP thresholds (auth-req-thresh / local-probe-req-thresh) tried to run `show ap client-match-refused`, `show ap arm config`, `show ap debug client-match`, and `show log rssi-to-cloud clientrssi` against an AP. Discovery via `central_list_supported_show_commands(device_family="aps", ...)` correctly returned a 686-command catalogue — but the executor `central_show_commands` rejected `device_type="aps"` because the parameter was typed `Literal["aos-s", "cx", "gateways"]` (APs omitted). The tool's docstring already incorrectly claimed AP support — so the AI agent reading the tool description believed APs were supported and then hit a Pydantic validation error at call time.
+
+Pure wrapper gap. Verified live: pycentral's `Troubleshooting.run_show_commands` already validates `device_type` against `subset=["aps", "gateways", "cx", "aos-s"]` and its docstring states "Supported device type includes AOS-S, AP, CX, and GATEWAY." The `_resolve_if_switch` helper at lines 11-19 already short-circuits cleanly for non-switch types (returns the serial unchanged), so APs flow through without needing any other change.
+
+Fix:
+- [`src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py`](src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py): widened `device_type` Literal from `["aos-s", "cx", "gateways"]` to `["aos-s", "aps", "cx", "gateways"]`. Corrected the docstring (which already lied) to match. Added a pointer to `central_list_supported_show_commands` for discovering the per-device catalogue — the AP catalogue is the broadest at hundreds of `show ap ...` commands.
+- [`docs/TOOLS.md`](docs/TOOLS.md): tool-page parameter table updated to list `aps`.
+
+No tool-count change. Closes #395.
+
 ## [3.2.3.4] - 2026-05-28
 
 **Patch — `central-qos-policy` Path picker + wrong-primitive detection (POLICY_QOS `association` field).** An operator hit a failure mode the skill didn't catch: a CNX role-based policy (POLICY_QOS with `association: ASSOCIATION_ROLE`) was created, then the AI was asked to SVI-bind it. The AI tried the device-rendered `sys_policy_pap_<role>` name, got `HTTP 400 "Cannot find in library"`, and concluded "no Central API path exists for this" — which was wrong in two ways: (a) a path absolutely exists, and (b) the skill we ship documents it. The skill simply never disambiguated POLICY_QOS's two `association` flavors, so the AI didn't see the off-ramp.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1199,8 +1199,8 @@ Rule shape:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | serial_number | str | Yes | Device serial number. |
-| device_type | str | Yes | `aos-s`, `cx`, or `gateways`. |
-| commands | str | Yes | Comma-separated show commands (e.g. `show version,show interfaces`). |
+| device_type | str | Yes | `aos-s`, `aps`, `cx`, or `gateways`. |
+| commands | str | Yes | Comma-separated show commands (e.g. `show version,show interfaces`). Use `central_list_supported_show_commands` to discover what a device accepts — the AP catalogue is the broadest. |
 
 #### `central_disconnect_users_ssid`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.3.4"
+version = "3.2.3.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -172,18 +172,20 @@ async def central_cable_test(
 async def central_show_commands(
     ctx: Context,
     serial_number: str,
-    device_type: Literal["aos-s", "cx", "gateways"],
+    device_type: Literal["aos-s", "aps", "cx", "gateways"],
     commands: str,
 ) -> dict | str:
     """
     Execute show commands on a device and return the output.
 
-    Supports AP, CX switch, and gateway devices. Use for
-    detailed device diagnostics.
+    Supports AOS-S switch, AP, CX switch, and gateway devices. Use for
+    detailed device diagnostics. Use ``central_list_supported_show_commands``
+    to discover which show commands a given device accepts (the AP catalogue
+    is the broadest — hundreds of AP-specific ``show ap ...`` commands).
 
     Parameters:
         serial_number: Device serial number (required).
-        device_type: Device type — "aos-s", "cx", or "gateways" (required).
+        device_type: Device type — "aos-s", "aps", "cx", or "gateways" (required).
         commands: Comma-separated show commands, e.g. "show version,show interfaces" (required).
     """
     conn = ctx.lifespan_context["central_conn"]


### PR DESCRIPTION
## Summary

- `central_show_commands` `device_type` Literal widened from `['aos-s', 'cx', 'gateways']` to `['aos-s', 'aps', 'cx', 'gateways']` so AP-specific show commands (`show ap client-match-refused`, `show ap arm config`, `show ap debug client-match`, `show log rssi-to-cloud clientrssi`, ...) are reachable through the executor.
- Tool docstring corrected — it already incorrectly claimed AP support, which is how an AI agent ended up calling with `device_type='aps'` and hitting a Pydantic validation error.
- No tool-count change. Pure wrapper widening; the underlying pycentral library and the `_resolve_if_switch` helper already handle APs correctly.

Verified live in the dev container:
- `pycentral.troubleshooting.Troubleshooting.run_show_commands` validates `device_type` against `subset=['aps', 'gateways', 'cx', 'aos-s']`; library docstring states "Supported device type includes AOS-S, AP, CX, and GATEWAY."
- `_resolve_if_switch` (lines 11-19) short-circuits for non-switch types — returns the serial unchanged — so APs need no stack-ID resolution path.

The catalogue lister `central_list_supported_show_commands` already accepts `device_family='aps'`; an agent could discover the AP catalogue but not execute against it.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] `pytest tests/ -q` — 1528 passed, 1 skipped
- [ ] Live-verify post-merge: from an AI session call `central_show_commands(serial_number=<ap_serial>, device_type='aps', commands='show version')` against a real AP and confirm the show output round-trips.

Closes #395.