### PR TITLE
feat(aos8): CLI config parser + aos8_parse_config tool (v3.3.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0.2] - 2026-06-05
+
+**Patch — AOS 8 CLI config parser + `aos8_parse_config` tool.** Adds an offline parser that turns a pasted/uploaded AOS 8 running-config (CLI) into the same canonical records the translation engine already consumes from `aos8_get_effective_config` — enabling the "paste your AOS 8 config into the AI" migration flow without a live controller.
+
+- **`aos8_parse_config`** (read tool, AOS 8 platform): `cli_text` → `{netdst, acl_sess, role, _warnings}`. Parses `netdestination`/`netdestination6`, `ip access-list session`/`ipv6 access-list session`, and `user-role` stanzas; captures source/destination discriminators, services, protocol/port, actions (incl. `src-nat` / `dst-nat` / `dual-nat pool <name> <port>` / `redirect`), `log`, and `invert`. Tolerant — unmodelled clauses surface as warnings / `_unparsed` rather than being dropped.
+- The output is interchangeable with `aos8_get_effective_config`, so it feeds the `central:policy` / `central:net_group` / `central:role` translations unchanged.
+- AOS 8 platform tool count: 47 → 48 (total registered surface 1961 → 1962).
+
 ## [3.3.0.1] - 2026-06-05
 
 **Patch — AOS 8 → Central policy/net-group translation drift fixes.** Corrects spec-confirmed mismatches in the AOS 8 `acl_sess` / `netdst` → Central CNX translation, validated against Central's live built-in policies.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Managing HPE networking infrastructure with AI assistants today means juggling m
 | **Staged Writes + Commit Workflow** | — | — | — | — | ✅ | ✅ | — | — |
 | **Guided Prompts** | ✅ | ✅ | — | — | — | — | ✅ | — |
 | **Dynamic Tool Discovery** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Underlying tools** | **1037 + 2 prompts** | **660 + 12 prompts** | **10** | **142** | **19** | **25** | **47 + 9 prompts** | **21** |
+| **Underlying tools** | **1037 + 2 prompts** | **660 + 12 prompts** | **10** | **142** | **19** | **25** | **48 + 9 prompts** | **21** |
 | **Exposed meta-tools (dynamic mode)** | **3** | **3** | **3** | **3** | **3** | **3** | **3** | **3** |
 | **Cross-Platform** | **3 tools + 3 prompts** | **3 tools + 3 prompts** | — | **1 tool** | — | — | — | — |
 
-> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1961 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (47 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
+> **Default tool surface (v3.0.0.0+)**: ships with `MCP_TOOL_MODE=code` by default. Code mode exposes only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`); all 1962 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Smallest initial token cost (~minimal context); best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` to use the v2.x default behavior — each platform exposes 3 meta-tools (`<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`) plus the 4 cross-platform static tools and 2 skills tools (24 total surface, ~3,700 tokens). The `static` mode was REMOVED in v3.0.0.0. Every tool's response is wrapped in a uniform envelope `{ok, status, data, message, tool, platform}`. v2.3.0.0 introduces **Skills** — markdown-defined multi-step procedures discoverable via `skills_list` / `skills_load`; see [docs/TOOLS.md#skills](docs/TOOLS.md). v2.4.0.0 adds **AOS8** (48 tools + 9 prompts) — see [INSTRUCTIONS.md](INSTRUCTIONS.md) for AOS8-specific operator guidance. v3.2.0.0 adds **HPE UXI** (21 tools). See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md).
 
 ### Aruba Central Guided Prompts
 
@@ -200,7 +200,7 @@ docker compose up -d
 docker compose logs
 ```
 
-Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 142 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 47 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1961 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
+Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 142 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 48 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 1962 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
 ### Docker Image
 
@@ -525,10 +525,10 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 │ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐│
 │ │  Mist  │ │Central │ │GreenLk │ │ClrPass │ │ Apstra │ │  Axis  │ │  AOS8  │ │  UXI   ││
 │ │ mist_* │ │centrl_*│ │grnlake │ │clrpass │ │apstra_*│ │ axis_* │ │ aos8_* │ │ uxi_*  ││
-│ │ 1037   │ │660tools│ │10 tools│ │142 tool│ │19 tools│ │25 tools│ │47 tools│ │21 tools││
+│ │ 1037   │ │660tools│ │10 tools│ │142 tool│ │19 tools│ │25 tools│ │48 tools│ │21 tools││
 │ │+2 prmt │ │+12prmt │ │        │ │        │ │        │ │        │ │+9 prmt │ │        ││
 │                                                                                         │
-│  All 1961 underlying tools reachable via call_tool() in code mode or via                │
+│  All 1962 underlying tools reachable via call_tool() in code mode or via                │
 │  per-platform meta-tools (<platform>_list_tools / get_schema / invoke) in dynamic mode. │
 │ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘ └───┬────┘│
 │     │          │          │          │          │          │          │          │       │
@@ -543,7 +543,7 @@ Set `ENABLE_UXI_WRITE_TOOLS=true` to expose the 10 UXI write tools (gated by eli
 
 - **FastMCP** framework with Python 3.12+
 - **Streamable HTTP** transport (modern MCP standard)
-- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1961 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
+- **Code tool mode by default (since v3.0.0.0)** — only `execute` + 5 discovery tools exposed; all 1962 underlying tools reachable via `await call_tool(name, params)` inside the sandbox. Smallest initial token cost; best for orchestrators driving small / local LLMs. Set `MCP_TOOL_MODE=dynamic` for the v2.x meta-tool surface (24 tools, ~3,700 tokens).
 - **Tool namespacing** — `mist_*`, `central_*`, `greenlake_*`, `clearpass_*`, `apstra_*`, `axis_*`, `aos8_*`, `uxi_*` prefixes prevent collisions
 - **Platform isolation** — each module manages its own API client and auth; a failing platform doesn't affect the others
 - **Non-root container** — runs as `mcpuser` (uid 1000)
@@ -607,7 +607,7 @@ The retry logic detects transient failures in two patterns: response-dict (Mist/
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (call `aos8_write_memory` after each change to persist) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (sensor/agent/group/assignment mutations) |
 | `DISABLE_ELICITATION` | `false` | Disable write confirmation prompts |
-| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1961 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
+| `MCP_TOOL_MODE` | `code` | Tool exposure: `code` (default since v3.0.0.0 — 6 tools at top level: `execute` + 5 discovery; all 1962 underlying tools reachable via `call_tool()` inside the sandbox) or `dynamic` (24 tools — 4 cross-platform + 21 per-platform meta-tools + 2 skills tools; underlying tools hidden until invoked via `<platform>_invoke_tool`). The `static` value was REMOVED in v3.0.0.0 |
 | `RETRY_MAX_ATTEMPTS` | `3` | Max retry attempts on transient failures (5xx reads, 429 reads+writes). Set to `1` to disable retry |
 | `RETRY_INITIAL_DELAY` | `1.0` | Initial retry backoff seconds (exponential: 1s, 2s, 4s) |
 | `RETRY_MAX_DELAY` | `60.0` | Cap on a single retry sleep (also caps `Retry-After` header values) |
@@ -680,7 +680,7 @@ hpe-networking-mcp/
 │       ├── clearpass/           # 142 ClearPass tools + pyclearpass SDK client
 │       ├── apstra/              # 19 Apstra tools + async httpx client
 │       ├── axis/                # 25 Axis Atmos Cloud tools + httpx client (JWT bearer)
-│       ├── aos8/                # 47 AOS8 tools + 9 prompts + UIDARUBA session client
+│       ├── aos8/                # 48 AOS8 tools + 9 prompts + UIDARUBA session client
 │       ├── manage_wlan.py       # Cross-platform WLAN management tool
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
@@ -803,25 +803,25 @@ If tools time out after ~4 minutes, check that:
 - Node.js is installed: `npx --version`
 - The container didn't lose connectivity after sleep: `docker compose restart`
 
-### Tool Surface Looks Wrong (6 tools vs. 1961)
+### Tool Surface Looks Wrong (6 tools vs. 1962)
 
-Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1961 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
+Since v3.0.0.0, the server defaults to `MCP_TOOL_MODE=code`: only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1962 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. A correctly configured server with all 8 platforms enabled will advertise **6 tools** to the AI client.
 
 Check the mode in the logs:
 
 ```bash
 docker compose logs | grep "Tool mode"
-# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1961 underlying via call_tool)
+# "Tool mode: code"      → default since v3.0.0.0 (6 exposed tools, 1962 underlying via call_tool)
 # "Tool mode: dynamic"   → opt-in to v2.x meta-tool surface (24 exposed: 21 per-platform + 4 cross-platform + 2 skills)
 ```
 
 To use the v2.x meta-tool discovery surface (each platform exposes `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`), set `MCP_TOOL_MODE=dynamic` in `docker-compose.yml` under `environment`:
 ```yaml
 - MCP_TOOL_MODE=dynamic   # 24 exposed; per-platform meta-tools + cross-platform + skills
-- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1961 (default since v3.0.0.0)
+- MCP_TOOL_MODE=code      # 6 exposed; sandboxed call_tool() reaches all 1962 (default since v3.0.0.0)
 ```
 
-The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1961 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
+The `static` mode (every underlying tool visible up front) was REMOVED in v3.0.0.0 — at 1962 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` now raises an error at startup with a migration message.
 
 See [docs/MIGRATING_TO_V2.md](docs/MIGRATING_TO_V2.md) for the v1.x → v2.x meta-tool history.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -9,18 +9,18 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1961 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 1962 underlying tools
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
 - **`skills_list(filter=...)`** — list bundled multi-step runbooks (since v2.3.0.0)
 - **`skills_load(name=...)`** — load a runbook to execute
 
-All 1961 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
+All 1962 per-platform tools documented below still exist and are reachable via `await call_tool(name, params)` inside `execute()`. The per-platform sections below serve as the **full tool index** — humans read them directly; the AI discovers them via the discovery tools (`tags`, `search`, `get_schema`).
 
 **Why code mode is the default since v3.0.0.0**: smallest initial token cost, single-round-trip multi-step orchestration, and validated against small local LLMs (Qwen3 4B Q4_K_M; see [#246](https://github.com/nowireless4u/hpe-networking-mcp/issues/246) reassessment).
 
-Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1961 tools / ~64K tokens it was no longer practical.
+Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface (per-platform discovery — see next section). The `static` mode was REMOVED in v3.0.0.0 — at 1962 tools / ~64K tokens it was no longer practical.
 
 ## Dynamic mode (opt-in since v3.0.0.0; was the v2.x default)
 
@@ -39,7 +39,7 @@ With `MCP_TOOL_MODE=dynamic` the AI sees **24 tools**:
   - `skills_list(filter=...)` — list bundled multi-step runbooks
   - `skills_load(name=...)` — load a runbook to execute
 
-The 1961 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
+The 1962 per-platform tools are reachable via `<platform>_invoke_tool(name=..., arguments={...})`. Best when an orchestrator wants explicit per-tool dispatch rather than the sandboxed Python composition that code mode provides.
 
 ## Code mode details (the default — see above for surface summary)
 
@@ -96,7 +96,7 @@ If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMidd
 - **`code` (default since v3.0.0.0)** — best for orchestrators driving small / local LLMs, multi-step aggregations, cross-platform joins, filter/map/reduce workflows. Smallest initial token cost. Validated against Qwen3 4B Q4_K_M via OpenClaw (see #246 reassessment).
 - **`dynamic` (opt-in since v3.0.0.0; was the v2.x default)** — best when the orchestrator wants explicit per-tool dispatch via `<platform>_invoke_tool` rather than sandboxed Python composition. Stable, production-tested for lookup-style questions.
 
-The `static` mode was REMOVED in v3.0.0.0 — at 1961 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
+The `static` mode was REMOVED in v3.0.0.0 — at 1962 tools / ~64K tokens it was no longer practical. Setting `MCP_TOOL_MODE=static` raises ValueError at startup.
 
 ## Overview
 
@@ -2296,7 +2296,7 @@ in `platforms/axis/__init__.py` if Axis ever flips them on.
 | `axis_get_ip_feed_categories` | `GET /api/v1.0/IpCategoriesFeed` |
 | `axis_manage_ip_feed_category` | `POST/PUT/DELETE /api/v1.0/IpCategoriesFeed` |
 
-## Aruba OS 8 / Mobility Conductor (47 tools + 9 prompts)
+## Aruba OS 8 / Mobility Conductor (48 tools + 9 prompts)
 
 Tools are reachable via `await call_tool("aos8_<tool>", {...})` inside `execute()` in code mode (default since v3.0.0.0), or via the per-platform meta-tools (`aos8_list_tools`, `aos8_get_tool_schema`, `aos8_invoke_tool`) in dynamic mode. Write tools require `ENABLE_AOS8_WRITE_TOOLS=true`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.0.1"
+version = "3.3.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -17,7 +17,7 @@ Tools are namespaced by platform:
 
 Two modes are supported (the `static` mode was removed in v3.0.0.0):
 
-- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1961 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
+- **`MCP_TOOL_MODE=code`** (default since v3.0.0.0) — only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are visible at the top level. All 1962 underlying tools are reachable from inside a sandboxed Python `execute()` block via `await call_tool("<platform>_invoke_tool", {"name": "<tool>", "params": {...}})` — see the in-sandbox dispatch note below; the ~1000 spec-driven Mist tools are reachable **only** through `mist_invoke_tool`, not by direct name. The smallest initial surface; best for orchestrators driving small / local LLMs.
 - **`MCP_TOOL_MODE=dynamic`** (opt-in since v3.0.0.0; was the v2.x default) — 24 tools visible:
     - **4 cross-platform tools**: `health`, `site_health_check`, `site_rf_check`, `manage_wlan_profile`
     - **3 meta-tools per platform × 8 platforms** = 24: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`

--- a/src/hpe_networking_mcp/platforms/aos8/__init__.py
+++ b/src/hpe_networking_mcp/platforms/aos8/__init__.py
@@ -50,6 +50,7 @@ TOOLS: dict[str, list[str]] = {
     "differentiators": [
         "aos8_get_md_hierarchy",
         "aos8_get_effective_config",
+        "aos8_parse_config",
         "aos8_get_pending_changes",
         "aos8_get_rf_neighbors",
         "aos8_get_cluster_state",

--- a/src/hpe_networking_mcp/platforms/aos8/cli_parser.py
+++ b/src/hpe_networking_mcp/platforms/aos8/cli_parser.py
@@ -1,0 +1,350 @@
+"""AOS 8 CLI → canonical config-record parser (a source-record producer).
+
+This is the CLI counterpart to ``aos8_get_effective_config`` (which produces
+records from the REST API). It parses pasted/uploaded AOS 8 running-config CLI
+into the **same record dicts the translation engine already consumes** —
+``netdst`` (netdestination), ``acl_sess`` (session ACL), and ``role``
+(user-role) — so the existing ``translations`` engine maps them unchanged.
+
+It is deliberately pure and deterministic (text in, records out, no I/O), and
+tolerant: a line/clause it can't fully model is captured under an ``_unparsed``
+marker rather than dropped, so coverage gaps are visible to the caller and the
+engine's ``unmapped_fields`` handling.
+
+Record shapes match the engine's input contract (see each target spec's
+``sources.aos8.objects[].live_shape_example``):
+
+* netdestination → ``{"dstname": str, "netdst__entry": [{"_objname": ...}]}``
+* session ACL    → ``{"accname": str, "acl_sess__v4policy": [...], "acl_sess__v6policy": [...]}``
+* user-role      → ``{"rname": str, "role__acl": [{"acl_type": "session", "pname": ...}], ...}``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# AOS 8 session-ACL action keywords → value the engine's _build_action expects
+# (keys of translations.preprocessing.aos8_policy._AOS8_ACTION_TO_CENTRAL).
+_ACTIONS = {
+    "permit": "permit",
+    "deny": "deny",
+    "src-nat": "src-nat",
+    "dst-nat": "dst-nat",
+    "dual-nat": "dual-nat",
+    "redirect": "redirect",
+    "route": "route",
+    # Recognised so the rule structure is captured; the engine treats these as
+    # unmapped actions (see policy_v1.json unmapped_fields) — parsing them here
+    # keeps the rule from being dropped as ``_unparsed``.
+    "captive": "captive",
+    "mirror": "mirror",
+    "blacklist": "blacklist",
+}
+
+# Trailing rule options we recognise (everything else is captured raw).
+_OPTION_KEYWORDS = {"log", "position", "time-range", "queue", "tos", "dot1p-priority", "blacklist", "disable-scanning"}
+
+
+def parse_aos8_cli(text: str) -> dict[str, Any]:
+    """Parse AOS 8 CLI text into canonical config records grouped by object.
+
+    Args:
+        text: AOS 8 running-config CLI (``netdestination`` / ``ip access-list
+            session`` / ``user-role`` stanzas, ``!``-delimited).
+
+    Returns:
+        ``{"netdst": [...], "acl_sess": [...], "role": [...], "_warnings": [...]}``
+        — record lists ready to feed the translation engine, plus a list of
+        human-readable warnings for clauses that weren't fully modelled.
+    """
+    netdst: list[dict[str, Any]] = []
+    acl_sess: list[dict[str, Any]] = []
+    role: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for header, body in _stanzas(text):
+        tokens = header.split()
+        kind = tokens[0] if tokens else ""
+        if kind == "netdestination" and len(tokens) >= 2:
+            netdst.append(_parse_netdestination(tokens[1], body, warnings))
+        elif kind == "ip" and tokens[:3] == ["ip", "access-list", "session"] and len(tokens) >= 4:
+            acl_sess.append(_parse_acl_session(tokens[3], body, warnings))
+        elif kind == "netdestination6" and len(tokens) >= 2:
+            netdst.append(_parse_netdestination(tokens[1], body, warnings, ipv6=True))
+        elif kind == "user-role" and len(tokens) >= 2:
+            role.append(_parse_user_role(tokens[1], body, warnings))
+        # other stanza types (ip access-list eth, etc.) are out of scope here
+
+    return {"netdst": netdst, "acl_sess": acl_sess, "role": role, "_warnings": warnings}
+
+
+# --------------------------------------------------------------------------- #
+# Stanza splitting
+# --------------------------------------------------------------------------- #
+
+
+def _stanzas(text: str) -> list[tuple[str, list[str]]]:
+    """Split CLI into (header, body-lines) stanzas delimited by ``!``.
+
+    A stanza header is a non-indented line; its body is the following indented
+    lines up to the next ``!`` or non-indented line.
+    """
+    out: list[tuple[str, list[str]]] = []
+    header: str | None = None
+    body: list[str] = []
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if line.strip() == "!":
+            if header is not None:
+                out.append((header, body))
+            header, body = None, []
+            continue
+        if line[0].isspace():  # indented → body line
+            if header is not None:
+                body.append(line.strip())
+        else:  # non-indented → new header
+            if header is not None:
+                out.append((header, body))
+            header, body = line.strip(), []
+    if header is not None:
+        out.append((header, body))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# netdestination
+# --------------------------------------------------------------------------- #
+
+
+def _parse_netdestination(name: str, body: list[str], warnings: list[str], *, ipv6: bool = False) -> dict[str, Any]:
+    pfx = "netdst6" if ipv6 else "netdst"
+    entries: list[dict[str, Any]] = []
+    record: dict[str, Any] = {"dstname": name}
+    for line in body:
+        t = line.split()
+        if not t:
+            continue
+        kw = t[0]
+        if kw == "host" and len(t) >= 2:
+            entries.append({"_objname": f"{pfx}__host", "address": t[1]})
+        elif kw == "network" and len(t) >= 3:
+            entries.append({"_objname": f"{pfx}__network", "address": t[1], "netmask": t[2]})
+        elif kw == "network" and len(t) == 2:
+            # IPv6 / CIDR form: ``network <prefix>/<len>`` (single token).
+            entries.append({"_objname": f"{pfx}__network", "address": t[1]})
+        elif kw == "invert":
+            record["invert"] = True
+        elif kw == "name" and len(t) >= 2:
+            entries.append({"_objname": f"{pfx}__name", "host_name": t[1]})
+        elif kw == "range" and len(t) >= 3:
+            # The net_group preprocessing maps host/network/name only — range
+            # has no Central items[] mapping yet. Emit a typed entry so the gap
+            # is visible rather than silently dropped.
+            entries.append({"_objname": f"{pfx}__range", "start": t[1], "end": t[2]})
+            warnings.append(
+                f"netdestination {name!r}: 'range {t[1]} {t[2]}' has no engine "
+                "mapping (net_group handles host/network/name)"
+            )
+        elif kw == "description":
+            record["description"] = line.split(" ", 1)[1] if " " in line else ""
+        else:
+            warnings.append(f"netdestination {name!r}: unparsed line {line!r}")
+    record[f"{pfx}__entry"] = entries
+    return record
+
+
+# --------------------------------------------------------------------------- #
+# user-role
+# --------------------------------------------------------------------------- #
+
+
+def _parse_user_role(name: str, body: list[str], warnings: list[str]) -> dict[str, Any]:
+    record: dict[str, Any] = {"rname": name}
+    acls: list[dict[str, Any]] = []
+    for line in body:
+        t = line.split()
+        if not t:
+            continue
+        if t[:2] == ["access-list", "session"] and len(t) >= 3:
+            acls.append({"acl_type": "session", "pname": t[2]})
+        elif t[0] == "vlan" and len(t) >= 2:
+            record["role__vlan"] = {"vlanstr": t[1]}
+        elif t[0] == "max-sessions" and len(t) >= 2:
+            record["role__max_sess"] = {"max_sess": int(t[1])} if t[1].isdigit() else {"max_sess": t[1]}
+        elif t[0] == "captive-portal" and len(t) >= 2 and t[0] != "no":
+            record["role__cp"] = {"cp_profile_name": t[1]}
+        elif t[0] == "reauthentication-interval" and len(t) >= 2:
+            record["role__reauth"] = {"reauthperiod": int(t[1])} if t[1].isdigit() else {"reauthperiod": t[1]}
+        elif t[0] in ("bw-contract", "no", "dialer", "pool", "vpn-ip-pool", "via"):
+            # known-but-unmodelled role attributes — note, don't fail
+            warnings.append(f"user-role {name!r}: unmodelled clause {line!r}")
+        else:
+            warnings.append(f"user-role {name!r}: unparsed line {line!r}")
+    if acls:
+        record["role__acl"] = acls
+    return record
+
+
+# --------------------------------------------------------------------------- #
+# ip access-list session
+# --------------------------------------------------------------------------- #
+
+
+def _parse_acl_session(name: str, body: list[str], warnings: list[str]) -> dict[str, Any]:
+    v4: list[dict[str, Any]] = []
+    v6: list[dict[str, Any]] = []
+    for line in body:
+        t = line.split()
+        if not t:
+            continue
+        is_v6 = t[0] == "ipv6"
+        if is_v6:
+            t = t[1:]
+        rule = _parse_acl_rule(t, name, line, warnings)
+        if rule is None:
+            continue
+        (v6 if is_v6 else v4).append(rule)
+    return {"accname": name, "acl_sess__v4policy": v4, "acl_sess__v6policy": v6}
+
+
+def _consume_address(t: list[str], i: int, side: str) -> tuple[dict[str, Any], int] | None:
+    """Consume a source/dest address spec starting at token index ``i``.
+
+    ``side`` is ``"s"`` (source) or ``"d"`` (destination). Returns the fields to
+    merge into the rule plus the next token index, or ``None`` if unrecognised.
+    """
+    disc = "src" if side == "s" else "dst"
+    kw = t[i]
+    if kw == "any":
+        return {disc: f"{side}any"}, i + 1
+    if kw == "user":
+        return {disc: f"{side}user"}, i + 1
+    if kw == "localip":
+        return {disc: f"{side}localip"}, i + 1
+    if kw == "host" and i + 1 < len(t):
+        return {disc: f"{side}host", ("sipaddr" if side == "s" else "dipaddr"): t[i + 1]}, i + 2
+    if kw == "network" and i + 1 < len(t):
+        addr_f = "snetaddr" if side == "s" else "dnetaddr"
+        mask_f = "snetmask" if side == "s" else "dnetmask"
+        nxt = t[i + 1]
+        if "/" in nxt:
+            # IPv6 / CIDR single-token prefix: ``network fc00::/7``. Split into
+            # bare address + prefix length so the engine builds ``addr/len``.
+            addr, _, plen = nxt.partition("/")
+            return {disc: f"{side}network", addr_f: addr, mask_f: plen}, i + 2
+        if i + 2 < len(t):
+            return {disc: f"{side}network", addr_f: nxt, mask_f: t[i + 2]}, i + 3
+        return None
+    if kw == "alias" and i + 1 < len(t):
+        return {disc: f"{side}alias", ("srcalias" if side == "s" else "dstalias"): t[i + 1]}, i + 2
+    if kw == "user-role" and i + 1 < len(t):
+        return {disc: f"{side}userrole", ("surname" if side == "s" else "durname"): t[i + 1]}, i + 2
+    return None
+
+
+def _parse_acl_rule(t: list[str], acl: str, line: str, warnings: list[str]) -> dict[str, Any] | None:
+    """Parse one session-ACL rule's tokens (after any leading ``ipv6``)."""
+    rule: dict[str, Any] = {"service_app": "service"}
+    i = 0
+    src = _consume_address(t, i, "s")
+    if src is None:
+        warnings.append(f"acl {acl!r}: unparsed source in {line!r}")
+        return {"_unparsed": line}
+    rule.update(src[0])
+    i = src[1]
+    dst = _consume_address(t, i, "d")
+    if dst is None:
+        warnings.append(f"acl {acl!r}: unparsed destination in {line!r}")
+        return {"_unparsed": line}
+    rule.update(dst[0])
+    i = dst[1]
+
+    # Split the remainder into service-tokens / action / options at the first
+    # recognised action keyword.
+    rest = t[i:]
+    action_idx = next((k for k, tok in enumerate(rest) if tok in _ACTIONS), None)
+    if action_idx is None:
+        warnings.append(f"acl {acl!r}: no action keyword in {line!r}")
+        return {"_unparsed": line}
+    svc_tokens = rest[:action_idx]
+    action = rest[action_idx]
+    opts = rest[action_idx + 1 :]
+
+    _apply_service(rule, svc_tokens, acl, line, warnings)
+    rule["action"] = _ACTIONS[action]
+    _apply_action_args(rule, action, opts)
+    if "log" in opts:
+        rule["log"] = True
+    return rule
+
+
+def _apply_service(rule: dict[str, Any], svc: list[str], acl: str, line: str, warnings: list[str]) -> None:
+    if not svc or svc == ["any"]:
+        rule["svc"] = "service-any"
+        return
+    head = svc[0]
+    if head in ("tcp", "udp", "tcp-udp"):
+        rule["svc"] = "tcp_udp" if head == "tcp-udp" else head
+        rule["proto"] = head
+        ports = [x for x in svc[1:] if x.isdigit()]
+        if ports:
+            rule["port1"] = int(ports[0])
+            if len(ports) > 1:
+                rule["port2"] = int(ports[1])
+        return
+    if head == "icmp":
+        rule["svc"] = "icmp"
+        return
+    if head.isdigit():  # raw protocol number
+        rule["svc"] = "proto"
+        rule["proto"] = head
+        return
+    if head in ("app", "appcategory", "webcategory", "web-reputation") and len(svc) >= 2:
+        rule["service_app"] = "app_opt"
+        rule["app_web_type"] = {
+            "app": "app",
+            "appcategory": "app_cat",
+            "webcategory": "web_cc_cat",
+            "web-reputation": "web_cc_rep",
+        }[head]
+        rule["appname"] = svc[1]
+        return
+    # named service object (svc-*, or a user service name)
+    rule["svc"] = "service-name"
+    rule["service-name"] = head
+    if len(svc) > 1:
+        warnings.append(f"acl {acl!r}: extra service tokens {svc[1:]} in {line!r}")
+
+
+def _apply_action_args(rule: dict[str, Any], action: str, opts: list[str]) -> None:
+    if action == "dst-nat":
+        nums = [o for o in opts if o.isdigit()]
+        if nums:
+            rule["dnatport"] = int(nums[0])
+        # Optional explicit NAT target IP: ``dst-nat <ip> <port>`` (OSU configs
+        # use the port-only form; capture the IP form too for completeness).
+        ips = [o for o in opts if not o.isdigit() and ("." in o or ":" in o)]
+        if ips:
+            rule["dnataddr"] = ips[0]
+    elif action == "dual-nat":
+        # Form: ``dual-nat pool <pool-name> <port>``.
+        if "pool" in opts:
+            j = opts.index("pool")
+            if j + 1 < len(opts):
+                rule["dualnatpool"] = opts[j + 1]
+        nums = [o for o in opts if o.isdigit()]
+        if nums:
+            rule["dualnatport"] = int(nums[0])
+    elif action == "redirect":
+        if "tunnel-group" in opts:
+            j = opts.index("tunnel-group")
+            rule["re_dir"] = "tunnel-group"
+            if j + 1 < len(opts):
+                rule["tungrpname"] = opts[j + 1]
+        elif "tunnel" in opts:
+            j = opts.index("tunnel")
+            rule["re_dir"] = "tunnel"
+            if j + 1 < len(opts) and opts[j + 1].isdigit():
+                rule["tunid"] = int(opts[j + 1])

--- a/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
@@ -21,6 +21,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.cli_parser import parse_aos8_cli
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     get_object,
@@ -30,6 +31,7 @@ from hpe_networking_mcp.platforms.aos8.tools._helpers import (
 __all__ = [
     "aos8_get_md_hierarchy",
     "aos8_get_effective_config",
+    "aos8_parse_config",
     "aos8_get_pending_changes",
     "aos8_get_rf_neighbors",
     "aos8_get_cluster_state",
@@ -102,6 +104,51 @@ async def aos8_get_effective_config(
         )
     except Exception as exc:  # noqa: BLE001
         return format_aos8_error(exc, f"fetch effective config for {object_name}")
+
+
+# ---------------------------------------------------------------------------
+# DIFF-02b — Offline AOS 8 CLI → canonical translation records
+# ---------------------------------------------------------------------------
+
+
+@tool(name="aos8_parse_config", capability=Capability.READ)
+async def aos8_parse_config(ctx: Context, cli_text: str) -> dict[str, Any]:
+    """Parse pasted AOS 8 running-config CLI into canonical translation records.
+
+    This is the offline, paste-driven counterpart to
+    ``aos8_get_effective_config``. Where that tool pulls config records from a
+    live Conductor via the REST API, this one turns AOS 8 CLI **text** — the
+    kind an operator copies out of ``show running-config`` or a captured
+    config file — into the **same record shapes the translation engine
+    consumes**. It is a pure offline parse: it does **not** call the tenant or
+    use ``ctx`` at all, so it works with no AOS 8 connection configured.
+
+    It recognises ``netdestination`` / ``netdestination6``,
+    ``ip access-list session`` / ``ipv6 access-list session``, and
+    ``user-role`` stanzas, producing:
+
+    * ``netdst`` — netdestination records (feed ``central:net_group``)
+    * ``acl_sess`` — session-ACL records (feed ``central:policy``)
+    * ``role`` — user-role records (feed ``central:role``)
+    * ``_warnings`` — human-readable notes for clauses that weren't fully
+      modelled (nothing is silently dropped; unparseable rules are also
+      captured under an ``_unparsed`` marker on the record).
+
+    The result is interchangeable with the output of
+    ``aos8_get_effective_config``: hand it straight to the ``central:*``
+    translations exactly the same way, enabling the "paste your AOS 8 config
+    into the AI" migration flow without live controller access.
+
+    Args:
+        ctx: FastMCP request context (unused — this is an offline parse, but
+            kept for tool-signature consistency with the AOS 8 platform).
+        cli_text: AOS 8 running-config CLI text (``!``-delimited stanzas).
+
+    Returns:
+        ``{"netdst": [...], "acl_sess": [...], "role": [...],
+        "_warnings": [...]}`` — translation-ready records plus warnings.
+    """
+    return parse_aos8_cli(cli_text)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_aos8_cli_parser.py
+++ b/tests/unit/test_aos8_cli_parser.py
@@ -1,0 +1,292 @@
+"""Unit tests for the AOS 8 CLI → canonical-record parser.
+
+Exercises ``parse_aos8_cli`` against small, synthetic AOS 8 CLI snippets and
+asserts the parsed record shapes (netdestination / session-ACL / user-role),
+the warning channel for clauses that aren't fully modelled, and the parser →
+translation-engine integration path for a dual-nat session-ACL rule.
+
+All snippets use GENERIC placeholder names only (corp-servers, BRANCH-1,
+cp-portal, example.com, employee, guest, 10.0.0.0/24, fc00::/7) — never
+real-customer data.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.aos8.cli_parser import parse_aos8_cli
+from hpe_networking_mcp.translations.engine import emit_calls
+from hpe_networking_mcp.translations.loader import load_translations
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- #
+# netdestination
+# --------------------------------------------------------------------------- #
+
+
+def test_netdestination_host_network_name() -> None:
+    """host / network (dotted-quad mask) / name(FQDN) entries parse correctly."""
+    res = parse_aos8_cli(
+        "netdestination corp-servers\n  host 10.0.0.5\n  network 10.0.0.0 255.255.255.0\n  name example.com\n!\n"
+    )
+    assert len(res["netdst"]) == 1
+    rec = res["netdst"][0]
+    assert rec["dstname"] == "corp-servers"
+    entries = rec["netdst__entry"]
+    assert entries[0] == {"_objname": "netdst__host", "address": "10.0.0.5"}
+    assert entries[1] == {
+        "_objname": "netdst__network",
+        "address": "10.0.0.0",
+        "netmask": "255.255.255.0",
+    }
+    assert entries[2] == {"_objname": "netdst__name", "host_name": "example.com"}
+    # Well-formed lines produce no warnings.
+    assert res["_warnings"] == []
+
+
+def test_netdestination6_ipv6_network() -> None:
+    """netdestination6 with a single-token IPv6 CIDR keeps the prefix intact."""
+    res = parse_aos8_cli("netdestination6 v6-net\n  network fc00::/7\n!\n")
+    rec = res["netdst"][0]
+    assert rec["dstname"] == "v6-net"
+    # IPv6 / CIDR form keeps the prefix in one token (no separate netmask).
+    assert rec["netdst6__entry"] == [{"_objname": "netdst6__network", "address": "fc00::/7"}]
+
+
+def test_netdestination_invert_clause() -> None:
+    """An ``invert`` clause sets the record-level invert flag."""
+    res = parse_aos8_cli("netdestination corp-servers\n  invert\n  host 10.0.0.5\n!\n")
+    rec = res["netdst"][0]
+    assert rec["invert"] is True
+
+
+def test_netdestination_range_warns() -> None:
+    """A ``range`` line is captured as a typed entry AND warns (no engine map)."""
+    res = parse_aos8_cli("netdestination corp-servers\n  range 10.0.0.10 10.0.0.20\n!\n")
+    rec = res["netdst"][0]
+    assert rec["netdst__entry"] == [{"_objname": "netdst__range", "start": "10.0.0.10", "end": "10.0.0.20"}]
+    assert any("range 10.0.0.10 10.0.0.20" in w for w in res["_warnings"])
+
+
+# --------------------------------------------------------------------------- #
+# ip access-list session
+# --------------------------------------------------------------------------- #
+
+
+def _only_rule(cli: str) -> dict:
+    """Parse a single-rule ACL snippet and return that v4 rule."""
+    res = parse_aos8_cli(cli)
+    assert len(res["acl_sess"]) == 1
+    rules = res["acl_sess"][0]["acl_sess__v4policy"]
+    assert len(rules) == 1
+    return rules[0]
+
+
+def test_acl_any_any_any_permit() -> None:
+    """``any any any permit`` → src/dst any, service-any, permit."""
+    rule = _only_rule("ip access-list session corp-acl\n  any any any permit\n!\n")
+    assert rule["src"] == "sany"
+    assert rule["dst"] == "dany"
+    assert rule["svc"] == "service-any"
+    assert rule["action"] == "permit"
+    assert "_unparsed" not in rule
+
+
+def test_acl_user_network_tcp_port_deny_log() -> None:
+    """``user network ... tcp 443 deny log`` parses proto/port/action/log."""
+    rule = _only_rule("ip access-list session corp-acl\n  user network 10.0.0.0 255.255.255.0 tcp 443 deny log\n!\n")
+    assert rule["src"] == "suser"
+    assert rule["dst"] == "dnetwork"
+    assert rule["dnetaddr"] == "10.0.0.0"
+    assert rule["dnetmask"] == "255.255.255.0"
+    assert rule["svc"] == "tcp"
+    assert rule["proto"] == "tcp"
+    assert rule["port1"] == 443
+    assert rule["action"] == "deny"
+    assert rule["log"] is True
+
+
+def test_acl_user_alias_named_service_permit() -> None:
+    """``user alias corp-servers svc-https permit`` → dalias + named service."""
+    rule = _only_rule("ip access-list session corp-acl\n  user alias corp-servers svc-https permit\n!\n")
+    assert rule["src"] == "suser"
+    assert rule["dst"] == "dalias"
+    assert rule["dstalias"] == "corp-servers"
+    assert rule["svc"] == "service-name"
+    assert rule["service-name"] == "svc-https"
+    assert rule["action"] == "permit"
+
+
+def test_acl_any_any_named_service_src_nat() -> None:
+    """``any any svc-icmp src-nat`` → both-any, named service, src-nat action."""
+    rule = _only_rule("ip access-list session corp-acl\n  any any svc-icmp src-nat\n!\n")
+    assert rule["src"] == "sany"
+    assert rule["dst"] == "dany"
+    assert rule["svc"] == "service-name"
+    assert rule["service-name"] == "svc-icmp"
+    assert rule["action"] == "src-nat"
+
+
+def test_acl_user_any_dst_nat_port() -> None:
+    """``user any svc-http dst-nat 8080`` captures the dst-nat port."""
+    rule = _only_rule("ip access-list session corp-acl\n  user any svc-http dst-nat 8080\n!\n")
+    assert rule["action"] == "dst-nat"
+    assert rule["dnatport"] == 8080
+    assert rule["service-name"] == "svc-http"
+
+
+def test_acl_user_any_dual_nat_pool_port() -> None:
+    """``user any svc-https dual-nat pool corp-pool 8081`` sets pool + port."""
+    rule = _only_rule("ip access-list session corp-acl\n  user any svc-https dual-nat pool corp-pool 8081\n!\n")
+    assert rule["action"] == "dual-nat"
+    assert rule["dualnatpool"] == "corp-pool"
+    assert rule["dualnatport"] == 8081
+
+
+def test_acl_ipv6_rule_lands_in_v6policy() -> None:
+    """An ``ipv6 ...`` rule is routed into the v6 policy array, not v4."""
+    res = parse_aos8_cli("ip access-list session corp-acl\n  ipv6 user any icmpv6 deny\n!\n")
+    acl = res["acl_sess"][0]
+    assert acl["acl_sess__v4policy"] == []
+    v6 = acl["acl_sess__v6policy"]
+    assert len(v6) == 1
+    rule = v6[0]
+    assert rule["src"] == "suser"
+    assert rule["dst"] == "dany"
+    assert rule["action"] == "deny"
+    # NOTE: the parser treats ``icmpv6`` as a named-service object (it only
+    # special-cases the literal token ``icmp``), so it surfaces as a
+    # service-name rather than an icmp service. See the test-suite docstring /
+    # the agent report for the flagged behaviour.
+    assert rule["svc"] == "service-name"
+    assert rule["service-name"] == "icmpv6"
+
+
+# --------------------------------------------------------------------------- #
+# user-role
+# --------------------------------------------------------------------------- #
+
+
+def test_user_role_fields_and_acl_bindings() -> None:
+    """user-role parses vlan / max-sessions / access-list session / captive-portal."""
+    res = parse_aos8_cli(
+        "user-role employee\n"
+        "  vlan 100\n"
+        "  max-sessions 10\n"
+        "  access-list session corp-acl\n"
+        "  access-list session guest-acl\n"
+        "  captive-portal cp-portal\n"
+        "!\n"
+    )
+    assert len(res["role"]) == 1
+    rec = res["role"][0]
+    assert rec["rname"] == "employee"
+    assert rec["role__vlan"] == {"vlanstr": "100"}
+    assert rec["role__max_sess"] == {"max_sess": 10}
+    assert rec["role__cp"] == {"cp_profile_name": "cp-portal"}
+    assert rec["role__acl"] == [
+        {"acl_type": "session", "pname": "corp-acl"},
+        {"acl_type": "session", "pname": "guest-acl"},
+    ]
+    assert res["_warnings"] == []
+
+
+# --------------------------------------------------------------------------- #
+# coverage / warnings
+# --------------------------------------------------------------------------- #
+
+
+def test_multi_stanza_counts_and_warning_capture() -> None:
+    """A multi-object snippet parses to the right counts; unparseable lines warn."""
+    res = parse_aos8_cli(
+        "netdestination corp-servers\n"
+        "  host 10.0.0.5\n"
+        "  totally-bogus-clause xyz\n"  # unparseable line inside a known stanza
+        "!\n"
+        "netdestination6 v6-net\n"
+        "  network fc00::/7\n"
+        "!\n"
+        "ip access-list session corp-acl\n"
+        "  any any any permit\n"
+        "  garbledsrc garbleddst something permit\n"  # unparseable rule
+        "!\n"
+        "user-role employee\n"
+        "  vlan 100\n"
+        "  access-list session corp-acl\n"
+        "!\n"
+    )
+    # 2 netdst (corp-servers + v6-net), 1 acl, 1 role.
+    assert len(res["netdst"]) == 2
+    assert len(res["acl_sess"]) == 1
+    assert len(res["role"]) == 1
+
+    # Unparseable lines are surfaced in _warnings (never silently lost).
+    assert any("totally-bogus-clause" in w for w in res["_warnings"])
+    assert any("garbledsrc garbleddst" in w for w in res["_warnings"])
+
+    # The unparseable ACL rule is captured under an _unparsed marker...
+    v4 = res["acl_sess"][0]["acl_sess__v4policy"]
+    unparsed = [r for r in v4 if "_unparsed" in r]
+    assert len(unparsed) == 1
+    assert unparsed[0]["_unparsed"] == "garbledsrc garbleddst something permit"
+
+    # ...while the well-formed permit rule has NO _unparsed marker.
+    well_formed = [r for r in v4 if "_unparsed" not in r]
+    assert len(well_formed) == 1
+    assert well_formed[0]["action"] == "permit"
+
+
+def test_unrecognized_stanza_type_is_skipped() -> None:
+    """A stanza whose header kind is out of scope is dropped (no crash)."""
+    res = parse_aos8_cli("ip access-list eth some-eth-acl\n  permit any\n!\nuser-role employee\n  vlan 100\n!\n")
+    # eth ACLs are out of scope — only the user-role survives.
+    assert res["netdst"] == []
+    assert res["acl_sess"] == []
+    assert len(res["role"]) == 1
+    assert res["role"][0]["rname"] == "employee"
+
+
+# --------------------------------------------------------------------------- #
+# integration: parser → central:policy translation engine
+# --------------------------------------------------------------------------- #
+
+
+def test_parsed_acl_feeds_central_policy_translation() -> None:
+    """A parsed dual-nat ACL rule round-trips through the real central:policy engine."""
+    cli = (
+        "ip access-list session corp-acl\n"
+        "  user any svc-https dual-nat pool corp-pool 8081\n"
+        "!\n"
+        "user-role employee\n"
+        "  access-list session corp-acl\n"
+        "!\n"
+    )
+    parsed = parse_aos8_cli(cli)
+    acl_record = parsed["acl_sess"][0]
+    role_records = parsed["role"]
+
+    translation = load_translations()["central:policy"]
+    calls = emit_calls(
+        translation,
+        acl_record,
+        "aos8",
+        runtime_values={"central_scope_id": "scope-abc", "role_records": role_records},
+    )
+
+    assert calls, "expected at least one target call from the policy translation"
+    body = calls[0].body
+    assert body is not None
+    assert body["name"] == "corp-acl"
+
+    policy_rules = body["security-policy"]["policy-rule"]
+    assert len(policy_rules) == 1
+    action = policy_rules[0]["action"]
+    assert action["type"] == "ACTION_DUAL_NAT"
+    # The parser-derived dualnatpool / dualnatport land in Central's dual-nat sub-shape.
+    assert action["dual-nat"] == {"nat-pool": "corp-pool", "port": 8081}
+
+    # The role that bound the ACL drives the policy-rule source role-list,
+    # proving the parsed role record flowed through role_attribution.
+    assert policy_rules[0]["condition"]["source"]["role-list"] == ["employee"]

--- a/tests/unit/test_aos8_init.py
+++ b/tests/unit/test_aos8_init.py
@@ -47,11 +47,11 @@ EXPECTED_CATEGORY_COUNTS = {
     "alerts": 3,
     "wlan": 4,
     "troubleshooting": 7,
-    "differentiators": 9,
+    "differentiators": 10,
 }
 
-# Phase 5 adds 12 write tools; Phase 7 adds 9 differentiator tools.
-# Total is 26 read + 12 write + 9 diff = 47
+# Phase 5 adds 12 write tools; Phase 7 adds the differentiator tools.
+# Total is 26 read + 12 write + 10 diff = 48
 EXPECTED_WRITE_TOOLS = {
     "aos8_manage_ssid_profile",
     "aos8_manage_virtual_ap",
@@ -76,8 +76,9 @@ EXPECTED_DIFF_TOOLS = {
     "aos8_get_ap_wired_ports",
     "aos8_get_ipsec_tunnels",
     "aos8_get_md_health_check",
+    "aos8_parse_config",
 }
-EXPECTED_TOTAL = len(EXPECTED_TOOLS) + len(EXPECTED_WRITE_TOOLS) + len(EXPECTED_DIFF_TOOLS)  # 26 + 12 + 9 = 47
+EXPECTED_TOTAL = len(EXPECTED_TOOLS) + len(EXPECTED_WRITE_TOOLS) + len(EXPECTED_DIFF_TOOLS)  # 26 + 12 + 10 = 48
 
 
 def test_tools_dict_complete():
@@ -96,7 +97,7 @@ def test_tools_dict_complete():
     assert "writes" in TOOLS, "TOOLS dict missing 'writes' category"
     assert set(TOOLS["writes"]) == EXPECTED_WRITE_TOOLS, "TOOLS['writes'] mismatch"
 
-    # Phase 7: differentiators category must be present (9 tools)
+    # Phase 7: differentiators category must be present (10 tools)
     assert "differentiators" in TOOLS, "TOOLS dict missing 'differentiators' category"
     assert set(TOOLS["differentiators"]) == EXPECTED_DIFF_TOOLS, "TOOLS['differentiators'] mismatch"
 


### PR DESCRIPTION
## Summary

Adds an **offline AOS-8 CLI config parser** + the `aos8_parse_config` tool, enabling the "**paste your AOS-8 config into the AI**" migration flow — no live controller required. It turns a pasted/uploaded AOS-8 running-config into the *same* canonical records the translation engine already consumes from `aos8_get_effective_config`, so the output drops straight into the `central:policy` / `central:net_group` / `central:role` translations unchanged.

## What's here

- **`platforms/aos8/cli_parser.py`** — `parse_aos8_cli(text) -> {netdst, acl_sess, role, _warnings}`. Parses `netdestination`/`netdestination6`, `ip access-list session`/`ipv6 access-list session`, and `user-role` stanzas. Captures source/destination discriminators, services, protocol/port, actions (`permit`/`deny`/`src-nat`/`dst-nat`/`dual-nat pool <name> <port>`/`redirect`/`captive`/…), `log`, and netdestination `invert`. **Tolerant**: anything it can't fully model surfaces as a warning / `_unparsed` marker rather than being dropped, so coverage gaps stay visible.
- **`aos8_parse_config`** tool (`differentiators.py`, `capability=READ`) — pure offline parse, registered in the AOS-8 `TOOLS` dict.
- **15 unit tests** (`test_aos8_cli_parser.py`) covering every stanza/discriminator/action, plus an integration test feeding a parsed record through the real `central:policy` translation.

## Validation

- **1608 tests pass**, ruff + mypy clean.
- Validated on a real-world config: **436 ACL rules, 0 unparsed**; the NAT path is validated end-to-end (`dual-nat pool localip 8081` → `{"dual-nat": {"nat-pool": "localip", "port": 8081}}`).
- The dual-nat handling closed a real gap: the parser had no `dual-nat` branch, so NAT rules using a pool would silently lose their pool/port — now captured and validated against the `central:policy` dual-nat shape (#424).

## Notes

- CNX target shapes come from the current vendored OAS + live built-ins (the migrated `central:policy` translation, #424).
- AOS-8 tool count: 47 → 48 (total registered surface 1961 → 1962).
