### PR TITLE
docs: align override-pattern docs with the !override fix (#452 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ cp docker-compose.override.yml.example docker-compose.override.yml
 # edit to match the platforms you actually use
 ```
 
-The template shows a Mist-only deployment with `!reset` directives dropping every other platform's secret references — both the service-level `secrets:` list **and** the top-level `secrets:` block, which you need to do both halves of for Compose to stop trying to bind-mount the unused files. Adjust the `secrets: !reset - <names>` under `services:` to keep whichever platforms you need, and `!reset` only the top-level entries you're actually dropping. The template also has examples for per-platform write-tool flags, log level, and tool mode overrides.
+The template shows a Mist-only deployment that drops every other platform's secret references — and you need to do **both halves** for Compose to stop trying to bind-mount the unused files: the service-level `secrets:` list **and** the top-level `secrets:` block. The two halves use different Compose tags. Adjust the `secrets: !override` list under `services:` to keep whichever platforms you need — `!override` replaces the base list with just your entries (don't use `!reset` on this list; it empties it and mounts nothing). Then `!reset` only the top-level entries you're actually dropping, which removes those map keys so Compose won't resolve their files. The template also has examples for per-platform write-tool flags, log level, and tool mode overrides.
 
 `docker-compose.override.yml` is already in `.gitignore`, so your per-deployment tailoring never ends up in git. With the Mist-only override in place, you only need `secrets/mist_api_token` and `secrets/mist_host` on disk — every other secret file can be absent.
 
-> **Compose version required:** `!reset` needs Docker Compose v2.24 or newer. If you're on an older Compose, either upgrade (recommended) or skip the override file and edit `docker-compose.yml` directly, commenting out the unused platform's service-level and top-level secret entries.
+> **Compose version required:** the `!override` and `!reset` tags both need Docker Compose v2.24 or newer. If you're on an older Compose, either upgrade (recommended) or skip the override file and edit `docker-compose.yml` directly, commenting out the unused platform's service-level and top-level secret entries.
 
 ### 4. Start
 
@@ -229,7 +229,7 @@ You don't need credentials for all eight platforms. The server detects which pla
 - **Only ClearPass configured** → Only `clearpass_*` tools available; other platforms disabled
 - **No valid credentials** → Server refuses to start with a clear error message
 
-Add a platform later by populating its secret files (or removing the override's `!reset` lines) and restarting the container. The server logs which platforms are enabled at startup:
+Add a platform later by populating its secret files (and, if you dropped it in the override, adding its names back to the service-level `secrets: !override` list and removing its top-level `!reset` lines), then restarting the container. The server logs which platforms are enabled at startup:
 
 ```
 Mist: credentials loaded (token: abcd...wxyz, host: api.mist.com)

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -14,10 +14,16 @@
 #     compose file.
 #   • How to change the exposed port.
 #
-# The !reset tag tells Compose "remove this item from the merged config"
-# and requires Compose v2.24+. If you're on an older Compose, upgrade or
-# remove the whole override file and instead edit docker-compose.yml
-# directly.
+# Two Compose merge tags are used below (both require Compose v2.24+):
+#   • !override — REPLACE the base value instead of merging into it. Used on the
+#     service-level `secrets:` LIST so your shortened list replaces the base
+#     list wholesale (a plain merge would union them back to every platform;
+#     !reset on a list with items empties it, mounting nothing — see issue #452).
+#   • !reset — REMOVE this key from the merged config. Used on the top-level
+#     `secrets:` MAP entries you're dropping, so Compose won't resolve their
+#     file: paths.
+# If you're on an older Compose, upgrade or remove the whole override file and
+# instead edit docker-compose.yml directly.
 # ============================================================================
 
 services:
@@ -41,15 +47,17 @@ services:
       # Example: pin static-mode surface (v1.x behavior). Default is dynamic.
       # - MCP_TOOL_MODE=static
 
-    # Drop the secret references for platforms you aren't using. After !reset,
-    # list only the ones you keep. Without this, docker compose will try to
-    # bind-mount every secret file declared in the base compose file and fail
-    # if one is missing.
+    # Drop the secret references for platforms you aren't using. Use !override
+    # (NOT !reset) on this service-level list: !override replaces the base list
+    # with just the entries below, so list only the ones you keep. Without this,
+    # docker compose will try to bind-mount every secret file declared in the
+    # base compose file and fail if one is missing. (!reset here would empty the
+    # list and mount nothing — the failure in issue #452.)
     #
     # The example below is a Mist-only deployment. Adjust for your mix of
-    # platforms — keep the service-level secret names you use, and !reset the
-    # top-level secrets dict entries you don't. Do both halves: the service's
-    # `secrets:` list AND the top-level `secrets:` block.
+    # platforms, and do BOTH halves: list the service's `secrets:` you keep here
+    # (via !override), AND !reset the top-level `secrets:` entries you're dropping
+    # (below).
     secrets: !override
       - mist_api_token
       - mist_host


### PR DESCRIPTION
Follow-up to #453 (which fixed #452).

#453 corrected the executable line in `docker-compose.override.yml.example` — the service-level `secrets:` went from `!reset` to `!override` — but the surrounding **guidance** (the example's own comments and the README walkthrough) still told users to `!reset` the service-level list, which is exactly what reproduces #452. This PR makes the docs consistent with the fix.

## Why the two halves use different tags
- **Service-level `secrets:`** is a **list**. `!override` *replaces* the base list with just your entries. `!reset` on a list-with-items empties it → nothing mounts → "No platforms have valid credentials" (#452).
- **Top-level `secrets:`** is a **map**. `name: !reset` *removes* that key so Compose won't resolve its `file:` path. This half correctly stays `!reset`.

## Changes
- **`docker-compose.override.yml.example`** — header comment now explains both tags and when each applies; the service-level comment says use `!override` (not `!reset`) and why (cites #452). Top-level `!reset` guidance unchanged (it was correct). No YAML nodes changed — comments only.
- **`README.md`** —
  - the override walkthrough now shows `secrets: !override` for the service list (was `secrets: !reset - <names>`),
  - the "Compose version required" note names both `!override` and `!reset` (both need v2.24+, so the bound is unchanged),
  - the "add a platform later" step now covers re-adding to the `!override` list **and** removing the top-level `!reset`.

## Scope
Docs-only — README + the example template, neither under `src/`. No runtime artifact changed, so no version bump or CHANGELOG entry (consistent with how #453 shipped). No test references the example file.