### PR TITLE
feat(central): scope hierarchy + global-scope read tools (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3.7] - 2026-06-02
+
+**Patch — Central scope: add `central_get_global_scope` + `central_get_hierarchy` read tools.** Wraps the New Central Scope Management reads `GET network-config/v1/global` (tenant-root `scopeId`) and `GET network-config/v1/hierarchy` (child-scope tree for a given `scope_id` + `scope_type`: org / site-collection / site / device-group / device). Both follow the `ToolError` structured-error contract (raise on non-2xx, success returns the response body). Registered under `TOOLS["sites"]`; covered by `tests/unit/test_central_scope_hierarchy.py`. Surfaced by an OpenAPI coverage audit of the vendored Central specs (closes #402).
+
 ## [3.2.3.6] - 2026-05-29
 
 **Patch — regen sync: Mist tools against vendored spec 2604.1.2 + Central payload-schemas artifact against refreshed `api-endpoints/central/config/` snapshot.** Routine maintenance bump landing the regen output from the maintainer's release-time ritual (`uv run python scripts/regenerate_mist_tools.py` + `uv run python scripts/distill_central_config_schemas.py`). Tool count unchanged: still **1037 Mist tools**, still **613 Central tools**.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1926 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 140 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1926 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -528,7 +528,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 │ │ 1037   │ │622tools│ │10 tools│ │140 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │ │        ││
 │                                                                                         │
-│  All 1924 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1926 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘│
 │     │          │          │          │          │          │          │          │       │
@@ -543,7 +543,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1924 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1926 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `uxi_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -607,7 +607,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (sensor/agent/group/assignment mutations) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1924 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1926 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -803,25 +803,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1924)
+### Tool Surface Looks Wrong (6 tools vs. 1926)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1924 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1926 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1924 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1926 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1924 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1926 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1926 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1924 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1926 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1924 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1926 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1926 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1924 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1926 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1924 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1926 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -717,7 +717,7 @@ logged and skipped; the rest of the catalog still loads. See
 
 ---
 
-## Aruba Central (623 tools + 12 prompts)
+## Aruba Central (625 tools + 12 prompts)
 
 > **v3.1.1.0**: bulk-imported 197 net-new config-model object types (389 net-new tools across 19 new modules) from the gitignored local snapshot at `api-endpoints/central/config/`. See the **Config-Model Tools** section at the end of the Central section for the new module inventory and the `central_get_<type>` / `central_manage_<type>` naming convention. The 15 hand-curated tool pairs documented in detail below (sites, devices, alerts, security_policy, wlan_profiles, gateway_clusters, named_vlans, aliases, server_groups, config_assignments, scope, gateway_cluster_intent) keep their tuned docstrings and edge-case handling.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.2.3.6"
+version = "3.2.3.7"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -17,7 +17,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1915 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1917 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 7 platforms** = 21: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
@@ -372,6 +372,9 @@ When asked to create a new site based on an existing site:
 - **Sites**: central_get_sites, central_get_site_health, central_get_site_name_id_mapping
   - Use `central_get_sites` for site configuration data (address, timezone, scopeName). Supports OData filter on scopeName, address, city, state, country, zipcode, collectionName.
   - Use `central_get_site_health` for health metrics and device/client counts. Pass `site_name` (string or list) to filter.
+- **Scope**: central_get_global_scope, central_get_hierarchy
+  - Use `central_get_global_scope` to get the tenant-root `scopeId` (top of the scope tree).
+  - Use `central_get_hierarchy(scope_id, scope_type)` to walk the child scopes (site-collections, sites, device-groups, devices) under a given scope. `scope_type` is one of `org`, `site-collection`, `site`, `device-group`, `device`.
 - **AP Monitoring**: central_get_aps, central_get_ap_wlans
   - Use `central_get_aps` for filtered AP listing (status, model, firmware, deployment, site). More AP-specific filters than `central_get_devices`.
   - Use `central_get_ap_wlans` to see which WLANs a specific AP is broadcasting (by serial number).

--- a/src/hpe_networking_mcp/platforms/central/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/__init__.py
@@ -9,7 +9,13 @@ from hpe_networking_mcp.config import ServerConfig
 
 # Tool categories mapped to module names and their tool names
 TOOLS = {
-    "sites": ["central_get_sites", "central_get_site_health", "central_get_site_name_id_mapping"],
+    "sites": [
+        "central_get_sites",
+        "central_get_site_health",
+        "central_get_site_name_id_mapping",
+        "central_get_global_scope",
+        "central_get_hierarchy",
+    ],
     "devices": ["central_get_devices", "central_find_device"],
     "clients": ["central_get_clients", "central_find_client"],
     "alerts": [

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -1,5 +1,9 @@
+from typing import Annotated
+
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pycentral.new_monitoring import MonitoringSites
+from pydantic import Field
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import SiteData
@@ -130,3 +134,67 @@ async def central_get_site_name_id_mapping(ctx: Context) -> dict:
         )
     )
     return mapping
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_global_scope(ctx: Context) -> dict | str:
+    """Get the Global scope id for the tenant.
+
+    Returns the root/global ``scopeId`` — the top of the Central scope hierarchy.
+    Use it as the ``scope_id`` (with ``scope_type='org'``) when rooting
+    ``central_get_hierarchy`` at the tenant root.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path="network-config/v1/global",
+        api_params={},
+    )
+    code = response.get("code", 0)
+    if not 200 <= code < 300:
+        msg = response.get("msg", "unknown error")
+        raise ToolError({"status_code": code or 502, "message": f"Failed to fetch global scope id: {msg}"})
+    return response.get("msg", {})
+
+
+@tool(annotations=READ_ONLY)
+async def central_get_hierarchy(
+    ctx: Context,
+    scope_id: Annotated[
+        str,
+        Field(
+            description=(
+                "scopeId of the resource to root the hierarchy at (site, "
+                "site-collection, device-group, or org). Get the tenant-root id "
+                "from central_get_global_scope."
+            ),
+        ),
+    ],
+    scope_type: Annotated[
+        str,
+        Field(
+            description=(
+                "Scope type of scope_id — one of 'org', 'site-collection', 'site', 'device-group', or 'device'."
+            ),
+        ),
+    ],
+) -> dict | str:
+    """Get the scope hierarchy rooted at a given scope.
+
+    Returns the tree of child scopes (site-collections, sites, device-groups,
+    devices) beneath the resource identified by ``scope_id`` + ``scope_type``.
+    """
+    conn = ctx.lifespan_context["central_conn"]
+    response = retry_central_command(
+        central_conn=conn,
+        api_method="GET",
+        api_path="network-config/v1/hierarchy",
+        api_params={"id": scope_id, "type": scope_type},
+    )
+    code = response.get("code", 0)
+    if not 200 <= code < 300:
+        msg = response.get("msg", "unknown error")
+        detail = f"Failed to fetch scope hierarchy for {scope_type} {scope_id!r}: {msg}"
+        raise ToolError({"status_code": code or 502, "message": detail})
+    return response.get("msg", {})

--- a/tests/unit/test_central_scope_hierarchy.py
+++ b/tests/unit/test_central_scope_hierarchy.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Central scope hierarchy/global read tools.
+
+Covers ``central_get_global_scope`` and ``central_get_hierarchy`` — thin
+wrappers over the New Central Scope Management API (``network-config/v1/global``
+and ``network-config/v1/hierarchy``). Mocks ``retry_central_command`` at the
+import site; it's the only thing the wrappers call besides
+``ctx.lifespan_context["central_conn"]``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+pytestmark = pytest.mark.unit
+
+_PATCH = "hpe_networking_mcp.platforms.central.tools.sites.retry_central_command"
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCentralGetGlobalScope:
+    @patch(_PATCH)
+    async def test_calls_global_endpoint_no_params(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_global_scope
+
+        mock_cmd.return_value = {"code": 200, "msg": {"scopeId": "100"}}
+        result = await central_get_global_scope(_ctx())
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == "network-config/v1/global"
+        assert kwargs["api_params"] == {}
+        assert result == {"scopeId": "100"}
+
+    @patch(_PATCH)
+    async def test_missing_msg_returns_empty_dict(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_global_scope
+
+        mock_cmd.return_value = {"code": 200}
+        assert await central_get_global_scope(_ctx()) == {}
+
+    @patch(_PATCH)
+    async def test_non_2xx_raises_toolerror(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_global_scope
+
+        mock_cmd.return_value = {"code": 500, "msg": "boom"}
+        with pytest.raises(ToolError) as exc:
+            await central_get_global_scope(_ctx())
+        assert exc.value.args[0]["status_code"] == 500
+
+
+class TestCentralGetHierarchy:
+    @patch(_PATCH)
+    async def test_passes_id_and_type(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_hierarchy
+
+        mock_cmd.return_value = {"code": 200, "msg": {"children": []}}
+        result = await central_get_hierarchy(_ctx(), scope_id="42", scope_type="site-collection")
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        assert kwargs["api_path"] == "network-config/v1/hierarchy"
+        assert kwargs["api_params"] == {"id": "42", "type": "site-collection"}
+        assert result == {"children": []}
+
+    @patch(_PATCH)
+    async def test_non_2xx_raises_toolerror_with_code(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_hierarchy
+
+        mock_cmd.return_value = {"code": 404, "msg": "not found"}
+        with pytest.raises(ToolError) as exc:
+            await central_get_hierarchy(_ctx(), scope_id="x", scope_type="org")
+        assert exc.value.args[0]["status_code"] == 404
+
+    @patch(_PATCH)
+    async def test_zero_code_defaults_to_502(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.sites import central_get_hierarchy
+
+        mock_cmd.return_value = {"msg": "transport failure"}
+        with pytest.raises(ToolError) as exc:
+            await central_get_hierarchy(_ctx(), scope_id="x", scope_type="org")
+        assert exc.value.args[0]["status_code"] == 502


### PR DESCRIPTION
## Summary

Adds two New Central **Scope Management** read tools surfaced by the OpenAPI coverage audit of the vendored Central specs:

- `central_get_global_scope` — `GET network-config/v1/global` → tenant-root `scopeId` (top of the scope tree).
- `central_get_hierarchy(scope_id, scope_type)` — `GET network-config/v1/hierarchy` → the child-scope tree (site-collections / sites / device-groups / devices) under a given scope. `scope_type` ∈ org / site-collection / site / device-group / device.

Both follow the `ToolError` structured-error contract (raise with a status code on non-2xx; success returns the response body), live in `sites.py` alongside the existing scope/site tools, and are registered under `TOOLS["sites"]`.

## Tests

`tests/unit/test_central_scope_hierarchy.py` — 6 tests: success path/params, missing-`msg` → `{}`, `ToolError` on 4xx and 5xx, and the 502 default when the response carries no code. ruff / ruff format / mypy clean; unit suite green.

## Docs

- Tool-count numbers incremented +2 per file. Note: README/TOOLS.md were at `1924`, INSTRUCTIONS at `1915` — a pre-existing drift, left as-is (only incremented) per the agreed approach. Central per-platform count `623` → `625` in `docs/TOOLS.md`.
- New tools added to the INSTRUCTIONS "Tool Categories" list under a **Scope** entry.
- CHANGELOG `3.2.3.7`; `pyproject.toml` version bumped.

Closes #402
