### PR TITLE
fix(central): fold case + synonyms on MRT read-tool enum filters (closes #455, #456, #457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.8.1] - 2026-06-09
+
+**Patch — Central read-tool enum filters now fold case + known synonyms (#455, #456, #457).** Three MRT read tools rejected reasonable-but-non-canonical enum inputs with a hard validation error. A new shared `coerce_enum` helper (a Pydantic `BeforeValidator`) folds recognized case/alias variants onto the canonical `Literal` value while keeping the enum in the JSON schema (discoverability) and still rejecting genuinely invalid values.
+
+- **`central_get_top_aps_by_usage`** (#455) — the tool's description advertised a `combined` metric, but the enum value is `usage`; `metric="combined"` was rejected. Now `'combined'` is accepted as an alias for `'usage'`, the description/enum agree, and the metric is matched case-insensitively.
+- **`central_get_clients`** (#456) — `status="CONNECTED"` (valid value, wrong case) was rejected. The `status`, `connection_type`, and `tunnel_type` filters are now case-insensitive.
+- **`central_get_alerts`** (#457) — `status="Open"` (a common synonym) was rejected; the enum is `Active`/`Cleared`/`Deferred`. `status`, `device_type`, and `category` are now case-insensitive, and `Open` is accepted as a synonym for `Active`.
+
+Invalid values still fail with the standard `Input should be …` message listing the canonical values. New unit tests cover the folding, the synonym maps, schema-enum preservation, and rejection of unknown values. (The `central_get_applications` HTTP 400, #458, is tracked separately.)
+
 ## [3.3.8.0] - 2026-06-08
 
 **Minor — aos-migration Stage 9b now wires the full AAA chain + surfaces target collisions (#437).** Closes the gap where Stage 9b's deterministic preview documented only five translation IDs while six more shipped specs (the AAA chain) were silently omitted — an operator could read the preview as complete when it skipped auth-servers, server-groups, and auth profiles entirely.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.8.0"
+version = "3.3.8.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
@@ -11,6 +11,7 @@ from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     build_odata_filter,
     clean_alert_data,
+    coerce_enum,
     retry_central_command,
 )
 
@@ -44,9 +45,19 @@ OPERATIONAL = ToolAnnotations(
 async def central_get_alerts(
     ctx: Context,
     site_id: str,
-    status: Literal["Active", "Cleared", "Deferred"] | None = "Active",
-    device_type: Literal["Access Point", "Gateway", "Switch", "Bridge"] | None = None,
-    category: Literal["Clients", "System", "LAN", "WLAN", "WAN", "Cluster", "Routing", "Security"] | None = None,
+    status: Annotated[
+        Literal["Active", "Cleared", "Deferred"] | None,
+        # "Open"/"open" is a common synonym for an unresolved alert → map to "Active".
+        coerce_enum(("Active", "Cleared", "Deferred"), {"open": "Active"}),
+    ] = "Active",
+    device_type: Annotated[
+        Literal["Access Point", "Gateway", "Switch", "Bridge"] | None,
+        coerce_enum(("Access Point", "Gateway", "Switch", "Bridge")),
+    ] = None,
+    category: Annotated[
+        Literal["Clients", "System", "LAN", "WLAN", "WAN", "Cluster", "Routing", "Security"] | None,
+        coerce_enum(("Clients", "System", "LAN", "WLAN", "WAN", "Cluster", "Routing", "Security")),
+    ] = None,
     sort: str = "severity desc",
     limit: int = 50,
     cursor: int | None = None,
@@ -69,7 +80,9 @@ async def central_get_alerts(
     Parameters:
         - site_id: Site identifier. Obtain by calling
           central_get_site_health(site_name="<name>") and reading site_id from the result.
-        - status: "Active" (default) for unresolved alerts, "Cleared" for resolved ones.
+        - status: "Active" (default) for unresolved/open alerts, "Cleared" for resolved
+          ones, "Deferred" for snoozed ones. Case-insensitive; "Open" is accepted as a
+          synonym for "Active".
         - device_type: Narrow to a device class — "Access Point", "Gateway", "Switch",
           or "Bridge".
         - category: Narrow to an alert domain — "Clients", "System", "LAN", "WLAN",

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
@@ -11,6 +11,7 @@ from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     build_odata_filter,
     clean_client_data,
+    coerce_enum,
 )
 
 MISSING_CLIENT_RESPONSE = "Resource not found for the given input."
@@ -32,11 +33,14 @@ async def central_get_clients(
     site_id: str | None = None,
     site_name: str | None = None,
     serial_number: str | None = None,
-    connection_type: Literal["Wired", "Wireless"] | None = None,
-    status: Literal["Connected", "Failed"] | None = None,
+    connection_type: Annotated[Literal["Wired", "Wireless"] | None, coerce_enum(("Wired", "Wireless"))] = None,
+    status: Annotated[Literal["Connected", "Failed"] | None, coerce_enum(("Connected", "Failed"))] = None,
     wlan_name: str | None = None,
     vlan_id: str | None = None,
-    tunnel_type: Literal["Port-based", "User-based", "Overlay"] | None = None,
+    tunnel_type: Annotated[
+        Literal["Port-based", "User-based", "Overlay"] | None,
+        coerce_enum(("Port-based", "User-based", "Overlay")),
+    ] = None,
     start_query_time: str | None = None,
     end_query_time: str | None = None,
 ) -> list[Client] | str:
@@ -51,11 +55,11 @@ async def central_get_clients(
         - site_id: Exact site ID.
         - site_name: Exact site name.
         - serial_number: Serial number of the device to which the client is connected.
-        - connection_type: "Wired" or "Wireless".
-        - status: "Connected" or "Failed".
+        - connection_type: "Wired" or "Wireless" (case-insensitive).
+        - status: "Connected" or "Failed" (case-insensitive).
         - wlan_name: WLAN name filter (wireless clients only).
         - vlan_id: VLAN ID filter.
-        - tunnel_type: "Port-based", "User-based", or "Overlay".
+        - tunnel_type: "Port-based", "User-based", or "Overlay" (case-insensitive).
         - start_query_time: Start of the query time window (ISO 8601).
         - end_query_time: End of the query time window (ISO 8601).
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -14,7 +14,7 @@ from pydantic import Field
 
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
-from hpe_networking_mcp.platforms.central.utils import retry_central_command
+from hpe_networking_mcp.platforms.central.utils import coerce_enum, retry_central_command
 
 
 def _get(conn, path: str, params: dict | None = None) -> dict | str:
@@ -291,18 +291,22 @@ async def central_get_top_aps_by_usage(
     ctx: Context,
     metric: Annotated[
         _UsageMetric,
+        coerce_enum(("wireless", "wired", "usage"), {"combined": "usage"}),
         Field(
             description=(
                 "``'wireless'`` (top-aps-by-wireless-usage), ``'wired'`` "
-                "(top-aps-by-wired-usage), or ``'usage'`` (combined "
-                "top-aps-by-usage)."
+                "(top-aps-by-wired-usage), or ``'usage'`` — the combined "
+                "wired+wireless view (top-aps-by-usage). The synonym "
+                "``'combined'`` is accepted as an alias for ``'usage'``, "
+                "and values are matched case-insensitively."
             ),
         ),
     ],
     top_n: Annotated[int, Field(ge=1, le=100, description="Number of APs to return (default 10).")] = 10,
     filter: str | None = None,
 ) -> dict | str:
-    """Get top-N APs by usage (wireless / wired / combined).
+    """Get top-N APs by usage — metric ``'wireless'`` / ``'wired'`` / ``'usage'``
+    (``'usage'`` = combined wired+wireless; ``'combined'`` is accepted as an alias).
 
     Consolidates the three ``/top-aps-by-{wireless,wired,}usage`` endpoints.
     """

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from fastmcp.exceptions import ToolError
 from loguru import logger
+from pydantic import BeforeValidator
 
 from hpe_networking_mcp.platforms.central.models import (
     Alert,
@@ -29,6 +30,44 @@ _RETRY_BACKOFF_CAP_SECS = 5.0
 def _retry_backoff_secs(attempt: int) -> float:
     """Seconds to wait before the next retry (1-indexed attempt). Capped exponential."""
     return min(_RETRY_BACKOFF_BASE_SECS * (2 ** (attempt - 1)), _RETRY_BACKOFF_CAP_SECS)
+
+
+def coerce_enum(canonical: tuple[str, ...], aliases: dict[str, str] | None = None) -> BeforeValidator:
+    """Build a Pydantic ``BeforeValidator`` that folds case-insensitive and known
+    alias inputs onto a canonical enum value, leaving the enclosing ``Literal`` intact.
+
+    Attach it to a ``Literal`` tool parameter so callers (and LLMs) can pass a value in
+    any case, or a documented synonym, without a hard validation rejection::
+
+        status: Annotated[
+            Literal["Connected", "Failed"] | None,
+            coerce_enum(("Connected", "Failed")),
+        ] = None
+
+    The ``Literal`` still surfaces as an ``enum`` in the generated JSON schema (so the
+    canonical values stay discoverable), and genuinely invalid values still fail with
+    the standard ``Input should be 'Connected' or 'Failed'`` message — this validator
+    only rewrites recognized case / alias variants and passes everything else through
+    unchanged. ``None`` and non-string inputs are returned untouched.
+
+    Args:
+        canonical: The canonical enum values, in the exact case declared in the Literal.
+        aliases: Optional ``{synonym: canonical}`` map (e.g. ``{"combined": "usage"}``);
+            synonym keys are matched case-insensitively.
+
+    Returns:
+        A ``BeforeValidator`` suitable for use inside ``Annotated[...]``.
+    """
+    lookup = {value.lower(): value for value in canonical}
+    if aliases:
+        lookup.update({alias.lower(): target for alias, target in aliases.items()})
+
+    def _coerce(value: Any) -> Any:
+        if isinstance(value, str):
+            return lookup.get(value.lower(), value)
+        return value
+
+    return BeforeValidator(_coerce)
 
 
 def normalize_site_name_filter(value: str | list[str] | None) -> list[str] | None:

--- a/tests/unit/test_central_enum_coercion.py
+++ b/tests/unit/test_central_enum_coercion.py
@@ -1,0 +1,109 @@
+"""Unit tests for ``coerce_enum`` — the case-insensitive / alias folding applied to
+Central read-tool enum filters (issues #455, #456, #457).
+
+The helper builds a Pydantic ``BeforeValidator`` that folds recognized case / alias
+variants onto a canonical ``Literal`` value, while leaving the ``Literal`` itself
+(and thus the JSON-schema ``enum`` + the rejection of genuinely invalid values)
+intact. These tests validate the exact ``(canonical, aliases)`` sets the three tools
+use, through a ``TypeAdapter`` over the same ``Annotated[Literal[...], coerce_enum(...)]``
+shape the tool signatures declare.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from hpe_networking_mcp.platforms.central.utils import coerce_enum
+
+pytestmark = pytest.mark.unit
+
+
+# central_get_clients.status
+_ClientStatus = TypeAdapter(Annotated[Literal["Connected", "Failed"] | None, coerce_enum(("Connected", "Failed"))])
+# central_get_alerts.status (with the "open" -> "Active" synonym)
+_AlertStatus = TypeAdapter(
+    Annotated[
+        Literal["Active", "Cleared", "Deferred"] | None,
+        coerce_enum(("Active", "Cleared", "Deferred"), {"open": "Active"}),
+    ]
+)
+# central_get_top_aps_by_usage.metric (with the "combined" -> "usage" alias)
+_UsageMetric = TypeAdapter(
+    Annotated[Literal["wireless", "wired", "usage"], coerce_enum(("wireless", "wired", "usage"), {"combined": "usage"})]
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Connected", "Connected"),  # exact
+        ("CONNECTED", "Connected"),  # upper
+        ("connected", "Connected"),  # lower
+        ("cOnNeCtEd", "Connected"),  # mixed
+        ("Failed", "Failed"),
+        ("FAILED", "Failed"),
+        (None, None),  # optional passthrough
+    ],
+)
+def test_client_status_case_folding(raw: str | None, expected: str | None) -> None:
+    assert _ClientStatus.validate_python(raw) == expected
+
+
+def test_client_status_rejects_unknown() -> None:
+    with pytest.raises(ValidationError):
+        _ClientStatus.validate_python("Disconnected")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Active", "Active"),
+        ("active", "Active"),
+        ("Open", "Active"),  # synonym (#457)
+        ("OPEN", "Active"),  # synonym, any case
+        ("Cleared", "Cleared"),
+        ("deferred", "Deferred"),
+    ],
+)
+def test_alert_status_synonym_and_case(raw: str, expected: str) -> None:
+    assert _AlertStatus.validate_python(raw) == expected
+
+
+def test_alert_status_rejects_unknown() -> None:
+    with pytest.raises(ValidationError):
+        _AlertStatus.validate_python("Snoozed")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("usage", "usage"),
+        ("combined", "usage"),  # alias (#455) — the doc word that used to be rejected
+        ("COMBINED", "usage"),
+        ("wireless", "wireless"),
+        ("WIRED", "wired"),
+    ],
+)
+def test_usage_metric_combined_alias(raw: str, expected: str) -> None:
+    assert _UsageMetric.validate_python(raw) == expected
+
+
+def test_usage_metric_rejects_unknown() -> None:
+    with pytest.raises(ValidationError):
+        _UsageMetric.validate_python("bandwidth")
+
+
+def test_schema_enum_preserved() -> None:
+    """The Literal's enum must remain in the JSON schema (discoverability intact)."""
+    schema = _UsageMetric.json_schema()
+    assert schema.get("enum") == ["wireless", "wired", "usage"], schema
+
+
+def test_non_string_passthrough() -> None:
+    """Non-string inputs are returned untouched (no spurious coercion)."""
+    ta = TypeAdapter(Annotated[int | None, coerce_enum(("Active",))])
+    assert ta.validate_python(5) == 5
+    assert ta.validate_python(None) is None


### PR DESCRIPTION
Closes #455, closes #456, closes #457.

Three Central MRT read tools rejected reasonable-but-non-canonical enum inputs with a hard `literal_error`, surfaced while assembling a site dashboard from the MRT reads. This adds a shared `coerce_enum` helper (a Pydantic `BeforeValidator`) that folds recognized **case** and **alias** variants onto the canonical `Literal` value — while keeping the `Literal`'s `enum` in the generated JSON schema (so the canonical values stay discoverable) and still rejecting genuinely invalid values with the standard `Input should be …` message.

## Fixes
- **`central_get_top_aps_by_usage`** (#455) — the tool's description advertised a `combined` metric, but the enum value for the combined view is `usage`, so `metric="combined"` was rejected (the caller followed our own docs). Now `'combined'` is accepted as an alias for `'usage'`, the description and enum agree, and the metric is matched case-insensitively.
- **`central_get_clients`** (#456) — `status="CONNECTED"` (a valid value, wrong case) was rejected. `status`, `connection_type`, and `tunnel_type` are now case-insensitive.
- **`central_get_alerts`** (#457) — `status="Open"` (a common synonym) was rejected; the enum is `Active`/`Cleared`/`Deferred`. `status`, `device_type`, and `category` are now case-insensitive, and `Open` is accepted as a synonym for `Active`. The `status` description now spells out the canonical values + meaning.

I applied the helper to **all** user-facing enum filters on these two read tools (not only the reported param) to avoid a partial fix that leaves sibling filters brittle to the same class of error.

## How it works
`coerce_enum(canonical, aliases=None)` returns a `BeforeValidator` that lower-cases the input, maps it via `{lower(canonical|alias): canonical}`, and passes anything unrecognized (and `None`/non-strings) through unchanged so the enclosing `Literal` still validates it. Because it runs *before* the `Literal`, the schema enum is untouched and invalid values still fail cleanly.

## Tests
- `tests/unit/test_central_enum_coercion.py` — case folding, the `combined→usage` and `open→Active` synonym maps, **schema-enum preservation**, rejection of unknown values, and non-string passthrough, validated through a `TypeAdapter` over the exact `Annotated[Literal[...], coerce_enum(...)]` shape the tool signatures use.
- Full suite: **1717 passed, 1 skipped**; ruff / format / mypy clean.

## Scope
The `central_get_applications` HTTP 400 (#458) is a separate runtime/API issue and is tracked + fixed separately. Patch bump 3.3.8.0 → 3.3.8.1; CHANGELOG updated.