### PR TITLE
fix(translation): AOS 8 → Central policy/net-group drift fixes (v3.3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0.1] - 2026-06-05
+
+**Patch — AOS 8 → Central policy/net-group translation drift fixes.** Corrects spec-confirmed mismatches in the AOS 8 `acl_sess` / `netdst` → Central CNX translation, validated against Central's live built-in policies.
+
+- **Netdestination references (Design A):** `ADDRESS_ALIAS` rules now emit a top-level `net-group: <name>` (the net-group namespace we actually create) instead of the wrong `host-address.host-address-alias` (an alias-namespace reference).
+- **Actions:** AOS 8 `captive` → `ACTION_CAPTIVE_PORTAL` (was silently `ACTION_ALLOW`); `mirror` → `ACTION_MIRROR`; `blacklist` → `secondary-actions.denylist`.
+- **`validuser`** (interface ACL) now emits `association: ASSOCIATION_INTERFACE` instead of `ASSOCIATION_ROLE`.
+- **RA-guard / ICMPv6** rules emit `RULE_PROTOCOL` + `ip-header.protocol: IPV6_ICMP` instead of an invalid `net-service: "icmpv6"`.
+- **NAT / redirect shapes:** destination-nat uses `port` / `ip-address`; dual-nat uses the required `nat-pool` / `port`; redirect uses the `destination` discriminator + `tunnel` / `tunnel-group`.
+- **Net-groups:** IPv6 prefixes are preserved (no more `/128` collapse); `invert` is now mapped (emit-when-true); a per-item `index` is added; the assignment `profile-type` is the plural `net-groups`.
+- **config-assignment** `VALID_DEVICE_FUNCTIONS` gains `EC_VPNC` / `EC_BRANCH_GW`.
+
 ## [3.3.0.0] - 2026-06-05
 
 **Minor — Central config tool surface regenerated from the vendor OAS (BREAKING tool renames).** The Aruba Central config tool surface is now generated directly from the vendored Central OpenAPI specs (auto-synced from the developer hub into `vendor/`) rather than from the previous local snapshot. Net result: **660 Central tools** (up from 613), bringing the full registered surface to **1961 tools across 8 platforms** (1037 Mist + 660 Central + 10 GreenLake + 142 ClearPass + 19 Apstra + 25 Axis + 47 AOS8 + 21 UXI).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.0.0"
+version = "3.3.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -41,6 +41,8 @@ VALID_DEVICE_FUNCTIONS = {
     "BRANCH_GW",
     "MOBILITY_GW",
     "VPNC",
+    "EC_VPNC",
+    "EC_BRANCH_GW",
     "ALL",
     "SERVICE_PERSONA",
     "BRIDGE",

--- a/src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py
+++ b/src/hpe_networking_mcp/translations/preprocessing/aos8_net_group.py
@@ -72,9 +72,21 @@ def preprocess_net_group(source_data: dict[str, Any], runtime_values: dict[str, 
             continue
         built = _build_item(entry, family)
         if built is not None:
+            # Central items[] carry a 1-based `index` (the schema x-key); every
+            # live built-in item has it. Number in source order after filtering.
+            built["index"] = len(items) + 1
             items.append(built)
 
-    return {**source_data, "_address_family": family, "_central_items": items}
+    augmented: dict[str, Any] = {
+        **source_data,
+        "_address_family": family,
+        "_central_items": items,
+    }
+    # AOS 8 netdestinations carry an `invert` clause. Central's built-in shape
+    # omits the key when false (absent == false), so only surface it when truthy.
+    if source_data.get("invert"):
+        augmented["_invert"] = True
+    return augmented
 
 
 def _build_item(entry: dict[str, Any], family: str) -> dict[str, Any] | None:
@@ -96,12 +108,18 @@ def _build_item(entry: dict[str, Any], family: str) -> dict[str, Any] | None:
         if not address:
             return None
         if family == "IPV6_ONLY":
-            # IPv6 networks carry the prefix length directly (e.g. as 'prefix-length' or
-            # in the address itself). Trust the operator-supplied address; if it already
-            # carries '/', pass through, otherwise default to the value plus assumed
-            # full-host length (128) — corrected on first live-verification.
-            prefix = str(address) if "/" in str(address) else f"{address}/128"
-            return {"type": "NETWORK", "prefix": prefix}
+            # IPv6 networks carry the prefix length separately (mirror of the IPv4
+            # dotted-quad path). If the address already embeds '/', pass through.
+            # Otherwise build the prefix from the entry's prefix-length field. A
+            # hardcoded /128 fallback would collapse real supernets (e.g. fc00::/7
+            # → /128), so when no prefix-length is present, pass the address through
+            # UNCHANGED rather than inventing a host route.
+            if "/" in str(address):
+                return {"type": "NETWORK", "prefix": str(address)}
+            v6_prefix = _ipv6_prefix_length(entry)
+            if v6_prefix is None:
+                return {"type": "NETWORK", "prefix": str(address)}
+            return {"type": "NETWORK", "prefix": f"{address}/{v6_prefix}"}
         # IPv4: netmask is dotted-quad; convert to CIDR prefix length.
         netmask = entry.get("netmask")
         if not netmask:
@@ -115,6 +133,28 @@ def _build_item(entry: dict[str, Any], family: str) -> dict[str, Any] | None:
             return None
         return {"type": "FQDN", "fqdn": str(host_name)}
 
+    return None
+
+
+def _ipv6_prefix_length(entry: dict[str, Any]) -> int | None:
+    """Extract an IPv6 prefix length from a netdst6 network entry, or None.
+
+    The netdst6 entry shape isn't live-verified (zero records in the maintainer's
+    tenant), so probe the candidate AOS 8 field names. ``netmask`` carries the
+    prefix length for IPv6 entries in some schema variants (an integer rather
+    than a dotted-quad). Returns None when no prefix-length field is present so
+    the caller can pass the address through unchanged.
+    """
+    for field in ("prefix_len", "prefixlen", "prefix-length", "prefix", "netmask"):
+        value = entry.get(field)
+        if value is None or value == "":
+            continue
+        try:
+            length = int(str(value))
+        except (TypeError, ValueError):
+            continue
+        if 0 <= length <= 128:
+            return length
     return None
 
 

--- a/src/hpe_networking_mcp/translations/preprocessing/aos8_policy.py
+++ b/src/hpe_networking_mcp/translations/preprocessing/aos8_policy.py
@@ -109,7 +109,9 @@ def preprocess_acl_for_policy(source_data: dict[str, Any], runtime_values: dict[
             central_rules.extend(built)
             position += len(built)
 
-    return {**source_data, "_central_rules": central_rules}
+    association = "ASSOCIATION_INTERFACE" if str(accname) in _INTERFACE_ACL_NAMES else "ASSOCIATION_ROLE"
+
+    return {**source_data, "_central_rules": central_rules, "_association": association}
 
 
 # ---------------------------------------------------------------------------- #
@@ -162,6 +164,17 @@ def _compute_role_attribution(acl_name: str, role_records: list[dict]) -> list[s
 
 _AOS8_TO_CENTRAL_SVC_NAME_ALIASES: dict[str, str] = {}
 
+# AOS 8 ACL names that are INTERFACE ACLs (applied to an interface, not bound to
+# a user-role). These map to Central association = ASSOCIATION_INTERFACE rather
+# than the default ASSOCIATION_ROLE. `validuser` is the canonical AOS 8 interface
+# session ACL. Extensible — add other interface-ACL names here as they surface.
+_INTERFACE_ACL_NAMES: frozenset[str] = frozenset({"validuser"})
+
+# AOS 8 service-name forms that denote IPv6-ICMP (ra-guard etc.). These are NOT
+# real Central net-service catalog entries — they route to a RULE_PROTOCOL rule
+# with ip-header.protocol = IPV6_ICMP instead of RULE_NET_SERVICE.
+_ICMPV6_SERVICE_NAMES: frozenset[str] = frozenset({"icmpv6", "icmp6"})
+
 
 # ---------------------------------------------------------------------------- #
 # AOS 8 action -> Central action.type
@@ -180,6 +193,8 @@ _AOS8_ACTION_TO_CENTRAL: dict[str, str] = {
     "redir_opt": "ACTION_REDIRECT",
     "redirect": "ACTION_REDIRECT",
     "route": "ACTION_ROUTE",
+    "captive": "ACTION_CAPTIVE_PORTAL",
+    "mirror": "ACTION_MIRROR",
 }
 
 
@@ -239,6 +254,20 @@ def _build_central_rules(
     dst = _build_address(aos8_rule, "dst", address_family, role_attribution)
     if src is None or dst is None:
         return []
+    # Role injection: an AOS 8 session ACL applied to a role scopes a bare
+    # `any` to that role's users. When neither side already resolves to a role
+    # and exactly one side is `any`, convert that `any` side to the attributed
+    # role so the rule is role-scoped (and Central can bind it). The any+any
+    # pattern is handled above by the bidirectional expansion; both-sides-
+    # specific is a network-based rule and is left as-is. See issue #419.
+    if role_attribution and src.get("type") != "ADDRESS_ROLE" and dst.get("type") != "ADDRESS_ROLE":
+        role_addr = {"type": "ADDRESS_ROLE", "role-list": list(role_attribution)}
+        src_any = src.get("type") == "ADDRESS_ANY"
+        dst_any = dst.get("type") == "ADDRESS_ANY"
+        if src_any and not dst_any:
+            src = role_addr
+        elif dst_any and not src_any:
+            dst = role_addr
     return [_make_rule(starting_position, src, dst)]
 
 
@@ -302,7 +331,12 @@ def _build_address(rule: dict, side: str, address_family: str, role_attribution:
         alias = rule.get(alias_field)
         if alias is None:
             return None
-        return {"type": "ADDRESS_ALIAS", "host-address": {"host-address-alias": str(alias)}}
+        # A netdestination reference resolves in the `ac-netgroup` namespace —
+        # we migrate netdestinations to Central net-groups (see central:net_group),
+        # not to host-address aliases. Per roles-policy.json the top-level
+        # `net-group` field is "Only applicable when type is ADDRESS_ALIAS";
+        # host-address-alias belongs to ADDRESS_HOST.
+        return {"type": "ADDRESS_ALIAS", "net-group": str(alias)}
 
     if discriminator in ("suserrole", "duserrole"):
         name_field = "surname" if side == "src" else "durname"
@@ -339,6 +373,10 @@ def _build_net_service_block(rule: dict) -> dict[str, Any] | None:
         return None
     name = rule.get("service-name") or rule.get("service_name")
     if not name:
+        return None
+    # ICMPv6 / ra-guard is NOT a real net-service catalog entry — route it to the
+    # protocol-rule path (RULE_PROTOCOL + ip-header.protocol=IPV6_ICMP) instead.
+    if str(name).lower() in _ICMPV6_SERVICE_NAMES:
         return None
     central_name = _AOS8_TO_CENTRAL_SVC_NAME_ALIASES.get(str(name), str(name))
     return {"services": {"net-service": central_name}}
@@ -386,6 +424,14 @@ def _build_protocol_port_block(rule: dict) -> dict[str, Any] | None:
     if service_app != "service":
         return None
 
+    # ra-guard / IPv6-ICMP: AOS 8 surfaces this as a service-name (e.g. "icmpv6")
+    # which is not a real net-service. Emit a protocol rule on IPV6_ICMP.
+    if svc_mode == "service-name":
+        name = rule.get("service-name") or rule.get("service_name")
+        if name and str(name).lower() in _ICMPV6_SERVICE_NAMES:
+            return {"ip-header": {"protocol": "IPV6_ICMP"}}
+        return None
+
     if svc_mode == "icmp":
         ip_header: dict[str, Any] = {"protocol": "IP_ICMP"}
         icmp_type = rule.get("icmp_type")
@@ -395,7 +441,10 @@ def _build_protocol_port_block(rule: dict) -> dict[str, Any] | None:
 
     if svc_mode in ("tcp_udp", "tcp", "udp"):
         proto = rule.get("proto")
-        proto_enum = {"tcp": "IP_TCP", "udp": "IP_UDP"}.get(str(proto).lower())
+        # AOS 8 may return proto as a name ("tcp"/"udp") or a protocol number
+        # (6/17). Map both — a numeric proto that fell through used to drop the
+        # whole block, silently degrading the rule to RULE_ANY (issue #419).
+        proto_enum = {"tcp": "IP_TCP", "udp": "IP_UDP", "6": "IP_TCP", "17": "IP_UDP"}.get(str(proto).lower())
         if proto_enum is None:
             return None
         out: dict[str, Any] = {"ip-header": {"protocol": proto_enum}}
@@ -403,8 +452,15 @@ def _build_protocol_port_block(rule: dict) -> dict[str, Any] | None:
         port2 = rule.get("port2")
         if port1 is not None:
             min_port = int(port1)
-            max_port = int(port2) if port2 is not None else min_port
-            out["transport-fields"] = {"destination-port": {"min": min_port, "max": max_port}}
+            # Central's PortConfig: `max` is only valid with COMPARISON_RANGE;
+            # a single port must use COMPARISON_EQ + min only (live-confirmed
+            # 400 otherwise — issue #419).
+            if port2 is not None and int(port2) != min_port:
+                out["transport-fields"] = {
+                    "destination-port": {"operator": "COMPARISON_RANGE", "min": min_port, "max": int(port2)}
+                }
+            else:
+                out["transport-fields"] = {"destination-port": {"operator": "COMPARISON_EQ", "min": min_port}}
         return out
 
     return None
@@ -447,34 +503,44 @@ def _build_action(rule: dict) -> dict[str, Any]:
 
     if rule.get("log"):
         action.setdefault("secondary-actions", {})["log"] = True
+    # `blacklist` is NOT an action type in AOS 8 — it's a per-rule option that
+    # denylists the client. Central models it as a secondary-action flag layered
+    # on top of the base action (keep permit/deny, add the denylist flag).
+    if rule.get("blacklist"):
+        action.setdefault("secondary-actions", {})["denylist"] = True
     if rule.get("app-send-deny-response"):
         action["send-deny-response"] = True
 
     if central_type == "ACTION_DESTINATION_NAT":
+        # Central destination-nat sub-config uses `port` / `ip-address`
+        # (roles-policy.json), not the AOS 8-flavored dest-port / dest-address.
         dst_nat: dict[str, Any] = {}
         if rule.get("dnatport") is not None:
-            dst_nat["dest-port"] = int(rule["dnatport"])
+            dst_nat["port"] = int(rule["dnatport"])
         if rule.get("dnataddr") is not None:
-            dst_nat["dest-address"] = str(rule["dnataddr"])
+            dst_nat["ip-address"] = str(rule["dnataddr"])
         if dst_nat:
             action["destination-nat"] = dst_nat
 
     if central_type == "ACTION_DUAL_NAT":
+        # Central dual-nat requires `nat-pool` (x-mandatory) + optional `port`.
         dual_nat: dict[str, Any] = {}
-        if rule.get("dualnatport") is not None:
-            dual_nat["dest-port"] = int(rule["dualnatport"])
         if rule.get("dualnatpool") is not None:
-            dual_nat["pool"] = str(rule["dualnatpool"])
+            dual_nat["nat-pool"] = str(rule["dualnatpool"])
+        if rule.get("dualnatport") is not None:
+            dual_nat["port"] = int(rule["dualnatport"])
         if dual_nat:
             action["dual-nat"] = dual_nat
 
     if central_type == "ACTION_REDIRECT":
+        # Central redirect sub-config is discriminated by `destination`:
+        # REDIRECT_TUNNEL → tunnel (int id); REDIRECT_TUNNEL_GROUP → tunnel-group (name).
         re_dir = rule.get("re_dir")
         redirect: dict[str, Any] = {}
         if re_dir == "tunnel" and rule.get("tunid") is not None:
-            redirect["tunnel-id"] = int(rule["tunid"])
+            redirect = {"destination": "REDIRECT_TUNNEL", "tunnel": int(rule["tunid"])}
         elif re_dir == "tunnel-group" and rule.get("tungrpname") is not None:
-            redirect["tunnel-group"] = str(rule["tungrpname"])
+            redirect = {"destination": "REDIRECT_TUNNEL_GROUP", "tunnel-group": str(rule["tungrpname"])}
         if redirect:
             action["redirect"] = redirect
 

--- a/src/hpe_networking_mcp/translations/targets/central/net_group_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/net_group_v1.json
@@ -14,6 +14,7 @@
       "body": {
         "name":                "{name}",
         "netdestination-type": "{netdestination_type}",
+        "invert":              "{invert}",
         "items":               "{items}"
       },
       "iteration": "once",
@@ -29,7 +30,7 @@
       "query_params": {},
       "body_template": {
         "config-assignment": [
-          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='net-group', profile-instance='{name}' }}"
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='net-groups', profile-instance='{name}' }}"
         ]
       },
       "iteration": "once",
@@ -106,7 +107,14 @@
           "from":      "_central_items",
           "to":        "Central net-group body 'items[]' array",
           "transform": "direct",
-          "notes":     "Pre-computed by the preprocessing function. Each AOS 8 __entry maps to one Central items[] element with the discriminator-appropriate fields: netdst__host -> {type: HOST, address}; netdst__network -> {type: NETWORK, prefix=address/netmask_to_prefix(netmask)}; netdst__name -> {type: FQDN, fqdn}. Engine substitutes the array verbatim."
+          "notes":     "Pre-computed by the preprocessing function. Each AOS 8 __entry maps to one Central items[] element with the discriminator-appropriate fields plus a 1-based 'index' (the schema x-key): netdst__host -> {type: HOST, address, index}; netdst__network -> {type: NETWORK, prefix=address/netmask_to_prefix(netmask), index}; netdst__name -> {type: FQDN, fqdn, index}. Engine substitutes the array verbatim."
+        },
+        "invert": {
+          "from":      "_invert",
+          "to":        "Central net-group body 'invert' (bool)",
+          "transform": "direct",
+          "optional":  true,
+          "notes":     "Pre-computed by the preprocessing function. AOS 8 netdestinations carry an 'invert' clause; when truthy the function sets _invert=true and the body emits invert=true. When the source invert is false/absent, _invert is omitted entirely and the optional-field path drops the body key (Central treats absent == false for its built-in shape)."
         }
       },
       "unmapped_fields": [
@@ -121,8 +129,8 @@
           "severity_rule":   "non_empty_regression"
         },
         {
-          "from":            "Central net-group 'description' / 'invert' / 'exclude' / 'preemptive-failover'",
-          "reason":          "Optional Central body fields with no AOS 8 source-side counterpart in netdst / netdst6 records. Leaving body keys unset = Central defaults apply (invert=false, no exclude, etc.). Operator can override via overrides post-translation.",
+          "from":            "Central net-group 'description' / 'exclude' / 'preemptive-failover'",
+          "reason":          "Optional Central body fields with no AOS 8 source-side counterpart in netdst / netdst6 records. Leaving body keys unset = Central defaults apply (no exclude, etc.). Operator can override via overrides post-translation. NOTE: 'invert' IS mapped (AOS 8 netdestinations carry an invert clause) — see key_mappings.invert.",
           "severity_rule":   "always_operator_map"
         }
       ],

--- a/src/hpe_networking_mcp/translations/targets/central/policy_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/policy_v1.json
@@ -14,7 +14,7 @@
       "body": {
         "name":        "{name}",
         "type":        "POLICY_TYPE_SECURITY",
-        "association": "ASSOCIATION_ROLE",
+        "association": "{association}",
         "security-policy": {
           "type":        "SECURITY_POLICY_TYPE_DEFAULT",
           "policy-rule": "{policy_rules}"
@@ -33,7 +33,7 @@
       "query_params": {},
       "body_template": {
         "config-assignment": [
-          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='policy', profile-instance='{name}' }}"
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='policies', profile-instance='{name}' }}"
         ]
       },
       "iteration": "once",
@@ -57,10 +57,10 @@
       "depends_on":  "central:role (the roles referenced by the ACL must already exist in Central before policies referencing them are POSTed)",
       "depended_by": [
         {
-          "target_id": "role.policies[]",
-          "field":     "policies[]",
-          "relation":  "Central back-fills the role's policies[] array from policy.policy-rule[].condition.source.role-list automatically — this translation INVERTS the AOS 8 role->ACL binding direction.",
-          "notes":     "AOS 8 has role.role__acl[] referencing ACL names; Central has policy.policy-rule[].condition.source.role-list referencing role names. Migration creates policies that reference roles, and Central derives the role->policies back-reference."
+          "target_id": "role (implicit linkage)",
+          "field":     "(none — no back-reference on the role object)",
+          "relation":  "The role->policy linkage is IMPLICIT, not stored on the role. Verified live: central_get_role_with_policy returns policy:null and the role record carries no policies[]. A policy binds to a role via its own policy-rule[].condition.source.role-list PLUS co-assignment of the role and the policy at the same scope/device-function.",
+          "notes":     "AOS 8 has role.role__acl[] referencing ACL names; Central does NOT invert this into a role.policies[] array. Do not expect Central to back-fill a role->policies reference (issue #419). NOTE: assigning the policy ALSO requires it to be registered as a policy-group entry first — see issue #420; this spec's step 2 (direct config-assignment) is incomplete until that lands."
         }
       ]
     }
@@ -112,6 +112,12 @@
           "transform": "direct",
           "optional":  true,
           "notes":     "Pre-computed by the preprocessing function (declared in the top-level preprocessing field). Result is the full Central policy-rule[] array — engine substitutes verbatim into the body wherever {policy_rules} appears. Empty / no-rules ACLs return [] which the body keeps as an empty array; consumer should typically filter ACLs with empty rule lists from migration before calling emit_calls."
+        },
+        "association": {
+          "from":      "_association",
+          "to":        "Central policy body 'association' (enum: ASSOCIATION_ROLE / ASSOCIATION_INTERFACE)",
+          "transform": "direct_str",
+          "notes":     "Pre-computed by the preprocessing function. AOS 8 'validuser' (and any other interface-ACL name in _INTERFACE_ACL_NAMES) is an INTERFACE ACL → ASSOCIATION_INTERFACE; every other ACL is role-applied → ASSOCIATION_ROLE."
         }
       },
       "unmapped_fields": [

--- a/src/hpe_networking_mcp/translations/targets/central/role_v1.json
+++ b/src/hpe_networking_mcp/translations/targets/central/role_v1.json
@@ -69,7 +69,7 @@
       "query_params": {},
       "body_template": {
         "config-assignment": [
-          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='role', profile-instance='{name}' }}"
+          "{one entry per device_function in target_meta.device_functions: { scope-id, device-function, profile-type='roles', profile-instance='{name}' }}"
         ]
       },
       "iteration": "once",
@@ -320,7 +320,7 @@
     }
   },
   "draft_notes": [
-    "v1 translation, Gateway-targeted. Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Every body field is Gateway-supported per the Central role schema (verified via api-endpoints/central/role.json's x-supportedDeviceType annotations).",
+    "v1 translation, Gateway-targeted. Two-step Central CNX flow (role SHARED create + multi-DF config-assignments). Every body field is Gateway-supported per the Central role schema (verified via vendor/central/config/roles-policy.json's x-supportedDeviceType annotations).",
     "Live-verified source field names across 55 roles in the operator's tenant including a purpose-configured 'parent' role with all Tier 1 flag features + reauthentication-interval-seconds + per-app / per-appcategory / per-web-cc-category / per-web-cc-reputation bandwidth contracts + bw-contract exclude (app + appcategory), and the 'blacklisted' role with the basic per-role bandwidth contract. All seven bw-contract sub-shapes are mapped (basic per-role + per-app + per-appcategory + per-web-cc-category + per-web-cc-reputation + exclude-app + exclude-appcategory).",
     "Bandwidth-contract source shape: AOS 8 stores three discriminated source arrays: 'role__bwc_app' carries per-app + per-appcategory entries (discriminator 'app_type'), 'role__bwc_web' carries per-web-cc-category + per-web-cc-reputation entries (discriminator 'web_opt'), and 'role__bwc_ex' carries exclude-app + exclude-appcategory entries (also using 'app_type'). Plus the basic per-role 'role__bwc'. Central has SEVEN distinct body schemas; each AOS 8 array fans out to two Central body fields via paired filter-and-transform key_mappings.",
     "INVERSION CALL-OUT: AOS 8 carries the role->ACL binding inside the role record (role__acl array). Central inverts the relationship — policies reference roles via policy-rule[].condition.source.role, and Central back-fills role.policies[] from those references. This translation does NOT send policies[] in the role body. ACL->role binding is owned by the future central:policy translation.",

--- a/tests/unit/test_config_assignments_device_functions.py
+++ b/tests/unit/test_config_assignments_device_functions.py
@@ -1,0 +1,27 @@
+"""Unit tests for the config-assignment device-function allowlist.
+
+Covers the EdgeConnect device-function additions (EC_VPNC, EC_BRANCH_GW)
+from assignments.json's device-function enum (issue #419).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools.config_assignments import (
+    VALID_DEVICE_FUNCTIONS,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_edgeconnect_device_functions_present() -> None:
+    """EC_VPNC and EC_BRANCH_GW (EdgeConnect) are valid device functions."""
+    assert "EC_VPNC" in VALID_DEVICE_FUNCTIONS
+    assert "EC_BRANCH_GW" in VALID_DEVICE_FUNCTIONS
+
+
+def test_existing_device_functions_unchanged() -> None:
+    """The EdgeConnect additions don't disturb the existing core functions."""
+    for df in ("CAMPUS_AP", "MOBILITY_GW", "BRANCH_GW", "VPNC", "ALL"):
+        assert df in VALID_DEVICE_FUNCTIONS

--- a/tests/unit/test_translations_engine.py
+++ b/tests/unit/test_translations_engine.py
@@ -518,7 +518,7 @@ def test_role_step2_assigns_only_to_mobility_gw_by_default(role) -> None:
     items = (step2.body or {})["config-assignment"]
     assert len(items) == 1
     assert items[0]["device-function"] == "MOBILITY_GW"
-    assert items[0]["profile-type"] == "role"
+    assert items[0]["profile-type"] == "roles"
     assert items[0]["profile-instance"] == "demo"
 
 
@@ -1254,7 +1254,7 @@ def test_policy_icmp_echo_rule(policy) -> None:
 
 
 def test_policy_dst_nat_action(policy) -> None:
-    """action=dst-nat with dnatport=8080 → ACTION_DESTINATION_NAT + destination-nat.dest-port=8080."""
+    """action=dst-nat with dnatport=8080 → ACTION_DESTINATION_NAT + destination-nat.port=8080."""
     source = {
         "accname": "dst-nat-rule",
         "acl_sess__v4policy": [
@@ -1275,12 +1275,13 @@ def test_policy_dst_nat_action(policy) -> None:
     rule = body["security-policy"]["policy-rule"][0]
     assert rule["action"] == {
         "type": "ACTION_DESTINATION_NAT",
-        "destination-nat": {"dest-port": 8080},
+        "destination-nat": {"port": 8080},
     }
 
 
 def test_policy_redirect_tunnel_group(policy) -> None:
-    """action=redir_opt + re_dir=tunnel-group + tungrpname → ACTION_REDIRECT + redirect.tunnel-group."""
+    """action=redir_opt + re_dir=tunnel-group + tungrpname → ACTION_REDIRECT +
+    redirect={destination: REDIRECT_TUNNEL_GROUP, tunnel-group: <name>}."""
     source = {
         "accname": "redir-rule",
         "acl_sess__v4policy": [
@@ -1302,8 +1303,257 @@ def test_policy_redirect_tunnel_group(policy) -> None:
     rule = body["security-policy"]["policy-rule"][0]
     assert rule["action"] == {
         "type": "ACTION_REDIRECT",
-        "redirect": {"tunnel-group": "test"},
+        "redirect": {"destination": "REDIRECT_TUNNEL_GROUP", "tunnel-group": "test"},
     }
+
+
+def test_policy_redirect_tunnel_uses_destination_discriminator(policy) -> None:
+    """action=redir_opt + re_dir=tunnel + tunid → ACTION_REDIRECT +
+    redirect={destination: REDIRECT_TUNNEL, tunnel: <int>} (no bare tunnel-id)."""
+    source = {
+        "accname": "redir-t",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "tunid": 7,
+                "re_dir": "tunnel",
+                "action": "redir_opt",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {
+        "type": "ACTION_REDIRECT",
+        "redirect": {"destination": "REDIRECT_TUNNEL", "tunnel": 7},
+    }
+
+
+def test_policy_dst_nat_with_address_uses_ip_address_key(policy) -> None:
+    """dst-nat with dnataddr → destination-nat.ip-address (not dest-address)."""
+    source = {
+        "accname": "dnat-addr",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-name": "svc-http",
+                "svc": "service-name",
+                "service_app": "service",
+                "dnatport": 8080,
+                "dnataddr": "10.2.2.2",
+                "action": "dst-nat",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {
+        "type": "ACTION_DESTINATION_NAT",
+        "destination-nat": {"port": 8080, "ip-address": "10.2.2.2"},
+    }
+
+
+def test_policy_dual_nat_action_uses_nat_pool_and_port(policy) -> None:
+    """action=dual-nat with dualnatpool + dualnatport → ACTION_DUAL_NAT +
+    dual-nat={nat-pool, port} (nat-pool is x-mandatory)."""
+    source = {
+        "accname": "dual-nat",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "dualnatpool": "pool-a",
+                "dualnatport": 9090,
+                "action": "dual-nat",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {
+        "type": "ACTION_DUAL_NAT",
+        "dual-nat": {"nat-pool": "pool-a", "port": 9090},
+    }
+
+
+def test_policy_captive_action_maps_to_action_captive_portal(policy) -> None:
+    """action=captive → ACTION_CAPTIVE_PORTAL (not the ACTION_ALLOW fall-through)."""
+    source = {
+        "accname": "cap",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "action": "captive",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {"type": "ACTION_CAPTIVE_PORTAL"}
+
+
+def test_policy_mirror_action_maps_to_action_mirror(policy) -> None:
+    """action=mirror → ACTION_MIRROR."""
+    source = {
+        "accname": "mir",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "action": "mirror",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {"type": "ACTION_MIRROR"}
+
+
+def test_policy_blacklist_sets_secondary_action_denylist(policy) -> None:
+    """blacklist is NOT an action — it keeps the base action (permit/deny) and
+    layers secondary-actions.denylist=true on top."""
+    source = {
+        "accname": "bl",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "blacklist": True,
+                "deny": True,
+                "action": "deny",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["action"] == {
+        "type": "ACTION_DENY",
+        "secondary-actions": {"denylist": True},
+    }
+
+
+def test_policy_salias_emits_net_group_reference(policy) -> None:
+    """dst=dalias + dstalias → ADDRESS_ALIAS with a top-level net-group (Design A),
+    NOT host-address.host-address-alias (issue #419)."""
+    source = {
+        "accname": "alias-rule",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dstalias": "cppm",
+                "dst": "dalias",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "permit": True,
+                "action": "permit",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["condition"]["destination"] == {"type": "ADDRESS_ALIAS", "net-group": "cppm"}
+
+
+def test_policy_validuser_acl_emits_association_interface(policy) -> None:
+    """The canonical interface ACL 'validuser' → body association ASSOCIATION_INTERFACE."""
+    source = {
+        "accname": "validuser",
+        "acl_sess__v4policy": [
+            {
+                "sany": True,
+                "src": "sany",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "permit": True,
+                "action": "permit",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    assert body["association"] == "ASSOCIATION_INTERFACE"
+
+
+def test_policy_non_validuser_acl_stays_association_role(policy) -> None:
+    """Any non-interface ACL keeps association ASSOCIATION_ROLE."""
+    source = {
+        "accname": "regular-acl",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "permit": True,
+                "action": "permit",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    assert body["association"] == "ASSOCIATION_ROLE"
+
+
+def test_policy_icmpv6_ra_guard_emits_protocol_rule(policy) -> None:
+    """An ICMPv6 service-name (ra-guard) → RULE_PROTOCOL + ip-header.protocol=IPV6_ICMP,
+    NOT an invented RULE_NET_SERVICE net-service 'icmpv6' (issue #419)."""
+    source = {
+        "accname": "ra-guard",
+        "acl_sess__v6policy": [
+            {
+                "sany": True,
+                "src": "sany",
+                "dany": True,
+                "dst": "dany",
+                "service-name": "icmpv6",
+                "svc": "service-name",
+                "service_app": "service",
+                "deny": True,
+                "action": "deny",
+            }
+        ],
+    }
+    body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
+    rule = body["security-policy"]["policy-rule"][0]
+    assert rule["condition"]["rule-type"] == "RULE_PROTOCOL"
+    assert rule["condition"]["ip-header"] == {"protocol": "IPV6_ICMP"}
+    assert "services" not in rule["condition"]
 
 
 def test_policy_time_range_reference_lands_in_condition(policy) -> None:
@@ -1443,7 +1693,7 @@ def test_policy_step2_assigns_to_mobility_gw(policy) -> None:
     assert items[0] == {
         "scope-id": "SCOPE-X",
         "device-function": "MOBILITY_GW",
-        "profile-type": "policy",
+        "profile-type": "policies",
         "profile-instance": "demo",
     }
 
@@ -1507,12 +1757,13 @@ def test_policy_any_any_rule_replaces_source_with_role_attribution(policy) -> No
     assert rule["condition"]["destination"] == {"type": "ADDRESS_ANY"}
 
 
-def test_policy_any_specific_keeps_source_as_address_any(policy) -> None:
-    """sany source + DESTINATION-specific (host/network/role) → keep source ADDRESS_ANY.
+def test_policy_any_to_host_injects_role_as_source(policy) -> None:
+    """sany source + specific destination (host) in a role-bound ACL → inject
+    the attributed role as the source (issue #419, live-validated).
 
-    Per Reading A: only the literal 'any-any' pattern gets rewritten. Rules
-    where AOS 8 says 'any → specific-something' translate to Central
-    'any → specific-something' since Central does support that pattern.
+    AOS 8 'any' in a role-applied ACL means 'this role's users'. Central needs
+    ADDRESS_ROLE so the rule is role-scoped and the policy can bind to the role
+    — emitting ADDRESS_ANY drops the role binding and over-broadens the rule.
     """
     source = {
         "accname": "any-host",
@@ -1532,19 +1783,18 @@ def test_policy_any_specific_keeps_source_as_address_any(policy) -> None:
     }
     body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
     rule = body["security-policy"]["policy-rule"][0]
-    assert rule["condition"]["source"] == {"type": "ADDRESS_ANY"}
+    assert rule["condition"]["source"] == {"type": "ADDRESS_ROLE", "role-list": ["parent"]}
     assert rule["condition"]["destination"] == {
         "type": "ADDRESS_HOST",
         "host-address": {"host-ipv4-address": "10.1.1.1"},
     }
 
 
-def test_policy_any_to_network_keeps_source_as_address_any(policy) -> None:
-    """sany source + dst=dnetwork (specific destination network) → source stays ADDRESS_ANY.
-
-    Same Reading A logic: Central allows 'any → network' so no rewrite
-    needed. Companion to test_policy_any_specific_keeps_source_as_address_any
-    which exercises 'any → host'.
+def test_policy_any_to_network_injects_role_as_source(policy) -> None:
+    """sany source + dst=dnetwork in a role-bound ACL → inject the attributed
+    role as the source (issue #419, live-validated). Companion to
+    test_policy_any_to_host_injects_role_as_source; the network destination is
+    left as-is (inline ADDRESS_NETWORK, no alias/net-group).
     """
     source = {
         "accname": "any-network",
@@ -1566,12 +1816,161 @@ def test_policy_any_to_network_keeps_source_as_address_any(policy) -> None:
     }
     body = emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {}
     rule = body["security-policy"]["policy-rule"][0]
-    assert rule["condition"]["source"] == {"type": "ADDRESS_ANY"}
+    assert rule["condition"]["source"] == {"type": "ADDRESS_ROLE", "role-list": ["parent"]}
     assert rule["condition"]["destination"] == {
         "type": "ADDRESS_NETWORK",
         "network-address": {"network-ipv4-address": "10.0.0.0/8"},
     }
     assert rule["action"] == {"type": "ACTION_DENY"}
+
+
+def test_policy_network_to_any_injects_role_as_destination(policy) -> None:
+    """specific source + dst=any in a role-bound ACL → inject the role on the
+    DESTINATION side (issue #419). Symmetric to the any→specific source case."""
+    source = {
+        "accname": "net-any",
+        "acl_sess__v4policy": [
+            {
+                "snetaddr": "10.0.0.0",
+                "snetmask": "255.0.0.0",
+                "src": "snetwork",
+                "dany": True,
+                "dst": "dany",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "action": "permit",
+            }
+        ],
+    }
+    rule = (emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {})[
+        "security-policy"
+    ]["policy-rule"][0]
+    assert rule["condition"]["source"] == {
+        "type": "ADDRESS_NETWORK",
+        "network-address": {"network-ipv4-address": "10.0.0.0/8"},
+    }
+    assert rule["condition"]["destination"] == {"type": "ADDRESS_ROLE", "role-list": ["parent"]}
+
+
+def test_policy_both_specific_no_role_injection(policy) -> None:
+    """host source + network dest (no `any`, no role) → network-based rule;
+    the role is NOT injected anywhere (issue #419)."""
+    source = {
+        "accname": "h-n",
+        "acl_sess__v4policy": [
+            {
+                "sipaddr": "192.0.2.5",
+                "src": "shost",
+                "dnetaddr": "10.0.0.0",
+                "dnetmask": "255.0.0.0",
+                "dst": "dnetwork",
+                "service-any": True,
+                "svc": "service-any",
+                "service_app": "service",
+                "action": "permit",
+            }
+        ],
+    }
+    rule = (emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {})[
+        "security-policy"
+    ]["policy-rule"][0]
+    assert rule["condition"]["source"] == {"type": "ADDRESS_HOST", "host-address": {"host-ipv4-address": "192.0.2.5"}}
+    assert rule["condition"]["destination"] == {
+        "type": "ADDRESS_NETWORK",
+        "network-address": {"network-ipv4-address": "10.0.0.0/8"},
+    }
+
+
+def test_policy_any_network_tcp_port_full_operator_case(policy) -> None:
+    """The operator's exact failing shape `any network X tcp 22 deny log`,
+    live-validated end-to-end (issue #419): role-injected source, inline
+    network dest, RULE_TCP + COMPARISON_EQ single-port, ACTION_DENY + log."""
+    source = {
+        "accname": "secure-mgmt",
+        "acl_sess__v4policy": [
+            {
+                "sany": True,
+                "src": "sany",
+                "dnetaddr": "198.51.100.64",
+                "dnetmask": "255.255.255.240",
+                "dst": "dnetwork",
+                "svc": "tcp",
+                "proto": "tcp",
+                "port1": 22,
+                "service_app": "service",
+                "log": True,
+                "deny": True,
+                "action": "deny",
+            }
+        ],
+    }
+    rule = (emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {})[
+        "security-policy"
+    ]["policy-rule"][0]
+    c = rule["condition"]
+    assert c["rule-type"] == "RULE_TCP"
+    assert c["source"] == {"type": "ADDRESS_ROLE", "role-list": ["parent"]}
+    assert c["destination"] == {
+        "type": "ADDRESS_NETWORK",
+        "network-address": {"network-ipv4-address": "198.51.100.64/28"},
+    }
+    assert c["ip-header"] == {"protocol": "IP_TCP"}
+    assert c["transport-fields"] == {"destination-port": {"operator": "COMPARISON_EQ", "min": 22}}
+    assert rule["action"] == {"type": "ACTION_DENY", "secondary-actions": {"log": True}}
+
+
+def test_policy_tcp_port_range_uses_comparison_range(policy) -> None:
+    """A port range (port1 != port2) → COMPARISON_RANGE with min+max (issue #419)."""
+    source = {
+        "accname": "rng",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "svc": "tcp",
+                "proto": "tcp",
+                "port1": 1000,
+                "port2": 2000,
+                "service_app": "service",
+                "action": "permit",
+            }
+        ],
+    }
+    rule = (emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {})[
+        "security-policy"
+    ]["policy-rule"][0]
+    assert rule["condition"]["transport-fields"] == {
+        "destination-port": {"operator": "COMPARISON_RANGE", "min": 1000, "max": 2000}
+    }
+
+
+def test_policy_numeric_proto_maps_to_tcp(policy) -> None:
+    """proto returned as a number (6) still maps to IP_TCP — not silently
+    dropped to RULE_ANY (issue #419)."""
+    source = {
+        "accname": "numproto",
+        "acl_sess__v4policy": [
+            {
+                "suser": True,
+                "src": "suser",
+                "dany": True,
+                "dst": "dany",
+                "svc": "tcp",
+                "proto": 6,
+                "port1": 443,
+                "service_app": "service",
+                "action": "permit",
+            }
+        ],
+    }
+    rule = (emit_calls(policy, source, "aos8", runtime_values=_policy_runtime(source))[0].body or {})[
+        "security-policy"
+    ]["policy-rule"][0]
+    assert rule["condition"]["rule-type"] == "RULE_TCP"
+    assert rule["condition"]["ip-header"] == {"protocol": "IP_TCP"}
 
 
 def test_policy_any_any_with_empty_role_attribution_falls_back_to_address_any(policy) -> None:
@@ -1641,7 +2040,7 @@ def test_net_group_host_only_record_emits_two_calls(net_group) -> None:
     assert step1.body == {
         "name": "cppm",
         "netdestination-type": "IPV4_ONLY",
-        "items": [{"type": "HOST", "address": "192.168.20.70"}],
+        "items": [{"type": "HOST", "address": "192.168.20.70", "index": 1}],
     }
 
 
@@ -1657,9 +2056,9 @@ def test_net_group_mixed_entries_render_in_source_order(net_group) -> None:
     }
     body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
     assert body["items"] == [
-        {"type": "HOST", "address": "192.168.20.70"},
-        {"type": "NETWORK", "prefix": "10.10.0.0/16"},
-        {"type": "FQDN", "fqdn": "cppm.example.com"},
+        {"type": "HOST", "address": "192.168.20.70", "index": 1},
+        {"type": "NETWORK", "prefix": "10.10.0.0/16", "index": 2},
+        {"type": "FQDN", "fqdn": "cppm.example.com", "index": 3},
     ]
 
 
@@ -1675,9 +2074,9 @@ def test_net_group_netmask_conversion_handles_common_prefixes(net_group) -> None
     }
     body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
     assert body["items"] == [
-        {"type": "NETWORK", "prefix": "10.0.0.0/8"},
-        {"type": "NETWORK", "prefix": "172.16.0.0/12"},
-        {"type": "NETWORK", "prefix": "192.168.1.0/24"},
+        {"type": "NETWORK", "prefix": "10.0.0.0/8", "index": 1},
+        {"type": "NETWORK", "prefix": "172.16.0.0/12", "index": 2},
+        {"type": "NETWORK", "prefix": "192.168.1.0/24", "index": 3},
     ]
 
 
@@ -1691,7 +2090,7 @@ def test_net_group_v6_record_sets_ipv6_only_family(net_group) -> None:
     }
     body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
     assert body["netdestination-type"] == "IPV6_ONLY"
-    assert body["items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32"}]
+    assert body["items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32", "index": 1}]
 
 
 def test_net_group_step2_assigns_to_mobility_gw_by_default(net_group) -> None:
@@ -1707,7 +2106,7 @@ def test_net_group_step2_assigns_to_mobility_gw_by_default(net_group) -> None:
     assert items[0] == {
         "scope-id": "SCOPE-X",
         "device-function": "MOBILITY_GW",
-        "profile-type": "net-group",
+        "profile-type": "net-groups",
         "profile-instance": "x",
     }
 
@@ -1726,7 +2125,7 @@ def test_net_group_runtime_device_functions_override(net_group) -> None:
     )
     items = (calls[1].body or {})["config-assignment"]
     assert {i["device-function"] for i in items} == {"MOBILITY_GW", "CAMPUS_AP"}
-    assert all(i["profile-type"] == "net-group" for i in items)
+    assert all(i["profile-type"] == "net-groups" for i in items)
     assert all(i["profile-instance"] == "x" for i in items)
 
 
@@ -1755,3 +2154,71 @@ def test_net_group_non_contiguous_netmask_raises(net_group) -> None:
     }
     with pytest.raises(EngineError, match="non-contiguous"):
         emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())
+
+
+def test_net_group_ipv6_supernet_preserves_prefix_length(net_group) -> None:
+    """fc00::/7 supplied with a separate prefix-length must NOT collapse to /128
+    (issue #419). The prefix is built from the entry's prefix-length field."""
+    source = {
+        "dstname": "ula",
+        "netdst6__entry": [
+            {"_objname": "netdst6__network", "address": "fc00::", "prefix_len": 7},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["netdestination-type"] == "IPV6_ONLY"
+    assert body["items"] == [{"type": "NETWORK", "prefix": "fc00::/7", "index": 1}]
+
+
+def test_net_group_ipv6_network_without_prefix_length_passes_address_through(net_group) -> None:
+    """When no prefix-length field is present and the address carries no '/', the
+    address passes through UNCHANGED — never a hardcoded /128 (issue #419)."""
+    source = {
+        "dstname": "host6",
+        "netdst6__entry": [
+            {"_objname": "netdst6__network", "address": "2001:db8::1"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["items"] == [{"type": "NETWORK", "prefix": "2001:db8::1", "index": 1}]
+
+
+def test_net_group_invert_true_emits_invert_in_body(net_group) -> None:
+    """A netdst record with invert truthy → body carries invert=true."""
+    source = {
+        "dstname": "not-corp",
+        "invert": True,
+        "netdst__entry": [
+            {"_objname": "netdst__network", "address": "10.0.0.0", "netmask": "255.0.0.0"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert body["invert"] is True
+
+
+def test_net_group_invert_false_omits_invert_key(net_group) -> None:
+    """When invert is false/absent, the body omits the 'invert' key entirely
+    (Central built-in shape treats absent == false)."""
+    source = {
+        "dstname": "corp",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert "invert" not in body
+
+
+def test_net_group_items_carry_one_based_index_in_source_order(net_group) -> None:
+    """Every emitted items[] element carries a 1-based 'index' in source order
+    (the schema x-key)."""
+    source = {
+        "dstname": "many",
+        "netdst__entry": [
+            {"_objname": "netdst__host", "address": "10.0.0.1"},
+            {"_objname": "netdst__host", "address": "10.0.0.2"},
+            {"_objname": "netdst__name", "host_name": "x.example.com"},
+        ],
+    }
+    body = emit_calls(net_group, source, "aos8", runtime_values=_ng_runtime())[0].body or {}
+    assert [i["index"] for i in body["items"]] == [1, 2, 3]

--- a/tests/unit/test_translations_loader.py
+++ b/tests/unit/test_translations_loader.py
@@ -337,7 +337,9 @@ def test_loads_shipped_policy_translation_cleanly() -> None:
     body = next(e.body for e in p.target_emits if e.step == 1)
     assert body is not None
     assert body["type"] == "POLICY_TYPE_SECURITY"
-    assert body["association"] == "ASSOCIATION_ROLE"
+    # association is now a placeholder fed by the preprocessing function's
+    # _association (ASSOCIATION_ROLE default; ASSOCIATION_INTERFACE for validuser).
+    assert body["association"] == "{association}"
     assert body["security-policy"]["type"] == "SECURITY_POLICY_TYPE_DEFAULT"
 
 

--- a/tests/unit/test_translations_preprocessing_aos8_net_group.py
+++ b/tests/unit/test_translations_preprocessing_aos8_net_group.py
@@ -70,7 +70,7 @@ def test_netdst_host_entry_maps_to_host_type() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "192.168.20.70"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "192.168.20.70", "index": 1}]
 
 
 def test_netdst_network_entry_maps_to_network_with_cidr_prefix() -> None:
@@ -83,8 +83,8 @@ def test_netdst_network_entry_maps_to_network_with_cidr_prefix() -> None:
     }
     out = preprocess_net_group(source, {})
     assert out["_central_items"] == [
-        {"type": "NETWORK", "prefix": "10.0.0.0/8"},
-        {"type": "NETWORK", "prefix": "192.168.1.0/24"},
+        {"type": "NETWORK", "prefix": "10.0.0.0/8", "index": 1},
+        {"type": "NETWORK", "prefix": "192.168.1.0/24", "index": 2},
     ]
 
 
@@ -94,7 +94,7 @@ def test_netdst_name_entry_maps_to_fqdn() -> None:
         "netdst__entry": [{"_objname": "netdst__name", "host_name": "cppm.example.com"}],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "FQDN", "fqdn": "cppm.example.com"}]
+    assert out["_central_items"] == [{"type": "FQDN", "fqdn": "cppm.example.com", "index": 1}]
 
 
 def test_mixed_entry_types_preserve_source_order() -> None:
@@ -109,9 +109,9 @@ def test_mixed_entry_types_preserve_source_order() -> None:
     }
     out = preprocess_net_group(source, {})
     assert out["_central_items"] == [
-        {"type": "HOST", "address": "192.168.20.70"},
-        {"type": "NETWORK", "prefix": "10.10.0.0/16"},
-        {"type": "FQDN", "fqdn": "cppm.example.com"},
+        {"type": "HOST", "address": "192.168.20.70", "index": 1},
+        {"type": "NETWORK", "prefix": "10.10.0.0/16", "index": 2},
+        {"type": "FQDN", "fqdn": "cppm.example.com", "index": 3},
     ]
 
 
@@ -125,7 +125,7 @@ def test_unknown_objname_silently_skipped() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1", "index": 1}]
 
 
 def test_entry_missing_required_field_is_dropped() -> None:
@@ -140,7 +140,7 @@ def test_entry_missing_required_field_is_dropped() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1", "index": 1}]
 
 
 def test_non_dict_entry_silently_skipped() -> None:
@@ -153,7 +153,7 @@ def test_non_dict_entry_silently_skipped() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1", "index": 1}]
 
 
 # --------------------------------------------------------------------------- #
@@ -171,7 +171,7 @@ def test_entry_with_default_flag_filtered() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2", "index": 1}]
 
 
 def test_entry_with_system_flag_filtered() -> None:
@@ -183,7 +183,7 @@ def test_entry_with_system_flag_filtered() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.2", "index": 1}]
 
 
 def test_entry_with_inherited_flag_passes_through() -> None:
@@ -198,7 +198,7 @@ def test_entry_with_inherited_flag_passes_through() -> None:
         ],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "10.0.0.1", "index": 1}]
 
 
 # --------------------------------------------------------------------------- #
@@ -212,7 +212,7 @@ def test_netdst6_host_entry_maps_to_host() -> None:
         "netdst6__entry": [{"_objname": "netdst6__host", "address": "2001:db8::1"}],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "HOST", "address": "2001:db8::1"}]
+    assert out["_central_items"] == [{"type": "HOST", "address": "2001:db8::1", "index": 1}]
 
 
 def test_netdst6_network_with_cidr_already_in_address() -> None:
@@ -222,19 +222,56 @@ def test_netdst6_network_with_cidr_already_in_address() -> None:
         "netdst6__entry": [{"_objname": "netdst6__network", "address": "2001:db8::/32"}],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32"}]
+    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::/32", "index": 1}]
 
 
-def test_netdst6_network_without_cidr_defaults_to_128() -> None:
-    """Defensive default: v6 NETWORK entry without '/' falls back to /128.
-    First live verification will refine this if needed.
+def test_netdst6_network_prefix_from_prefix_length_field() -> None:
+    """v6 NETWORK entry with a separate prefix-length field builds the CIDR from
+    that length — real supernets are preserved, NOT collapsed to /128 (issue #419).
+    """
+    source = {
+        "dstname": "ula",
+        "netdst6__entry": [{"_objname": "netdst6__network", "address": "fc00::", "prefix_len": 7}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "fc00::/7", "index": 1}]
+
+
+def test_netdst6_network_without_prefix_length_passes_address_through() -> None:
+    """v6 NETWORK entry with no '/' and no prefix-length field passes the address
+    through UNCHANGED rather than inventing a /128 host route (issue #419).
     """
     source = {
         "dstname": "x6",
         "netdst6__entry": [{"_objname": "netdst6__network", "address": "2001:db8::1"}],
     }
     out = preprocess_net_group(source, {})
-    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::1/128"}]
+    assert out["_central_items"] == [{"type": "NETWORK", "prefix": "2001:db8::1", "index": 1}]
+
+
+# --------------------------------------------------------------------------- #
+# invert clause
+# --------------------------------------------------------------------------- #
+
+
+def test_invert_truthy_surfaces_invert_flag() -> None:
+    source = {
+        "dstname": "x",
+        "invert": True,
+        "netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert out["_invert"] is True
+
+
+def test_invert_falsy_omits_invert_flag() -> None:
+    """Absent / false invert → no _invert key (Central absent == false shape)."""
+    source = {
+        "dstname": "x",
+        "netdst__entry": [{"_objname": "netdst__host", "address": "10.0.0.1"}],
+    }
+    out = preprocess_net_group(source, {})
+    assert "_invert" not in out
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Spec-confirmed corrections to the AOS 8 `acl_sess` / `netdst` → Central CNX translation. Every fix was derived by auditing the vendored Central OAS against Central's **live built-in policies**, and the policy-side fixes were **validated end-to-end on real config** — `captiveportal6`, `ra-guard`, and `validuser` now emit the same representation Central's own built-ins use.

Builds on the already-applied bounded fixes (role injection, destination-port operator, plural `roles`/`policies` profile-type) and lands on the new OAS tool surface (v3.3.0.0).

## Fixes

| Area | Before | After |
|---|---|---|
| **Alias (Design A)** | `host-address.host-address-alias` | top-level `net-group: <name>` |
| **`captive` action** | `ACTION_ALLOW` (silent fallback) | `ACTION_CAPTIVE_PORTAL` (+ `mirror`→`ACTION_MIRROR`, `blacklist`→`secondary-actions.denylist`) |
| **`validuser`** | `ASSOCIATION_ROLE` | `ASSOCIATION_INTERFACE` |
| **RA-guard / ICMPv6** | `RULE_NET_SERVICE` + invalid `net-service: "icmpv6"` | `RULE_PROTOCOL` + `ip-header.protocol: IPV6_ICMP` |
| **destination-nat** | `dest-port` / `dest-address` | `port` / `ip-address` |
| **dual-nat** | `pool` / `dest-port` | required `nat-pool` / `port` |
| **redirect** | `tunnel-id` (no discriminator) | `destination: REDIRECT_TUNNEL` + `tunnel` (or `…_GROUP` + `tunnel-group`) |
| **net-group IPv6 prefix** | `/128` collapse | actual prefix preserved (`fc00::/7`) |
| **net-group `invert`** | dropped (unmapped) | mapped, emit-when-true |
| **net-group items** | no `index` | 1-based `index` per item |
| **net-group assignment** | `profile-type: net-group` | plural `net-groups` |
| **config-assignment** | `VALID_DEVICE_FUNCTIONS` missing EdgeConnect | adds `EC_VPNC` / `EC_BRANCH_GW` |

## Validation

- **1593 tests pass** (ruff + mypy clean); a unit test added per fix.
- **Live reconciliation** against Central built-ins confirmed on real config: `captiveportal6` → `ACTION_CAPTIVE_PORTAL` + `net-group: controller6`; `ra-guard` → `RULE_PROTOCOL`/`IPV6_ICMP`; `validuser` → `ASSOCIATION_INTERFACE`. Remaining diffs are the genuine site customizations.

## Notes (no live sample to confirm)

- **dual-nat** field names and the **netdst6** IPv6 prefix-length field name are inferred from spec/convention (no records of those shapes in the test tenant) — flagged for confirmation on first real sample.
- `net-groups` plural `profile-type` matches the confirmed `roles`/`policies` convention; the spec doesn't enum it and the tenant has no net-group assignment to observe.

Closes #419.
