### PR TITLE
fix(central): validate central_get_applications time window up front (closes #458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.8.2] - 2026-06-09
+
+**Patch — `central_get_applications` now validates the time window up front (#458).** The applications endpoint expects epoch **milliseconds**; an ISO-8601 string, a plain date, or a reversed window produced an opaque upstream `HTTP 400 BAD_REQUEST` ("Your request was incorrect or incomplete") wrapped as a 502, leaving the caller with no idea what was wrong.
+
+- The tool now validates `start_query_time` / `end_query_time` before calling Central and raises a clear `ToolError` (400) naming the offending value and the expected format (e.g. *"start_query_time must be an epoch timestamp in milliseconds (e.g. '1780876800000'), got '2026-06-08T00:00:00Z'"*).
+- Epoch **seconds** (10-digit) are accepted as a convenience and normalized to ms (the seconds-vs-ms mixup is the most common mistake; 10- vs 13-digit values don't overlap for present-day timestamps).
+- `start_query_time` must be before `end_query_time`, and `site_id` must be non-empty — both checked with clear messages.
+
+Live-verified: the endpoint + its `v1alpha1` path are correct (a valid site_id + epoch-ms window returns data); the 400 was purely a malformed-input passthrough. New unit tests cover the helper and the tool-level validation paths.
+
 ## [3.3.8.1] - 2026-06-09
 
 **Patch — Central read-tool enum filters now fold case + known synonyms (#455, #456, #457).** Three MRT read tools rejected reasonable-but-non-canonical enum inputs with a hard validation error. A new shared `coerce_enum` helper (a Pydantic `BeforeValidator`) folds recognized case/alias variants onto the canonical `Literal` value while keeping the enum in the JSON schema (discoverability) and still rejecting genuinely invalid values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.8.1"
+version = "3.3.8.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -6,6 +6,42 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
+def _to_epoch_ms(label: str, value: str) -> int:
+    """Validate and normalize an epoch timestamp to milliseconds.
+
+    The Central applications endpoint expects epoch **milliseconds** and returns an
+    opaque ``HTTP 400 BAD_REQUEST`` for anything else (ISO-8601 strings, plain dates,
+    etc.). Validate up front so callers get an actionable error instead of the bare
+    upstream 400 (issue #458). Epoch **seconds** (10-digit) are accepted as a
+    convenience and converted to ms — the seconds-vs-ms mixup is the most common
+    mistake and 10- vs 13-digit values don't overlap for present-day timestamps.
+
+    Args:
+        label: Parameter name, used in the error message.
+        value: The raw timestamp string.
+
+    Returns:
+        The timestamp as integer epoch milliseconds.
+
+    Raises:
+        ToolError: 400 when ``value`` is not a numeric epoch timestamp.
+    """
+    s = str(value).strip()
+    if not s.isdigit():
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": (
+                    f"{label} must be an epoch timestamp in milliseconds "
+                    f"(e.g. '1780876800000'), got {value!r}. ISO-8601 timestamps and "
+                    "plain dates are not accepted — convert to epoch milliseconds first."
+                ),
+            }
+        )
+    # 10-digit value = epoch seconds → normalize to ms; 13-digit already ms.
+    return int(s) * 1000 if len(s) == 10 else int(s)
+
+
 @tool(annotations=READ_ONLY)
 async def central_get_applications(
     ctx: Context,
@@ -28,19 +64,36 @@ async def central_get_applications(
     Parameters:
         site_id: Site ID to scope the query (required).
         start_query_time: Start of the time window in epoch milliseconds (required).
-        end_query_time: End of the time window in epoch milliseconds (required).
+            Epoch seconds (10-digit) are accepted and converted. ISO-8601 strings and
+            plain dates are NOT accepted — the upstream API rejects them with a 400.
+        end_query_time: End of the time window in epoch milliseconds (required), and
+            must be after start_query_time. Same format rules as start_query_time.
         limit: Number of records per page (default 1000).
         offset: Starting record offset for pagination (default 0).
         client_id: Filter results to a specific client ID.
         filter: OData filter expression to narrow results.
         sort: Sort order for results.
     """
+    # Validate inputs up front so a bad timestamp yields an actionable error instead
+    # of the opaque upstream HTTP 400 (issue #458).
+    if not str(site_id).strip():
+        raise ToolError({"status_code": 400, "message": "site_id is required and must be non-empty."})
+    start_ms = _to_epoch_ms("start_query_time", start_query_time)
+    end_ms = _to_epoch_ms("end_query_time", end_query_time)
+    if start_ms >= end_ms:
+        raise ToolError(
+            {
+                "status_code": 400,
+                "message": (f"start_query_time ({start_query_time}) must be before end_query_time ({end_query_time})."),
+            }
+        )
+
     conn = ctx.lifespan_context["central_conn"]
 
     query_params: dict = {
         "site-id": site_id,
-        "start-query-time": start_query_time,
-        "end-query-time": end_query_time,
+        "start-query-time": start_ms,
+        "end-query-time": end_ms,
         "limit": limit,
         "offset": offset,
     }

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -12,9 +12,11 @@ def _to_epoch_ms(label: str, value: str) -> int:
     The Central applications endpoint expects epoch **milliseconds** and returns an
     opaque ``HTTP 400 BAD_REQUEST`` for anything else (ISO-8601 strings, plain dates,
     etc.). Validate up front so callers get an actionable error instead of the bare
-    upstream 400 (issue #458). Epoch **seconds** (10-digit) are accepted as a
-    convenience and converted to ms — the seconds-vs-ms mixup is the most common
-    mistake and 10- vs 13-digit values don't overlap for present-day timestamps.
+    upstream 400 (issue #458). Only the two sane digit lengths for present-day
+    timestamps are accepted: **13-digit** epoch milliseconds, or **10-digit** epoch
+    seconds (converted to ms — the seconds-vs-ms mixup is the most common mistake).
+    Any other length (an 11/12/14-digit typo) is rejected rather than passed through
+    to produce a second opaque upstream 400.
 
     Args:
         label: Parameter name, used in the error message.
@@ -24,17 +26,18 @@ def _to_epoch_ms(label: str, value: str) -> int:
         The timestamp as integer epoch milliseconds.
 
     Raises:
-        ToolError: 400 when ``value`` is not a numeric epoch timestamp.
+        ToolError: 400 when ``value`` is not a 10- or 13-digit epoch timestamp.
     """
     s = str(value).strip()
-    if not s.isdigit():
+    if not s.isdigit() or len(s) not in (10, 13):
         raise ToolError(
             {
                 "status_code": 400,
                 "message": (
                     f"{label} must be an epoch timestamp in milliseconds "
-                    f"(e.g. '1780876800000'), got {value!r}. ISO-8601 timestamps and "
-                    "plain dates are not accepted — convert to epoch milliseconds first."
+                    f"(13-digit, e.g. '1780876800000') or seconds (10-digit), got "
+                    f"{value!r}. ISO-8601 timestamps and plain dates are not accepted "
+                    "— convert to epoch milliseconds first."
                 ),
             }
         )

--- a/tests/unit/test_central_applications.py
+++ b/tests/unit/test_central_applications.py
@@ -45,8 +45,19 @@ def test_epoch_seconds_converted_to_ms() -> None:
     assert _to_epoch_ms("start_query_time", "1780876800") == 1780876800000
 
 
-@pytest.mark.parametrize("bad", ["2026-06-08T00:00:00Z", "2026-06-08", "yesterday", "", "12ab34"])
-def test_non_numeric_timestamp_rejected(bad: str) -> None:
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "2026-06-08T00:00:00Z",  # ISO-8601
+        "2026-06-08",  # plain date
+        "yesterday",  # word
+        "",  # empty
+        "12ab34",  # mixed
+        "178087680000",  # 12-digit typo (dropped a digit) — must not pass through
+        "17808768000000",  # 14-digit typo (extra digit)
+    ],
+)
+def test_malformed_timestamp_rejected(bad: str) -> None:
     with pytest.raises(ToolError) as exc:
         _to_epoch_ms("start_query_time", bad)
     payload = exc.value.args[0]

--- a/tests/unit/test_central_applications.py
+++ b/tests/unit/test_central_applications.py
@@ -1,0 +1,87 @@
+"""Unit tests for ``central_get_applications`` input validation (issue #458).
+
+The Central applications endpoint expects epoch **milliseconds** and returns an
+opaque ``HTTP 400 BAD_REQUEST`` for ISO-8601 strings, plain dates, or a reversed
+window. The tool now validates up front and raises a clear ``ToolError`` (400)
+before calling the API, and accepts epoch **seconds** as a convenience.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from hpe_networking_mcp.platforms.central.tools.applications import (
+    _to_epoch_ms,
+    central_get_applications,
+)
+
+pytestmark = pytest.mark.unit
+
+# The registry decorator returns the bare function when no server is active; fall
+# back to ``.fn`` in case a prior test created a server and wrapped it.
+_apps = getattr(central_get_applications, "fn", central_get_applications)
+
+
+class _Ctx:
+    """Minimal context — the validation paths raise before touching it."""
+
+    lifespan_context: dict[str, Any] = {}
+
+
+# --------------------------------------------------------------------------- #
+# _to_epoch_ms helper
+# --------------------------------------------------------------------------- #
+
+
+def test_epoch_ms_passthrough() -> None:
+    assert _to_epoch_ms("start_query_time", "1780876800000") == 1780876800000
+
+
+def test_epoch_seconds_converted_to_ms() -> None:
+    """10-digit epoch seconds are normalized to ms (the classic seconds-vs-ms mixup)."""
+    assert _to_epoch_ms("start_query_time", "1780876800") == 1780876800000
+
+
+@pytest.mark.parametrize("bad", ["2026-06-08T00:00:00Z", "2026-06-08", "yesterday", "", "12ab34"])
+def test_non_numeric_timestamp_rejected(bad: str) -> None:
+    with pytest.raises(ToolError) as exc:
+        _to_epoch_ms("start_query_time", bad)
+    payload = exc.value.args[0]
+    assert payload["status_code"] == 400
+    assert "epoch" in payload["message"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# Tool-level validation (raises before the API is called)
+# --------------------------------------------------------------------------- #
+
+
+async def test_empty_site_id_rejected() -> None:
+    with pytest.raises(ToolError) as exc:
+        await _apps(ctx=_Ctx(), site_id="  ", start_query_time="1780876800000", end_query_time="1780963200000")
+    assert exc.value.args[0]["status_code"] == 400
+    assert "site_id" in exc.value.args[0]["message"]
+
+
+async def test_iso_8601_window_rejected_with_clear_error() -> None:
+    """The exact failure the dashboard run hit: an ISO-8601 window → clear 400, not an
+    opaque upstream BAD_REQUEST."""
+    with pytest.raises(ToolError) as exc:
+        await _apps(
+            ctx=_Ctx(),
+            site_id="64061593875",
+            start_query_time="2026-06-08T00:00:00Z",
+            end_query_time="2026-06-09T00:00:00Z",
+        )
+    assert exc.value.args[0]["status_code"] == 400
+    assert "epoch" in exc.value.args[0]["message"].lower()
+
+
+async def test_reversed_window_rejected() -> None:
+    with pytest.raises(ToolError) as exc:
+        await _apps(ctx=_Ctx(), site_id="64061593875", start_query_time="1780963200000", end_query_time="1780876800000")
+    assert exc.value.args[0]["status_code"] == 400
+    assert "before" in exc.value.args[0]["message"]


### PR DESCRIPTION
Closes #458.

## Root cause (live-verified)
`central_get_applications` and its `network-monitoring/v1alpha1/applications` path are **correct** — a valid `site_id` + an epoch-millisecond window returns data cleanly. The `HTTP 400 BAD_REQUEST` the dashboard run hit was a **malformed-input passthrough**: the tool forwarded whatever it was given straight to Central, and the endpoint 400s on anything that isn't epoch-ms.

Reproduced live against the tenant:

| `start_query_time` / `end_query_time` | result |
|---|---|
| `1780876800000` / `1780963200000` (epoch-ms) | ✅ data |
| `2026-06-08T00:00:00Z` (ISO-8601) | ❌ upstream 400 |
| `2026-06-08` (plain date) | ❌ upstream 400 |
| end < start (reversed) | ❌ upstream 400 |

The model almost certainly passed an ISO/human time when building the "last 24h" window.

## Fix
Validate inputs **before** calling Central and raise a clear `ToolError` (400) instead of forwarding an opaque upstream 400:
- `start_query_time` / `end_query_time` must be numeric epoch timestamps; a non-numeric value (ISO-8601, plain date, …) is rejected with a message naming the bad value and the expected format.
- **Epoch seconds (10-digit) are accepted** and normalized to ms — the seconds-vs-ms mixup is the most common mistake, and 10- vs 13-digit values don't overlap for present-day timestamps.
- `start_query_time` must be before `end_query_time`; `site_id` must be non-empty.

No path/endpoint change (the `v1alpha1` route is correct).

## Tests
`tests/unit/test_central_applications.py` — the `_to_epoch_ms` helper (ms passthrough, seconds→ms, rejection of ISO/date/garbage) and tool-level validation (empty `site_id`, ISO window → clear 400, reversed window). Full suite: **1727 passed, 1 skipped**; ruff / format / mypy clean.

Patch bump 3.3.8.1 → 3.3.8.2; CHANGELOG updated.