### PR TITLE
ci(mist-sync): open PR with auto-merge instead of pushing to protected main

### DIFF
--- a/.github/workflows/sync-mist-openapi.yml
+++ b/.github/workflows/sync-mist-openapi.yml
@@ -1,12 +1,16 @@
 name: Sync Mist OpenAPI
 
 # Pulls the upstream Mist OpenAPI spec from mistsys/mist_openapi daily,
-# validates it parses cleanly, and auto-commits the updated vendored copy
-# to `main` if it changed. **Tool regeneration does NOT happen here** —
-# the maintainer runs the generator manually at release time so the
-# tool surface changes are reviewed before tagging.
+# validates it parses cleanly, and opens an auto-merge PR with the updated
+# vendored copy if it changed. **Tool regeneration does NOT happen here** —
+# the maintainer runs the generator manually at release time so the tool
+# surface changes are reviewed before tagging.
 #
-# See `vendor/mist_openapi.SOURCE.md` for the broader sync design.
+# Branch protection on `main` requires PRs + 4 status checks; the default
+# GITHUB_TOKEN cannot trigger downstream workflows on a PR it opens, so
+# this workflow uses a fine-grained PAT (secret: MIST_SYNC_PAT) to open
+# the PR and enable auto-merge. See vendor/mist_openapi.SOURCE.md for the
+# PAT-setup instructions.
 
 on:
   schedule:
@@ -15,7 +19,8 @@ on:
   workflow_dispatch: # manual run via the Actions UI
 
 permissions:
-  contents: write # to push spec updates to main
+  contents: write # peter-evans needs this to push the sync branch
+  pull-requests: write # to open / update the sync PR
   issues: write # to file a regression issue if the spec fails to parse
 
 jobs:
@@ -25,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MIST_SYNC_PAT }}
 
       - name: Fetch upstream spec
         id: fetch
@@ -103,12 +108,11 @@ jobs:
           # Refresh the "Current sync" block in SOURCE.md.
           python3 - <<'PY'
           import re
+          import subprocess
           from pathlib import Path
           src = Path("vendor/mist_openapi.SOURCE.md").read_text(encoding="utf-8")
           version = "${{ steps.validate.outputs.version }}"
           sha = "${{ steps.sha.outputs.sha }}"
-          today = "$(date -u +%Y-%m-%d)"
-          import subprocess
           today = subprocess.check_output(["date", "-u", "+%Y-%m-%d"]).decode().strip()
           new_block = (
               f"## Current sync\n\n"
@@ -125,22 +129,47 @@ jobs:
           Path("vendor/mist_openapi.SOURCE.md").write_text(new_text, encoding="utf-8")
           PY
 
-      - name: Commit and push
+      - name: Create or update sync PR
         if: steps.diff.outputs.changed == 'true'
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add vendor/mist_openapi.json vendor/mist_openapi.SOURCE.md
-          git commit -m "chore(vendor): sync Mist OpenAPI to ${{ steps.validate.outputs.version }} (auto)
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.MIST_SYNC_PAT }}
+          branch: chore/sync-mist-openapi
+          delete-branch: true
+          add-paths: |
+            vendor/mist_openapi.json
+            vendor/mist_openapi.SOURCE.md
+          commit-message: |
+            chore(vendor): sync Mist OpenAPI to ${{ steps.validate.outputs.version }} (auto)
 
-          Upstream: https://github.com/mistsys/mist_openapi
-          Blob SHA: ${{ steps.sha.outputs.sha }}
+            Upstream: https://github.com/mistsys/mist_openapi
+            Blob SHA: ${{ steps.sha.outputs.sha }}
 
-          Tool regeneration not run by this workflow — maintainer runs
-          \`uv run python scripts/regenerate_mist_tools.py\`
-          at release time before tagging."
-          git push origin main
+            Tool regeneration not run by this workflow — maintainer runs
+            `uv run python scripts/regenerate_mist_tools.py`
+            at release time before tagging.
+          title: "chore(vendor): sync Mist OpenAPI to ${{ steps.validate.outputs.version }}"
+          body: |
+            Automated daily sync of the upstream Mist OpenAPI spec.
+
+            - **Spec version**: `${{ steps.validate.outputs.version }}`
+            - **Upstream blob SHA**: `${{ steps.sha.outputs.sha }}`
+            - **Upstream**: https://github.com/mistsys/mist_openapi
+
+            Tool regeneration is **not** triggered by this PR — the maintainer
+            runs `uv run python scripts/regenerate_mist_tools.py` at release
+            time before tagging so tool-surface changes are reviewed before
+            shipping.
+
+            This PR has auto-merge enabled and will merge once required status
+            checks pass.
+
+      - name: Enable auto-merge on the sync PR
+        if: steps.cpr.outputs.pull-request-number
+        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.MIST_SYNC_PAT }}
 
       - name: File issue on validation failure
         if: failure() && steps.validate.outcome == 'failure'

--- a/vendor/mist_openapi.SOURCE.md
+++ b/vendor/mist_openapi.SOURCE.md
@@ -37,7 +37,7 @@ The GitHub Actions workflow at `.github/workflows/sync-mist-openapi.yml` runs da
 
 1. Fetches the upstream `mist.openapi.json` from `mistsys/mist_openapi:master`.
 2. Validates the spec parses cleanly as OpenAPI 3.x.
-3. If changed AND parses: auto-commits the new spec to `main` and updates this file's `Current sync` section.
+3. If changed AND parses: opens (or updates) a PR on `chore/sync-mist-openapi` with the new vendored spec + refreshed `Current sync` block, and enables auto-merge so CI gates the merge.
 4. If parse fails: opens a GitHub issue flagging the regression.
 
 **Tool regeneration does NOT happen on auto-sync.** Regeneration runs at release time, manually by the maintainer:
@@ -47,6 +47,17 @@ uv run python scripts/regenerate_mist_tools.py
 ```
 
 This decouples spec freshness from release cadence — the vendored spec is always current, but the live Mist tool surface only changes when the maintainer deliberately ships.
+
+### PAT requirement
+
+`main` is branch-protected (PRs + 4 required status checks). The default `GITHUB_TOKEN` cannot trigger downstream workflows on a PR it opens, so the sync workflow uses a fine-grained PAT (repo secret `MIST_SYNC_PAT`) to open the PR — without it the PR sits forever waiting on CI that never runs.
+
+One-time setup:
+
+1. Create a fine-grained PAT scoped to this repo only.
+2. Permissions: **Contents: read & write**, **Pull requests: read & write**.
+3. Save as repo secret `MIST_SYNC_PAT`.
+4. Ensure `allow_auto_merge` is enabled at the repo level (Settings → General → Pull Requests → Allow auto-merge).
 
 ## Stats (at current sync)
 


### PR DESCRIPTION
## Summary

- The Mist OpenAPI auto-sync workflow has been silently broken on every actual drift since `main` was branch-protected. Its final step (`git push origin main`) is rejected by branch protection (4 required status checks, no bypass actors). Quiet no-op days masked the failure — `vendor/mist_openapi.json` has only ever been touched by human PRs (#306, #348), never the bot.
- Switch to [`peter-evans/create-pull-request@v6`](https://github.com/peter-evans/create-pull-request) opening a PR on the stable branch `chore/sync-mist-openapi` (so daily drift updates one rolling PR instead of spamming N). Auto-merge is enabled on the PR so CI gates the merge.
- Both PR-creation and auto-merge use a fine-grained PAT (`secrets.MIST_SYNC_PAT`). The default `GITHUB_TOKEN` cannot trigger downstream workflows on a PR it opens — the bot PR would be stuck forever waiting on CI/Security checks that never run.

## One-time setup required before this works end-to-end

1. **Create a fine-grained PAT** scoped to this repo only.
   - Permissions: **Contents: read & write**, **Pull requests: read & write**.
2. **Add as a repo secret** named `MIST_SYNC_PAT` (Settings → Secrets and variables → Actions → New repository secret).
3. **Enable repo-level auto-merge**: Settings → General → Pull Requests → check "Allow auto-merge". Currently `allow_auto_merge: false` on the repo.

Until those three are in place, the workflow will fail at the `Create or update sync PR` step (`token` evaluates empty).

## Why no version bump

`.github/workflows/` is repo infrastructure, not a shipped runtime artifact under `src/`. Per the version-bump rule in CLAUDE.md, infrastructure-only changes don't get a version bump.

## Test plan

- [ ] Maintainer creates the PAT, adds the `MIST_SYNC_PAT` secret, and enables `allow_auto_merge` per the steps above.
- [ ] After merge: trigger a manual run via Actions → Sync Mist OpenAPI → Run workflow (`workflow_dispatch`). Upstream is currently at 2604.1.2 vs. our vendored 2604.1.1, so a real drift will be detected.
- [ ] Verify a PR is opened on `chore/sync-mist-openapi` with the vendored spec + SOURCE.md updates, that CI/Security run on the PR, and that auto-merge fires when checks pass.
- [ ] Confirm `vendor/mist_openapi.SOURCE.md` "Current sync" block shows the new version + SHA on `main` after the auto-merge completes.

This fix is not unit-testable; it's only end-to-end verifiable post-merge via `workflow_dispatch`.