### PR TITLE
feat(mcp-apps): Generative UI dashboards + unified MCP_APP_ENABLE flag (BREAKING: drops MCP_ENABLE_FILE_UPLOAD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.9.0] - 2026-06-10
+
+**Minor — Generative UI dashboards + a single `MCP_APP_ENABLE` switch for all MCP-Apps providers.** The model can now build a live, interactive dashboard from the data it gathered — "build me an MRT dashboard for site HOME" → it pulls the Central/ClearPass data, then calls `generate_prefab_ui` and a Prefab app (tabs, KPI cards, charts, searchable data tables) renders inline. Live-validated end to end.
+
+### ⚠️ BREAKING
+- **`MCP_ENABLE_FILE_UPLOAD` is removed; use `MCP_APP_ENABLE`.** A single switch now gates *all* MCP-Apps capabilities (the `FileUpload` provider **and** the new `GenerativeUI` provider) — both emit `ui://` MCP-Apps resources that render only in MCP-Apps hosts (Claude Desktop / ChatGPT / claude.ai). If you set `MCP_ENABLE_FILE_UPLOAD=true`, change it to `MCP_APP_ENABLE=true` (file upload silently disables otherwise).
+
+### Added
+- **`GenerativeUI` provider** (FastMCP 3.2.0+, behind `MCP_APP_ENABLE`): exposes `generate_prefab_ui` + `search_prefab_components`, re-exposed top-level in code mode. The tool description is augmented with networking-specific guidance steering dashboard/visualization requests to it, plus an explicit **data contract** (values passed via `data` become globals by key — not a `data` variable) that eliminates the `NameError: name 'data'` trap.
+- **Deno** is baked into the image (the Prefab sandbox shells out to it for server-side validation; it does not auto-install).
+
+### Fixed
+- **Response envelope pass-through for the prefab tools** — `generate_prefab_ui` / `search_prefab_components` carry `x-fastmcp-wrap-result` output schemas; the envelope was stripping their required `result` field (same class as #293/#302). Now bypassed.
+- **`central_get_applications` made forgiving** (surfaced during dashboard testing): `start_query_time`/`end_query_time` accept epoch ms (13-digit), epoch seconds (10-digit), **or ISO-8601** (the sandbox blocks `time.now()`, so an LLM naturally passes ISO) — all normalized to epoch ms; the `sort` param accepts OData (`usage desc`) **and** the `-field` shorthand (`-usage` → `usage desc`).
+- **`central_get_ap_trend` throughput** now sends the API-required `interface-type` query param (WIRELESS / WIRED / LTE; defaults WIRELESS) — it was 400ing on every call without it. cpu/memory/power dimensions are unaffected.
+
+New unit tests for the provider wiring (single-flag gating, envelope pass-through, description/data-contract), the applications time/sort normalization, and the ap_trend interface-type. Full suite green.
+
 ## [3.3.8.2] - 2026-06-09
 
 **Patch — `central_get_applications` now validates the time window up front (#458).** The applications endpoint expects epoch **milliseconds**; an ISO-8601 string, a plain date, or a reversed window produced an opaque upstream `HTTP 400 BAD_REQUEST` ("Your request was incorrect or incomplete") wrapped as a 502, leaving the caller with no idea what was wrong.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ FROM python:3.12-slim-bookworm
 # Install uv in runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+# Deno binary — required ONLY by the optional Generative UI provider
+# (MCP_ENABLE_GENERATIVE_UI), which runs Prefab/Pyodide in a Deno subprocess for
+# server-side validation. prefab_ui does shutil.which("deno") and raises if it's
+# absent (it does NOT auto-install). Harmless dead weight when the feature is off.
+COPY --from=denoland/deno:bin /deno /usr/local/bin/deno
+
 # Create non-root user
 RUN groupadd -g 1000 mcpuser && useradd -u 1000 -g mcpuser -m mcpuser
 
@@ -43,6 +49,8 @@ ENV MCP_PORT=8000
 ENV MCP_HOST=0.0.0.0
 ENV LOG_LEVEL=info
 ENV SECRETS_DIR=/run/secrets
+# Deno download cache (Generative UI / Prefab sandbox) — under the writable HOME.
+ENV DENO_DIR=/home/mcpuser/.cache/deno
 ENV ENABLE_MIST_WRITE_TOOLS=false
 ENV ENABLE_CENTRAL_WRITE_TOOLS=false
 ENV DISABLE_ELICITATION=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ FROM python:3.12-slim-bookworm
 # Install uv in runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-# Deno binary — required ONLY by the optional Generative UI provider
-# (MCP_ENABLE_GENERATIVE_UI), which runs Prefab/Pyodide in a Deno subprocess for
-# server-side validation. prefab_ui does shutil.which("deno") and raises if it's
-# absent (it does NOT auto-install). Harmless dead weight when the feature is off.
+# Deno binary — required ONLY by the optional Generative UI provider (enabled via
+# MCP_APP_ENABLE), which runs Prefab/Pyodide in a Deno subprocess for server-side
+# validation. prefab_ui does shutil.which("deno") and raises if it's absent (it
+# does NOT auto-install). Harmless dead weight when the MCP-Apps providers are off.
 COPY --from=denoland/deno:bin /deno /usr/local/bin/deno
 
 # Create non-root user

--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ Write/mutation tools (e.g., creating WLANs in Mist, modifying configurations) ar
 | `ENABLE_AXIS_WRITE_TOOLS` | `false` | Enable Axis Atmos Cloud write/mutation tools (every write stages — call `axis_commit_changes` to apply) |
 | `ENABLE_AOS8_WRITE_TOOLS` | `false` | Enable AOS8 write tools (12 tools; every write returns `requires_write_memory_for` — call `aos8_write_memory` explicitly) |
 | `ENABLE_UXI_WRITE_TOOLS` | `false` | Enable UXI write tools (10 tools: sensor/agent/group/assignment mutations) |
-| `MCP_ENABLE_FILE_UPLOAD` | `false` | Register the FastMCP `FileUpload` provider — exposes `file_manager` (drag/pick upload UI) + `list_files` / `read_file` at the top level (the upload UI renders only in MCP-Apps hosts e.g. Claude Desktop / ChatGPT). Lets operators upload an AOS 8 config for the `aos-migration` skill instead of pasting it. |
+| `MCP_APP_ENABLE` | `false` | Single switch for all MCP-Apps capabilities. Registers the FastMCP `FileUpload` provider (`file_manager` drag/pick upload UI + `list_files` / `read_file`) **and** the `GenerativeUI` provider (`generate_prefab_ui` — the model writes a live Prefab dashboard from data it collected — + `search_prefab_components`). All UIs render only in MCP-Apps hosts (e.g. Claude Desktop / ChatGPT / claude.ai). |
 | `DISABLE_ELICITATION` | `false` | Skip user confirmation for write tools (**use with caution**) |
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.8.2"
+version = "3.3.9.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -23,7 +23,7 @@ Two modes are supported (the `static` mode was removed in v3.0.0.0):
     - **3 meta-tools per platform × 8 platforms** = 24: `<platform>_list_tools`, `<platform>_get_tool_schema`, `<platform>_invoke_tool`
     - **2 skills tools** (since v2.3.0.0): `skills_list`, `skills_load`
 
-**Optional file upload** (`MCP_ENABLE_FILE_UPLOAD=true`, off by default): `file_manager` (drag/pick upload UI) plus `list_files` / `read_file` are exposed at the top level — even in code mode. The upload UI renders only in MCP-Apps hosts (Claude Desktop / ChatGPT); elsewhere `file_manager` is a callable tool with no rendered widget. Use it to let an operator upload an AOS 8 config for the `aos-migration` skill instead of pasting it.
+**Optional MCP-Apps providers** (`MCP_APP_ENABLE=true`, off by default — one switch for both): `file_manager` (drag/pick upload UI) plus `list_files` / `read_file`, and `generate_prefab_ui` (the model writes a live Prefab dashboard from data it collected) plus `search_prefab_components`, are exposed at the top level — even in code mode. The UIs render only in MCP-Apps hosts (Claude Desktop / ChatGPT / claude.ai); elsewhere these are callable tools with no rendered widget. Use `file_manager` to let an operator upload an AOS 8 config for the `aos-migration` skill instead of pasting it; use `generate_prefab_ui` for any dashboard / visualization request.
 
 The discovery patterns below describe **dynamic mode** (the v2.x default). In **code mode**, two discovery paths work — pick whichever your client surfaced:
 

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -65,7 +65,7 @@ _NO_ENVELOPE_TOOLS: frozenset[str] = frozenset(
         "get_schema",
         "skills_list",
         "skills_load",
-        # GenerativeUI provider (MCP_ENABLE_GENERATIVE_UI). Both tools carry an
+        # GenerativeUI provider (MCP_APP_ENABLE). Both tools carry an
         # ``x-fastmcp-wrap-result`` output schema requiring a top-level ``result``
         # key; wrapping them in the envelope strips ``result`` and the tool's own
         # output validation fails with "'result' is a required property" — the same

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -65,6 +65,17 @@ _NO_ENVELOPE_TOOLS: frozenset[str] = frozenset(
         "get_schema",
         "skills_list",
         "skills_load",
+        # GenerativeUI provider (MCP_ENABLE_GENERATIVE_UI). Both tools carry an
+        # ``x-fastmcp-wrap-result`` output schema requiring a top-level ``result``
+        # key; wrapping them in the envelope strips ``result`` and the tool's own
+        # output validation fails with "'result' is a required property" — the same
+        # failure mode as the discovery tools above (#293/#302). ``generate_prefab_ui``
+        # also returns a ``$prefab`` UI view (caught by the marker bypass below), but
+        # naming it here covers its non-UI/error returns too. Names are the
+        # GenerativeUI defaults — keep in sync if the provider is constructed with
+        # custom tool_name / components_tool_name.
+        "generate_prefab_ui",
+        "search_prefab_components",
     }
 )
 

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -31,12 +31,13 @@ def _to_epoch_ms(label: str, value: str) -> int:
     * **13-digit** epoch milliseconds — used as-is.
     * **10-digit** epoch seconds — converted to ms (the seconds-vs-ms mixup is the
       most common mistake; 10- vs 13-digit values don't overlap for present-day times).
-    * **ISO-8601** datetimes (e.g. ``2026-06-08T23:00:00Z``) — converted to ms. This
-      is the natural form for an LLM that can't read the clock inside the code-mode
-      sandbox (``datetime.now()`` / ``time.time()`` are blocked there), so accept it
-      and do the conversion server-side where a clock is available.
+    * **ISO-8601** datetimes *and bare dates* (e.g. ``2026-06-08T23:00:00Z`` or
+      ``2026-06-08``, taken as midnight UTC) — converted to ms. ISO is the natural
+      form for an LLM that can't read the clock inside the code-mode sandbox
+      (``datetime.now()`` / ``time.time()`` are blocked there), so accept it and do
+      the conversion server-side where a clock is available.
 
-    Anything else (a plain date, a word, an 11/12/14-digit typo) is rejected.
+    Anything else (a word, an 11/12/14-digit typo, a malformed datetime) is rejected.
 
     Args:
         label: Parameter name, used in the error message.
@@ -79,7 +80,9 @@ def _normalize_sort(value: str) -> str:
     """
     s = value.strip()
     if s and s[0] in "+-" and " " not in s and "," not in s:
-        return f"{s[1:].strip()} {'desc' if s[0] == '-' else 'asc'}"
+        field = s[1:].strip()
+        if field:  # ignore a bare "-"/"+" (no field) — leave it for Central to reject
+            return f"{field} {'desc' if s[0] == '-' else 'asc'}"
     return s
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
@@ -6,17 +8,35 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 
+def _parse_iso_to_epoch_ms(value: str) -> int | None:
+    """Parse an ISO-8601 datetime to epoch milliseconds, or return None if it isn't
+    a parseable ISO-8601 string. A naive datetime (no offset) is assumed UTC."""
+    iso = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        dt = datetime.fromisoformat(iso)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
 def _to_epoch_ms(label: str, value: str) -> int:
-    """Validate and normalize an epoch timestamp to milliseconds.
+    """Validate and normalize a timestamp to epoch milliseconds.
 
     The Central applications endpoint expects epoch **milliseconds** and returns an
-    opaque ``HTTP 400 BAD_REQUEST`` for anything else (ISO-8601 strings, plain dates,
-    etc.). Validate up front so callers get an actionable error instead of the bare
-    upstream 400 (issue #458). Only the two sane digit lengths for present-day
-    timestamps are accepted: **13-digit** epoch milliseconds, or **10-digit** epoch
-    seconds (converted to ms — the seconds-vs-ms mixup is the most common mistake).
-    Any other length (an 11/12/14-digit typo) is rejected rather than passed through
-    to produce a second opaque upstream 400.
+    opaque ``HTTP 400 BAD_REQUEST`` for anything else, so normalize up front and give
+    an actionable error for genuinely bad input (issue #458). Accepted forms:
+
+    * **13-digit** epoch milliseconds — used as-is.
+    * **10-digit** epoch seconds — converted to ms (the seconds-vs-ms mixup is the
+      most common mistake; 10- vs 13-digit values don't overlap for present-day times).
+    * **ISO-8601** datetimes (e.g. ``2026-06-08T23:00:00Z``) — converted to ms. This
+      is the natural form for an LLM that can't read the clock inside the code-mode
+      sandbox (``datetime.now()`` / ``time.time()`` are blocked there), so accept it
+      and do the conversion server-side where a clock is available.
+
+    Anything else (a plain date, a word, an 11/12/14-digit typo) is rejected.
 
     Args:
         label: Parameter name, used in the error message.
@@ -26,23 +46,25 @@ def _to_epoch_ms(label: str, value: str) -> int:
         The timestamp as integer epoch milliseconds.
 
     Raises:
-        ToolError: 400 when ``value`` is not a 10- or 13-digit epoch timestamp.
+        ToolError: 400 when ``value`` is not a recognized timestamp form.
     """
     s = str(value).strip()
-    if not s.isdigit() or len(s) not in (10, 13):
-        raise ToolError(
-            {
-                "status_code": 400,
-                "message": (
-                    f"{label} must be an epoch timestamp in milliseconds "
-                    f"(13-digit, e.g. '1780876800000') or seconds (10-digit), got "
-                    f"{value!r}. ISO-8601 timestamps and plain dates are not accepted "
-                    "— convert to epoch milliseconds first."
-                ),
-            }
-        )
-    # 10-digit value = epoch seconds → normalize to ms; 13-digit already ms.
-    return int(s) * 1000 if len(s) == 10 else int(s)
+    if s.isdigit() and len(s) in (10, 13):
+        # 10-digit = epoch seconds → ms; 13-digit already ms.
+        return int(s) * 1000 if len(s) == 10 else int(s)
+    iso_ms = _parse_iso_to_epoch_ms(s)
+    if iso_ms is not None:
+        return iso_ms
+    raise ToolError(
+        {
+            "status_code": 400,
+            "message": (
+                f"{label} must be epoch milliseconds (13-digit, e.g. '1780876800000'), "
+                f"epoch seconds (10-digit), or an ISO-8601 datetime (e.g. "
+                f"'2026-06-08T23:00:00Z'); got {value!r}."
+            ),
+        }
+    )
 
 
 @tool(annotations=READ_ONLY)
@@ -66,11 +88,11 @@ async def central_get_applications(
 
     Parameters:
         site_id: Site ID to scope the query (required).
-        start_query_time: Start of the time window in epoch milliseconds (required).
-            Epoch seconds (10-digit) are accepted and converted. ISO-8601 strings and
-            plain dates are NOT accepted — the upstream API rejects them with a 400.
-        end_query_time: End of the time window in epoch milliseconds (required), and
-            must be after start_query_time. Same format rules as start_query_time.
+        start_query_time: Start of the time window (required). Accepts epoch
+            milliseconds (13-digit), epoch seconds (10-digit), or an ISO-8601
+            datetime (e.g. "2026-06-08T23:00:00Z"); all are normalized to epoch ms.
+        end_query_time: End of the time window (required), must be after
+            start_query_time. Same accepted formats as start_query_time.
         limit: Number of records per page (default 1000).
         offset: Starting record offset for pagination (default 0).
         client_id: Filter results to a specific client ID.

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -67,6 +67,22 @@ def _to_epoch_ms(label: str, value: str) -> int:
     )
 
 
+def _normalize_sort(value: str) -> str:
+    """Normalize a sort expression to the OData ``<field> asc|desc`` form Central wants.
+
+    The endpoint rejects the common ``-field`` / ``+field`` shorthand (e.g. ``-usage``)
+    with an opaque 400 — it only accepts ``<field> desc`` / ``<field> asc``. Convert the
+    single-field leading-sign shorthand; pass anything already OData-shaped (or a
+    multi-field / comma list) through unchanged for Central to validate.
+
+    ``-usage`` -> ``usage desc`` · ``+usage`` -> ``usage asc`` · ``usage desc`` -> unchanged
+    """
+    s = value.strip()
+    if s and s[0] in "+-" and " " not in s and "," not in s:
+        return f"{s[1:].strip()} {'desc' if s[0] == '-' else 'asc'}"
+    return s
+
+
 @tool(annotations=READ_ONLY)
 async def central_get_applications(
     ctx: Context,
@@ -97,7 +113,9 @@ async def central_get_applications(
         offset: Starting record offset for pagination (default 0).
         client_id: Filter results to a specific client ID.
         filter: OData filter expression to narrow results.
-        sort: Sort order for results.
+        sort: OData sort order, "<field> asc|desc" (e.g. "usage desc" for the top
+            apps by traffic). The "-field" / "+field" shorthand is also accepted and
+            normalized (e.g. "-usage" -> "usage desc").
     """
     # Validate inputs up front so a bad timestamp yields an actionable error instead
     # of the opaque upstream HTTP 400 (issue #458).
@@ -127,7 +145,7 @@ async def central_get_applications(
     if filter:
         query_params["filter"] = filter
     if sort:
-        query_params["sort"] = sort
+        query_params["sort"] = _normalize_sort(sort)
 
     try:
         resp = retry_central_command(

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -60,14 +60,28 @@ async def central_get_ap_trend(
             ),
         ),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
+    interface_type: Annotated[
+        Literal["WIRELESS", "WIRED", "LTE"] | None,
+        coerce_enum(("WIRELESS", "WIRED", "LTE")),
+        Field(
+            description=(
+                "Interface to aggregate throughput over — REQUIRED by the API for "
+                "``dimension='throughput'`` (defaults to ``'WIRELESS'`` if omitted). "
+                "Ignored for the cpu/memory/power dimensions."
+            ),
+        ),
+    ] = None,
+    start: Annotated[str | None, Field(description="ISO-8601 start timestamp (optional; defaults to last 3h).")] = None,
+    end: Annotated[str | None, Field(description="ISO-8601 end timestamp (optional; defaults to last 3h).")] = None,
 ) -> dict | str:
     """Get one of an AP's top-level time-series trends.
 
     Consolidates the four trend endpoints under
     ``/aps/:serial/<dim>-trends`` (throughput, cpu-utilization,
-    memory-utilization, power-consumption).
+    memory-utilization, power-consumption). Omit ``start`` / ``end`` for the
+    last-3-hours default. The ``throughput`` dimension additionally requires an
+    ``interface_type`` (WIRELESS / WIRED / LTE) — the API 400s without it; this tool
+    defaults it to ``WIRELESS`` so an AP throughput query works out of the box.
     """
     suffix_map = {
         "throughput": "throughput-trends",
@@ -76,10 +90,15 @@ async def central_get_ap_trend(
         "power": "power-consumption-trends",
     }
     conn = ctx.lifespan_context["central_conn"]
+    params = _time_params(start, end)
+    if dimension == "throughput":
+        # interface-type is a mandatory query param for throughput-trends (enum
+        # WIRELESS/WIRED/LTE); WIRELESS is the sensible default for an AP.
+        params["interface-type"] = interface_type or "WIRELESS"
     return _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/{suffix_map[dimension]}",
-        _time_params(start, end),
+        params,
     )
 
 

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -242,6 +242,40 @@ def _file_upload_enabled() -> bool:
     return os.environ.get("MCP_ENABLE_FILE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
 
 
+def _generative_ui_enabled() -> bool:
+    """Whether the experimental Generative UI provider is enabled (env-gated)."""
+    import os
+
+    return os.environ.get("MCP_ENABLE_GENERATIVE_UI", "").strip().lower() in ("1", "true", "yes")
+
+
+# Prepended to the GenerativeUI tool's own description. Tool descriptions are part
+# of the function-calling contract a client uses to PICK a tool — unlike
+# INSTRUCTIONS.md, which MCP clients treat as untrusted server content and largely
+# ignore (see the project_mcp_memory_arch_finding note). Putting the steer HERE is
+# what actually makes the model reach for generate_prefab_ui instead of hand-writing
+# HTML for a dashboard request.
+_GENERATIVE_UI_GUIDANCE = (
+    "USE THIS TOOL FIRST for any request to build, render, draw, show, or visualize "
+    "a dashboard, report, chart, graph, table, scorecard, status board, or any "
+    "graphical / interactive view of network data (Juniper Mist, Aruba Central + MRT, "
+    "HPE GreenLake, ClearPass, Apstra, Axis, AOS 8, UXI). Workflow: gather the data "
+    "first (platform read tools / an `execute` block), then pass it here and compose "
+    "the view from Prefab components (metric cards, bar/line/area/pie charts, data "
+    "tables, badges) with reactive state for in-window filtering. Do NOT hand-write "
+    "raw HTML as a text response for visualization requests — render it through this "
+    "tool so the client shows a live, interactive widget instead of a static blob.\n\n"
+    "DATA CONTRACT (avoids the #1 error): pass the values you gathered as the `data` "
+    "argument, which MUST be a dict. Each TOP-LEVEL KEY of that dict becomes a global "
+    "variable of that same name inside your `code` — reference those names directly. "
+    "Example: data={'devices': [...], 'top_aps': [...]} -> in code use `devices` and "
+    "`top_aps`. There is NO variable named `data` in the sandbox; writing `data[...]` "
+    "or `data.get(...)` raises `NameError: name 'data' is not defined`. Embed the real "
+    "values you collected (do not invent placeholders).\n\n"
+    "---\n\n"
+)
+
+
 def create_server(config: ServerConfig) -> FastMCP:
     """Create and configure the FastMCP server with all enabled platform tools."""
     from hpe_networking_mcp.middleware.elicitation import (
@@ -333,6 +367,39 @@ def create_server(config: ServerConfig) -> FastMCP:
 
         mcp.add_provider(FileUpload())
         logger.info("File upload: FileUpload provider registered (MCP_ENABLE_FILE_UPLOAD=true)")
+
+    # --- Generative UI (experimental, env-gated) ---
+    # MCP_ENABLE_GENERATIVE_UI=true registers FastMCP's GenerativeUI provider
+    # (FastMCP 3.2.0+; the fastmcp[apps] extra is already pinned). It exposes a
+    # `generate_prefab_ui` tool — the model writes Prefab Python that renders as
+    # a live dashboard from data it collected (e.g. AP health across sites) — a
+    # `search_prefab_components` discovery tool, and a `ui://` streaming-renderer
+    # resource. In code mode the CodeMode transform would bury the two tools, so
+    # _register_code_mode() re-exposes them top-level via discovery_tools (their
+    # `ui` render metadata rides through intact). Renders only in MCP-Apps hosts
+    # (Claude Desktop / ChatGPT / claude.ai); a no-op visual in Claude Code.
+    # Server-side validation uses Deno (auto-installs on first use).
+    if _generative_ui_enabled():
+        import asyncio
+
+        from fastmcp.apps.generative import GenerativeUI
+
+        mcp.add_provider(GenerativeUI())
+        logger.info("Generative UI: GenerativeUI provider registered (MCP_ENABLE_GENERATIVE_UI=true)")
+
+        # Steer dashboard/visualization requests to this tool by prepending
+        # networking-specific guidance to its description (preserving the upstream
+        # Prefab authoring instructions). get_tool returns the live instance and the
+        # change persists to list_tools, so this covers BOTH code and dynamic mode.
+        # create_server runs before the event loop, so a one-shot asyncio.run is safe
+        # (same justification as the code-mode re-expose below).
+        try:
+            _gen_tool = asyncio.run(mcp.get_tool("generate_prefab_ui"))
+            if _gen_tool is not None:
+                _gen_tool.description = _GENERATIVE_UI_GUIDANCE + (_gen_tool.description or "")
+                logger.info("Generative UI: generate_prefab_ui description augmented with dashboard guidance")
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Generative UI: could not augment generate_prefab_ui description: {}", e)
 
     # --- Cross-platform aggregators ---
     # These are workarounds for dynamic mode's "AI picks one platform and stops"
@@ -615,6 +682,22 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
                 logger.info("File upload: {} re-exposed top-level in code mode", app_tool_name)
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning("File upload: could not expose {} top-level: {}", app_tool_name, e)
+
+    # Same pattern for Generative UI: re-expose its two model-visible tools so
+    # CodeMode doesn't bury them behind `execute`. generate_prefab_ui carries the
+    # MCP-Apps `ui` render metadata (the streaming Prefab renderer); it rides
+    # through the discovery factory unchanged. The `ui://` renderer resource is
+    # not a tool, so the CodeMode tool transform leaves it untouched.
+    if _generative_ui_enabled():
+        import asyncio
+
+        for app_tool_name in ("generate_prefab_ui", "search_prefab_components"):
+            try:
+                app_tool = asyncio.run(mcp.get_tool(app_tool_name))
+                discovery_tools.append(lambda get_catalog, _t=app_tool: _t)
+                logger.info("Generative UI: {} re-exposed top-level in code mode", app_tool_name)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Generative UI: could not expose {} top-level: {}", app_tool_name, e)
 
     mcp.add_transform(
         CodeMode(

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -235,18 +235,16 @@ async def lifespan(server: FastMCP):
         logger.info("Server shutdown complete")
 
 
-def _file_upload_enabled() -> bool:
-    """Whether the experimental FileUpload provider is enabled (env-gated)."""
+def _mcp_apps_enabled() -> bool:
+    """Whether the MCP-Apps providers are enabled (env-gated by ``MCP_APP_ENABLE``).
+
+    A single switch for every MCP-Apps capability — the ``FileUpload`` provider and
+    the ``GenerativeUI`` provider — since both emit ``ui://`` MCP-Apps resources that
+    only render in MCP-Apps hosts. Off by default.
+    """
     import os
 
-    return os.environ.get("MCP_ENABLE_FILE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
-
-
-def _generative_ui_enabled() -> bool:
-    """Whether the experimental Generative UI provider is enabled (env-gated)."""
-    import os
-
-    return os.environ.get("MCP_ENABLE_GENERATIVE_UI", "").strip().lower() in ("1", "true", "yes")
+    return os.environ.get("MCP_APP_ENABLE", "").strip().lower() in ("1", "true", "yes")
 
 
 # Prepended to the GenerativeUI tool's own description. Tool descriptions are part
@@ -355,37 +353,31 @@ def create_server(config: ServerConfig) -> FastMCP:
     if config.uxi:
         _register_uxi_tools(mcp, config)
 
-    # --- File upload (experimental, env-gated test) ---
-    # MCP_ENABLE_FILE_UPLOAD=true registers FastMCP's FileUpload provider,
-    # which exposes a `file_manager` drag/pick upload tool carrying MCP-Apps
-    # `ui` render metadata. In code mode the CodeMode transform would hide it,
-    # so _register_code_mode() re-exposes it top-level via discovery_tools (it
-    # rides through with its `ui` metadata intact — verified). Renders only in
-    # MCP-Apps hosts (Claude Desktop / ChatGPT); a no-op visual in Claude Code.
-    if _file_upload_enabled():
-        from fastmcp.apps.file_upload import FileUpload
-
-        mcp.add_provider(FileUpload())
-        logger.info("File upload: FileUpload provider registered (MCP_ENABLE_FILE_UPLOAD=true)")
-
-    # --- Generative UI (experimental, env-gated) ---
-    # MCP_ENABLE_GENERATIVE_UI=true registers FastMCP's GenerativeUI provider
-    # (FastMCP 3.2.0+; the fastmcp[apps] extra is already pinned). It exposes a
-    # `generate_prefab_ui` tool — the model writes Prefab Python that renders as
-    # a live dashboard from data it collected (e.g. AP health across sites) — a
-    # `search_prefab_components` discovery tool, and a `ui://` streaming-renderer
-    # resource. In code mode the CodeMode transform would bury the two tools, so
-    # _register_code_mode() re-exposes them top-level via discovery_tools (their
-    # `ui` render metadata rides through intact). Renders only in MCP-Apps hosts
-    # (Claude Desktop / ChatGPT / claude.ai); a no-op visual in Claude Code.
-    # Server-side validation uses Deno (auto-installs on first use).
-    if _generative_ui_enabled():
+    # --- MCP-Apps providers (experimental, env-gated by MCP_APP_ENABLE) ---
+    # One switch enables every MCP-Apps capability. Both providers emit `ui://`
+    # MCP-Apps resources that render only in MCP-Apps hosts (Claude Desktop /
+    # ChatGPT / claude.ai); they're no-op visuals in Claude Code.
+    #
+    # FileUpload: exposes a `file_manager` drag/pick upload tool (carrying MCP-Apps
+    # `ui` render metadata) plus `list_files` / `read_file`. In code mode the
+    # CodeMode transform would hide them, so _register_code_mode() re-exposes them
+    # top-level via discovery_tools (their `ui` metadata rides through intact).
+    #
+    # GenerativeUI: exposes `generate_prefab_ui` — the model writes Prefab Python
+    # that renders as a live dashboard from data it collected (e.g. AP health across
+    # sites) — a `search_prefab_components` discovery tool, and a `ui://` streaming
+    # renderer resource. Server-side validation uses Deno (baked into the image).
+    if _mcp_apps_enabled():
         import asyncio
 
+        from fastmcp.apps.file_upload import FileUpload
         from fastmcp.apps.generative import GenerativeUI
 
+        mcp.add_provider(FileUpload())
+        logger.info("MCP Apps: FileUpload provider registered (MCP_APP_ENABLE=true)")
+
         mcp.add_provider(GenerativeUI())
-        logger.info("Generative UI: GenerativeUI provider registered (MCP_ENABLE_GENERATIVE_UI=true)")
+        logger.info("MCP Apps: GenerativeUI provider registered (MCP_APP_ENABLE=true)")
 
         # Steer dashboard/visualization requests to this tool by prepending
         # networking-specific guidance to its description (preserving the upstream
@@ -662,42 +654,35 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
         SkillsLoadDiscoveryTool(skill_registry),
     ]
 
-    # If the FileUpload provider is registered, re-expose its model-visible
-    # tools top-level so CodeMode doesn't bury them behind `execute`:
-    #   - file_manager — renders the upload UI (carries MCP-Apps `ui` meta)
-    #   - list_files / read_file — let a skill/AI enumerate + read what was
-    #     uploaded (the aos-migration upload branch's read_file fallback path)
-    # A discovery factory is `(get_catalog) -> Tool`; ours ignores the catalog
-    # and returns the already-registered Tool unchanged, so file_manager's `ui`
-    # render metadata survives the transform. create_server() runs before the
+    # If the MCP-Apps providers are registered (MCP_APP_ENABLE), re-expose their
+    # model-visible tools top-level so CodeMode doesn't bury them behind `execute`:
+    #   FileUpload  — file_manager (renders the upload UI; carries MCP-Apps `ui`
+    #                 meta) + list_files / read_file (the aos-migration upload
+    #                 branch's read_file fallback path). store_files is app-only
+    #                 (UI-internal) and intentionally NOT re-exposed.
+    #   GenerativeUI — generate_prefab_ui (carries the streaming-renderer `ui`
+    #                 meta) + search_prefab_components.
+    # A discovery factory is `(get_catalog) -> Tool`; ours ignores the catalog and
+    # returns the already-registered Tool unchanged, so the `ui` render metadata
+    # survives the transform. The `ui://` renderer resources are not tools, so the
+    # CodeMode tool transform leaves them untouched. create_server() runs before the
     # event loop starts, so a one-shot asyncio.run to fetch each tool is safe.
-    # store_files is app-only (UI-internal) and intentionally NOT re-exposed.
-    if _file_upload_enabled():
+    if _mcp_apps_enabled():
         import asyncio
 
-        for app_tool_name in ("file_manager", "list_files", "read_file"):
+        for app_tool_name in (
+            "file_manager",
+            "list_files",
+            "read_file",
+            "generate_prefab_ui",
+            "search_prefab_components",
+        ):
             try:
                 app_tool = asyncio.run(mcp.get_tool(app_tool_name))
                 discovery_tools.append(lambda get_catalog, _t=app_tool: _t)
-                logger.info("File upload: {} re-exposed top-level in code mode", app_tool_name)
+                logger.info("MCP Apps: {} re-exposed top-level in code mode", app_tool_name)
             except Exception as e:  # pragma: no cover - defensive
-                logger.warning("File upload: could not expose {} top-level: {}", app_tool_name, e)
-
-    # Same pattern for Generative UI: re-expose its two model-visible tools so
-    # CodeMode doesn't bury them behind `execute`. generate_prefab_ui carries the
-    # MCP-Apps `ui` render metadata (the streaming Prefab renderer); it rides
-    # through the discovery factory unchanged. The `ui://` renderer resource is
-    # not a tool, so the CodeMode tool transform leaves it untouched.
-    if _generative_ui_enabled():
-        import asyncio
-
-        for app_tool_name in ("generate_prefab_ui", "search_prefab_components"):
-            try:
-                app_tool = asyncio.run(mcp.get_tool(app_tool_name))
-                discovery_tools.append(lambda get_catalog, _t=app_tool: _t)
-                logger.info("Generative UI: {} re-exposed top-level in code mode", app_tool_name)
-            except Exception as e:  # pragma: no cover - defensive
-                logger.warning("Generative UI: could not expose {} top-level: {}", app_tool_name, e)
+                logger.warning("MCP Apps: could not expose {} top-level: {}", app_tool_name, e)
 
     mcp.add_transform(
         CodeMode(

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -160,7 +160,7 @@ Route on the reply:
 
 For the richest offline result, ask the operator to bundle `show running-config` **plus** `show ap database`, `show lc-cluster group-membership`, and `show ap active` into the upload. Object classes the parser hasn't yet modeled are marked `inconclusive — not yet parsed (include the relevant show output / extend parser)`; readiness rules whose data is absent don't fire. The API path (option 1) is still the zero-parser-gap route.
 
-**Availability of option 2 (upload):** requires the server's file-upload capability (`MCP_ENABLE_FILE_UPLOAD=true`) AND an MCP-Apps-capable client (Claude Desktop / ChatGPT) to render the upload widget. If `file_manager` is not present in the catalog, tell the operator option 2 is unavailable on this server and offer option 3 (paste) instead.
+**Availability of option 2 (upload):** requires the server's MCP-Apps capability (`MCP_APP_ENABLE=true`) AND an MCP-Apps-capable client (Claude Desktop / ChatGPT) to render the upload widget. If `file_manager` is not present in the catalog, tell the operator option 2 is unavailable on this server and offer option 3 (paste) instead.
 
 ### Stage -1 — AOS 8 reachability gate (DETECT-01)
 

--- a/tests/unit/test_central_applications.py
+++ b/tests/unit/test_central_applications.py
@@ -14,6 +14,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms.central.tools.applications import (
+    _normalize_sort,
     _to_epoch_ms,
     central_get_applications,
 )
@@ -75,6 +76,27 @@ def test_unparseable_timestamp_rejected(bad: str) -> None:
     payload = exc.value.args[0]
     assert payload["status_code"] == 400
     assert "epoch" in payload["message"].lower() or "iso" in payload["message"].lower()
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_sort helper
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("-usage", "usage desc"),  # Mongo/Django shorthand the model used → OData
+        ("+usage", "usage asc"),
+        ("-bytes", "bytes desc"),
+        ("usage desc", "usage desc"),  # already OData → unchanged
+        ("usage asc", "usage asc"),
+        ("usage desc, name asc", "usage desc, name asc"),  # multi-field → unchanged
+        ("usage", "usage"),  # bare field → left for Central to interpret
+    ],
+)
+def test_normalize_sort(raw: str, expected: str) -> None:
+    assert _normalize_sort(raw) == expected
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_central_applications.py
+++ b/tests/unit/test_central_applications.py
@@ -93,6 +93,8 @@ def test_unparseable_timestamp_rejected(bad: str) -> None:
         ("usage asc", "usage asc"),
         ("usage desc, name asc", "usage desc, name asc"),  # multi-field → unchanged
         ("usage", "usage"),  # bare field → left for Central to interpret
+        ("-", "-"),  # bare sign, no field → passed through (no " desc")
+        ("+", "+"),
     ],
 )
 def test_normalize_sort(raw: str, expected: str) -> None:

--- a/tests/unit/test_central_applications.py
+++ b/tests/unit/test_central_applications.py
@@ -45,24 +45,36 @@ def test_epoch_seconds_converted_to_ms() -> None:
     assert _to_epoch_ms("start_query_time", "1780876800") == 1780876800000
 
 
+def test_iso_8601_converted_to_epoch_ms() -> None:
+    """ISO-8601 is the natural form for an LLM that can't read the sandbox clock — accept
+    it and convert server-side (2026-06-08T23:00:00Z = 1780959600000 ms)."""
+    assert _to_epoch_ms("start_query_time", "2026-06-08T23:00:00Z") == 1780959600000
+    # Naive (no offset) is assumed UTC.
+    assert _to_epoch_ms("start_query_time", "2026-06-08T23:00:00") == 1780959600000
+
+
+def test_plain_date_converted_to_epoch_ms() -> None:
+    """A bare date is a valid ISO-8601 window boundary (midnight UTC)."""
+    assert _to_epoch_ms("start_query_time", "2026-06-08") == 1780876800000
+
+
 @pytest.mark.parametrize(
     "bad",
     [
-        "2026-06-08T00:00:00Z",  # ISO-8601
-        "2026-06-08",  # plain date
         "yesterday",  # word
         "",  # empty
         "12ab34",  # mixed
-        "178087680000",  # 12-digit typo (dropped a digit) — must not pass through
+        "178087680000",  # 12-digit typo (dropped a digit) — not a valid epoch or ISO
         "17808768000000",  # 14-digit typo (extra digit)
+        "2026-13-40",  # ISO-shaped but invalid date
     ],
 )
-def test_malformed_timestamp_rejected(bad: str) -> None:
+def test_unparseable_timestamp_rejected(bad: str) -> None:
     with pytest.raises(ToolError) as exc:
         _to_epoch_ms("start_query_time", bad)
     payload = exc.value.args[0]
     assert payload["status_code"] == 400
-    assert "epoch" in payload["message"].lower()
+    assert "epoch" in payload["message"].lower() or "iso" in payload["message"].lower()
 
 
 # --------------------------------------------------------------------------- #
@@ -77,22 +89,27 @@ async def test_empty_site_id_rejected() -> None:
     assert "site_id" in exc.value.args[0]["message"]
 
 
-async def test_iso_8601_window_rejected_with_clear_error() -> None:
-    """The exact failure the dashboard run hit: an ISO-8601 window → clear 400, not an
-    opaque upstream BAD_REQUEST."""
+async def test_unparseable_window_rejected_with_clear_error() -> None:
+    """A genuinely unparseable timestamp still yields a clear 400 before the API call."""
     with pytest.raises(ToolError) as exc:
         await _apps(
             ctx=_Ctx(),
             site_id="64061593875",
-            start_query_time="2026-06-08T00:00:00Z",
+            start_query_time="last tuesday",
             end_query_time="2026-06-09T00:00:00Z",
         )
     assert exc.value.args[0]["status_code"] == 400
-    assert "epoch" in exc.value.args[0]["message"].lower()
 
 
 async def test_reversed_window_rejected() -> None:
+    """Reversed window is caught after normalization (works across mixed input forms:
+    an ISO start that resolves after an epoch-ms end)."""
     with pytest.raises(ToolError) as exc:
-        await _apps(ctx=_Ctx(), site_id="64061593875", start_query_time="1780963200000", end_query_time="1780876800000")
+        await _apps(
+            ctx=_Ctx(),
+            site_id="64061593875",
+            start_query_time="2026-06-09T00:00:00Z",
+            end_query_time="1780876800000",  # 2026-06-08 — earlier than the ISO start
+        )
     assert exc.value.args[0]["status_code"] == 400
     assert "before" in exc.value.args[0]["message"]

--- a/tests/unit/test_central_mrt_ap_trend.py
+++ b/tests/unit/test_central_mrt_ap_trend.py
@@ -1,0 +1,66 @@
+"""Unit tests for ``central_get_ap_trend`` interface-type handling.
+
+The ``throughput-trends`` endpoint requires an ``interface-type`` query param
+(WIRELESS / WIRED / LTE); the API 400s without it. The tool defaults it to
+WIRELESS for the throughput dimension and omits it for cpu/memory/power (where
+the endpoint doesn't accept it). Surfaced by live dashboard testing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools import mrt_ap
+
+pytestmark = pytest.mark.unit
+
+_trend = getattr(mrt_ap.central_get_ap_trend, "fn", mrt_ap.central_get_ap_trend)
+
+
+class _Ctx:
+    lifespan_context: dict[str, Any] = {"central_conn": object()}
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch the module-level ``_get`` to record (path, params) and return {}."""
+    captured: dict[str, Any] = {}
+
+    def fake_get(conn: Any, path: str, params: dict | None = None) -> dict:
+        captured["path"] = path
+        captured["params"] = params or {}
+        return {}
+
+    monkeypatch.setattr(mrt_ap, "_get", fake_get)
+    return captured
+
+
+async def test_throughput_defaults_interface_type_wireless(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch)
+    await _trend(ctx=_Ctx(), serial_number="CNT2M590SZ", dimension="throughput")
+    assert captured["path"].endswith("/throughput-trends")
+    assert captured["params"].get("interface-type") == "WIRELESS"
+
+
+async def test_throughput_interface_type_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch)
+    await _trend(ctx=_Ctx(), serial_number="CNT2M590SZ", dimension="throughput", interface_type="WIRED")
+    assert captured["params"].get("interface-type") == "WIRED"
+
+
+@pytest.mark.parametrize(
+    "dimension,suffix",
+    [
+        ("cpu", "/cpu-utilization-trends"),
+        ("memory", "/memory-utilization-trends"),
+        ("power", "/power-consumption-trends"),
+    ],
+)
+async def test_non_throughput_dimensions_omit_interface_type(
+    monkeypatch: pytest.MonkeyPatch, dimension: str, suffix: str
+) -> None:
+    captured = _capture(monkeypatch)
+    await _trend(ctx=_Ctx(), serial_number="CNT2M590SZ", dimension=dimension)
+    assert captured["path"].endswith(suffix)
+    assert "interface-type" not in captured["params"]

--- a/tests/unit/test_generative_ui.py
+++ b/tests/unit/test_generative_ui.py
@@ -1,0 +1,105 @@
+"""Unit tests for the env-gated Generative UI provider wiring.
+
+``MCP_ENABLE_GENERATIVE_UI=true`` registers FastMCP's ``GenerativeUI`` provider,
+which exposes ``generate_prefab_ui`` + ``search_prefab_components`` tools and a
+``ui://`` streaming-renderer resource. The provider is off by default; when on,
+both tools must survive the code-mode transform (re-exposed top-level) and ride
+alongside in dynamic mode. Mirrors the FileUpload provider's gating contract.
+
+These tests are intentionally SYNCHRONOUS. ``create_server()`` re-exposes the
+app-provider tools in code mode via a one-shot ``asyncio.run(mcp.get_tool(...))``,
+which is valid only when no event loop is already running — exactly how the real
+entrypoint calls it (before the server starts serving). Building the server from
+inside an ``async def`` test would nest event loops, the re-expose would silently
+no-op, and the test would assert against a state production never produces. So we
+build synchronously and drive the async list_* calls with our own ``asyncio.run``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hpe_networking_mcp.config import MistSecrets, ServerConfig
+from hpe_networking_mcp.server import create_server
+
+pytestmark = pytest.mark.unit
+
+_PREFAB_TOOLS = {"generate_prefab_ui", "search_prefab_components"}
+
+
+def _build(tool_mode: str) -> object:
+    """Build a real server (Mist-only, no aggregators pulled) in the given mode."""
+    cfg = ServerConfig(tool_mode=tool_mode, mist=MistSecrets(api_token="x", host="y"))
+    return create_server(cfg)
+
+
+def _tool_names(mcp: object) -> set[str]:
+    return {t.name for t in asyncio.run(mcp.list_tools())}  # type: ignore[attr-defined]
+
+
+def _tool_descriptions(mcp: object) -> dict[str, str]:
+    return {t.name: (t.description or "") for t in asyncio.run(mcp.list_tools())}  # type: ignore[attr-defined]
+
+
+def _resource_labels(mcp: object) -> list[str]:
+    items = asyncio.run(mcp.list_resources())  # type: ignore[attr-defined]
+    return [str(getattr(r, "name", getattr(r, "uri", r))) for r in items]
+
+
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var → the prefab tools must NOT be registered."""
+    monkeypatch.delenv("MCP_ENABLE_GENERATIVE_UI", raising=False)
+    names = _tool_names(_build("code"))
+    assert not (_PREFAB_TOOLS & names), f"generative-UI tools leaked while disabled: {_PREFAB_TOOLS & names}"
+
+
+def test_enabled_code_mode_reexposes_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flag on + code mode: both prefab tools survive the CodeMode transform
+    (re-exposed top-level) and the streaming renderer resource is present."""
+    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    mcp = _build("code")
+    names = _tool_names(mcp)
+    assert names >= _PREFAB_TOOLS, f"prefab tools missing top-level in code mode: {_PREFAB_TOOLS - names}"
+    # The CodeMode base surface (execute + 5 discovery tools) must still be there.
+    assert "execute" in names
+    labels = _resource_labels(mcp)
+    assert any("prefab" in s.lower() or "render" in s.lower() for s in labels), (
+        f"streaming renderer resource missing: {labels}"
+    )
+
+
+def test_enabled_dynamic_mode_exposes_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flag on + dynamic mode: the prefab tools ride alongside the others."""
+    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    names = _tool_names(_build("dynamic"))
+    assert names >= _PREFAB_TOOLS, f"prefab tools missing in dynamic mode: {_PREFAB_TOOLS - names}"
+
+
+def test_search_prefab_components_not_enveloped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: the prefab tools declare an ``x-fastmcp-wrap-result`` output schema
+    requiring a top-level ``result`` key. The ResponseEnvelopeMiddleware must NOT wrap
+    them — wrapping strips ``result`` and the tool's own output validation fails with
+    "'result' is a required property" (same class as discovery tools, #293/#302)."""
+    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    mcp = _build("code")
+    res = asyncio.run(mcp.call_tool("search_prefab_components", {"query": "card"}))  # type: ignore[attr-defined]
+    sc = getattr(res, "structured_content", None) or {}
+    assert "result" in sc, "wrap-result 'result' key stripped — envelope wrapped a prefab tool"
+    assert "ok" not in sc, "prefab tool got enveloped; it must be in _NO_ENVELOPE_TOOLS"
+
+
+def test_description_augmented_with_dashboard_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tool description (not INSTRUCTIONS.md) is what steers tool selection, so
+    generate_prefab_ui's description must carry the dashboard guidance AND keep the
+    upstream Prefab authoring instructions. Applies in both modes."""
+    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    for mode in ("code", "dynamic"):
+        desc = _tool_descriptions(_build(mode)).get("generate_prefab_ui", "")
+        assert "USE THIS TOOL FIRST" in desc, f"dashboard guidance missing in {mode} mode"
+        assert "dashboard" in desc.lower()
+        # The data->globals contract must be spelled out (prevents the NameError: 'data').
+        assert "DATA CONTRACT" in desc, f"data contract guidance missing in {mode} mode"
+        # Upstream Prefab authoring instructions must survive the prepend.
+        assert "PrefabApp" in desc, f"upstream Prefab instructions lost in {mode} mode"

--- a/tests/unit/test_generative_ui.py
+++ b/tests/unit/test_generative_ui.py
@@ -1,10 +1,11 @@
-"""Unit tests for the env-gated Generative UI provider wiring.
+"""Unit tests for the env-gated MCP-Apps provider wiring.
 
-``MCP_ENABLE_GENERATIVE_UI=true`` registers FastMCP's ``GenerativeUI`` provider,
-which exposes ``generate_prefab_ui`` + ``search_prefab_components`` tools and a
-``ui://`` streaming-renderer resource. The provider is off by default; when on,
-both tools must survive the code-mode transform (re-exposed top-level) and ride
-alongside in dynamic mode. Mirrors the FileUpload provider's gating contract.
+``MCP_APP_ENABLE=true`` is the single switch for every MCP-Apps capability — it
+registers BOTH FastMCP's ``GenerativeUI`` provider (``generate_prefab_ui`` +
+``search_prefab_components`` + a ``ui://`` streaming-renderer resource) AND the
+``FileUpload`` provider (``file_manager`` / ``list_files`` / ``read_file``). All
+are off by default; when on, the model-visible tools must survive the code-mode
+transform (re-exposed top-level) and ride alongside in dynamic mode.
 
 These tests are intentionally SYNCHRONOUS. ``create_server()`` re-exposes the
 app-provider tools in code mode via a one-shot ``asyncio.run(mcp.get_tool(...))``,
@@ -27,6 +28,8 @@ from hpe_networking_mcp.server import create_server
 pytestmark = pytest.mark.unit
 
 _PREFAB_TOOLS = {"generate_prefab_ui", "search_prefab_components"}
+_FILE_UPLOAD_TOOLS = {"file_manager", "list_files", "read_file"}
+_APP_TOOLS = _PREFAB_TOOLS | _FILE_UPLOAD_TOOLS
 
 
 def _build(tool_mode: str) -> object:
@@ -49,19 +52,21 @@ def _resource_labels(mcp: object) -> list[str]:
 
 
 def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No env var → the prefab tools must NOT be registered."""
-    monkeypatch.delenv("MCP_ENABLE_GENERATIVE_UI", raising=False)
+    """No env var → NO MCP-Apps tools (prefab OR file-upload) are registered."""
+    monkeypatch.delenv("MCP_APP_ENABLE", raising=False)
     names = _tool_names(_build("code"))
-    assert not (_PREFAB_TOOLS & names), f"generative-UI tools leaked while disabled: {_PREFAB_TOOLS & names}"
+    assert not (_APP_TOOLS & names), f"MCP-Apps tools leaked while disabled: {_APP_TOOLS & names}"
 
 
 def test_enabled_code_mode_reexposes_tools(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Flag on + code mode: both prefab tools survive the CodeMode transform
-    (re-exposed top-level) and the streaming renderer resource is present."""
-    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    """Flag on + code mode: the single switch brings up BOTH providers' tools past
+    the CodeMode transform (re-exposed top-level), and the streaming renderer
+    resource is present."""
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
     mcp = _build("code")
     names = _tool_names(mcp)
     assert names >= _PREFAB_TOOLS, f"prefab tools missing top-level in code mode: {_PREFAB_TOOLS - names}"
+    assert names >= _FILE_UPLOAD_TOOLS, f"file-upload tools missing in code mode: {_FILE_UPLOAD_TOOLS - names}"
     # The CodeMode base surface (execute + 5 discovery tools) must still be there.
     assert "execute" in names
     labels = _resource_labels(mcp)
@@ -71,10 +76,10 @@ def test_enabled_code_mode_reexposes_tools(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_enabled_dynamic_mode_exposes_tools(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Flag on + dynamic mode: the prefab tools ride alongside the others."""
-    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    """Flag on + dynamic mode: both providers' tools ride alongside the others."""
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
     names = _tool_names(_build("dynamic"))
-    assert names >= _PREFAB_TOOLS, f"prefab tools missing in dynamic mode: {_PREFAB_TOOLS - names}"
+    assert names >= _APP_TOOLS, f"MCP-Apps tools missing in dynamic mode: {_APP_TOOLS - names}"
 
 
 def test_search_prefab_components_not_enveloped(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -82,7 +87,7 @@ def test_search_prefab_components_not_enveloped(monkeypatch: pytest.MonkeyPatch)
     requiring a top-level ``result`` key. The ResponseEnvelopeMiddleware must NOT wrap
     them — wrapping strips ``result`` and the tool's own output validation fails with
     "'result' is a required property" (same class as discovery tools, #293/#302)."""
-    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
     mcp = _build("code")
     res = asyncio.run(mcp.call_tool("search_prefab_components", {"query": "card"}))  # type: ignore[attr-defined]
     sc = getattr(res, "structured_content", None) or {}
@@ -94,7 +99,7 @@ def test_description_augmented_with_dashboard_guidance(monkeypatch: pytest.Monke
     """The tool description (not INSTRUCTIONS.md) is what steers tool selection, so
     generate_prefab_ui's description must carry the dashboard guidance AND keep the
     upstream Prefab authoring instructions. Applies in both modes."""
-    monkeypatch.setenv("MCP_ENABLE_GENERATIVE_UI", "true")
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
     for mode in ("code", "dynamic"):
         desc = _tool_descriptions(_build(mode)).get("generate_prefab_ui", "")
         assert "USE THIS TOOL FIRST" in desc, f"dashboard guidance missing in {mode} mode"


### PR DESCRIPTION
Adds FastMCP's **GenerativeUI** provider so the model can build a live, interactive dashboard from data it gathered — *"build me an MRT dashboard for site HOME"* → it pulls the Central/ClearPass data, calls `generate_prefab_ui`, and a Prefab app (tabs, KPI cards, charts, searchable data tables) renders inline. **Live-validated end to end** against a real tenant.

## ⚠️ BREAKING — flag consolidation
`MCP_ENABLE_FILE_UPLOAD` is **removed**. A single **`MCP_APP_ENABLE`** now gates *all* MCP-Apps capabilities — both the existing `FileUpload` provider and the new `GenerativeUI` provider (they both emit `ui://` MCP-Apps resources). **Migration: set `MCP_APP_ENABLE=true`** where you had `MCP_ENABLE_FILE_UPLOAD=true`, or file upload silently disables.

## What's in it
**Generative UI** (`src/.../server.py`, `middleware/response_envelope.py`, `Dockerfile`)
- Register `GenerativeUI` + re-expose `generate_prefab_ui` / `search_prefab_components` top-level in code mode (same pattern as file_upload).
- `generate_prefab_ui` description augmented with networking dashboard guidance **and** an explicit **data contract** (values passed via `data` become globals *by key*, not a `data` variable) — this eliminates the `NameError: name 'data'` trap the model otherwise falls into (the sandbox has no clock/`data` global). Verified live: the model referenced every data key as a bare global, zero NameError.
- Response-envelope **pass-through** for the two prefab tools (they carry `x-fastmcp-wrap-result` schemas requiring a top-level `result`; the envelope was stripping it — same class as #293/#302).
- **Deno** baked into the image — the Prefab sandbox shells out to it for server-side validation and does **not** auto-install.

**Central read-tool forgiveness** (surfaced during dashboard testing; kept in this PR per maintainer preference)
- `central_get_applications`: `start_query_time`/`end_query_time` accept epoch-ms / epoch-seconds / **ISO-8601** (normalized to ms); `sort` accepts OData (`usage desc`) **and** `-field` shorthand (`-usage` → `usage desc`). Both were producing opaque upstream 400s.
- `central_get_ap_trend`: throughput dimension now sends the **API-required `interface-type`** (WIRELESS/WIRED/LTE, defaults WIRELESS) — it was 400ing on every call without it. cpu/memory/power unaffected.

## Tests
- `test_generative_ui.py` — single-flag gating (both providers up/down together), code+dynamic re-expose, renderer resource present, envelope pass-through, description + data-contract guidance.
- `test_central_applications.py` / `test_central_mrt_ap_trend.py` — time/sort normalization + the interface-type wiring.
- Full suite: **1747 passed, 1 skipped**; ruff / format / mypy clean.

## Notes for reviewer
- Rendering is host-dependent (MCP-Apps hosts only) — that's inherent to the spec, not this PR.
- GenerativeUI is **render-only** by design: model-authored Prefab can't call back to server tools (no `CallTool` against our tools), so a dashboard button can't fire an arbitrary tool — confirmed earlier.
- Maintainer reminder: your runtime `docker-compose.yml` still sets the old `MCP_ENABLE_FILE_UPLOAD=true` (now a no-op) — switch to `MCP_APP_ENABLE=true` after merge.