### PR TITLE
refactor(auth): shared AsyncTokenManager primitive; UXI + Apstra + template adopt (v3.3.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10.2] - 2026-06-11
+
+**Patch — shared async auth primitive (`platforms/_common/auth.py`); UXI + Apstra + `_template` adopt it.** First step of the platform-standardization effort (#466): one token lifecycle for all platforms instead of per-platform token managers. Pure refactor — no tool changes, no behavior changes.
+
+### Changed
+- **New `platforms/_common/auth.py`** — `AsyncTokenManager` (cached token + expiry buffer + `asyncio.Lock` with double-checked locking, `invalidate()` / `refresh()` / `prime()` / `static()`), `TokenResult`, the shared `AuthError` base, and the `oauth2_client_credentials(...)` fetch-strategy factory. Extracted verbatim-in-spirit from the two proven in-tree implementations rather than designed fresh:
+  - **UXI** donated the OAuth2 client-credentials flow (time-based expiry with 60-second buffer, lock-serialized refresh, token POST on a fresh no-base_url client). `UXIClient` now wires `oauth2_client_credentials` into an `AsyncTokenManager` and drops its inline `_ensure_token` / `_fetch_token_locked` / `_invalidate_token` machinery.
+  - **Apstra** donated the login-session flow (no expiry; 401 → forced re-login under the lock). `ApstraClient._login()` is now the manager's fetch strategy returning `TokenResult(token)`; `ApstraAuthError` subclasses the shared `AuthError`.
+- **`platforms/_template/client.py`** rewritten as the canonical consumer: static-token fetch strategy by default, with docstring pointers to the UXI (OAuth2) and Apstra (login-session) flavors. Credential *attachment* (header name, cookie/query-param injection) intentionally stays in the platform client — the manager owns acquisition, caching, and invalidation only.
+- Remaining platforms adopt in follow-ups per the #466 sequencing (GreenLake next — its 290-line sync OAuth2 provider collapses into the shared strategy; then AOS8; Central/ClearPass arrive via their httpx rebuilds #464/#465).
+
+### Tests
+- New `tests/unit/test_common_auth.py` (16 tests): lifecycle (cache/buffer/invalidate/refresh/concurrent single-fetch/empty-token guard) + OAuth2 fetcher (form encoding, default expiry, non-2xx propagation, missing `access_token`) + manager-with-fetcher end-to-end.
+- UXI/Apstra client tests updated to target the manager API; public client surfaces unchanged.
+
 ## [3.3.10.1] - 2026-06-10
 
 **Patch — defensive hardening for unavailable/misconfigured platforms, an async-token fix, and a PII sweep gap.** A batch of bug fixes from a `bug`-label triage. No new tools or behavior changes for configured platforms.

--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ hpe-networking-mcp/
 │   ├── middleware/              # null-strip, validation-catch, sandbox-error-catch, elicitation, retry
 │   ├── skills/                  # Markdown-defined multi-step procedures + skills engine
 │   └── platforms/
-│       ├── _common/             # Shared tool registry + meta-tool factory (dynamic mode)
+│       ├── _common/             # Shared tool registry, capability annotations, async auth primitive
 │       ├── health.py            # Cross-platform health probe tool
 │       ├── mist/                # 1037 Mist tools (spec-driven) + 2 prompts + API client
 │       ├── central/             # 660 Central tools + 12 prompts + API client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.10.1"
+version = "3.3.10.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/auth.py
+++ b/src/hpe_networking_mcp/platforms/_common/auth.py
@@ -102,7 +102,15 @@ class AsyncTokenManager:
 
     @classmethod
     def static(cls, token: str, *, name: str) -> AsyncTokenManager:
-        """Build a manager for a fixed, never-refreshed token."""
+        """Build a manager for a fixed, never-refreshed token.
+
+        Raises:
+            AuthError: If ``token`` is empty — same guard as the fetch path,
+                so a missing secret fails loudly at construction instead of
+                producing requests with a blank credential.
+        """
+        if not token:
+            raise AuthError(f"{name}: static token is empty")
 
         async def fetch() -> TokenResult:
             return TokenResult(token)
@@ -122,7 +130,14 @@ class AsyncTokenManager:
         return self._expires_at
 
     def prime(self, token: str, expires_in: float | None = None) -> None:
-        """Seed the cache directly (static tokens, tests)."""
+        """Seed the cache directly (static tokens, tests).
+
+        Raises:
+            AuthError: If ``token`` is empty — an empty cached token would
+                pass ``_is_fresh()`` and be sent as a blank credential.
+        """
+        if not token:
+            raise AuthError(f"{self._name}: cannot prime with an empty token")
         self._token = token
         self._expires_at = time.time() + expires_in if expires_in is not None else None
 

--- a/src/hpe_networking_mcp/platforms/_common/auth.py
+++ b/src/hpe_networking_mcp/platforms/_common/auth.py
@@ -1,0 +1,229 @@
+"""Shared async token lifecycle for all platform clients.
+
+Extracted from the two proven in-tree implementations (UXI's OAuth2
+client-credentials flow and Apstra's login-session flow) so every platform
+shares one lifecycle instead of maintaining its own token manager:
+
+* ``AsyncTokenManager`` owns the cached token, its expiry, and an
+  ``asyncio.Lock`` with double-checked locking so concurrent callers
+  trigger exactly one acquisition.
+* The *fetch strategy* is a coroutine the platform supplies — what request
+  acquires a token is per-platform; when to run it is shared:
+
+  - OAuth2 client-credentials → ``oauth2_client_credentials(...)`` builds
+    the fetcher (UXI, GreenLake, Central, ClearPass).
+  - Login-session endpoints → the platform passes its own login coroutine
+    returning a :class:`TokenResult` with ``expires_in=None`` (Apstra, AOS 8).
+  - Static tokens → ``AsyncTokenManager.static(...)`` (Mist, Axis).
+
+How the credential is *attached* to requests (bearer header, custom header,
+cookie + query param) stays in the platform client; the manager only owns
+acquisition, caching, and invalidation.
+
+Sharing note: managers are per-client by default. When two platforms accept
+tokens from the same issuer and credential set, construct one manager and
+pass it to both clients — the lock and cache then serve both platforms.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import httpx
+from loguru import logger
+
+from hpe_networking_mcp.utils.logging import mask_secret
+
+_DEFAULT_EXPIRY_BUFFER_SECS = 60.0
+_DEFAULT_AUTH_TIMEOUT = 10.0
+
+TokenFetcher = Callable[[], Awaitable["TokenResult"]]
+
+
+class AuthError(RuntimeError):
+    """Raised when token acquisition fails in a way the platform can't retry.
+
+    Platform-specific auth errors (e.g. ``ApstraAuthError``) subclass this so
+    call sites can catch either the platform flavor or the shared base.
+    """
+
+
+@dataclass(frozen=True)
+class TokenResult:
+    """Outcome of one token acquisition.
+
+    Args:
+        token: The acquired credential value.
+        expires_in: Seconds until expiry, or ``None`` for tokens with no
+            known lifetime (login-session tokens live until a 401 forces
+            re-login; static tokens never expire).
+    """
+
+    token: str
+    expires_in: float | None = None
+
+
+class AsyncTokenManager:
+    """Cached-token lifecycle with double-checked locking.
+
+    Usage in a platform client::
+
+        self._tokens = AsyncTokenManager(fetch, name="uxi", expiry_buffer=60.0)
+        ...
+        token = await self._tokens.get_token()      # cached or fetched
+        ...
+        self._tokens.invalidate()                   # e.g. after a 401
+        token = await self._tokens.refresh()        # force re-acquisition
+    """
+
+    def __init__(
+        self,
+        fetch: TokenFetcher,
+        *,
+        name: str,
+        expiry_buffer: float = _DEFAULT_EXPIRY_BUFFER_SECS,
+    ) -> None:
+        """
+        Args:
+            fetch: Coroutine performing one token acquisition.
+            name: Platform label used in log lines.
+            expiry_buffer: Seconds before expiry at which a token counts as
+                stale and is proactively re-fetched.
+        """
+        self._fetch = fetch
+        self._name = name
+        self._buffer = expiry_buffer
+        self._token: str | None = None
+        self._expires_at: float | None = None  # Unix timestamp; None = no expiry
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def static(cls, token: str, *, name: str) -> AsyncTokenManager:
+        """Build a manager for a fixed, never-refreshed token."""
+
+        async def fetch() -> TokenResult:
+            return TokenResult(token)
+
+        manager = cls(fetch, name=name)
+        manager.prime(token)
+        return manager
+
+    @property
+    def token(self) -> str | None:
+        """The cached token, or ``None`` if not yet acquired / invalidated."""
+        return self._token
+
+    @property
+    def expires_at(self) -> float | None:
+        """Unix timestamp the cached token expires at, or ``None`` for no expiry."""
+        return self._expires_at
+
+    def prime(self, token: str, expires_in: float | None = None) -> None:
+        """Seed the cache directly (static tokens, tests)."""
+        self._token = token
+        self._expires_at = time.time() + expires_in if expires_in is not None else None
+
+    def invalidate(self) -> None:
+        """Drop the cached token so the next ``get_token()`` re-fetches."""
+        self._token = None
+        self._expires_at = None
+
+    def _is_fresh(self) -> bool:
+        if self._token is None:
+            return False
+        if self._expires_at is None:
+            return True
+        return time.time() + self._buffer < self._expires_at
+
+    async def get_token(self) -> str:
+        """Return the cached token, acquiring one under the lock if stale."""
+        if self._is_fresh():
+            assert self._token is not None
+            return self._token
+        async with self._lock:
+            # Re-check inside the lock — another coroutine may have fetched.
+            if not self._is_fresh():
+                await self._fetch_locked()
+        if self._token is None:  # guard: assert is stripped under python -O
+            raise AuthError(f"{self._name}: token fetch succeeded but no token is cached")
+        return self._token
+
+    async def refresh(self) -> str:
+        """Force re-acquisition under the lock (e.g. after a 401) and return it."""
+        async with self._lock:
+            self.invalidate()
+            await self._fetch_locked()
+        if self._token is None:
+            raise AuthError(f"{self._name}: token refresh succeeded but no token is cached")
+        return self._token
+
+    async def _fetch_locked(self) -> None:
+        """Run the fetch strategy and cache its result. Caller holds the lock."""
+        result = await self._fetch()
+        if not result.token:
+            raise AuthError(f"{self._name}: fetch strategy returned an empty token")
+        self._token = result.token
+        self._expires_at = time.time() + result.expires_in if result.expires_in is not None else None
+
+
+def oauth2_client_credentials(
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    *,
+    name: str,
+    timeout: float = _DEFAULT_AUTH_TIMEOUT,
+    default_expires_in: float = 3600.0,
+    _client_factory: Callable[[], httpx.AsyncClient] | None = None,
+) -> TokenFetcher:
+    """Build a fetch strategy for the OAuth2 client-credentials grant.
+
+    Extracted from the UXI client. Each fetch uses a fresh
+    ``httpx.AsyncClient`` with NO base_url so the SSO hostname always
+    resolves correctly regardless of the API client's base URL.
+
+    Args:
+        token_url: Absolute token-endpoint URL.
+        client_id: OAuth2 client id.
+        client_secret: OAuth2 client secret.
+        name: Platform label used in log lines.
+        timeout: Token request timeout in seconds.
+        default_expires_in: Expiry to assume when the response omits
+            ``expires_in``.
+        _client_factory: Test hook — supplies the ``httpx.AsyncClient`` used
+            for the token POST (e.g. one carrying a ``MockTransport``).
+
+    Returns:
+        A coroutine suitable as :class:`AsyncTokenManager`'s ``fetch``.
+
+    Raises:
+        httpx.HTTPStatusError: (from the fetcher) on a non-2xx token response.
+        AuthError: (from the fetcher) when the response lacks ``access_token``.
+    """
+    factory = _client_factory or (lambda: httpx.AsyncClient(timeout=timeout))
+
+    async def fetch() -> TokenResult:
+        logger.info("{}: requesting new access token (client_id: {})", name, mask_secret(client_id))
+        async with factory() as auth_http:
+            response = await auth_http.post(
+                token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        response.raise_for_status()
+        body = response.json()
+        token = body.get("access_token")
+        if not token:
+            raise AuthError(f"{name}: token response is missing 'access_token'")
+        expires_in = float(body.get("expires_in", default_expires_in))
+        logger.info("{}: token acquired (expires_in={}s)", name, expires_in)
+        return TokenResult(token=token, expires_in=expires_in)
+
+    return fetch

--- a/src/hpe_networking_mcp/platforms/_template/client.py
+++ b/src/hpe_networking_mcp/platforms/_template/client.py
@@ -5,24 +5,28 @@ This is the minimal pattern most modern REST APIs need: bearer token in the
 ``request()`` shortcut that handles auth + 401 retry, and a
 ``health_check()`` that the cross-platform ``health`` probe calls.
 
-When copying this template, the auth flavor is the most common thing to change:
+Token acquisition, caching, and lock-serialized refresh run through the
+shared :class:`AsyncTokenManager` (``platforms/_common/auth.py``). When
+copying this template, the *fetch strategy* is the thing to change:
 
-- **Bearer token (this template)** — keep as-is; set ``self._token``
-  from config in ``__init__``.
-- **OAuth2 client_credentials** — replace ``_login_locked`` with a token
-  endpoint call; cache + auto-refresh on 401 + before expiry. See
-  ``platforms/greenlake/auth.py`` for the canonical implementation.
-- **Username/password login endpoint** — replace ``_login_locked`` with
-  a POST to the login endpoint that returns a session token. See
-  ``platforms/apstra/client.py``.
+- **Static token (this template)** — ``_fetch_token`` reads the token from
+  config; no refresh endpoint.
+- **OAuth2 client_credentials** — pass
+  ``oauth2_client_credentials(token_url, client_id, client_secret, name=...)``
+  as the manager's fetch instead of a method. See ``platforms/uxi/client.py``.
+- **Username/password login endpoint** — make ``_fetch_token`` POST to the
+  login endpoint and return ``TokenResult(token)`` (no expiry — the token
+  lives until a 401 forces re-login). See ``platforms/apstra/client.py``.
 - **Vendor SDK** — skip this file entirely; wrap the SDK in a thin
-  adapter that exposes ``.health_check()`` and your tool surface. See
-  ``platforms/mist/client.py``.
+  adapter that exposes ``.health_check()`` and your tool surface.
+
+How the credential is *attached* to requests stays here in the client —
+override ``_auth_headers`` for custom header names, or the request methods
+themselves for cookie / query-param auth (see ``platforms/aos8/client.py``).
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any
 
@@ -31,18 +35,22 @@ from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
 from loguru import logger
 
+from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, AuthError, TokenResult
+
 # When copying this template, replace this import with your platform's secrets type.
 # from hpe_networking_mcp.config import MyplatformSecrets  # noqa: ERA001
 from hpe_networking_mcp.utils.logging import mask_secret
 
 _REQUEST_TIMEOUT = 30.0
-_AUTH_TIMEOUT = 10.0
+_AUTH_TIMEOUT = 10.0  # pass as `timeout=` to oauth2_client_credentials / login POSTs
 
 
-class TemplateAuthError(RuntimeError):
+class TemplateAuthError(AuthError):
     """Raised when the platform's auth handshake fails.
 
-    Rename to ``<Platform>AuthError`` when copying.
+    Rename to ``<Platform>AuthError`` when copying. Subclassing the shared
+    ``AuthError`` lets call sites catch either the platform flavor or the
+    base.
     """
 
 
@@ -62,8 +70,9 @@ class TemplateClient:
     def __init__(self, config: Any) -> None:
         # Replace ``Any`` with your ``<Platform>Secrets`` type.
         self._config = config
-        self._token: str | None = getattr(config, "api_token", None)
-        self._lock = asyncio.Lock()
+        # Static-token flavor: ``_fetch_token`` reads from config. For OAuth2,
+        # pass ``oauth2_client_credentials(...)`` as the fetch instead.
+        self._tokens = AsyncTokenManager(self._fetch_token, name="Template")
         # Replace with your real base URL — typically built from config fields.
         base_url = getattr(config, "base_url", "https://example.invalid")
         self._http = httpx.AsyncClient(
@@ -81,45 +90,21 @@ class TemplateClient:
         """Close the underlying httpx client. Called from ``server.py:lifespan``."""
         await self._http.aclose()
 
-    async def _ensure_token(self) -> str:
-        """Return the cached token, acquiring one under the lock if needed.
+    async def _fetch_token(self) -> TokenResult:
+        """Fetch strategy for :class:`AsyncTokenManager`.
 
-        For static-token auth (this template's default) the token comes
-        from config directly. For OAuth2 / login-endpoint flavors,
-        replace with a real acquisition routine.
-        """
-        if self._token is not None:
-            return self._token
-        async with self._lock:
-            if self._token is None:
-                await self._login_locked()
-            assert self._token is not None
-            return self._token
-
-    async def _refresh_token(self) -> str:
-        """Force-refresh the token under the lock.
-
-        For static-token auth this just re-reads the config (same token);
-        for refreshable auth it calls the token endpoint.
-        """
-        async with self._lock:
-            self._token = None
-            await self._login_locked()
-            assert self._token is not None
-            return self._token
-
-    async def _login_locked(self) -> None:
-        """Acquire a fresh token. Caller must hold ``self._lock``.
-
-        Default implementation: pull the token from config (static
-        bearer token, no refresh endpoint). Replace with a POST to your
-        login / token endpoint for OAuth2 / username-password flavors.
+        Default implementation: pull the token from config (static bearer
+        token, no refresh endpoint) — ``expires_in=None`` means it never
+        goes stale. For a username/password login endpoint, POST to it
+        here instead and return the session token (see Apstra). For
+        OAuth2, drop this method and pass ``oauth2_client_credentials``
+        to the manager (see UXI).
         """
         token = getattr(self._config, "api_token", None)
         if not token:
             raise TemplateAuthError("No api_token in config and no token endpoint configured.")
-        self._token = token
         logger.info("Template: token loaded {}", mask_secret(token))
+        return TokenResult(token)
 
     def _auth_headers(self, token: str) -> dict[str, str]:
         """Build the headers for an authenticated request.
@@ -143,7 +128,7 @@ class TemplateClient:
         timeout: float | None = None,
     ) -> httpx.Response:
         """Send an authenticated request, refreshing the token once on 401."""
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         kwargs: dict[str, Any] = {"headers": self._auth_headers(token)}
         if json_body is not None:
             kwargs["json"] = json_body
@@ -155,7 +140,7 @@ class TemplateClient:
         response = await self._http.request(method, path, **kwargs)
         if response.status_code == 401:
             logger.info("Template: 401 on {} {} — refreshing token once", method, path)
-            token = await self._refresh_token()
+            token = await self._tokens.refresh()
             kwargs["headers"] = self._auth_headers(token)
             response = await self._http.request(method, path, **kwargs)
         response.raise_for_status()
@@ -172,7 +157,7 @@ class TemplateClient:
         Override with a real reachability check (e.g. GET /health) if
         your platform exposes one.
         """
-        await self._ensure_token()
+        await self._tokens.get_token()
         return True
 
 

--- a/src/hpe_networking_mcp/platforms/apstra/client.py
+++ b/src/hpe_networking_mcp/platforms/apstra/client.py
@@ -2,15 +2,16 @@
 
 Apstra authenticates via POST /api/user/login (username/password) which returns
 a bearer token used in the ``AuthToken`` header. There is no refresh endpoint;
-on 401 the only recourse is re-login. An asyncio.Lock serializes token
-acquisition across concurrent callers.
+on 401 the only recourse is re-login. Token caching and lock-serialized
+acquisition run through the shared :class:`AsyncTokenManager` primitive
+(``platforms/_common/auth.py`` — its login-session flow was extracted from
+this client); the login request itself stays here as the fetch strategy.
 
 SSL verification is honored from config (source used verify=False unconditionally).
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any
 
@@ -20,13 +21,14 @@ from fastmcp.server.dependencies import get_context
 from loguru import logger
 
 from hpe_networking_mcp.config import ApstraSecrets
+from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, AuthError, TokenResult
 from hpe_networking_mcp.utils.logging import mask_secret
 
 _REQUEST_TIMEOUT = 30.0
 _AUTH_TIMEOUT = 10.0
 
 
-class ApstraAuthError(RuntimeError):
+class ApstraAuthError(AuthError):
     """Raised when Apstra login fails."""
 
 
@@ -42,8 +44,7 @@ class ApstraClient:
 
     def __init__(self, config: ApstraSecrets) -> None:
         self._config = config
-        self._token: str | None = None
-        self._lock = asyncio.Lock()
+        self._tokens = AsyncTokenManager(self._login, name="Apstra")
         base_url = f"https://{config.server}:{config.port}"
         self._http = httpx.AsyncClient(
             base_url=base_url,
@@ -60,26 +61,12 @@ class ApstraClient:
         """Close the underlying httpx client."""
         await self._http.aclose()
 
-    async def _ensure_token(self) -> str:
-        """Return the cached token, acquiring one under the lock if needed."""
-        if self._token is not None:
-            return self._token
-        async with self._lock:
-            if self._token is None:
-                await self._login_locked()
-            assert self._token is not None
-            return self._token
+    async def _login(self) -> TokenResult:
+        """Fetch strategy for :class:`AsyncTokenManager` — one login request.
 
-    async def _refresh_token(self) -> str:
-        """Force-refresh the token under the lock."""
-        async with self._lock:
-            self._token = None
-            await self._login_locked()
-            assert self._token is not None
-            return self._token
-
-    async def _login_locked(self) -> None:
-        """Perform the login request. Caller must hold ``self._lock``."""
+        Returns a session token with no expiry: Apstra tokens live until a
+        401 forces re-login.
+        """
         payload = {"username": self._config.username, "password": self._config.password}
         logger.info("Apstra: requesting new AuthToken from {}", self._config.server)
         try:
@@ -105,8 +92,8 @@ class ApstraClient:
         if not token:
             raise ApstraAuthError(f"Apstra login response missing 'token' field: {body}")
 
-        self._token = token
         logger.info("Apstra: obtained AuthToken {}", mask_secret(token))
+        return TokenResult(token)
 
     def _auth_headers(self, token: str) -> dict[str, str]:
         return {
@@ -141,7 +128,7 @@ class ApstraClient:
             httpx.HTTPStatusError: On 4xx/5xx other than 401-retry.
             httpx.HTTPError: On transport errors.
         """
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         kwargs: dict[str, Any] = {"headers": self._auth_headers(token)}
         if json_body is not None:
             kwargs["json"] = json_body
@@ -153,7 +140,7 @@ class ApstraClient:
         response = await self._http.request(method, path, **kwargs)
         if response.status_code == 401:
             logger.info("Apstra: 401 on {} {} — refreshing token once", method, path)
-            token = await self._refresh_token()
+            token = await self._tokens.refresh()
             kwargs["headers"] = self._auth_headers(token)
             response = await self._http.request(method, path, **kwargs)
         response.raise_for_status()
@@ -166,7 +153,7 @@ class ApstraClient:
 
     async def health_check(self) -> bool:
         """Probe credentials by acquiring a token. Returns True if login succeeds."""
-        await self._ensure_token()
+        await self._tokens.get_token()
         return True
 
 

--- a/src/hpe_networking_mcp/platforms/uxi/client.py
+++ b/src/hpe_networking_mcp/platforms/uxi/client.py
@@ -1,22 +1,18 @@
 """Aruba UXI REST API client with async httpx and OAuth2 token management.
 
 Authenticates via POST to the GreenLake SSO endpoint using client-credentials
-grant. Tokens have a 7199-second TTL; a 60-second buffer triggers proactive
-refresh. An asyncio.Lock serializes concurrent refresh under load.
+grant, through the shared :class:`AsyncTokenManager` primitive
+(``platforms/_common/auth.py`` — extracted from this client). Tokens have a
+7199-second TTL; a 60-second buffer triggers proactive refresh, and the
+manager's lock serializes concurrent refresh under load.
 
 Base URL: ``https://api.capenetworks.com/networking-uxi/v1alpha1``
 Token URL: ``https://sso.common.cloud.hpe.com/as/token.oauth2``
-
-IMPORTANT: The token POST uses a separate httpx.AsyncClient with NO base_url.
-Never reuse self._http for the token request — it is bound to api.capenetworks.com
-and would resolve the SSO hostname incorrectly (Pitfall 5).
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
-import time
 from typing import Any
 
 import httpx
@@ -25,7 +21,7 @@ from fastmcp.server.dependencies import get_context
 from loguru import logger
 
 from hpe_networking_mcp.config import UXISecrets
-from hpe_networking_mcp.utils.logging import mask_secret
+from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, oauth2_client_credentials
 
 _TOKEN_URL = "https://sso.common.cloud.hpe.com/as/token.oauth2"  # nosec B105
 _UXI_BASE_URL = "https://api.capenetworks.com/networking-uxi/v1alpha1"
@@ -46,9 +42,22 @@ class UXIClient:
 
     def __init__(self, config: UXISecrets) -> None:
         self._config = config
-        self._token: str | None = None
-        self._expires_at: float = 0.0  # Unix timestamp; 0 = always expired (D-01)
-        self._lock = asyncio.Lock()  # serializes concurrent refresh (D-02)
+        # 60-second buffer triggers proactive refresh (D-04); the manager's
+        # lock serializes concurrent refresh (D-02). The token POST runs on a
+        # fresh httpx.AsyncClient with NO base_url so the SSO hostname always
+        # resolves correctly (Pitfall 5) — never reuse self._http for it.
+        self._tokens = AsyncTokenManager(
+            oauth2_client_credentials(
+                _TOKEN_URL,
+                config.client_id,
+                config.client_secret,
+                name="UXI",
+                timeout=_AUTH_TIMEOUT,
+                default_expires_in=7199.0,
+            ),
+            name="UXI",
+            expiry_buffer=_TOKEN_BUFFER_SECS,
+        )
         self._http = httpx.AsyncClient(
             base_url=_UXI_BASE_URL,
             timeout=_REQUEST_TIMEOUT,
@@ -58,58 +67,16 @@ class UXIClient:
         """Close the underlying httpx client. Called from server.py lifespan."""
         await self._http.aclose()
 
-    async def _ensure_token(self) -> str:
-        """Return cached token, acquiring one under the lock if needed or expired."""
-        if self._token and time.time() + _TOKEN_BUFFER_SECS < self._expires_at:
-            return self._token
-        async with self._lock:
-            # Re-check inside lock — another coroutine may have refreshed
-            if self._token and time.time() + _TOKEN_BUFFER_SECS < self._expires_at:
-                return self._token
-            await self._fetch_token_locked()
-        if self._token is None:  # guard: assert is stripped under python -O
-            raise RuntimeError("UXI token fetch succeeded but self._token is still None")
-        return self._token
-
-    def _invalidate_token(self) -> None:
-        """Force token re-fetch on the next request (e.g. after a 401)."""
-        self._token = None
-        self._expires_at = 0.0
-
-    async def _fetch_token_locked(self) -> None:
-        """POST to GreenLake SSO to acquire a new access token.
-
-        Caller must hold self._lock. Uses a separate httpx.AsyncClient with NO
-        base_url so the SSO hostname resolves correctly (Pitfall 5 prevention).
-        """
-        logger.info("UXI: requesting new access token (client_id: {})", mask_secret(self._config.client_id))
-        async with httpx.AsyncClient(timeout=_AUTH_TIMEOUT) as auth_http:
-            resp = await auth_http.post(
-                _TOKEN_URL,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": self._config.client_id,
-                    "client_secret": self._config.client_secret,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-        resp.raise_for_status()
-        body = resp.json()
-        self._token = body["access_token"]
-        expires_in = body.get("expires_in", 7199)
-        self._expires_at = time.time() + expires_in
-        logger.info("UXI: token acquired (expires_in={}s)", expires_in)
-
     async def _get_json(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
         """Issue an authenticated GET request and return parsed JSON."""
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
         response = await self._http.request("GET", path, headers=headers, params=params)
         if response.status_code == 401:
-            self._invalidate_token()
+            self._tokens.invalidate()
         response.raise_for_status()
         return response.json()
 
@@ -149,40 +116,40 @@ class UXIClient:
 
     async def uxi_post(self, path: str, json_body: Any) -> Any:
         """POST a JSON body to the UXI API and return parsed JSON."""
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
         response = await self._http.request("POST", path, headers=headers, json=json_body)
         if response.status_code == 401:
-            self._invalidate_token()
+            self._tokens.invalidate()
         response.raise_for_status()
         return response.json()
 
     async def uxi_patch(self, path: str, json_body: Any) -> Any:
         """PATCH a resource on the UXI API and return parsed JSON."""
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
         response = await self._http.request("PATCH", path, headers=headers, json=json_body)
         if response.status_code == 401:
-            self._invalidate_token()
+            self._tokens.invalidate()
         response.raise_for_status()
         return response.json()
 
     async def uxi_delete(self, path: str) -> dict[str, Any]:
         """DELETE a resource on the UXI API."""
-        token = await self._ensure_token()
+        token = await self._tokens.get_token()
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
         response = await self._http.request("DELETE", path, headers=headers)
         if response.status_code == 401:
-            self._invalidate_token()
+            self._tokens.invalidate()
         response.raise_for_status()
         if response.status_code == 204 or not response.content:
             return {"status_code": response.status_code}

--- a/tests/unit/test_apstra_client.py
+++ b/tests/unit/test_apstra_client.py
@@ -54,10 +54,10 @@ class TestApstraClientLogin:
             return httpx.Response(201, json={"token": "apstra-token-abc"})
 
         _install_mock_transport(client, handler)
-        await client._ensure_token()
-        assert client._token == "apstra-token-abc"
+        await client._tokens.get_token()
+        assert client._tokens.token == "apstra-token-abc"
         # Second call must not re-login
-        await client._ensure_token()
+        await client._tokens.get_token()
         assert len(calls) == 1
         await client.aclose()
 
@@ -68,8 +68,8 @@ class TestApstraClientLogin:
             return httpx.Response(200, json={"token": "200-token"})
 
         _install_mock_transport(client, handler)
-        await client._ensure_token()
-        assert client._token == "200-token"
+        await client._tokens.get_token()
+        assert client._tokens.token == "200-token"
         await client.aclose()
 
     async def test_login_non_2xx_raises(self):
@@ -80,7 +80,7 @@ class TestApstraClientLogin:
 
         _install_mock_transport(client, handler)
         with pytest.raises(ApstraAuthError, match="401"):
-            await client._ensure_token()
+            await client._tokens.get_token()
         await client.aclose()
 
     async def test_login_missing_token_raises(self):
@@ -91,7 +91,7 @@ class TestApstraClientLogin:
 
         _install_mock_transport(client, handler)
         with pytest.raises(ApstraAuthError, match="missing 'token'"):
-            await client._ensure_token()
+            await client._tokens.get_token()
         await client.aclose()
 
     async def test_login_non_json_raises(self):
@@ -102,7 +102,7 @@ class TestApstraClientLogin:
 
         _install_mock_transport(client, handler)
         with pytest.raises(ApstraAuthError, match="non-JSON"):
-            await client._ensure_token()
+            await client._tokens.get_token()
         await client.aclose()
 
     async def test_login_serialized_under_lock(self):
@@ -121,7 +121,7 @@ class TestApstraClientLogin:
 
         _install_mock_transport(client, handler)
         release.set()
-        await asyncio.gather(client._ensure_token(), client._ensure_token(), client._ensure_token())
+        await asyncio.gather(client._tokens.get_token(), client._tokens.get_token(), client._tokens.get_token())
         assert call_count == 1
         await client.aclose()
 
@@ -203,11 +203,11 @@ class TestApstraClientRequest:
             return httpx.Response(201, json={"token": f"t-{logins}"})
 
         _install_mock_transport(client, handler)
-        await client._ensure_token()
-        assert client._token == "t-1"
-        new_token = await client._refresh_token()
+        await client._tokens.get_token()
+        assert client._tokens.token == "t-1"
+        new_token = await client._tokens.refresh()
         assert new_token == "t-2"
-        assert client._token == "t-2"
+        assert client._tokens.token == "t-2"
         await client.aclose()
 
 

--- a/tests/unit/test_common_auth.py
+++ b/tests/unit/test_common_auth.py
@@ -1,0 +1,224 @@
+"""Unit tests for the shared auth primitive (``platforms/_common/auth.py``).
+
+The primitive is extracted from the two proven in-tree implementations:
+
+* UXI's OAuth2 client-credentials flow (time-based expiry cache + buffer).
+* Apstra's login-session flow (no expiry; token lives until a 401 forces
+  re-login).
+
+Both flows share one lifecycle: double-checked locking around a cached token,
+``invalidate()`` on auth failure, and ``refresh()`` to force re-acquisition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from hpe_networking_mcp.platforms._common.auth import (
+    AsyncTokenManager,
+    AuthError,
+    TokenResult,
+    oauth2_client_credentials,
+)
+
+
+def _counting_fetch(results: list[TokenResult]):
+    """Build a fetch coroutine that pops results in order and counts calls."""
+    calls: list[int] = []
+
+    async def fetch() -> TokenResult:
+        calls.append(1)
+        return results.pop(0) if len(results) > 1 else results[0]
+
+    return fetch, calls
+
+
+@pytest.mark.unit
+class TestAsyncTokenManagerLifecycle:
+    async def test_first_get_token_fetches(self):
+        fetch, calls = _counting_fetch([TokenResult("tok-1", expires_in=3600)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        assert mgr.token is None
+        token = await mgr.get_token()
+        assert token == "tok-1"
+        assert len(calls) == 1
+
+    async def test_cached_token_not_refetched(self):
+        fetch, calls = _counting_fetch([TokenResult("tok-1", expires_in=3600)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        await mgr.get_token()
+        await mgr.get_token()
+        await mgr.get_token()
+        assert len(calls) == 1
+
+    async def test_no_expiry_token_lives_until_invalidated(self):
+        """Login-session flavor: expires_in=None means valid until invalidated."""
+        fetch, calls = _counting_fetch([TokenResult("session-tok", expires_in=None)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        await mgr.get_token()
+        assert mgr.expires_at is None
+        await mgr.get_token()
+        assert len(calls) == 1
+
+    async def test_token_within_buffer_is_refetched(self):
+        """UXI flavor: a token expiring inside the buffer window is stale."""
+        fetch, calls = _counting_fetch([TokenResult("tok-n", expires_in=3600)])
+        mgr = AsyncTokenManager(fetch, name="test", expiry_buffer=60.0)
+        mgr.prime("about-to-expire", expires_in=30.0)  # 30 s < 60 s buffer
+        token = await mgr.get_token()
+        assert token == "tok-n"
+        assert len(calls) == 1
+
+    async def test_token_beyond_buffer_is_cached(self):
+        fetch, calls = _counting_fetch([TokenResult("tok-n", expires_in=3600)])
+        mgr = AsyncTokenManager(fetch, name="test", expiry_buffer=60.0)
+        mgr.prime("still-good", expires_in=600.0)
+        token = await mgr.get_token()
+        assert token == "still-good"
+        assert not calls
+
+    async def test_invalidate_forces_refetch(self):
+        fetch, calls = _counting_fetch([TokenResult("tok-1", expires_in=3600)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        await mgr.get_token()
+        mgr.invalidate()
+        assert mgr.token is None
+        await mgr.get_token()
+        assert len(calls) == 2
+
+    async def test_refresh_forces_refetch_and_returns_new_token(self):
+        results = [TokenResult("tok-1", expires_in=3600), TokenResult("tok-2", expires_in=3600)]
+        calls: list[int] = []
+
+        async def fetch() -> TokenResult:
+            calls.append(1)
+            return results[len(calls) - 1]
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        assert await mgr.get_token() == "tok-1"
+        assert await mgr.refresh() == "tok-2"
+        assert mgr.token == "tok-2"
+        assert len(calls) == 2
+
+    async def test_concurrent_get_token_fetches_once(self):
+        """Double-checked locking: N concurrent callers, exactly one fetch."""
+        calls: list[int] = []
+
+        async def slow_fetch() -> TokenResult:
+            calls.append(1)
+            await asyncio.sleep(0.01)
+            return TokenResult("tok-1", expires_in=3600)
+
+        mgr = AsyncTokenManager(slow_fetch, name="test")
+        tokens = await asyncio.gather(*(mgr.get_token() for _ in range(5)))
+        assert tokens == ["tok-1"] * 5
+        assert len(calls) == 1
+
+    async def test_fetch_returning_empty_token_raises(self):
+        async def fetch() -> TokenResult:
+            return TokenResult("", expires_in=3600)
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        with pytest.raises(AuthError, match="empty token"):
+            await mgr.get_token()
+
+    def test_prime_sets_token_and_expiry(self):
+        async def fetch() -> TokenResult:  # pragma: no cover - never called
+            raise AssertionError("fetch must not run")
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        mgr.prime("primed", expires_in=100.0)
+        assert mgr.token == "primed"
+        assert mgr.expires_at is not None
+        assert mgr.expires_at == pytest.approx(time.time() + 100.0, abs=5.0)
+
+    def test_static_constructor_yields_fixed_token(self):
+        mgr = AsyncTokenManager.static("fixed-tok", name="test")
+        assert mgr.token == "fixed-tok"
+        assert mgr.expires_at is None
+
+
+@pytest.mark.unit
+class TestOAuth2ClientCredentials:
+    """The OAuth2 fetcher extracted from UXI's `_fetch_token_locked`."""
+
+    def _fetcher(self, handler, **kwargs):
+        transport = httpx.MockTransport(handler)
+        return oauth2_client_credentials(
+            "https://sso.example.com/as/token.oauth2",
+            "my-client-id",
+            "my-client-secret",
+            name="test",
+            _client_factory=lambda: httpx.AsyncClient(transport=transport),
+            **kwargs,
+        )
+
+    async def test_posts_client_credentials_form(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"access_token": "oauth-tok", "expires_in": 7199})
+
+        fetch = self._fetcher(handler)
+        result = await fetch()
+        assert result.token == "oauth-tok"
+        assert result.expires_in == 7199
+        request = captured[0]
+        assert request.method == "POST"
+        assert request.url == "https://sso.example.com/as/token.oauth2"
+        body = request.content.decode()
+        assert "grant_type=client_credentials" in body
+        assert "client_id=my-client-id" in body
+        assert "client_secret=my-client-secret" in body
+
+    async def test_missing_expires_in_uses_default(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"access_token": "tok"})
+
+        fetch = self._fetcher(handler, default_expires_in=1234.0)
+        result = await fetch()
+        assert result.expires_in == 1234.0
+
+    async def test_non_2xx_raises_http_status_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"error": "invalid_client"})
+
+        fetch = self._fetcher(handler)
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch()
+
+    async def test_missing_access_token_raises_auth_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"token_type": "Bearer"})
+
+        fetch = self._fetcher(handler)
+        with pytest.raises(AuthError, match="access_token"):
+            await fetch()
+
+
+@pytest.mark.unit
+class TestManagerWithOAuth2EndToEnd:
+    async def test_manager_drives_oauth2_fetcher(self):
+        tokens = iter(["tok-a", "tok-b"])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"access_token": next(tokens), "expires_in": 3600})
+
+        transport = httpx.MockTransport(handler)
+        fetch = oauth2_client_credentials(
+            "https://sso.example.com/as/token.oauth2",
+            "cid",
+            "csecret",
+            name="e2e",
+            _client_factory=lambda: httpx.AsyncClient(transport=transport),
+        )
+        mgr = AsyncTokenManager(fetch, name="e2e", expiry_buffer=60.0)
+        assert await mgr.get_token() == "tok-a"
+        assert await mgr.get_token() == "tok-a"  # cached
+        mgr.invalidate()
+        assert await mgr.get_token() == "tok-b"

--- a/tests/unit/test_common_auth.py
+++ b/tests/unit/test_common_auth.py
@@ -141,6 +141,18 @@ class TestAsyncTokenManagerLifecycle:
         assert mgr.token == "fixed-tok"
         assert mgr.expires_at is None
 
+    def test_static_rejects_empty_token(self):
+        with pytest.raises(AuthError, match="static token is empty"):
+            AsyncTokenManager.static("", name="test")
+
+    def test_prime_rejects_empty_token(self):
+        async def fetch() -> TokenResult:  # pragma: no cover - never called
+            raise AssertionError("fetch must not run")
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        with pytest.raises(AuthError, match="empty token"):
+            mgr.prime("")
+
 
 @pytest.mark.unit
 class TestOAuth2ClientCredentials:

--- a/tests/unit/test_uxi_client.py
+++ b/tests/unit/test_uxi_client.py
@@ -7,7 +7,6 @@ Covers UXI-AUTH-02, UXI-AUTH-03, UXI-AUTH-04 from the phase requirements.
 from __future__ import annotations
 
 import inspect
-import time
 from unittest.mock import patch
 
 import pytest
@@ -70,13 +69,13 @@ class TestUXIClientInit:
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        assert client._token is None
+        assert client._tokens.token is None
 
-    def test_init_expires_at_is_zero(self):
+    def test_init_no_expiry_until_first_fetch(self):
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        assert client._expires_at == 0.0
+        assert client._tokens.expires_at is None  # no token yet → first get_token() fetches
 
     def test_init_http_client_has_base_url(self):
         from hpe_networking_mcp.platforms.uxi.client import _UXI_BASE_URL, UXIClient
@@ -87,65 +86,61 @@ class TestUXIClientInit:
 
 @pytest.mark.unit
 class TestUXIClientTokenExpiry:
-    """UXI-AUTH-04: Time-based token expiry with 60-second buffer."""
+    """UXI-AUTH-04: Time-based token expiry with 60-second buffer (via AsyncTokenManager)."""
 
-    async def test_ensure_token_calls_fetch_when_expires_at_zero(self):
-        """_expires_at=0.0 means always-expired; _fetch_token_locked must be called."""
+    async def test_get_token_fetches_when_no_token_cached(self):
+        """A fresh client has no cached token; the first get_token() must fetch."""
+        from hpe_networking_mcp.platforms._common.auth import TokenResult
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        assert client._expires_at == 0.0  # always expired
-
         fetch_called = []
 
         async def mock_fetch():
             fetch_called.append(True)
-            client._token = "fresh-token"
-            client._expires_at = time.time() + 7199
+            return TokenResult("fresh-token", expires_in=7199)
 
-        client._fetch_token_locked = mock_fetch
-        token = await client._ensure_token()
-        assert fetch_called, "_fetch_token_locked was not called for expired token"
+        client._tokens._fetch = mock_fetch
+        token = await client._tokens.get_token()
+        assert fetch_called, "fetch was not called for a client with no cached token"
         assert token == "fresh-token"
 
-    async def test_ensure_token_returns_cached_when_valid(self):
+    async def test_get_token_returns_cached_when_valid(self):
         """Valid cached token (within TTL) must be returned without re-fetching."""
         from hpe_networking_mcp.platforms.uxi.client import _TOKEN_BUFFER_SECS, UXIClient
 
         client = UXIClient(_make_secrets())
-        client._token = "cached-token"
         # Set expiry well beyond the buffer
-        client._expires_at = time.time() + _TOKEN_BUFFER_SECS + 600
+        client._tokens.prime("cached-token", expires_in=_TOKEN_BUFFER_SECS + 600)
 
         fetch_called = []
 
         async def mock_fetch():
             fetch_called.append(True)
 
-        client._fetch_token_locked = mock_fetch
-        token = await client._ensure_token()
-        assert not fetch_called, "_fetch_token_locked should NOT be called for valid cached token"
+        client._tokens._fetch = mock_fetch
+        token = await client._tokens.get_token()
+        assert not fetch_called, "fetch should NOT be called for valid cached token"
         assert token == "cached-token"
 
-    async def test_ensure_token_refreshes_when_within_buffer(self):
+    async def test_get_token_refreshes_when_within_buffer(self):
         """Token expiring within the 60-second buffer triggers a refresh."""
+        from hpe_networking_mcp.platforms._common.auth import TokenResult
         from hpe_networking_mcp.platforms.uxi.client import _TOKEN_BUFFER_SECS, UXIClient
 
         client = UXIClient(_make_secrets())
-        client._token = "about-to-expire"
         # Set expiry within the buffer window (30 seconds from now < 60 second buffer)
-        client._expires_at = time.time() + (_TOKEN_BUFFER_SECS - 30)
+        client._tokens.prime("about-to-expire", expires_in=_TOKEN_BUFFER_SECS - 30)
 
         fetch_called = []
 
         async def mock_fetch():
             fetch_called.append(True)
-            client._token = "refreshed-token"
-            client._expires_at = time.time() + 7199
+            return TokenResult("refreshed-token", expires_in=7199)
 
-        client._fetch_token_locked = mock_fetch
-        token = await client._ensure_token()
-        assert fetch_called, "_fetch_token_locked must be called when token is within buffer"
+        client._tokens._fetch = mock_fetch
+        token = await client._tokens.get_token()
+        assert fetch_called, "fetch must be called when token is within buffer"
         assert token == "refreshed-token"
 
 
@@ -158,8 +153,7 @@ class TestUXIClientPaginationParams:
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        client._token = "tok"
-        client._expires_at = time.time() + 9999
+        client._tokens.prime("tok", expires_in=9999)
 
         captured_params = {}
 
@@ -179,8 +173,7 @@ class TestUXIClientPaginationParams:
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        client._token = "tok"
-        client._expires_at = time.time() + 9999
+        client._tokens.prime("tok", expires_in=9999)
 
         captured_params = {}
 
@@ -198,8 +191,7 @@ class TestUXIClientPaginationParams:
         from hpe_networking_mcp.platforms.uxi.client import UXIClient
 
         client = UXIClient(_make_secrets())
-        client._token = "tok"
-        client._expires_at = time.time() + 9999
+        client._tokens.prime("tok", expires_in=9999)
 
         captured_params = {}
 


### PR DESCRIPTION
## What

First step of the platform-standardization effort (References #466 — step 1 of its proposed sequence; intentionally **not** a closing keyword, the effort is multi-PR).

Extracts the two proven in-tree token lifecycles into a shared primitive, `platforms/_common/auth.py`:

- **`AsyncTokenManager`** — cached token + expiry buffer + `asyncio.Lock` with double-checked locking; `get_token()` / `refresh()` / `invalidate()` / `prime()` / `static()`.
- **`TokenResult`** — one acquisition's outcome; `expires_in=None` models login-session tokens that live until a 401.
- **`AuthError`** — shared base; platform flavors subclass it (`ApstraAuthError`, `TemplateAuthError`).
- **`oauth2_client_credentials(...)`** — fetch-strategy factory for the client-credentials grant (extracted from UXI, including the fresh no-base_url client for the token POST).

The split of responsibilities: the manager owns *when* to acquire/cache/invalidate; the platform supplies *what request* acquires the token (fetch strategy) and *how the credential attaches* to requests (header/cookie/query stays in the client — this is what lets AOS 8's UIDARUBA flavor adopt later without contorting the primitive).

## Adopters in this PR

- **UXI** (OAuth2 donor): drops inline `_ensure_token` / `_fetch_token_locked` / `_invalidate_token`; wires `oauth2_client_credentials` into a manager with the existing 60 s buffer and 7199 s default TTL.
- **Apstra** (login-session donor): `_login()` becomes the manager's fetch strategy returning `TokenResult(token)`; 401 → `refresh()` retry preserved.
- **`_template/client.py`**: rewritten as the canonical consumer (static-token strategy by default, docstrings point to the OAuth2/login-session flavors).

Public client surfaces are unchanged: `request()`, `get_json()`, `uxi_get/post/patch/delete`, `health_check()`, accessors, `format_http_error` all keep their signatures and behavior.

## Why extraction, not new design

Both donors already implement exactly the lifecycle every platform needs (UXI: time-based expiry + lock-serialized refresh; Apstra: re-login-on-401 under lock). The primitive is their union, with no behavior changes — so the existing client test suites double as regression coverage for the extraction.

## Follow-ups (per #466 sequencing)

1. GreenLake adopts (its 290-line sync OAuth2 provider collapses into the shared strategy; removes the #463 `to_thread` band-aid).
2. AOS 8 adopts the login-session flavor (cookie + query-param attachment stays in its client).
3. Central (#464) and ClearPass (#465) rebuilds target the primitive directly — no new per-platform token managers.

## Tests

- New `tests/unit/test_common_auth.py` (16 tests): lifecycle (cache / buffer / no-expiry / invalidate / refresh / concurrent single-fetch / empty-token guard), OAuth2 fetcher (form encoding, default expiry, non-2xx propagation, missing `access_token`), and manager+fetcher end-to-end.
- UXI/Apstra unit tests updated to target the manager API (they previously monkeypatched the now-removed private internals).
- Full suite in Docker: **1786 passed, 1 skipped**; ruff + format + mypy + bandit clean.