### PR TITLE
fix(translations): WebCC-category ACL rules no longer degrade to RULE_ANY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0.3] - 2026-06-06
+
+**Patch — fix AOS 8 → Central policy translation silently dropping WebCC-category rules.** A `web-cc-category` session-ACL rule (e.g. `user any web-cc-category malware-sites deny`) was translated to a blanket `RULE_ANY` instead of `RULE_WEB_CATEGORY` — silently turning a category-specific deny into a **deny-everything** rule.
+
+- **Root cause:** AOS 8 REST emits `app_web_type == "web_cat"` for WebCC-category rules (live-verified on an 8.13 Mobility Conductor), but the policy preprocessing only recognised the `"web_cc_cat"` spelling, so category rules fell through `_build_services_block` (returning `None`) and were classified `RULE_ANY`. The reputation path (`web_cc_rep`) was unaffected.
+- **Fix:** `_build_services_block` now accepts both `web_cat` and `web_cc_cat`. Category rules emit `condition.services.web-category` → `RULE_WEB_CATEGORY`, mapped through the WebCC-category enum table (e.g. `keyloggers/monitoring` → `KEYLOGGERS-AND-MONITORING`).
+- Added `tests/unit/test_translations_preprocessing_aos8_policy.py` with real-record regression coverage; the broader `central:policy` surface (NAT / redirect / app / icmp / time-range / host / userrole / localip / web-reputation) was re-verified against a live conductor and is correct.
+
 ## [3.3.0.2] - 2026-06-05
 
 **Patch — AOS 8 CLI config parser + `aos8_parse_config` tool.** Adds an offline parser that turns a pasted/uploaded AOS 8 running-config (CLI) into the same canonical records the translation engine already consumes from `aos8_get_effective_config` — enabling the "paste your AOS 8 config into the AI" migration flow without a live controller.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.0.2"
+version = "3.3.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/translations/preprocessing/aos8_policy.py
+++ b/src/hpe_networking_mcp/translations/preprocessing/aos8_policy.py
@@ -399,7 +399,12 @@ def _build_services_block(rule: dict) -> dict[str, Any] | None:
             return None
         central_val = AOS8_APP_CATEGORY_TO_CENTRAL.get(str(cat), str(cat).upper())
         return {"services": {"app-category": central_val}}
-    if awt == "web_cc_cat":
+    if awt in ("web_cc_cat", "web_cat"):
+        # AOS 8 REST emits ``web_cat`` for WebCC-category rules (live-verified on
+        # 8.13 — see /md/Campus block-high-risk_web); the older ``web_cc_cat``
+        # spelling never matched real API output, so category rules silently
+        # fell through to the RULE_ANY default (a category-deny became a
+        # deny-everything). Accept both.
         cat = rule.get("webcccatgname")
         if not cat:
             return None

--- a/tests/unit/test_translations_preprocessing_aos8_policy.py
+++ b/tests/unit/test_translations_preprocessing_aos8_policy.py
@@ -1,0 +1,83 @@
+"""Unit tests for ``translations/preprocessing/aos8_policy.py``.
+
+Regression coverage for the WebCC-category rule bug: AOS 8 REST emits
+``app_web_type == "web_cat"`` for ``web-cc-category`` session-ACL rules
+(live-verified on an 8.13 Mobility Conductor — ``/md/Campus``
+``block-high-risk_web``). The preprocessing only recognised the
+``"web_cc_cat"`` spelling, so real category rules fell through
+``_build_services_block`` (returning ``None``) and ``_determine_rule_type``
+classified them as ``RULE_ANY`` — silently turning a category-specific deny
+into a deny-everything rule. These tests pin both spellings.
+
+Engine-level integration lives in ``test_translations_engine.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.translations.preprocessing.aos8_policy import (
+    _build_services_block,
+    _determine_rule_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _web_cat_rule(catg: str = "malware-sites") -> dict:
+    """A real-shape WebCC-category session-ACL rule as AOS 8 REST returns it."""
+    return {
+        "suser": True,
+        "src": "suser",
+        "dst": "dany",
+        "webcccatgname": catg,
+        "app_web_type": "web_cat",  # the spelling the live API actually emits
+        "service_app": "app_opt",
+        "appdeny": True,
+        "appaction": "appdeny_opt",
+    }
+
+
+def test_web_cat_builds_web_category_services() -> None:
+    """``web_cat`` (real API spelling) must produce a web-category services block."""
+    out = _build_services_block(_web_cat_rule("malware-sites"))
+    assert out == {"services": {"web-category": "MALWARE-SITES"}}
+
+
+def test_web_cat_enum_table_mapping() -> None:
+    """Category names route through the enum table, not the naive fallback."""
+    out = _build_services_block(_web_cat_rule("keyloggers/monitoring"))
+    assert out == {"services": {"web-category": "KEYLOGGERS-AND-MONITORING"}}
+
+
+def test_web_cc_cat_legacy_spelling_still_handled() -> None:
+    """The older ``web_cc_cat`` spelling must keep working (backward compatible)."""
+    rule = _web_cat_rule()
+    rule["app_web_type"] = "web_cc_cat"
+    out = _build_services_block(rule)
+    assert out == {"services": {"web-category": "MALWARE-SITES"}}
+
+
+def test_web_cat_rule_type_is_web_category_not_any() -> None:
+    """Regression: the category rule must classify as RULE_WEB_CATEGORY, not RULE_ANY."""
+    rule = _web_cat_rule()
+    services = _build_services_block(rule)
+    assert services is not None  # the bug returned None here
+    rule_type = _determine_rule_type(rule, services, None)
+    assert rule_type == "RULE_WEB_CATEGORY"
+    assert rule_type != "RULE_ANY"
+
+
+def test_web_reputation_unaffected() -> None:
+    """The reputation path (already correct) must remain intact."""
+    rule = {
+        "src": "sany",
+        "dst": "dany",
+        "web_rep2": "high-risk2",
+        "app_web_type": "web_cc_rep",
+        "service_app": "app_opt",
+        "appdeny": True,
+        "appaction": "appdeny_opt",
+    }
+    out = _build_services_block(rule)
+    assert out == {"services": {"web-reputation": "HIGH_RISK"}}


### PR DESCRIPTION
Closes #426.

## Summary
AOS 8 `web-cc-category` session-ACL rules were silently translated to a blanket `RULE_ANY` deny instead of `RULE_WEB_CATEGORY` — turning a category-specific deny into a **deny-everything** rule.

## Root cause
The live AOS 8 REST API emits `app_web_type == "web_cat"` for WebCC-category rules (verified on an 8.13 Mobility Conductor), but `_build_services_block` only matched `"web_cc_cat"`. Category rules therefore returned `None` and `_determine_rule_type` defaulted them to `RULE_ANY`. The reputation path (`web_cc_rep`) was already correct.

## Fix
- `_build_services_block` accepts both `web_cat` and `web_cc_cat`; category rules emit `condition.services.web-category` → `RULE_WEB_CATEGORY` via the WebCC-category enum table (e.g. `keyloggers/monitoring` → `KEYLOGGERS-AND-MONITORING`).
- New `tests/unit/test_translations_preprocessing_aos8_policy.py` with real-record regression coverage (5 tests).

## Validation
- **1613 passed**, ruff + format + mypy clean.
- Found during a full live-conductor audit of all 5 shipped translations (`central:policy / net_group / role / vlan_id / named_vlan`). `web_cat` was the only functional defect; the rest (NAT, redirect, app, icmp, time-range, host, userrole, localip, web-reputation, net-group CIDR, role vlan/captive-portal, VLAN alias chains) verified correct.

## Notes
- Patch bump 3.3.0.2 → 3.3.0.3.
- Two non-blocking observations deferred (separate from this fix): `role__pool_l2tp` (VIA/L2TP pool) is dropped without a gap note; `central:named_vlan` emits a placeholder `vlan-id-ranges: ["1"]` alongside the real value in one alias step.