### PR TITLE
feat(central)!: rebuild Central on async httpx — remove pycentral SDK (v3.3.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.11.0] - 2026-06-11
+
+**Minor — Central rebuilt on async httpx; pycentral SDK removed entirely.** Closes #464. Step 2 of the platform-standardization effort (#466). No release/tag until the auth migration completes across all platforms.
+
+### Changed
+- **New `CentralClient`** (`platforms/central/client.py`) replaces `pycentral.NewCentralBase`. The `command()` return contract (`{code, msg, headers}`), header construction, None-param stripping, empty-body omission, and 401→refresh-once behavior are mirrored from pycentral 2.0a17 so the ~660 Central tools are unaffected at the response layer. Token acquisition runs through the shared `AsyncTokenManager` with a new `auth_style="basic"` mode on `oauth2_client_credentials` (pycentral used `client_secret_basic` at the HPE SSO endpoint; verified live).
+- **Every Central call is now genuinely async.** Previously each call blocked the event loop: `central_conn.command()` was synchronous on the main tool path, `retry_central_command` slept with `time.sleep`, `fetch_site_data_parallel` used a ThreadPoolExecutor, and `NewCentralBase.__init__` did a blocking token fetch inside the lifespan handler. All four are gone — `retry_central_command`/`paginated_fetch`/`fetch_site_data_parallel`/`build_scope_tree` are `async def`, retries use `asyncio.sleep`, parallel fetches use `asyncio.gather`, client construction is lazy/non-blocking, and the `asyncio.to_thread` band-aids in `site_health_check`/`site_rf_check` are removed. ~91 call sites across 35 files now await the chokepoint.
+- **New `platforms/central/monitoring_api.py`** — faithful async port of the pycentral monitoring/troubleshooting helper subset we used (`get_all_sites`/`get_all_aps`/`get_all_clients`/`get_all_device_inventory` pagination loops, AP/gateway stats + trend merging, ping/traceroute/cable-test/show-commands initiate-and-poll flows, disconnect actions). Exception message formats are byte-identical to the SDK (two call sites string-match them). Retry layering simplified: pycentral's hidden 3-attempt transport retry no longer multiplies under `retry_central_command`'s 5 attempts.
+- `pycentral` removed from dependencies (was pinned to alpha `2.0a17`). A permanent guard test (`TestNoPycentralAnywhere`) AST-scans `src/` and fails if any pycentral import reappears.
+
+### Fixed
+- **`central_get_ap_stats` / `central_get_gateway_stats` time windows were broken in production**: the tools passed `from_timestamp`/`to_timestamp` to SDK functions whose signatures only accept `start_time`/`end_time`, raising `TypeError` on every time-windowed call. Call sites now pass the correct kwargs (caught by the port's signature-fidelity check; covered by the live integration suite).
+- Generated MRT troubleshooting tools returned un-executed coroutines after the async flip (13 `_post_action` call sites) — caught by an AST audit for un-awaited async calls and fixed; the audit also validated the rest of the sweep.
+
+### Tests
+- New `tests/unit/test_central_client.py` (pycentral-compat contract: return shape, param stripping, body semantics, Bearer/Accept headers, 401-refresh-once, lazy construction, health probe) + `client_secret_basic` tests in `test_common_auth.py`.
+- Central test fixtures converted to async mocks; live integration fixtures are now function-scoped (an `httpx.AsyncClient` cannot outlive its event loop).
+- Full suite **1802 passed** in Docker including live integration tests against a real tenant (token fetch, reads, pagination, time-windowed stats); ruff + format + mypy + bandit clean.
+
 ## [3.3.10.2] - 2026-06-11
 
 **Patch — shared async auth primitive (`platforms/_common/auth.py`); UXI + Apstra + `_template` adopt it.** First step of the platform-standardization effort (#466): one token lifecycle for all platforms instead of per-platform token managers. Pure refactor — no tool changes, no behavior changes.

--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ hpe-networking-mcp/
 │       ├── sync_prompts.py      # Cross-platform WLAN sync prompts
 │       ├── site_health_check.py # Cross-platform site health aggregator
 │       └── site_rf_check.py     # Cross-platform Wi-Fi RF dashboard
-├── tests/                       # Unit and integration tests (1158+ unit tests)
+├── tests/                       # Unit and integration tests (1770+ unit tests)
 ├── docs/                        # PRD, PRP, tool reference
 ├── secrets/                     # Secret files (only .example committed)
 ├── .github/workflows/           # CI, security, Docker publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.10.2"
+version = "3.3.11.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
@@ -19,10 +19,8 @@ dependencies = [
     "fastmcp[code-mode,apps]>=3.4.0",
     # MCP protocol — GreenLake requires >=1.20.0
     "mcp[cli]>=1.20.0",
-    # HPE Aruba Central API client
-    "pycentral==2.0a17",
-    # Async HTTP client — used by Mist (v3.1.0.0 spec-driven, replaced mistapi),
-    # GreenLake, Apstra, Axis, AOS 8
+    # Async HTTP client — used by all platforms (Central since v3.3.11.0,
+    # replacing pycentral; Mist since v3.1.0.0, replacing mistapi)
     "httpx>=0.28.0",
     # Data validation — GreenLake explicit, others via FastMCP
     "pydantic>=2.12.0",
@@ -97,7 +95,6 @@ disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
-    "pycentral.*",
     "pyclearpass.*",
     "fastmcp.tools.*",
 ]

--- a/src/hpe_networking_mcp/platforms/_common/auth.py
+++ b/src/hpe_networking_mcp/platforms/_common/auth.py
@@ -31,6 +31,7 @@ import asyncio
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 from loguru import logger
@@ -190,6 +191,7 @@ def oauth2_client_credentials(
     client_secret: str,
     *,
     name: str,
+    auth_style: str = "post",
     timeout: float = _DEFAULT_AUTH_TIMEOUT,
     default_expires_in: float = 3600.0,
     _client_factory: Callable[[], httpx.AsyncClient] | None = None,
@@ -205,6 +207,10 @@ def oauth2_client_credentials(
         client_id: OAuth2 client id.
         client_secret: OAuth2 client secret.
         name: Platform label used in log lines.
+        auth_style: How credentials reach the token endpoint —
+            ``"post"`` (RFC 6749 ``client_secret_post``: id + secret in the
+            form body; UXI flavor) or ``"basic"`` (``client_secret_basic``:
+            HTTP Basic header; what pycentral used for Central).
         timeout: Token request timeout in seconds.
         default_expires_in: Expiry to assume when the response omits
             ``expires_in``.
@@ -215,22 +221,29 @@ def oauth2_client_credentials(
         A coroutine suitable as :class:`AsyncTokenManager`'s ``fetch``.
 
     Raises:
+        ValueError: If ``auth_style`` is not ``"post"`` or ``"basic"``.
         httpx.HTTPStatusError: (from the fetcher) on a non-2xx token response.
         AuthError: (from the fetcher) when the response lacks ``access_token``.
     """
+    if auth_style not in ("post", "basic"):
+        raise ValueError(f"auth_style must be 'post' or 'basic', got {auth_style!r}")
     factory = _client_factory or (lambda: httpx.AsyncClient(timeout=timeout))
 
     async def fetch() -> TokenResult:
         logger.info("{}: requesting new access token (client_id: {})", name, mask_secret(client_id))
+        form = {"grant_type": "client_credentials"}
+        post_kwargs: dict[str, Any] = {}
+        if auth_style == "basic":
+            post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
+        else:
+            form["client_id"] = client_id
+            form["client_secret"] = client_secret
         async with factory() as auth_http:
             response = await auth_http.post(
                 token_url,
-                data={
-                    "grant_type": "client_credentials",
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                },
+                data=form,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
+                **post_kwargs,
             )
         response.raise_for_status()
         body = response.json()

--- a/src/hpe_networking_mcp/platforms/central/client.py
+++ b/src/hpe_networking_mcp/platforms/central/client.py
@@ -1,46 +1,183 @@
-"""Central API connection helpers.
+"""Central async API client (replaces the pycentral ``NewCentralBase`` SDK).
 
-Tools obtain the connection from ``ctx.lifespan_context["central_conn"]``
-rather than importing a global singleton.  The ``create_connection`` factory
-and ``verify_connection`` health-check are used by the server lifespan handler.
+Tools obtain the client from ``ctx.lifespan_context["central_conn"]`` (via
+``utils.get_central_conn``) rather than importing a global singleton.
+
+The ``command()`` method preserves pycentral's calling convention and return
+contract exactly — ``{"code": int, "msg": parsed-json-or-text, "headers":
+dict}`` — so the ~660 Central tools that consume responses through
+``retry_central_command`` are unaffected by the SDK removal.
+
+Behavior intentionally mirrored from pycentral 2.0a17 ``base.py``:
+
+* Token endpoint ``https://sso.common.cloud.hpe.com/as/token.oauth2`` with
+  ``client_secret_basic`` (HTTP Basic) credentials.
+* ``Authorization: Bearer <token>`` on every request; default
+  ``Content-Type``/``Accept`` of ``application/json``.
+* ``None``-valued query params stripped; empty-dict bodies not sent.
+* One token refresh + retry on a 401 response.
+* Connection limits tuned for Central (max 7 connections, 5 keep-alive).
+
+Differences (deliberate): token acquisition is lazy and async via the shared
+:class:`AsyncTokenManager` (pycentral fetched synchronously at construction),
+expiry is tracked proactively from ``expires_in`` (pycentral only reacted to
+401s), and transport-level retries live in ``retry_central_command`` alone
+(pycentral layered 3 internal retries under our 5, multiplying worst-case
+attempts).
 """
 
+from __future__ import annotations
+
+import contextlib
+import json
+from typing import Any
+
+import httpx
+from loguru import logger
+
 from hpe_networking_mcp.config import CentralSecrets
+from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, oauth2_client_credentials
 
-try:
-    from pycentral import NewCentralBase
-except ImportError:  # allow import even if pycentral is missing at lint time
-    NewCentralBase = None  # type: ignore[assignment,misc]
-
-
-def create_connection(secrets: CentralSecrets) -> "NewCentralBase":
-    """Build a new ``NewCentralBase`` instance from config secrets."""
-    if NewCentralBase is None:
-        raise RuntimeError("pycentral is not installed")
-    return NewCentralBase(
-        token_info={
-            "new_central": {
-                "base_url": secrets.base_url,
-                "client_id": secrets.client_id,
-                "client_secret": secrets.client_secret,
-            }
-        },
-    )
+_TOKEN_URL = "https://sso.common.cloud.hpe.com/as/token.oauth2"  # nosec B105 - same HPE SSO endpoint pycentral used
+_REQUEST_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+_AUTH_TIMEOUT = 10.0
+_LIMITS = httpx.Limits(max_connections=7, max_keepalive_connections=5, keepalive_expiry=30)
 
 
-def verify_connection(conn: "NewCentralBase") -> None:
-    """Verify credentials are valid by making a lightweight GET to the Central API.
+class CentralClient:
+    """Async HPE Aruba Networking Central API client.
 
-    Raises ``RuntimeError`` with a clear message if the connection fails.
+    Usage in tools (unchanged from the pycentral era, plus ``await``)::
+
+        conn = get_central_conn(ctx)
+        resp = await conn.command(api_method="GET", api_path="network-monitoring/v1/aps")
+        items = resp["msg"]["items"]
     """
-    try:
-        conn.command(
+
+    def __init__(self, config: CentralSecrets) -> None:
+        self._config = config
+        self._tokens = AsyncTokenManager(
+            oauth2_client_credentials(
+                _TOKEN_URL,
+                config.client_id,
+                config.client_secret,
+                name="Central",
+                auth_style="basic",
+                timeout=_AUTH_TIMEOUT,
+            ),
+            name="Central",
+        )
+        self._http = httpx.AsyncClient(
+            base_url=config.base_url,
+            timeout=_REQUEST_TIMEOUT,
+            limits=_LIMITS,
+        )
+
+    @property
+    def base_url(self) -> str:
+        """Return the configured Central API gateway base URL."""
+        return str(self._http.base_url)
+
+    async def aclose(self) -> None:
+        """Close the underlying httpx client. Called from ``server.py:lifespan``."""
+        await self._http.aclose()
+
+    async def command(
+        self,
+        api_method: str,
+        api_path: str,
+        api_params: dict[str, Any] | None = None,
+        api_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Execute one Central API call; pycentral-compatible return contract.
+
+        Args:
+            api_method: HTTP method (GET, POST, PUT, PATCH, DELETE).
+            api_path: Endpoint path appended to the base URL
+                (e.g. ``network-monitoring/v1/aps``).
+            api_params: Query parameters; ``None``-valued entries are stripped.
+            api_data: JSON request body; an empty/None dict sends no body.
+
+        Returns:
+            ``{"code": int, "msg": parsed JSON or raw text, "headers": dict}``.
+
+        Raises:
+            httpx.HTTPError: On transport-level failures (connect, timeout,
+                protocol). Status errors are NOT raised — the status comes
+                back in ``code``, exactly as pycentral behaved.
+        """
+        params = {k: v for k, v in (api_params or {}).items() if v is not None}
+        token = await self._tokens.get_token()
+        response = await self._send(api_method, api_path, params, api_data, token)
+        if response.status_code == 401:
+            logger.info("Central: 401 on {} {} — refreshing token once", api_method, api_path)
+            token = await self._tokens.refresh()
+            response = await self._send(api_method, api_path, params, api_data, token)
+
+        msg: Any = response.text
+        with contextlib.suppress(ValueError, json.JSONDecodeError):
+            msg = response.json()
+        return {"code": response.status_code, "msg": msg, "headers": dict(response.headers)}
+
+    async def _send(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any],
+        body: dict[str, Any] | None,
+        token: str,
+    ) -> httpx.Response:
+        kwargs: dict[str, Any] = {
+            "headers": {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        }
+        if params:
+            kwargs["params"] = params
+        if body:
+            kwargs["json"] = body
+        return await self._http.request(method, path, **kwargs)
+
+    async def health_check(self) -> bool:
+        """Probe credentials + reachability with a 1-item sites-health read."""
+        resp = await self.command(
             api_method="GET",
             api_path="network-monitoring/v1/sites-health",
             api_params={"limit": 1},
         )
+        return isinstance(resp.get("code"), int) and 200 <= resp["code"] < 300
+
+
+def create_connection(secrets: CentralSecrets) -> CentralClient:
+    """Build a new :class:`CentralClient` from config secrets.
+
+    Construction is cheap and non-blocking — the first API call triggers the
+    initial token fetch (pycentral fetched synchronously in ``__init__``,
+    which used to block the lifespan event loop at startup).
+    """
+    return CentralClient(secrets)
+
+
+async def verify_connection(conn: CentralClient) -> None:
+    """Verify credentials are valid by making a lightweight GET to the Central API.
+
+    Raises:
+        RuntimeError: With a clear message if the connection fails.
+    """
+    try:
+        ok = await conn.health_check()
     except Exception as exc:
         raise RuntimeError(
             f"Central API connectivity check failed: {exc}. "
-            "Check base_url, client_id, and client_secret in secrets.json"
+            "Check central_base_url, central_client_id, and central_client_secret secrets."
         ) from exc
+    if not ok:
+        raise RuntimeError(
+            "Central API connectivity check failed (non-2xx response). "
+            "Check central_base_url, central_client_id, and central_client_secret secrets."
+        )
+
+
+__all__ = ["CentralClient", "create_connection", "verify_connection"]

--- a/src/hpe_networking_mcp/platforms/central/monitoring_api.py
+++ b/src/hpe_networking_mcp/platforms/central/monitoring_api.py
@@ -1,0 +1,3109 @@
+"""Faithful async port of the pycentral monitoring/troubleshooting helper subset.
+
+Ported as part of the pycentral SDK removal. The SDK's static-method classes
+(``MonitoringAPs``, ``MonitoringGateways``, ``MonitoringSites``,
+``MonitoringDevices``, ``Clients``, ``Troubleshooting``) become module-level
+async functions that call ``await conn.command(...)`` against the repo's
+:class:`~hpe_networking_mcp.platforms.central.client.CentralClient`.
+
+IMPORTANT: exception MESSAGE FORMATS are load-bearing — call sites string-match
+them (e.g. ``tools/clients.py`` matches the missing-client text embedded in the
+"Error retrieving data from ..." message raised by :func:`execute_get`). Do not
+reword any raised message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from loguru import logger
+
+
+class ParameterError(ValueError):
+    """Invalid or missing parameter (local stand-in for pycentral's ParameterError)."""
+
+
+# --- Constants (verbatim from the SDK modules) -----------------------------------
+
+AP_LIMIT = 100
+WLAN_LIMIT = 100
+GATEWAY_LIMIT = 100
+SITE_LIMIT = 100
+DEVICE_LIMIT = 1000
+CLIENT_LIMIT = 1000
+
+_GATEWAY_API_VERSION = "v1alpha1"
+
+SUPPORTED_DEVICE_TYPES = ["aos-s", "cx", "aps", "gateways"]
+
+TROUBLESHOOTING_METHOD_DEVICE_MAPPING = {
+    "retrieve_arp_table_test": ["aos-s", "aps", "gateways"],
+    "locate_test": ["cx", "aps", "gateways"],
+    "http_test": ["cx", "aps", "gateways"],
+    "poe_bounce_test": ["cx", "aos-s", "gateways"],
+    "port_bounce_test": ["cx", "aos-s", "gateways"],
+    "speedtest_test": ["aps"],
+    "aaa_test": ["cx", "aps"],
+    "tcp_test": ["aps"],
+    "iperf_test": ["gateways"],
+    "cable_test": ["cx", "aos-s"],
+    "nslookup_test": ["aps"],
+    "disconnect_user_mac_addr": ["aps"],
+    "disconnect_all_users": ["aps"],
+    "disconnect_all_users_ssid": ["aps"],
+    "disconnect_all_clients": ["gateways"],
+    "disconnect_client_mac_addr": ["gateways"],
+}
+
+# --- URL generation (port of pycentral.utils.url_utils.generate_url) -------------
+
+_VERSIONS = ["v1alpha1", "v1"]
+_CATEGORIES: dict[str, dict[str, str]] = {
+    "monitoring": {"value": "network-monitoring", "latest": "v1"},
+    "troubleshooting": {"value": "network-troubleshooting", "latest": "v1alpha1"},
+}
+
+
+def _generate_url(api_endpoint: str, category: str = "monitoring", version: str = "latest") -> str:
+    """Generate the full API path for an endpoint, category, and version.
+
+    Mirrors pycentral's ``generate_url`` for the two categories this module
+    uses: ``monitoring`` resolves ``latest`` to ``v1`` under
+    ``network-monitoring/``; ``troubleshooting`` resolves ``latest`` to
+    ``v1alpha1`` under ``network-troubleshooting/``. Explicit versions must be
+    one of ``v1alpha1`` / ``v1``.
+
+    Args:
+        api_endpoint: Endpoint path to append.
+        category: API category name ("monitoring" or "troubleshooting").
+        version: API version ("latest", "v1", or "v1alpha1").
+
+    Returns:
+        Path in the form ``<category-value>/<version>/<api_endpoint>``.
+
+    Raises:
+        ValueError: If category or version is unsupported.
+        TypeError: If api_endpoint is not a string.
+    """
+    if category not in _CATEGORIES:
+        raise ValueError(f"Invalid category: {category}, Supported categories: {list(_CATEGORIES.keys())}")
+    if api_endpoint is not None and not isinstance(api_endpoint, str):
+        raise TypeError(f"Invalid type: {type(api_endpoint)} for api_endpoint, expected str")
+    category_value = _CATEGORIES[category]["value"]
+    if version == "latest":
+        version = _CATEGORIES[category]["latest"]
+    elif version not in _VERSIONS:
+        raise ValueError(f"Invalid version: {version}. Allowed versions: {_VERSIONS}")
+    return f"{category_value}/{version}/{api_endpoint}"
+
+
+# --- Core GET helper (port of monitoring_utils.execute_get) ----------------------
+
+
+async def execute_get(
+    conn: Any,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    version: str = "latest",
+) -> Any:
+    """Execute a GET request to the monitoring API.
+
+    Args:
+        conn: CentralClient connection object.
+        endpoint: API endpoint path (without the network-monitoring prefix).
+        params: Query parameters for the request.
+        version: API version to use (e.g. "v1alpha1", "v1"). Defaults to "latest".
+
+    Returns:
+        The ``msg`` portion of the API response.
+
+    Raises:
+        ParameterError: If conn is None or endpoint is invalid.
+        Exception: If the API call returns a non-200 status code. The message
+            format is load-bearing (string-matched by call sites) — do not change.
+    """
+    if not conn:
+        raise ParameterError("central_conn(Central connection) is required")
+
+    if not endpoint or (not isinstance(endpoint, str) and len(endpoint) == 0):
+        raise ParameterError("endpoint is required and must be a string")
+
+    if endpoint.startswith("/"):
+        # remove leading slash if present
+        endpoint = endpoint.lstrip("/")
+
+    path = _generate_url(endpoint, "monitoring", version)
+    resp = await conn.command(api_method="GET", api_path=path, api_params=params if params is not None else {})
+
+    if resp["code"] != 200:
+        raise Exception(f"Error retrieving data from {path}: {resp['code']} - {resp['msg']}")
+    return resp["msg"]
+
+
+# --- Timestamp helpers (verbatim from monitoring_utils) --------------------------
+
+
+def build_timestamp_filter(
+    start_time: str | int | float | None = None,
+    end_time: str | int | float | None = None,
+    duration: str | None = None,
+    fmt: str = "rfc3339",
+) -> tuple[str, str]:
+    """Build a formatted timestamp filter for API queries.
+
+    Behavior:
+        - If start_time and end_time are given, parses and converts them to the
+          requested format.
+        - If duration is given, computes timestamps relative to now.
+        - Max supported duration is 3 months (90 days).
+
+    Args:
+        start_time: RFC3339 or Unix timestamp (ms or s) for start.
+        end_time: RFC3339 or Unix timestamp (ms or s) for end.
+        duration: Duration string like '3h', '2d', '1w', '1m' (hours, days, weeks, minutes).
+        fmt: Output format, either 'rfc3339' or 'unix'.
+
+    Returns:
+        Tuple of (start_time, end_time) formatted strings.
+
+    Raises:
+        ValueError: If invalid parameter combinations are provided or duration exceeds maximum.
+    """
+    if (start_time or end_time) and duration:
+        raise ValueError("Cannot specify start/end timestamps together with duration.")
+    if (start_time and not end_time) or (end_time and not start_time):
+        raise ValueError("Both start_time and end_time must be provided together.")
+    if not duration and not (start_time and end_time):
+        raise ValueError("Provide either both start_time and end_time or a duration.")
+
+    if start_time and end_time:
+        return (
+            _format_timestamp(_parse_timestamp(start_time), fmt),
+            _format_timestamp(_parse_timestamp(end_time), fmt),
+        )
+
+    # --- Case 2: Duration (guaranteed non-None by the validation above) ---
+    if duration is None:  # pragma: no cover - re-checked only to narrow the type
+        raise ValueError("Provide either both start_time and end_time or a duration.")
+    unit_map = {"w": "weeks", "d": "days", "h": "hours", "m": "minutes"}
+    unit = duration[-1].lower()
+    if unit not in unit_map:
+        raise ValueError("Duration must end with w, h, d, or m (weeks, hours, days, mins).")
+
+    delta = timedelta(**{unit_map[unit]: int(duration[:-1])})
+    if delta > timedelta(days=90):
+        raise ValueError("Maximum supported duration is 3 months (90 days).")
+
+    now = datetime.now(UTC)
+    return _format_timestamp(now - delta, fmt), _format_timestamp(now, fmt)
+
+
+def _parse_timestamp(ts: str | int | float) -> datetime:
+    """Parse an RFC3339 string or Unix ms/s value into a UTC datetime."""
+    if isinstance(ts, str):
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            ts = float(ts)
+    val = float(ts)
+    if val > 1e10:
+        val /= 1000
+    return datetime.fromtimestamp(val, tz=UTC)
+
+
+def _format_timestamp(dt: datetime, fmt: str) -> str:
+    """Format a UTC datetime as a Unix ms string or RFC3339 string."""
+    if fmt == "unix":
+        return str(int(dt.timestamp() * 1000))
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def generate_timestamp_str(
+    start_time: str | int | float | None,
+    end_time: str | int | float | None,
+    duration: str | None,
+) -> str:
+    """Generate a timestamp filter string for API queries.
+
+    Args:
+        start_time: Start timestamp.
+        end_time: End timestamp.
+        duration: Duration string.
+
+    Returns:
+        Formatted filter string "timestamp gt <start> and timestamp lt <end>".
+    """
+    start_time, end_time = build_timestamp_filter(start_time=start_time, end_time=end_time, duration=duration)
+    return f"timestamp gt {start_time} and timestamp lt {end_time}"
+
+
+# --- Response-shaping helpers (verbatim from monitoring_utils) --------------------
+
+
+def simplified_site_resp(site: dict[str, Any]) -> dict[str, Any]:
+    """Simplify the site response structure for easier consumption.
+
+    Args:
+        site: Raw site data from API response.
+
+    Returns:
+        Simplified site data with restructured health, devices, clients, and alerts.
+    """
+    site["health"] = _groups_to_dict(site.get("health", {}).get("groups", []))
+    site["devices"] = {
+        "count": site.get("devices", {}).get("count", 0),
+        "health": _groups_to_dict(site.get("devices", {}).get("health", {}).get("groups", [])),
+    }
+    site["clients"] = {
+        "count": site.get("clients", {}).get("count", 0),
+        "health": _groups_to_dict(site.get("clients", {}).get("health", {}).get("groups", [])),
+    }
+    site["alerts"] = {
+        "critical": site.get("alerts", {}).get("groups", [{}])[0].get("count", 0)
+        if site.get("alerts", {}).get("groups")
+        else 0,
+        "total": site.get("alerts", {}).get("totalCount", 0),
+    }
+    site.pop("type", None)
+    return site
+
+
+def _groups_to_dict(groups_list: list[Any]) -> dict[str, Any]:
+    """Convert a list of group objects to a dictionary.
+
+    Args:
+        groups_list: List of group dictionaries with 'name' and 'value' keys.
+
+    Returns:
+        Dictionary with group names as keys and values as values.
+        Defaults to {"Poor": 0, "Fair": 0, "Good": 0}.
+    """
+    result: dict[str, Any] = {"Poor": 0, "Fair": 0, "Good": 0}
+    if isinstance(groups_list, list):
+        for group in groups_list:
+            if isinstance(group, dict) and "name" in group and "value" in group:
+                result[group["name"]] = group["value"]
+    return result
+
+
+def clean_raw_trend_data(raw_results: dict[str, Any], data: dict[str, dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Clean and restructure raw trend data from API response.
+
+    Args:
+        raw_results: Raw trend data containing 'graph' with 'keys' and 'samples'.
+        data: Existing data dictionary to append to.
+
+    Returns:
+        Dictionary with timestamps as keys and metric values as nested dictionaries.
+    """
+    if data is None:
+        data = {}
+    graph = raw_results.get("graph", {}) or {}
+    keys = graph.get("keys", []) or []
+    samples = graph.get("samples", []) or []
+
+    for s in samples:
+        ts = s.get("timestamp")
+        if not ts:
+            continue
+        vals = s.get("data")
+        if isinstance(vals, list | tuple):
+            for k, v in zip(keys, vals, strict=False):
+                data.setdefault(ts, {})[k] = v
+        else:
+            target_key = keys[0] if keys else None
+            if target_key:
+                data.setdefault(ts, {})[target_key] = vals
+            else:
+                # fallback to a generic key if none provided
+                data.setdefault(ts, {})["value"] = vals
+    return data
+
+
+def merged_dict_to_sorted_list(merged: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert a merged dictionary to a sorted list of timestamped entries.
+
+    Args:
+        merged: Dictionary with timestamps as keys.
+
+    Returns:
+        Sorted list of dictionaries with 'timestamp' key and all associated values.
+    """
+    # try strict RFC3339 parsing (Z -> +00:00), fallback to lexicographic
+    try:
+        keys = sorted(merged.keys(), key=lambda t: datetime.fromisoformat(t.replace("Z", "+00:00")))
+    except Exception:
+        keys = sorted(merged.keys())
+    return [{"timestamp": ts, **merged[ts]} for ts in keys]
+
+
+def _validate_mac_address(mac: str) -> bool:
+    """Validate a MAC address string in AA:BB:CC:DD:EE:FF format.
+
+    Args:
+        mac: MAC address string to validate.
+
+    Returns:
+        True if the MAC address is valid.
+
+    Raises:
+        ParameterError: If mac is missing or does not match the expected format.
+    """
+    _mac_pattern = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+    if not mac:
+        raise ParameterError("MAC address is required")
+    if not isinstance(mac, str) or not _mac_pattern.match(mac):
+        raise ParameterError(f"Invalid MAC address format: '{mac}'. Expected format: AA:BB:CC:DD:EE:FF")
+    return True
+
+
+def _validate_device_serial(serial_number: str) -> None:
+    """Validate an AP device serial_number.
+
+    Raises:
+        ParameterError: If serial_number is missing or not a string.
+    """
+    if not isinstance(serial_number, str) or not serial_number:
+        raise ParameterError("serial_number is required and must be a string")
+
+
+def _validate_central_conn_and_serial(central_conn: Any, serial_number: str) -> None:
+    """Validate central_conn and serial_number (gateway functions).
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    if central_conn is None:
+        raise ParameterError("central_conn is required")
+    if not isinstance(serial_number, str) or not serial_number:
+        raise ParameterError("serial_number is required and must be a string")
+
+
+# --- APs (port of new_monitoring.aps.MonitoringAPs) -------------------------------
+
+
+async def get_all_aps(
+    central_conn: Any,
+    filter_str: str | None = None,
+    sort: str | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve all access points (APs), handling pagination.
+
+    Args:
+        central_conn: CentralClient connection object.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+
+    Returns:
+        List of AP items.
+    """
+    aps: list[dict[str, Any]] = []
+    total_aps = None
+    next_page = 1
+    while True:
+        resp = await get_aps(central_conn, filter_str=filter_str, sort=sort, limit=AP_LIMIT, next_page=next_page)
+        if total_aps is None:
+            total_aps = resp.get("total", 0)
+
+        aps.extend(resp["items"])
+
+        if len(aps) == total_aps:
+            break
+
+        next_val = resp.get("next")
+        if not next_val:
+            break
+
+        next_page = int(next_val)
+    return aps
+
+
+async def get_aps(
+    central_conn: Any,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    limit: int = AP_LIMIT,
+    next_page: int = 1,
+) -> dict[str, Any]:
+    """Retrieve a single page of APs (``GET network-monitoring/v1/aps``).
+
+    Args:
+        central_conn: CentralClient connection object.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+        limit: Number of entries to return (default is 100).
+        next_page: Pagination cursor/index for next page (default is 1).
+
+    Returns:
+        API response for the aps endpoint (contains 'items', 'total', etc.).
+
+    Raises:
+        ParameterError: If limit or next_page values are invalid.
+    """
+    path = "aps"
+    if limit > AP_LIMIT:
+        raise ParameterError(f"limit cannot exceed {AP_LIMIT}")
+    if next_page < 1:
+        raise ParameterError("next_page must be 1 or greater")
+    params = {"filter": filter_str, "sort": sort, "limit": limit, "next": next_page}
+    return await execute_get(central_conn, endpoint=path, params=params)
+
+
+async def get_ap_details(central_conn: Any, serial_number: str) -> dict[str, Any]:
+    """Get details for a specific AP (``GET network-monitoring/v1/aps/{serial_number}``).
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+
+    Returns:
+        API response with AP details.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+    """
+    _validate_device_serial(serial_number)
+    path = f"aps/{serial_number}"
+    return await execute_get(central_conn, endpoint=path)
+
+
+async def get_ap_stats(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+    return_raw_response: bool = False,
+) -> list[dict[str, Any]] | list[Any]:
+    """Collect CPU, memory, and power-consumption statistics for an AP.
+
+    Default is to return sorted trend statistics for the API's default window.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+        start_time: Start time (epoch seconds or RFC3339) for range queries.
+        end_time: End time (epoch seconds or RFC3339) for range queries.
+        duration: Duration string (e.g. '5m') for relative queries.
+        return_raw_response: If True, return raw per-metric responses.
+
+    Returns:
+        Raw list of responses if return_raw_response is True; otherwise merged,
+        sorted trend statistics for the AP.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+        RuntimeError: If any of the parallel metric requests fail.
+    """
+    _validate_device_serial(serial_number)
+
+    # dispatch the three metric calls in parallel; helper functions handle timestamp logic
+    funcs = [get_ap_cpu_utilization, get_ap_memory_utilization, get_ap_poe_utilization]
+
+    async def _run(func: Callable[..., Awaitable[Any]]) -> Any:
+        try:
+            return await func(central_conn, serial_number, start_time, end_time, duration)
+        except Exception as e:
+            # propagate the error for the caller to handle, but include which call failed
+            raise RuntimeError(f"{func.__name__} metrics request failed: {e}") from e
+
+    raw_results = list(await asyncio.gather(*(_run(func) for func in funcs)))
+
+    if return_raw_response:
+        return raw_results
+
+    data: dict[str, dict[str, Any]] = {}
+    for resp in raw_results:
+        if not isinstance(resp, dict):
+            continue
+        data = clean_raw_trend_data(resp, data=data)
+    return merged_dict_to_sorted_list(data)
+
+
+async def get_ap_cpu_utilization(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve CPU utilization trends for an AP.
+
+    Calls ``GET network-monitoring/v1/aps/{serial_number}/cpu-utilization-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for cpu-utilization-trends.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+    """
+    _validate_device_serial(serial_number)
+    path = f"aps/{serial_number}/cpu-utilization-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=path)
+
+    return await execute_get(
+        central_conn,
+        endpoint=path,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+    )
+
+
+async def get_ap_memory_utilization(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve memory utilization trends for an AP.
+
+    Calls ``GET network-monitoring/v1/aps/{serial_number}/memory-utilization-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for memory-utilization-trends.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+    """
+    _validate_device_serial(serial_number)
+    path = f"aps/{serial_number}/memory-utilization-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=path)
+
+    return await execute_get(
+        central_conn,
+        endpoint=path,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+    )
+
+
+async def get_ap_poe_utilization(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve power consumption trends for an AP.
+
+    Calls ``GET network-monitoring/v1/aps/{serial_number}/power-consumption-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for power-consumption-trends.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+    """
+    _validate_device_serial(serial_number)
+    path = f"aps/{serial_number}/power-consumption-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=path)
+
+    return await execute_get(
+        central_conn,
+        endpoint=path,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+    )
+
+
+async def get_wlans(
+    central_conn: Any,
+    site_id: str | None = None,
+    serial_number: str | None = None,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    limit: int = WLAN_LIMIT,
+    next_page: int = 1,
+) -> dict[str, Any]:
+    """Retrieve a list of WLANs associated to a customer (``GET network-monitoring/v1/wlans``).
+
+    Args:
+        central_conn: CentralClient connection object.
+        site_id: ID of the Site for which WLAN information is requested. Max length 128.
+        serial_number: Serial number of an access point device. Max length 16.
+        filter_str: OData v4 filter string (limited; 'and' only). Max length 256.
+        sort: Comma separated list of sort expressions. Max length 256.
+        limit: Maximum number of WLANs to return (0-100).
+        next_page: Pagination cursor for next page (default is 1).
+
+    Returns:
+        API response containing 'items', 'count', 'total', and 'next'.
+
+    Raises:
+        ParameterError: If limit exceeds 100, next_page is less than 1, or any
+            string parameter exceeds its maximum length.
+    """
+    path = "wlans"
+
+    if limit > WLAN_LIMIT:
+        raise ParameterError(f"limit cannot exceed {WLAN_LIMIT}")
+    if next_page < 1:
+        raise ParameterError("next_page must be 1 or greater")
+
+    if site_id is not None and len(site_id) > 128:
+        raise ParameterError("site_id cannot exceed 128 characters")
+    if serial_number is not None and len(serial_number) > 16:
+        raise ParameterError("serial_number cannot exceed 16 characters")
+    if filter_str is not None and len(filter_str) > 256:
+        raise ParameterError("filter_str cannot exceed 256 characters")
+    if sort is not None and len(sort) > 256:
+        raise ParameterError("sort cannot exceed 256 characters")
+
+    params = {
+        "site-id": site_id,
+        "serial-number": serial_number,
+        "filter": filter_str,
+        "sort": sort,
+        "limit": limit,
+        "next": next_page,
+    }
+    return await execute_get(central_conn, endpoint=path, params=params)
+
+
+async def get_ap_wlans(central_conn: Any, serial_number: str) -> dict[str, Any]:
+    """Retrieve WLANs associated with an AP (``GET network-monitoring/v1/aps/{serial_number}/wlans``).
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the AP.
+
+    Returns:
+        API response of associated WLANs.
+
+    Raises:
+        ParameterError: If serial_number is missing/invalid.
+    """
+    _validate_device_serial(serial_number)
+    path = f"aps/{serial_number}/wlans"
+    return await execute_get(central_conn, endpoint=path)
+
+
+# --- Gateways (port of new_monitoring.gateways.MonitoringGateways) ----------------
+
+
+async def get_gateway_details(central_conn: Any, serial_number: str) -> dict[str, Any]:
+    """Get details for a specific gateway (``GET network-monitoring/v1alpha1/gateways/{serial_number}``).
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+
+    Returns:
+        API response with gateway details.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+    path = f"gateways/{serial_number}"
+    return await execute_get(central_conn, endpoint=path, version=_GATEWAY_API_VERSION)
+
+
+async def get_gateway_stats(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+    return_raw_response: bool = False,
+) -> list[dict[str, Any]] | list[Any]:
+    """Collect CPU, memory, and WAN-availability statistics for a gateway.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string (e.g. '5m') for relative queries.
+        return_raw_response: If True, return raw per-metric API responses.
+
+    Returns:
+        Raw list of responses if return_raw_response is True; otherwise merged,
+        sorted trend statistics for the gateway.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+        RuntimeError: If any of the parallel metric requests fail.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+
+    # dispatch the three metric calls in parallel; helper functions handle timestamp logic
+    funcs = [get_gateway_cpu_utilization, get_gateway_memory_utilization, get_gateway_wan_availability]
+
+    async def _run(func: Callable[..., Awaitable[Any]]) -> Any:
+        try:
+            return await func(central_conn, serial_number, start_time, end_time, duration)
+        except Exception as e:
+            # propagate the error for the caller to handle, but include which call failed
+            raise RuntimeError(f"{func.__name__} metrics request failed: {e}") from e
+
+    raw_results = []
+    for resp in await asyncio.gather(*(_run(func) for func in funcs)):
+        if isinstance(resp, list) and len(resp) == 1:
+            resp = resp[0]
+        raw_results.append(resp)
+
+    if return_raw_response:
+        return raw_results
+
+    data: dict[str, dict[str, Any]] = {}
+    for resp in raw_results:
+        if not isinstance(resp, dict):
+            continue
+        data = clean_raw_trend_data(resp, data=data)
+    return merged_dict_to_sorted_list(data)
+
+
+async def get_gateway_cpu_utilization(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve CPU utilization trends for a gateway.
+
+    Calls ``GET network-monitoring/v1alpha1/gateways/{serial_number}/cpu-utilization-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for cpu-utilization-trends.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+    endpoint = f"gateways/{serial_number}/cpu-utilization-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=endpoint, version=_GATEWAY_API_VERSION)
+
+    return await execute_get(
+        central_conn,
+        endpoint=endpoint,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+        version=_GATEWAY_API_VERSION,
+    )
+
+
+async def get_gateway_memory_utilization(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve memory utilization trends for a gateway.
+
+    Calls ``GET network-monitoring/v1alpha1/gateways/{serial_number}/memory-utilization-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for memory-utilization-trends.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+    endpoint = f"gateways/{serial_number}/memory-utilization-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=endpoint, version=_GATEWAY_API_VERSION)
+
+    return await execute_get(
+        central_conn,
+        endpoint=endpoint,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+        version=_GATEWAY_API_VERSION,
+    )
+
+
+async def get_gateway_wan_availability(
+    central_conn: Any,
+    serial_number: str,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+    duration: str | None = None,
+) -> Any:
+    """Retrieve WAN availability trends for a gateway.
+
+    Calls ``GET network-monitoring/v1alpha1/gateways/{serial_number}/wan-availability-trends``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+        start_time: Start time for range queries.
+        end_time: End time for range queries.
+        duration: Duration string for relative queries.
+
+    Returns:
+        API response for wan-availability-trends.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+    endpoint = f"gateways/{serial_number}/wan-availability-trends"
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=endpoint, version=_GATEWAY_API_VERSION)
+
+    return await execute_get(
+        central_conn,
+        endpoint=endpoint,
+        params={"filter": generate_timestamp_str(start_time=start_time, end_time=end_time, duration=duration)},
+        version=_GATEWAY_API_VERSION,
+    )
+
+
+async def get_tunnel_health_summary(central_conn: Any, serial_number: str) -> dict[str, Any]:
+    """Retrieve LAN tunnels health summary for a gateway.
+
+    Calls ``GET network-monitoring/v1alpha1/gateways/{serial_number}/lan-tunnels-health-summary``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the gateway.
+
+    Returns:
+        API response for lan-tunnels-health-summary.
+
+    Raises:
+        ParameterError: If central_conn is None or serial_number is missing/invalid.
+    """
+    _validate_central_conn_and_serial(central_conn, serial_number)
+    path = f"gateways/{serial_number}/lan-tunnels-health-summary"
+    return await execute_get(central_conn, endpoint=path, version=_GATEWAY_API_VERSION)
+
+
+# --- Sites (port of new_monitoring.sites.MonitoringSites) -------------------------
+
+
+async def get_all_sites(central_conn: Any, return_raw_response: bool = False) -> list[dict[str, Any]]:
+    """Retrieve all sites information including health details, handling pagination.
+
+    Args:
+        central_conn: CentralClient connection object.
+        return_raw_response: If True, return the raw API payloads.
+
+    Returns:
+        List of site records. If return_raw_response is False, each site
+        response is simplified via simplified_site_resp.
+    """
+    sites: list[dict[str, Any]] = []
+    total_sites = None
+    limit = SITE_LIMIT
+    offset = 0
+    while True:
+        response = await get_sites(central_conn, limit=limit, offset=offset)
+        if total_sites is None:
+            total_sites = response.get("total", 0)
+        sites.extend(response["items"])
+        if len(sites) == total_sites:
+            break
+        offset += limit
+    if not return_raw_response:
+        sites = [simplified_site_resp(site) for site in sites]
+    return sites
+
+
+async def get_sites(central_conn: Any, limit: int = SITE_LIMIT, offset: int = 0) -> dict[str, Any]:
+    """Retrieve a single page of site health information.
+
+    Calls ``GET network-monitoring/v1/sites-health``. Returns devices, clients,
+    and critical alerts with counts, along with health and health reasons per site.
+
+    Args:
+        central_conn: CentralClient connection object.
+        limit: Number of entries to return (default is 100).
+        offset: Number of entries to skip for pagination (default is 0).
+
+    Returns:
+        Raw API response for the requested page (typically contains 'items' and 'total').
+    """
+    params = {"limit": limit, "offset": offset}
+    path = "sites-health"
+    return await execute_get(central_conn, endpoint=path, params=params)
+
+
+# --- Devices (port of new_monitoring.devices.MonitoringDevices) -------------------
+
+
+async def get_all_device_inventory(
+    central_conn: Any,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    site_assigned: str | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve all devices from the account, including devices not yet onboarded.
+
+    Args:
+        central_conn: CentralClient connection object.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+        site_assigned: Filter by site-assigned status ("ASSIGNED" / "UNASSIGNED").
+
+    Returns:
+        Processed list of all devices from inventory.
+    """
+    devices: list[dict[str, Any]] = []
+    total_devices = None
+    next_int = 1
+    while True:
+        response = await get_device_inventory(
+            central_conn,
+            filter_str=filter_str,
+            sort=sort,
+            site_assigned=site_assigned,
+            limit=DEVICE_LIMIT,
+            next=next_int,
+        )
+        if total_devices is None:
+            total_devices = response.get("total", 0)
+        devices.extend(response.get("items", []))
+        if len(devices) == total_devices:
+            break
+        next_int += 1
+
+    return devices
+
+
+async def get_device_inventory(
+    central_conn: Any,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    site_assigned: str | None = None,
+    limit: int = DEVICE_LIMIT,
+    next: int = 1,  # parameter name kept identical to the SDK (shadows the builtin)
+) -> dict[str, Any]:
+    """Retrieve device data from the device inventory API.
+
+    Calls ``GET network-monitoring/v1/device-inventory``. Includes devices yet
+    to be onboarded as well as those already onboarded and monitored.
+
+    Args:
+        central_conn: CentralClient connection object.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+        site_assigned: Filter by site-assigned status ("ASSIGNED" / "UNASSIGNED").
+        limit: Number of entries to return.
+        next: Pagination cursor for next page of resources (default is 1).
+
+    Returns:
+        Raw API response containing device inventory.
+    """
+    params = {
+        "limit": limit,
+        "next": next,
+        "filter": filter_str,
+        "sort": sort,
+        "site-assigned": site_assigned,
+    }
+    path = "device-inventory"
+    return await execute_get(central_conn, endpoint=path, params=params)
+
+
+# --- Clients (port of new_monitoring.clients.Clients) -----------------------------
+
+
+async def get_all_clients(
+    central_conn: Any,
+    site_id: str | int | None = None,
+    site_name: str | None = None,
+    serial_number: str | None = None,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    duration: str | None = None,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+) -> list[dict[str, Any]]:
+    """Return all clients based on the provided parameters, handling pagination.
+
+    Args:
+        central_conn: CentralClient connection object.
+        site_id: Identifier of the site to query.
+        site_name: Name of the site to query.
+        serial_number: Device serial number to filter clients.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+        duration: Relative time window (e.g., '3h', '2d', '1w', '30m').
+        start_time: Start time (RFC 3339 date-time string).
+        end_time: End time (RFC 3339 date-time string).
+
+    Returns:
+        All client details for the specified parameters.
+
+    Raises:
+        ParameterError: If site_id or site_name is provided but invalid.
+    """
+    if site_id or site_name:
+        _validate_site_id(site_id, site_name)
+    clients: list[dict[str, Any]] = []
+    total_clients = None
+    next_page = 1
+    while True:
+        resp = await get_clients(
+            central_conn=central_conn,
+            site_id=site_id,
+            site_name=site_name,
+            serial_number=serial_number,
+            filter_str=filter_str,
+            sort=sort,
+            next_page=next_page,
+            limit=CLIENT_LIMIT,
+            duration=duration,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        if total_clients is None:
+            total_clients = resp.get("total", 0)
+        clients.extend(resp.get("items", []))
+        if len(clients) == total_clients:
+            break
+        next_val = resp.get("next")
+        if not next_val:
+            break
+        next_page = int(next_val)
+    return clients
+
+
+async def get_clients(
+    central_conn: Any,
+    site_id: str | int | None = None,
+    site_name: str | None = None,
+    serial_number: str | None = None,
+    filter_str: str | None = None,
+    sort: str | None = None,
+    next_page: int = 1,
+    limit: int = CLIENT_LIMIT,
+    duration: str | None = None,
+    start_time: str | int | None = None,
+    end_time: str | int | None = None,
+) -> dict[str, Any]:
+    """Fetch a page of clients based on provided parameters.
+
+    Calls ``GET network-monitoring/v1/clients``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        site_id: Identifier of the site to query.
+        site_name: Name of the site to query.
+        serial_number: Device serial number to query.
+        filter_str: Optional filter expression.
+        sort: Optional sort parameter.
+        next_page: Page token/index for pagination.
+        limit: Maximum number of items to return.
+        duration: Relative time window (e.g., '3h', '2d', '1w', '30m').
+        start_time: Start time (RFC 3339 date-time string).
+        end_time: End time (RFC 3339 date-time string).
+
+    Returns:
+        Raw API response containing keys like 'items', 'total', and 'next'.
+
+    Raises:
+        ParameterError: If site_id or site_name is provided but invalid.
+    """
+    path = "clients"
+
+    if site_id or site_name:
+        _validate_site_id(site_id, site_name)
+    params: dict[str, Any] = {
+        "site-id": site_id,
+        "site-name": site_name,
+        "serial-number": serial_number,
+        "filter": filter_str,
+        "sort": sort,
+        "next": next_page,
+        "limit": limit,
+    }
+    if start_time is None and end_time is None and duration is None:
+        return await execute_get(central_conn, endpoint=path, params=params)
+
+    params = _time_filter(params=params, start_time=start_time, end_time=end_time, duration=duration)
+
+    return await execute_get(central_conn, endpoint=path, params=params)
+
+
+async def get_client_details(central_conn: Any, client_mac: str) -> dict[str, Any]:
+    """Fetch details for a specific client by MAC address.
+
+    Calls ``GET network-monitoring/v1/clients/{client_mac}``. NOTE: the
+    missing-client error surfaces via :func:`execute_get`'s exception message,
+    which call sites string-match — do not change that format.
+
+    Args:
+        central_conn: CentralClient connection object.
+        client_mac: MAC address of the client to query.
+
+    Returns:
+        Client details as returned by the API.
+
+    Raises:
+        ParameterError: If client_mac is missing or malformed.
+    """
+    _validate_mac_address(client_mac)
+
+    path = f"clients/{client_mac}"
+    return await execute_get(central_conn, endpoint=path)
+
+
+def _time_filter(
+    params: dict[str, Any],
+    start_time: str | int | None,
+    end_time: str | int | None,
+    duration: str | None,
+) -> dict[str, Any]:
+    """Apply a time filter to params using RFC 3339 timestamps.
+
+    Args:
+        params: Existing query params to augment.
+        start_time: Start time (RFC 3339 date-time string).
+        end_time: End time (RFC 3339 date-time string).
+        duration: Relative time window (e.g., '3h', '2d', '1w', '30m').
+
+    Returns:
+        Params augmented with 'start-at' and 'end-at'.
+    """
+    start_rfc, end_rfc = build_timestamp_filter(
+        start_time=start_time,
+        end_time=end_time,
+        duration=duration,
+        fmt="rfc3339",
+    )
+    params["start-at"] = start_rfc
+    params["end-at"] = end_rfc
+    return params
+
+
+def _validate_site_id(site_id: str | int | None = None, site_name: str | None = None) -> None:
+    """Validate that at least one valid site identifier is provided.
+
+    Args:
+        site_id: Site identifier to validate.
+        site_name: Site name to validate.
+
+    Raises:
+        ParameterError: If site_id and site_name are not provided or invalid.
+    """
+    if site_id is None and site_name is None:
+        raise ParameterError("either site_id or site_name must be provided")
+
+    if site_id is not None and (not isinstance(site_id, str | int) or not site_id):
+        raise ParameterError("site_id must be a non-empty string or integer")
+
+    if site_name is not None and (not isinstance(site_name, str) or not site_name):
+        raise ParameterError("site_name must be a non-empty string")
+
+
+# --- Troubleshooting (port of troubleshooting.Troubleshooting subset) -------------
+
+
+def _validate_required_device_params(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    subset: list[str] | None = None,
+) -> str:
+    """Validate that required troubleshooting parameters are set.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        subset: Subset of supported device types for the calling test.
+
+    Returns:
+        Verified device_type in lower-case format.
+
+    Raises:
+        ParameterError: If any required parameter is missing or device type is unsupported.
+    """
+    if not central_conn or not device_type or not serial_number:
+        raise ParameterError(
+            "central_conn(Central connection), device_type(aps, cx, aos-s, gateways) and serial_number are required"
+        )
+    if (subset and device_type.lower() not in subset) or (device_type.lower() not in SUPPORTED_DEVICE_TYPES):
+        supported_devices = ", ".join(subset if subset else SUPPORTED_DEVICE_TYPES)
+        raise ParameterError(f"Unsupported device type: {device_type}, supported types are {supported_devices}")
+    return device_type.lower()
+
+
+def _get_task_id(api_response: dict[str, Any]) -> str:
+    """Extract the task ID from an async-operation API response.
+
+    Args:
+        api_response: The API response containing the task information.
+
+    Returns:
+        The extracted task ID.
+    """
+    return api_response.get("location", "").split("/")[-1]
+
+
+async def _poll_task_completion(
+    get_result_func: Callable[..., Awaitable[dict[str, Any]]],
+    task_id: str,
+    conn: Any,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+    *args: Any,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Generic polling for async-operation task completion.
+
+    Args:
+        get_result_func: Async function to call for getting the task result.
+        task_id: Task ID to poll for.
+        conn: CentralClient connection object.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+        *args: Additional positional arguments for get_result_func.
+        **kwargs: Additional keyword arguments for get_result_func.
+
+    Returns:
+        Final result from get_result_func.
+    """
+    result: dict[str, Any] = {}
+    for _attempt in range(max_attempts):
+        result = await get_result_func(conn, task_id, *args, **kwargs)
+        if result["status"] in ["COMPLETED", "FAILED"]:
+            return result
+        await asyncio.sleep(poll_interval)
+
+    logger.warning(f"Task {task_id} did not complete after {max_attempts} attempts. Current status: {result['status']}")
+    return result
+
+
+async def disconnect_all_clients(central_conn: Any, device_type: str, serial_number: str) -> dict[str, Any]:
+    """Disconnect all clients from the specified device (GATEWAY only).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response envelope from the API (``{"code", "msg", "headers"}``).
+
+    Raises:
+        Exception: If initiating the disconnect fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("disconnect_all_clients"),
+    )
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectClientAll", "troubleshooting"),
+    )
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate disconnect for all clients: {resp['code']} - {resp['msg']}")
+    logger.info(f"Disconnect all clients initiated successfully for {device_type} {serial_number}.")
+    return resp
+
+
+async def disconnect_all_users(central_conn: Any, device_type: str, serial_number: str) -> dict[str, Any]:
+    """Disconnect all users from the specified device (AP only).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aps').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response envelope from the API (``{"code", "msg", "headers"}``).
+
+    Raises:
+        Exception: If initiating the disconnect fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("disconnect_all_users"),
+    )
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserAll", "troubleshooting"),
+    )
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate disconnect for all users: {resp['code']} - {resp['msg']}")
+    logger.info(f"Disconnect all users initiated successfully for {device_type} {serial_number}.")
+    return resp
+
+
+async def disconnect_all_users_ssid(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    network: str,
+) -> dict[str, Any]:
+    """Disconnect all users from the specified device on a given network/SSID (AP only).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aps').
+        serial_number: Serial number of the device.
+        network: SSID of the network to disconnect users from.
+
+    Returns:
+        Response envelope from the API (``{"code", "msg", "headers"}``).
+
+    Raises:
+        ParameterError: If network parameter is invalid.
+        Exception: If initiating the disconnect fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("disconnect_all_users_ssid"),
+    )
+
+    api_data = {}
+    if not isinstance(network, str):
+        raise ParameterError("SSID must be a valid string.")
+    api_data["networkName"] = network
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserByNetwork", "troubleshooting"),
+        api_data=api_data,
+    )
+    if resp["code"] != 202:
+        raise Exception(
+            f"Failed to initiate disconnect for all users on SSID {network}: {resp['code']} - {resp['msg']}"
+        )
+    logger.info(f"Disconnect all users on SSID {network} initiated successfully for {device_type} {serial_number}.")
+    return resp
+
+
+async def disconnect_client_mac_addr(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    mac_address: str,
+) -> dict[str, Any]:
+    """Disconnect a client from the specified device by MAC address (GATEWAY only).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('gateways').
+        serial_number: Serial number of the device.
+        mac_address: MAC address of the client to disconnect.
+
+    Returns:
+        Response envelope from the API (``{"code", "msg", "headers"}``).
+
+    Raises:
+        ParameterError: If MAC address parameter is invalid.
+        Exception: If initiating the disconnect fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("disconnect_client_mac_addr"),
+    )
+
+    api_data = {}
+
+    if not isinstance(mac_address, str):
+        raise ParameterError("MAC address must be a valid string.")
+    api_data["clientMacAddress"] = mac_address
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectClientByMacAddress", "troubleshooting"),
+        api_data=api_data,
+    )
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate disconnect for mac {mac_address}: {resp['code']} - {resp['msg']}")
+    logger.info(f"Disconnect client {mac_address} initiated successfully for {device_type} {serial_number}.")
+    return resp
+
+
+async def disconnect_user_mac_addr(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    mac_address: str,
+) -> dict[str, Any]:
+    """Disconnect a user from the specified device by MAC address (AP only).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aps').
+        serial_number: Serial number of the device.
+        mac_address: MAC address of the user to disconnect.
+
+    Returns:
+        Response envelope from the API (``{"code", "msg", "headers"}``).
+
+    Raises:
+        ParameterError: If MAC address parameter is invalid.
+        Exception: If initiating the disconnect fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("disconnect_user_mac_addr"),
+    )
+
+    api_data = {}
+
+    if not isinstance(mac_address, str):
+        raise ParameterError("MAC address must be a valid string.")
+    api_data["userMacAddress"] = mac_address
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserByMacAddress", "troubleshooting"),
+        api_data=api_data,
+    )
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate disconnect for mac {mac_address}: {resp['code']} - {resp['msg']}")
+    logger.info(f"Disconnect user {mac_address} initiated successfully for {device_type} {serial_number}.")
+    return resp
+
+
+async def port_bounce_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a port bounce test on the specified device and poll for the result.
+
+    Supported device types: AOS-S, CX, and GATEWAY. Port bounce disables and
+    re-enables the port(s).
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error initiating the port bounce test.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("port_bounce_test"),
+    )
+
+    try:
+        response = await initiate_port_bounce_test(
+            central_conn=central_conn,
+            ports=ports,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_port_bounce_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating port bounce test for {device_type} {serial_number} on {ports}: {str(e)}")
+        raise
+
+
+async def initiate_port_bounce_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+) -> dict[str, Any]:
+    """Initiate a port bounce test on the specified device.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If the ports parameter is invalid.
+        Exception: If initiating the port bounce test fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("port_bounce_test"),
+    )
+
+    if not ports or not isinstance(ports, list):
+        raise ParameterError("Ports must be a non-empty list.")
+
+    api_data = {"ports": ports}
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/portBounce", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate port test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Port bounce test initiated successfully for {device_type} {serial_number} on {ports}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def get_port_bounce_test_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the results of a port bounce test on the specified device.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If retrieving the port bounce test result fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("port_bounce_test"),
+    )
+
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/portBounce/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get port bounce test result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"Port bounce test for {device_type} {serial_number} with task ID {task_id} is not yet completed. "
+            f"Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(
+            f"Port bounce test for {device_type} {serial_number} with task ID {task_id} has successfully completed."
+        )
+    return resp["msg"]
+
+
+async def poe_bounce_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a PoE bounce test on the specified device and poll for the result.
+
+    Supported device types: AOS-S, CX, and GATEWAY.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error initiating the PoE bounce test.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("poe_bounce_test"),
+    )
+    try:
+        response = await initiate_poe_bounce_test(
+            central_conn=central_conn,
+            ports=ports,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_poe_bounce_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating PoE bounce test for {device_type} {serial_number} on {ports}: {str(e)}")
+        raise
+
+
+async def initiate_poe_bounce_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+) -> dict[str, Any]:
+    """Initiate a PoE bounce test on the specified device.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If the ports parameter is invalid.
+        Exception: If there is an error initiating the PoE bounce test.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("poe_bounce_test"),
+    )
+
+    if not ports or not isinstance(ports, list):
+        raise ParameterError("Ports must be a non-empty list.")
+
+    api_data = {"ports": ports}
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/poeBounce", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate PoE test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"PoE bounce test initiated successfully for {device_type} {serial_number} on {ports}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def get_poe_bounce_test_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the results of a PoE bounce test on the specified device.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If retrieving the PoE bounce test result fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("poe_bounce_test"),
+    )
+
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/poeBounce/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get PoE bounce test result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"PoE bounce test for {device_type} {serial_number} with task ID {task_id} is not yet completed. "
+            f"Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(
+            f"PoE bounce test for {device_type} {serial_number} with task ID {task_id} has successfully completed."
+        )
+    return resp["msg"]
+
+
+# --- Ping tests (port of troubleshooting.Troubleshooting ping subset) -------------
+
+
+async def ping_aps_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    packet_size: int | None = None,
+    count: int | None = None,
+    source_interface: str | None = None,
+    source_vlan: int | None = None,
+    source_role: str | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified AP device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the ping test.
+        packet_size: Packet size in bytes (10-2000).
+        count: Number of ping packets to send.
+        source_interface: Port to use as source for ping.
+        source_vlan: VLAN ID to use as source for ping.
+        source_role: Role to use for ping.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "aps"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_ping_aps_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            packet_size=packet_size,
+            count=count,
+            source_interface=source_interface,
+            source_vlan=source_vlan,
+            source_role=source_role,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_ping_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating ping test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def ping_cx_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    use_ipv6: bool | None = None,
+    packet_size: int | None = None,
+    count: int | None = None,
+    use_management_interface: bool | None = None,
+    vrf_name: str | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified CX device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the ping test.
+        use_ipv6: Whether to use IPv6.
+        packet_size: Packet size in bytes (10-2000).
+        count: Number of ping packets to send.
+        use_management_interface: Whether to use the management interface.
+        vrf_name: Name of the VRF to use for the ping test.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "cx"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_ping_cx_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            use_ipv6=use_ipv6,
+            packet_size=packet_size,
+            count=count,
+            use_management_interface=use_management_interface,
+            vrf_name=vrf_name,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_ping_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating ping test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def ping_gateways_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    packet_size: int | None = None,
+    count: int | None = None,
+    use_ipv6: bool | None = None,
+    ttl: int | None = None,
+    dscp: int | None = None,
+    dont_fragment: bool | None = None,
+    source_interface: str | None = None,
+    source_vlan: int | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified Gateway device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the ping test.
+        packet_size: Packet size in bytes (10-2000).
+        count: Number of ping packets to send.
+        use_ipv6: Whether to use IPv6.
+        ttl: Time To Live for IP datagram (1-255).
+        dscp: DSCP packet header value between 0 and 63 (0-63).
+        dont_fragment: Whether to fragment or not.
+        source_interface: Port to use as source for ping.
+        source_vlan: VLAN ID to use as source for ping.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "gateways"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_ping_gateways_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            packet_size=packet_size,
+            count=count,
+            use_ipv6=use_ipv6,
+            ttl=ttl,
+            dscp=dscp,
+            dont_fragment=dont_fragment,
+            source_interface=source_interface,
+            source_vlan=source_vlan,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_ping_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating ping test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def initiate_ping_aps_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    packet_size: int | None = None,
+    count: int | None = None,
+    source_interface: str | None = None,
+    source_vlan: int | None = None,
+    source_role: str | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified AP device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/aps/{serial_number}/ping``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the ping test.
+        serial_number: Serial number of the device.
+        packet_size: Size of the ping packets.
+        count: Number of ping packets to send.
+        source_interface: Port to use as source for ping.
+        source_vlan: VLAN ID to use as source for ping.
+        source_role: Role to use for ping.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "aps"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if packet_size and isinstance(packet_size, int) and 10 <= packet_size <= 2000:
+        api_data["packetSize"] = packet_size
+    elif packet_size:
+        raise ParameterError("packet_size must be an integer value 10-2000.")
+
+    if count and isinstance(count, int) and 1 <= count <= 100:
+        api_data["count"] = count
+    elif count:
+        raise ParameterError("count must be an integer value between 1-100.")
+
+    if source_interface and isinstance(source_interface, str):
+        api_data["interfacePort"] = source_interface
+    elif source_interface:
+        raise ParameterError("source_interface must be a string value.")
+
+    if source_vlan and isinstance(source_vlan, int) and 1 <= source_vlan <= 4094:
+        api_data["vlan"] = source_vlan
+    elif source_vlan:
+        raise ParameterError("source_vlan must be an integer value 1-4094.")
+
+    if source_role and isinstance(source_role, str):
+        api_data["role"] = source_role
+    elif source_role:
+        raise ParameterError("source_role must be a string value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate ping test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Ping test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def initiate_ping_cx_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    use_ipv6: bool | None = None,
+    packet_size: int | None = None,
+    count: int | None = None,
+    use_management_interface: bool | None = None,
+    vrf_name: str | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified CX device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/cx/{serial_number}/ping``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the ping test.
+        serial_number: Serial number of the device.
+        use_ipv6: Whether to use IPv6.
+        packet_size: Size of the ping packets.
+        count: Number of ping packets to send.
+        use_management_interface: Whether to use the management interface.
+        vrf_name: Name of the VRF to use for the ping test.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "cx"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if use_ipv6 is not None and isinstance(use_ipv6, bool):
+        api_data["useIpv6"] = use_ipv6
+    elif use_ipv6 is not None:
+        raise ParameterError("use_ipv6 must be a boolean value.")
+
+    if packet_size and isinstance(packet_size, int):
+        api_data["packetSize"] = packet_size
+    elif packet_size:
+        raise ParameterError("packet_size must be an integer value.")
+
+    if count and isinstance(count, int) and 1 <= count <= 100:
+        api_data["count"] = count
+    elif count:
+        raise ParameterError("count must be an integer value between 1-100.")
+
+    if use_management_interface is not None and isinstance(use_management_interface, bool):
+        api_data["useManagementInterface"] = use_management_interface
+    elif use_management_interface is not None:
+        raise ParameterError("use_management_interface must be a boolean value.")
+
+    if vrf_name and isinstance(vrf_name, str):
+        api_data["vrfName"] = vrf_name
+    elif vrf_name:
+        raise ParameterError("vrf_name must be a string value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate ping test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Ping test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def initiate_ping_gateways_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    packet_size: int | None = None,
+    count: int | None = None,
+    use_ipv6: bool | None = None,
+    ttl: int | None = None,
+    dscp: int | None = None,
+    dont_fragment: bool | None = None,
+    source_interface: str | None = None,
+    source_vlan: int | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a ping test on the specified Gateway device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/gateways/{serial_number}/ping``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the ping test.
+        serial_number: Serial number of the device.
+        packet_size: Size of the ping packets.
+        count: Number of ping packets to send.
+        use_ipv6: Whether to use IPv6.
+        ttl: Time To Live for IP datagram (1-255).
+        dscp: DSCP packet header value between 0 and 63 (0-63).
+        dont_fragment: Whether to fragment or not.
+        source_interface: Port to use as source for ping.
+        source_vlan: VLAN ID to use as source for ping.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the ping test.
+    """
+    device_type = "gateways"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if packet_size and isinstance(packet_size, int) and 10 <= packet_size <= 2000:
+        api_data["packetSize"] = packet_size
+    elif packet_size:
+        raise ParameterError("packet_size must be an integer value 10-2000.")
+
+    if count and isinstance(count, int) and 1 <= count <= 100:
+        api_data["count"] = count
+    elif count:
+        raise ParameterError("count must be an integer value between 1-100.")
+
+    if ttl and isinstance(ttl, int) and 1 <= ttl <= 255:
+        api_data["ttl"] = ttl
+    elif ttl:
+        raise ParameterError("ttl must be an integer value between 1-255.")
+
+    if dscp and isinstance(dscp, int) and 0 <= dscp <= 63:
+        api_data["dscp"] = dscp
+    elif dscp:
+        raise ParameterError("dscp must be an integer value between 0-63.")
+
+    if source_interface and isinstance(source_interface, str):
+        api_data["sourceInterface"] = source_interface
+    elif source_interface:
+        raise ParameterError("source_interface must be a string value.")
+
+    if source_vlan and isinstance(source_vlan, int) and 1 <= source_vlan <= 4094:
+        api_data["vlan"] = source_vlan
+    elif source_vlan:
+        raise ParameterError("source_vlan must be an integer value 1-4094.")
+
+    if use_ipv6 is not None and isinstance(use_ipv6, bool):
+        api_data["useIpv6"] = use_ipv6
+    elif use_ipv6 is not None:
+        raise ParameterError("use_ipv6 must be a boolean value.")
+
+    if dont_fragment and isinstance(dont_fragment, bool):
+        api_data["dontFragmentFlag"] = dont_fragment
+    elif dont_fragment:
+        raise ParameterError("dont_fragment must be a boolean value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate ping test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Ping test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def get_ping_test_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the results of a ping test on the specified device.
+
+    Supported device types: AOS-S, AP, CX, and GATEWAY.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If retrieving the ping test result fails.
+    """
+    device_type = _validate_required_device_params(central_conn, device_type, serial_number)
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/ping/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get ping test result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"Ping test for {device_type} {serial_number} with task ID {task_id} is not yet completed. "
+            f"Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(f"Ping test for {device_type} {serial_number} with task ID {task_id} has successfully completed.")
+    return resp["msg"]
+
+
+# --- Traceroute tests (port of troubleshooting.Troubleshooting traceroute subset) --
+
+
+async def traceroute_aps_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    source_interface: str | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified AP device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the traceroute test.
+        source_interface: Port to use as source for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "aps"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_traceroute_aps_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            source_interface=source_interface,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_traceroute_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating traceroute test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def traceroute_cx_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    use_ipv6: bool | None = None,
+    use_management_interface: bool | None = None,
+    vrf_name: str | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified CX device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the traceroute test.
+        use_ipv6: Whether to use IPv6.
+        use_management_interface: Whether to use the management interface.
+        vrf_name: Name of the VRF to use for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "cx"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_traceroute_cx_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            use_ipv6=use_ipv6,
+            use_management_interface=use_management_interface,
+            vrf_name=vrf_name,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_traceroute_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating traceroute test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def traceroute_gateways_test(
+    central_conn: Any,
+    serial_number: str,
+    destination: str,
+    source_vlan_ip: str | None = None,
+    include_raw_output: bool | None = None,
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified Gateway device and poll for the test result.
+
+    Args:
+        central_conn: CentralClient connection object.
+        serial_number: Serial number of the device.
+        destination: Destination IP or hostname for the traceroute test.
+        source_vlan_ip: VLAN IP address to use as source for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "gateways"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    try:
+        response = await initiate_traceroute_gateways_test(
+            central_conn=central_conn,
+            destination=destination,
+            serial_number=serial_number,
+            source_vlan_ip=source_vlan_ip,
+            include_raw_output=include_raw_output,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_traceroute_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating traceroute test for {device_type} {serial_number} to {destination}: {str(e)}")
+        raise
+
+
+async def initiate_traceroute_aps_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    source_interface: str | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified AP device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/aps/{serial_number}/traceroute``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the traceroute test.
+        serial_number: Serial number of the device.
+        source_interface: Source interface to use for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "aps"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if source_interface and isinstance(source_interface, str):
+        api_data["sourceInterface"] = source_interface
+    elif source_interface:
+        raise ParameterError("source_interface must be a string value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_data=api_data,
+    )
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate traceroute test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Traceroute test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def initiate_traceroute_cx_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    use_ipv6: bool | None = None,
+    use_management_interface: bool | None = None,
+    vrf_name: str | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified CX device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/cx/{serial_number}/traceroute``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the traceroute test.
+        serial_number: Serial number of the device.
+        use_ipv6: Whether to use IPv6.
+        use_management_interface: Whether to use the management interface.
+        vrf_name: Name of the VRF to use for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "cx"
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if use_ipv6 is not None and isinstance(use_ipv6, bool):
+        api_data["useIpv6"] = use_ipv6
+    elif use_ipv6 is not None:
+        raise ParameterError("use_ipv6 must be a boolean value.")
+
+    if use_management_interface is not None and isinstance(use_management_interface, bool):
+        api_data["useManagementInterface"] = use_management_interface
+    elif use_management_interface is not None:
+        raise ParameterError("use_management_interface must be a boolean value.")
+
+    if vrf_name and isinstance(vrf_name, str):
+        api_data["vrfName"] = vrf_name
+    elif vrf_name:
+        raise ParameterError("vrf_name must be a string value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_data=api_data,
+    )
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate traceroute test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Traceroute test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def initiate_traceroute_gateways_test(
+    central_conn: Any,
+    destination: str,
+    serial_number: str,
+    source_vlan_ip: str | None = None,
+    include_raw_output: bool | None = None,
+) -> dict[str, Any]:
+    """Initiate a traceroute test on the specified Gateway device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/gateways/{serial_number}/traceroute``.
+
+    Args:
+        central_conn: CentralClient connection object.
+        destination: Destination IP or hostname for the traceroute test.
+        serial_number: Serial number of the device.
+        source_vlan_ip: VLAN IP address to use as source for the traceroute test.
+        include_raw_output: Whether to include raw output in the response.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If any parameter is invalid.
+        Exception: If there is an error initiating the traceroute test.
+    """
+    device_type = "gateways"
+
+    _validate_required_device_params(central_conn, device_type, serial_number)
+
+    if destination and isinstance(destination, str):
+        api_data: dict[str, Any] = {"destination": destination}
+    else:
+        raise ParameterError("Destination must be a valid IP address or hostname.")
+
+    if source_vlan_ip and isinstance(source_vlan_ip, str):
+        api_data["vlanIp"] = source_vlan_ip
+    elif source_vlan_ip:
+        raise ParameterError("source_vlan_ip must be a string value.")
+
+    if include_raw_output and isinstance(include_raw_output, bool):
+        api_data["includeRawOutput"] = include_raw_output
+    elif include_raw_output:
+        raise ParameterError("include_raw_output must be a boolean value.")
+
+    resp = await central_conn.command(
+        api_method="POST",
+        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_data=api_data,
+    )
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate traceroute test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(
+        f"Traceroute test initiated successfully for {device_type} {serial_number} to {destination}. Task ID: {task_id}"
+    )
+    return response
+
+
+async def get_traceroute_test_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the result of a traceroute test on the specified device.
+
+    Supported device types: AOS-S, AP, CX, and GATEWAY.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If there is an error retrieving the traceroute test result.
+    """
+    device_type = _validate_required_device_params(central_conn, device_type, serial_number)
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/traceroute/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get traceroute test result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"Traceroute test for {device_type} {serial_number} with task ID {task_id} is not yet completed. "
+            f"Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(
+            f"Traceroute test for {device_type} {serial_number} with task ID {task_id} has successfully completed."
+        )
+    return resp["msg"]
+
+
+# --- Cable test (port of troubleshooting.Troubleshooting cable subset) ------------
+
+
+async def cable_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Initiate a cable test on the specified device and poll for the test result.
+
+    Supported device types: AOS-S and CX.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s' or 'cx').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If initiating the cable test fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("cable_test"),
+    )
+
+    try:
+        response = await initiate_cable_test(
+            central_conn=central_conn,
+            ports=ports,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_cable_test_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error initiating cable test for {device_type} {serial_number} on {ports}: {str(e)}")
+        raise
+
+
+async def initiate_cable_test(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    ports: list[str],
+) -> dict[str, Any]:
+    """Initiate a cable test on the specified device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/{device_type}/{serial_number}/cableTest``.
+    Supported device types: AOS-S and CX.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s' or 'cx').
+        serial_number: Serial number of the device.
+        ports: List of the ports to test.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If the ports parameter is invalid.
+        Exception: If initiating the cable test fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("cable_test"),
+    )
+
+    if not ports or not isinstance(ports, list):
+        raise ParameterError("Ports must be a non-empty list.")
+
+    api_data = {"ports": ports}
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/cableTest", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(f"Failed to initiate cable test: {resp['code']} - {resp['msg']}")
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(f"Cable test initiated successfully for {device_type} {serial_number} on {ports}. Task ID: {task_id}")
+    return response
+
+
+async def get_cable_test_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the results of a cable test on the specified device.
+
+    Supported device types: AOS-S and CX.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s' or 'cx').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API.
+
+    Raises:
+        Exception: If retrieving the cable test result fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=TROUBLESHOOTING_METHOD_DEVICE_MAPPING.get("cable_test"),
+    )
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/cableTest/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get cable test result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"Cable test for {device_type} {serial_number} with task ID {task_id} is not yet completed. "
+            f"Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(f"Cable test for {device_type} {serial_number} with task ID {task_id} has successfully completed.")
+    return resp["msg"]
+
+
+# --- Show commands (port of troubleshooting.Troubleshooting show-command subset) ---
+
+
+async def run_show_commands(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    commands: str | list[str],
+    max_attempts: int = 5,
+    poll_interval: int = 5,
+) -> dict[str, Any]:
+    """Run 'show' command(s) on a device and poll for the test result.
+
+    Supported device types: AOS-S, AP, CX, and GATEWAY. All commands must
+    start with 'show '.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        commands: Single show command as a string (e.g., "show version") or a
+            list of show commands (e.g., ["show version", "show ip route"]).
+            Max 20 commands. All commands must start with 'show '.
+        max_attempts: Maximum number of polling attempts.
+        poll_interval: Time to wait between polls in seconds.
+
+    Returns:
+        Response from the test results API containing command output and status.
+
+    Raises:
+        Exception: If initiating the show command fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=["aps", "gateways", "cx", "aos-s"],
+    )
+
+    try:
+        response = await initiate_show_commands(
+            central_conn=central_conn,
+            device_type=device_type,
+            serial_number=serial_number,
+            commands=commands,
+        )
+
+        task_id = _get_task_id(response)
+
+        return await _poll_task_completion(
+            get_show_commands_result,
+            task_id,
+            central_conn,
+            max_attempts=max_attempts,
+            poll_interval=poll_interval,
+            device_type=device_type,
+            serial_number=serial_number,
+        )
+    except Exception as e:
+        logger.error(f"Error running show command on {device_type} {serial_number}: {str(e)}")
+        raise
+
+
+async def initiate_show_commands(
+    central_conn: Any,
+    device_type: str,
+    serial_number: str,
+    commands: str | list[str],
+) -> dict[str, Any]:
+    """Initiate an asynchronous execution of 'show' command(s) on a device.
+
+    Calls ``POST network-troubleshooting/v1alpha1/{device_type}/{serial_number}/showCommands``.
+    Supported device types: AOS-S, AP, CX, and GATEWAY. All commands must
+    start with 'show '.
+
+    Args:
+        central_conn: CentralClient connection object.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+        commands: Single show command as a string or list of show commands.
+            Max 20 commands. All commands must start with 'show '.
+
+    Returns:
+        Response from the API containing task ID and other details.
+
+    Raises:
+        ParameterError: If commands is not a valid string or list, the list is
+            empty or exceeds 20 items, or any command doesn't start with 'show '.
+        Exception: If initiating the show command fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=["aps", "gateways", "cx", "aos-s"],
+    )
+
+    # Normalize commands to a list
+    if isinstance(commands, str):
+        # Single command provided as string
+        if not commands or not commands.strip():
+            raise ParameterError("commands must be a non-empty string")
+
+        if not commands.strip().lower().startswith("show "):
+            raise ParameterError("Command must start with 'show '. Example: 'show ap debug system-status'")
+
+        commands_list = [commands]
+
+    elif isinstance(commands, list):
+        # List of commands provided
+        if len(commands) == 0:
+            raise ParameterError("commands list cannot be empty")
+
+        if len(commands) > 20:
+            raise ParameterError(f"commands list cannot exceed 20 items. Provided: {len(commands)}")
+
+        # Validate each command in the list
+        for idx, cmd in enumerate(commands):
+            if not cmd or not isinstance(cmd, str) or not cmd.strip():
+                raise ParameterError(f"Command at index {idx} must be a valid non-empty string")
+
+            if not cmd.strip().lower().startswith("show "):
+                raise ParameterError(f"Command at index {idx} must start with 'show '. Got: '{cmd}'")
+
+        commands_list = commands
+
+    else:
+        raise ParameterError(
+            "commands must be either a string (single command) or a list of strings (multiple commands)"
+        )
+
+    api_data = {"commands": commands_list}
+
+    api_path = _generate_url(f"{device_type}/{serial_number}/showCommands", "troubleshooting")
+    resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
+
+    if resp["code"] != 202:
+        raise Exception(
+            f"Failed to initiate show command for {device_type} {serial_number}: {resp['code']} - {resp['msg']}"
+        )
+
+    response = resp["msg"]
+    task_id = _get_task_id(response)
+    logger.info(f"Show command initiated successfully for {device_type} {serial_number}. Task ID: {task_id}")
+    return response
+
+
+async def get_show_commands_result(
+    central_conn: Any,
+    task_id: str,
+    device_type: str,
+    serial_number: str,
+) -> dict[str, Any]:
+    """Retrieve the results of a show command execution on a device.
+
+    Supported device types: AOS-S, AP, CX, and GATEWAY.
+
+    Args:
+        central_conn: CentralClient connection object.
+        task_id: Task ID to poll for.
+        device_type: Type of the device ('aos-s', 'aps', 'cx', or 'gateways').
+        serial_number: Serial number of the device.
+
+    Returns:
+        Response from the test results API containing command output and status.
+
+    Raises:
+        Exception: If retrieving the command result fails.
+    """
+    device_type = _validate_required_device_params(
+        central_conn,
+        device_type,
+        serial_number,
+        subset=["aps", "gateways", "cx", "aos-s"],
+    )
+    resp = await central_conn.command(
+        api_method="GET",
+        api_path=_generate_url(
+            f"{device_type}/{serial_number}/showCommands/async-operations/{task_id}",
+            "troubleshooting",
+        ),
+    )
+
+    if resp["code"] != 200:
+        raise Exception(f"Failed to get show command result: {resp['code']} - {resp['msg']}")
+
+    if resp["msg"].get("status") in ["RUNNING", "INITIATED"]:
+        logger.info(
+            f"Show command for {device_type} {serial_number} with task ID {task_id} "
+            f"is not yet completed. Current status: {resp['msg'].get('status')}"
+        )
+    else:
+        logger.info(
+            f"Show command for {device_type} {serial_number} with task ID {task_id} has successfully completed."
+        )
+
+    return resp["msg"]

--- a/src/hpe_networking_mcp/platforms/central/scope_builder.py
+++ b/src/hpe_networking_mcp/platforms/central/scope_builder.py
@@ -174,7 +174,7 @@ def _build_tree(device_data: dict, maps_data: dict) -> Tree:
 # ---------------------------------------------------------------------------
 
 
-def build_scope_tree(conn: Any) -> Tree:
+async def build_scope_tree(conn: Any) -> Tree:
     """Fetch scope data and scope maps from Central, return a treelib Tree.
 
     Makes two API calls:
@@ -182,17 +182,17 @@ def build_scope_tree(conn: Any) -> Tree:
       2. GET network-config/v1alpha1/scope-maps
 
     Args:
-        conn: pycentral connection object.
+        conn: CentralClient instance.
 
     Returns:
         A treelib Tree representing the scope hierarchy.
     """
-    device_resp = retry_central_command(
+    device_resp = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="cnxdevice/v1/debug/get_scope_data",
     )
-    maps_resp = retry_central_command(
+    maps_resp = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-config/v1alpha1/scope-maps",

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -3,8 +3,8 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
-from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
 
@@ -16,7 +16,7 @@ OPERATIONAL = ToolAnnotations(
 )
 
 
-def _resolve_switch_id(conn, serial_number: str) -> str:
+async def _resolve_switch_id(conn, serial_number: str) -> str:
     """Resolve a switch serial to its stack ID if stacked.
 
     The Central troubleshooting API returns 404 for stacked switch
@@ -29,7 +29,7 @@ def _resolve_switch_id(conn, serial_number: str) -> str:
     )
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}"),
@@ -65,10 +65,10 @@ async def central_disconnect_users_ssid(
         ssid: SSID/WLAN name to disconnect users from (required).
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_switch_id(conn, serial_number)
+    resolved_id = await _resolve_switch_id(conn, serial_number)
 
     try:
-        resp = Troubleshooting.disconnect_all_users_ssid(
+        resp = await monitoring_api.disconnect_all_users_ssid(
             central_conn=conn,
             device_type=device_type,
             serial_number=resolved_id,
@@ -98,10 +98,10 @@ async def central_disconnect_users_ap(
         device_type: Switch type — "aos-s" or "cx" (required).
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_switch_id(conn, serial_number)
+    resolved_id = await _resolve_switch_id(conn, serial_number)
 
     try:
-        resp = Troubleshooting.disconnect_all_users(
+        resp = await monitoring_api.disconnect_all_users(
             central_conn=conn,
             device_type=device_type,
             serial_number=resolved_id,
@@ -134,10 +134,10 @@ async def central_disconnect_client_switch(
         mac_address: Client MAC address to disconnect (required).
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_switch_id(conn, serial_number)
+    resolved_id = await _resolve_switch_id(conn, serial_number)
 
     try:
-        resp = Troubleshooting.disconnect_client_mac_addr(
+        resp = await monitoring_api.disconnect_client_mac_addr(
             central_conn=conn,
             device_type=device_type,
             serial_number=resolved_id,
@@ -170,7 +170,7 @@ async def central_disconnect_client_gateway(
     conn = get_central_conn(ctx)
 
     try:
-        resp = Troubleshooting.disconnect_user_mac_addr(
+        resp = await monitoring_api.disconnect_user_mac_addr(
             central_conn=conn,
             device_type="gateways",
             serial_number=serial_number,
@@ -200,7 +200,7 @@ async def central_disconnect_clients_gateway(
     conn = get_central_conn(ctx)
 
     try:
-        resp = Troubleshooting.disconnect_all_clients(
+        resp = await monitoring_api.disconnect_all_clients(
             central_conn=conn,
             device_type="gateways",
             serial_number=serial_number,
@@ -216,7 +216,7 @@ async def central_disconnect_clients_gateway(
 # ── Helpers ──────────────────────────────────────────────────────
 
 
-def _get_switch_total_poe(conn, serial_number: str) -> float:
+async def _get_switch_total_poe(conn, serial_number: str) -> float:
     """Get total PoE consumption for a switch via hardware-trends.
 
     Returns total watts consumed across all stack members.
@@ -227,7 +227,7 @@ def _get_switch_total_poe(conn, serial_number: str) -> float:
     )
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
@@ -246,13 +246,13 @@ def _get_switch_total_poe(conn, serial_number: str) -> float:
         return 0.0
 
 
-def _get_switch_ports(conn, serial_number: str) -> dict:
+async def _get_switch_ports(conn, serial_number: str) -> dict:
     """Fetch port status for a switch. Returns {port_id: port_info}."""
     from hpe_networking_mcp.platforms.central.utils import (
         retry_central_command,
     )
 
-    resp = retry_central_command(
+    resp = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=(f"network-monitoring/v1/switches/{serial_number}/interfaces"),
@@ -283,11 +283,11 @@ async def central_port_bounce_switch(
         ports: Comma-separated port list, e.g. "1/1/1,1/1/2".
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_switch_id(conn, serial_number)
+    resolved_id = await _resolve_switch_id(conn, serial_number)
     port_list = [p.strip() for p in ports.split(",")]
 
     try:
-        port_info = _get_switch_ports(conn, serial_number)
+        port_info = await _get_switch_ports(conn, serial_number)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error checking port status: {e}"}) from e
 
@@ -314,7 +314,7 @@ async def central_port_bounce_switch(
         }
 
     try:
-        resp = Troubleshooting.port_bounce_test(
+        resp = await monitoring_api.port_bounce_test(
             central_conn=conn,
             device_type="cx",
             serial_number=resolved_id,
@@ -348,12 +348,12 @@ async def central_poe_bounce_switch(
         ports: Comma-separated port list, e.g. "1/1/1,1/1/2".
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_switch_id(conn, serial_number)
+    resolved_id = await _resolve_switch_id(conn, serial_number)
     port_list = [p.strip() for p in ports.split(",")]
 
     # Quick pre-check: if total switch PoE consumption is 0,
     # skip the entire switch without checking individual ports
-    total_poe = _get_switch_total_poe(conn, serial_number)
+    total_poe = await _get_switch_total_poe(conn, serial_number)
     if total_poe == 0:
         return {
             "bounced": [],
@@ -363,7 +363,7 @@ async def central_poe_bounce_switch(
         }
 
     try:
-        port_info = _get_switch_ports(conn, serial_number)
+        port_info = await _get_switch_ports(conn, serial_number)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error checking port status: {e}"}) from e
 
@@ -394,7 +394,7 @@ async def central_poe_bounce_switch(
         }
 
     try:
-        resp = Troubleshooting.poe_bounce_test(
+        resp = await monitoring_api.poe_bounce_test(
             central_conn=conn,
             device_type="cx",
             serial_number=resolved_id,
@@ -432,7 +432,7 @@ async def central_port_bounce_gateway(
     port_list = [p.strip() for p in ports.split(",")]
 
     try:
-        resp = Troubleshooting.port_bounce_test(
+        resp = await monitoring_api.port_bounce_test(
             central_conn=conn,
             device_type="gateways",
             serial_number=serial_number,
@@ -468,7 +468,7 @@ async def central_poe_bounce_gateway(
     port_list = [p.strip() for p in ports.split(",")]
 
     try:
-        resp = Troubleshooting.poe_bounce_test(
+        resp = await monitoring_api.poe_bounce_test(
             central_conn=conn,
             device_type="gateways",
             serial_number=serial_number,

--- a/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
@@ -98,7 +98,7 @@ async def central_get_alert_configs(
         `rule_number`, `rule.duration`, `rule.condition[].severity`,
         `rule.condition[].expression.operator`, etc.).
     """
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
         api_path="network-notifications/v1/alert-config",
@@ -177,7 +177,7 @@ async def central_create_alert_config(
     if rules is not None:
         body["rules"] = rules
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="POST",
         api_path="network-notifications/v1/alert-config/create",
@@ -230,7 +230,7 @@ async def central_update_alert_config(
     if not body:
         return "No fields to update — pass at least one of `enabled`, `clear_timeout`, or `rules`."
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="PUT",
         api_path="network-notifications/v1/alert-config/update",
@@ -264,7 +264,7 @@ async def central_reset_alert_config(
     Returns: A mutation response. Note: this endpoint typically does NOT
     return `name` in the response (per the Central spec).
     """
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="DELETE",
         api_path="network-notifications/v1/alert-config/delete",

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -117,7 +117,7 @@ async def central_get_alerts(
     if cursor is not None:
         query_params["next"] = cursor
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
         api_path="network-notifications/v1/alerts",
@@ -185,7 +185,7 @@ async def central_get_alert_classification(
     if search is not None:
         query_params["search"] = search
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
         api_path="network-notifications/v1/alerts/classification",
@@ -217,7 +217,7 @@ async def central_get_alert_action_status(
 
     Returns the task status payload from Central.
     """
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
         api_path=f"network-notifications/v1/alerts/async-operations/{task_id}",
@@ -277,7 +277,7 @@ async def central_clear_alerts(
     if notes is not None:
         body["notes"] = notes
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="POST",
         api_path="network-notifications/v1/alerts/clear",
@@ -315,7 +315,7 @@ async def central_defer_alerts(
     """
     body = {"keys": keys, "deferUntil": defer_until}
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="POST",
         api_path="network-notifications/v1/alerts/defer",
@@ -348,7 +348,7 @@ async def central_reactivate_alerts(
     """
     body = {"keys": keys}
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="POST",
         api_path="network-notifications/v1/alerts/active",
@@ -384,7 +384,7 @@ async def central_set_alert_priority(
     """
     body = {"keys": keys, "priority": priority}
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="POST",
         api_path="network-notifications/v1/alerts/priority",

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -151,7 +151,7 @@ async def central_get_applications(
         query_params["sort"] = _normalize_sort(sort)
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             conn,
             api_method="GET",
             api_path="network-monitoring/v1alpha1/applications",

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -53,7 +53,7 @@ async def central_get_audit_logs(
         query_params["sort"] = sort
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             conn,
             api_method="GET",
             api_path="network-services/v1/audits",
@@ -90,7 +90,7 @@ async def central_get_audit_log_detail(
     conn = get_central_conn(ctx)
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             conn,
             api_method="GET",
             api_path=f"network-services/v1/audit/{id}",

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -2,8 +2,8 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.new_monitoring.clients import Clients
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Client
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -82,7 +82,7 @@ async def central_get_clients(
         raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
     try:
-        clients = Clients.get_all_clients(
+        clients = await monitoring_api.get_all_clients(
             central_conn=get_central_conn(ctx),
             site_id=site_id,
             site_name=site_name,
@@ -116,7 +116,7 @@ async def central_find_client(
     wired clients. The port field is omitted for wireless clients.
     """
     try:
-        result = Clients.get_client_details(
+        result = await monitoring_api.get_client_details(
             central_conn=get_central_conn(ctx),
             client_mac=mac_address,
         )

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -99,7 +99,7 @@ async def central_get_config_assignments(
     if device_function:
         api_params["device-function"] = device_function
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-config/v1alpha1/config-assignments",
@@ -241,7 +241,7 @@ async def central_manage_config_assignment(
             device_function,
         )
 
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
             api_path="network-config/v1alpha1/config-assignments",
@@ -281,7 +281,7 @@ async def central_manage_config_assignment(
             device_function,
         )
 
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=api_path,

--- a/src/hpe_networking_mcp/platforms/central/tools/config_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_health.py
@@ -58,7 +58,7 @@ async def central_get_device_config_issues(
         Central ``/network-config/v1alpha1/config-health/active-issue``
         response shape.
     """
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=get_central_conn(ctx),
         api_method="GET",
         api_path="network-config/v1alpha1/config-health/active-issue",
@@ -120,7 +120,7 @@ async def central_get_devices_config_health(
     if search is not None:
         api_params["search"] = search
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=get_central_conn(ctx),
         api_method="GET",
         api_path="network-config/v1alpha1/config-health/devices",
@@ -170,7 +170,7 @@ async def central_resync_device_config(
             }
         )
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=get_central_conn(ctx),
         api_method="POST",
         api_path="network-config/v1alpha1/config-health/devices-resync",

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -330,7 +330,7 @@ async def _execute_config_action(
 
     logger.info("Central config: {} {} — path: {}", api_method, resource_name, full_path)
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=api_method,
         api_path=full_path,
@@ -385,7 +385,7 @@ async def _execute_collection_site_action(
     api_data = {"scopeId": collection_id, "siteIds": site_ids}
     logger.info("Central config: {} sites {} collection {}", action, len(site_ids), collection_id)
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=api_method,
         api_path=api_path,

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -2,8 +2,8 @@ from typing import Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.new_monitoring import MonitoringDevices
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Device
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -90,7 +90,7 @@ async def central_get_devices(
     site_assigned_str: str | None = None if site_assigned is None else ("ASSIGNED" if site_assigned else "UNASSIGNED")
 
     try:
-        devices = MonitoringDevices.get_all_device_inventory(
+        devices = await monitoring_api.get_all_device_inventory(
             central_conn=get_central_conn(ctx),
             filter_str=filter_str,
             site_assigned=site_assigned_str,
@@ -138,7 +138,7 @@ async def central_find_device(
     except ValueError as e:
         raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
     try:
-        device_resp = MonitoringDevices.get_device_inventory(
+        device_resp = await monitoring_api.get_device_inventory(
             central_conn=get_central_conn(ctx),
             filter_str=filter_str,
         )

--- a/src/hpe_networking_mcp/platforms/central/tools/events.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/events.py
@@ -116,7 +116,7 @@ async def central_get_events(
         query_params["next"] = cursor
 
     try:
-        response = retry_central_command(
+        response = await retry_central_command(
             get_central_conn(ctx),
             api_method="GET",
             api_path="network-troubleshooting/v1/events",
@@ -172,7 +172,7 @@ async def central_get_events_count(
     except ValueError as e:
         raise ToolError({"status_code": 502, "message": f"Error: {e}"}) from e
 
-    response = retry_central_command(
+    response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
         api_path="network-troubleshooting/v1/event-filters",

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware.py
@@ -306,7 +306,7 @@ async def central_recommend_firmware(
         if next_cursor:
             params["next"] = next_cursor
 
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path="network-services/v1/firmware-details",

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -2,9 +2,8 @@ from typing import Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.new_monitoring.aps import MonitoringAPs
-from pycentral.new_monitoring.gateways import MonitoringGateways
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
@@ -87,7 +86,7 @@ async def central_get_aps(
             kwargs["filter_str"] = filter_str
         if sort:
             kwargs["sort"] = sort
-        aps = MonitoringAPs.get_all_aps(**kwargs)
+        aps = await monitoring_api.get_all_aps(**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching access points: {e}"}) from e
 
@@ -113,7 +112,7 @@ async def central_get_ap_wlans(
     """
     conn = get_central_conn(ctx)
     try:
-        resp = MonitoringAPs.get_ap_wlans(
+        resp = await monitoring_api.get_ap_wlans(
             central_conn=conn,
             serial_number=serial_number,
         )
@@ -147,7 +146,7 @@ async def central_get_ap_details(
     """
     conn = get_central_conn(ctx)
     try:
-        resp = MonitoringAPs.get_ap_details(
+        resp = await monitoring_api.get_ap_details(
             central_conn=conn,
             serial_number=serial_number,
         )
@@ -177,7 +176,7 @@ async def central_get_switch_details(
     """
     conn = get_central_conn(ctx)
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}"),
@@ -196,7 +195,7 @@ async def central_get_switch_details(
     # Enrich with hardware-trends PoE data for all stack
     # members (switchTrends only shows the conductor)
     try:
-        hw_resp = retry_central_command(
+        hw_resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
@@ -261,7 +260,7 @@ async def central_get_gateway_details(
     """
     conn = get_central_conn(ctx)
     try:
-        resp = MonitoringGateways.get_gateway_details(
+        resp = await monitoring_api.get_gateway_details(
             central_conn=conn,
             serial_number=serial_number,
         )

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -17,8 +17,8 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import coerce_enum, get_central_conn, retry_central_command
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -95,7 +95,7 @@ async def central_get_ap_trend(
         # interface-type is a mandatory query param for throughput-trends (enum
         # WIRELESS/WIRED/LTE); WIRELESS is the sensible default for an AP.
         params["interface-type"] = interface_type or "WIRELESS"
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/{suffix_map[dimension]}",
         params,
@@ -114,7 +114,7 @@ async def central_get_ap_radios(
 ) -> dict | str:
     """List the radios on an AP (2.4, 5, 6 GHz typically)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/aps/{serial_number}/radios")
+    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/radios")
 
 
 _RadioTrendDimension = Literal["throughput", "channel-utilization", "channel-quality", "noise-floor", "frames"]
@@ -146,7 +146,7 @@ async def central_get_ap_radio_trend(
         "frames": "frames-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -165,7 +165,7 @@ async def central_get_ap_ports(
 ) -> dict | str:
     """List the Ethernet ports on an AP."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/aps/{serial_number}/ports")
+    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/ports")
 
 
 _PortTrendDimension = Literal["throughput", "frames", "crc", "collisions"]
@@ -191,7 +191,7 @@ async def central_get_ap_port_trend(
         "collisions": "collisions-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/ports/{port_index}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -210,7 +210,7 @@ async def central_get_ap_tunnels(
 ) -> dict | str:
     """List active tunnels on an AP."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels")
+    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels")
 
 
 @tool(annotations=READ_ONLY)
@@ -221,7 +221,7 @@ async def central_get_ap_tunnel(
 ) -> dict | str:
     """Get one tunnel's detail on an AP."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}")
+    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}")
 
 
 _TunnelTrendDimension = Literal["throughput", "packet-loss", "mos", "jitter", "latency"]
@@ -253,7 +253,7 @@ async def central_get_ap_tunnel_trend(
         "latency": "latency-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -277,7 +277,7 @@ async def central_get_ap_wlans_monitoring(
     ``/aps/:serial/wlans`` endpoint directly.
     """
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/aps/{serial_number}/wlans")
+    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/wlans")
 
 
 @tool(annotations=READ_ONLY)
@@ -290,7 +290,7 @@ async def central_get_ap_wlan_throughput(
 ) -> dict | str:
     """Get throughput trend for one WLAN as broadcast by one AP."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/aps/{serial_number}/wlans/{wlan_name}/throughput-trends",
         _time_params(start, end),
@@ -338,7 +338,7 @@ async def central_get_top_aps_by_usage(
     params: dict = {"topN": top_n}
     if filter:
         params["filter"] = filter
-    return _get(conn, f"network-monitoring/v1/{suffix_map[metric]}", params)
+    return await _get(conn, f"network-monitoring/v1/{suffix_map[metric]}", params)
 
 
 # ---------------------------------------------------------------------------
@@ -358,7 +358,7 @@ async def central_get_radios(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/radios", params)
+    return await _get(conn, "network-monitoring/v1/radios", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -373,7 +373,7 @@ async def central_get_bssids(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/bssids", params)
+    return await _get(conn, "network-monitoring/v1/bssids", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -393,7 +393,7 @@ async def central_get_wlans_monitoring(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/wlans", params)
+    return await _get(conn, "network-monitoring/v1/wlans", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -403,7 +403,7 @@ async def central_get_wlan_monitoring_detail(
 ) -> dict | str:
     """Get one WLAN's monitoring-side detail by name."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/wlans/{wlan_name}")
+    return await _get(conn, f"network-monitoring/v1/wlans/{wlan_name}")
 
 
 @tool(annotations=READ_ONLY)
@@ -418,7 +418,7 @@ async def central_get_swarms(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/swarms", params)
+    return await _get(conn, "network-monitoring/v1/swarms", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -428,7 +428,7 @@ async def central_get_swarm(
 ) -> dict | str:
     """Get one swarm / IAP cluster's detail."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/swarms/{cluster_id}")
+    return await _get(conn, f"network-monitoring/v1/swarms/{cluster_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -447,4 +447,4 @@ async def central_get_applications_v1(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/applications", params)
+    return await _get(conn, "network-monitoring/v1/applications", params)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
@@ -15,8 +15,8 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -49,7 +49,7 @@ async def central_get_clients_trend(
         params["end"] = end
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/clients-trend", params)
+    return await _get(conn, "network-monitoring/v1/clients-trend", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -63,7 +63,7 @@ async def central_get_clients_topn_usage(
     params: dict = {"topN": top_n}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/clients-topn-usage", params)
+    return await _get(conn, "network-monitoring/v1/clients-topn-usage", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -80,7 +80,7 @@ async def central_get_client_mobility_trail(
         params["start"] = start
     if end:
         params["end"] = end
-    return _get(conn, f"network-monitoring/v1/clients/{mac_address}/mobility-trail", params)
+    return await _get(conn, f"network-monitoring/v1/clients/{mac_address}/mobility-trail", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -90,7 +90,7 @@ async def central_get_client_detail(
 ) -> dict | str:
     """Get one client's full record (deeper than ``central_get_clients`` list view)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/clients/{mac_address}")
+    return await _get(conn, f"network-monitoring/v1/clients/{mac_address}")
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +108,7 @@ async def central_get_client_onboarding_score(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/client-onboarding-score", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-score", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -126,7 +126,7 @@ async def central_get_client_onboarding_stage_export(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/client-onboarding-stage/export", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/export", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -139,7 +139,7 @@ async def central_get_client_onboarding_stage_reasons(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/client-onboarding-stage/reasons", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/reasons", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -152,7 +152,7 @@ async def central_get_client_onboarding_stage_count(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/client-onboarding-stage/count", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/count", params)
 
 
 # ---------------------------------------------------------------------------
@@ -202,4 +202,4 @@ async def central_get_firewall_sessions(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, path_map[scope], params)
+    return await _get(conn, path_map[scope], params)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
@@ -17,8 +17,8 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -56,7 +56,7 @@ async def central_get_gateways(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/gateways", params)
+    return await _get(conn, "network-monitoring/v1/gateways", params)
 
 
 _GwTrendDimension = Literal["cpu", "memory", "hardware-temperature", "wan-availability", "vpn-availability"]
@@ -88,7 +88,7 @@ async def central_get_gateway_trend(
         "vpn-availability": "vpn-availability-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -107,7 +107,7 @@ async def central_get_gateway_ports(
 ) -> dict | str:
     """List ports on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports")
 
 
 @tool(annotations=READ_ONLY)
@@ -118,7 +118,7 @@ async def central_get_gateway_port(
 ) -> dict | str:
     """Get one gateway-port's detail."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports/{port_number}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports/{port_number}")
 
 
 _GwPortTrendDimension = Literal["throughput", "frames", "frames-errors", "frames-packets"]
@@ -146,7 +146,7 @@ async def central_get_gateway_port_trend(
         "frames-packets": "frames-packets-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -165,7 +165,7 @@ async def central_get_gateway_tunnels(
 ) -> dict | str:
     """List active tunnels terminating on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels")
 
 
 @tool(annotations=READ_ONLY)
@@ -176,7 +176,7 @@ async def central_get_gateway_tunnel(
 ) -> dict | str:
     """Get one tunnel's detail on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}")
 
 
 _GwTunnelTrendDimension = Literal["throughput", "status", "dropped-packet"]
@@ -201,7 +201,7 @@ async def central_get_gateway_tunnel_trend(
         "dropped-packet": "dropped-packet-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -222,7 +222,7 @@ async def central_get_gateway_tunnels_health_summary(
 ) -> dict | str:
     """Get tunnel health summary for a gateway (LAN-side or WAN-side rollup)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/{scope}-tunnels-health-summary")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/{scope}-tunnels-health-summary")
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +237,7 @@ async def central_get_gateway_vlans_runtime(
 ) -> dict | str:
     """List runtime VLANs on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans")
 
 
 @tool(annotations=READ_ONLY)
@@ -248,7 +248,7 @@ async def central_get_gateway_vlan_runtime(
 ) -> dict | str:
     """Get one runtime VLAN's detail on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans/{vlan_id}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans/{vlan_id}")
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +263,7 @@ async def central_get_gateway_uplinks(
 ) -> dict | str:
     """List uplinks (WAN links) on a gateway."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks")
 
 
 @tool(annotations=READ_ONLY)
@@ -274,7 +274,7 @@ async def central_get_gateway_uplink(
 ) -> dict | str:
     """Get one gateway-uplink's detail."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}")
 
 
 _UplinkTrendDimension = Literal["throughput", "wan-compression", "wan-availability"]
@@ -299,7 +299,7 @@ async def central_get_gateway_uplink_trend(
         "wan-availability": "wan-availability-trends",
     }
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/{suffix_map[dimension]}",
         _time_params(start, end),
@@ -314,7 +314,7 @@ async def central_get_gateway_uplink_probes(
 ) -> dict | str:
     """List configured uplink probes on a gateway uplink."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes")
 
 
 @tool(annotations=READ_ONLY)
@@ -328,7 +328,7 @@ async def central_get_gateway_uplink_probe_performance(
 ) -> dict | str:
     """Get performance trend for one specific uplink probe."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes/{probe}/performance-trends",
         _time_params(start, end),
@@ -352,7 +352,7 @@ async def central_get_gateway_uplink_vpn_availability(
     ``link-tag`` used elsewhere.
     """
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-monitoring/v1/gateways/{serial_number}/uplinks/{vlan_id}/vpn-availability-trends",
         _time_params(start, end),
@@ -378,7 +378,7 @@ async def central_get_gateway_dhcp(
 ) -> dict | str:
     """Get DHCP state on a gateway (pools or active client leases)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/gateways/{serial_number}/dhcp-{view}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/dhcp-{view}")
 
 
 # ---------------------------------------------------------------------------
@@ -393,7 +393,7 @@ async def central_get_cluster_members(
 ) -> dict | str:
     """List member gateways of a cluster."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/members")
+    return await _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/members")
 
 
 _ClusterSummaryKind = Literal[
@@ -423,7 +423,7 @@ async def central_get_cluster_summary(
 ) -> dict | str:
     """Get one of the cluster-level summary endpoints."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/{kind}")
+    return await _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/{kind}")
 
 
 @tool(annotations=READ_ONLY)
@@ -446,4 +446,4 @@ async def central_get_cluster_capacity_trends(
     conn = get_central_conn(ctx)
     base = f"network-monitoring/v1/clusters/{cluster_name}/capacity-trends"
     path = f"{base}/{serial_number}" if serial_number else base
-    return _get(conn, path, _time_params(start, end))
+    return await _get(conn, path, _time_params(start, end))

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
@@ -17,8 +17,8 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -42,7 +42,7 @@ async def central_get_site_health_detail(
     endpoint directly for one site's full health detail.
     """
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/site-health/{site_id}")
+    return await _get(conn, f"network-monitoring/v1/site-health/{site_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -57,7 +57,7 @@ async def central_get_sites_client_health(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/sites-client-health", params)
+    return await _get(conn, "network-monitoring/v1/sites-client-health", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -70,7 +70,7 @@ async def central_get_tenant_device_health(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/tenant-device-health", params)
+    return await _get(conn, "network-monitoring/v1/tenant-device-health", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -83,4 +83,4 @@ async def central_get_tenant_client_health(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/tenant-client-health", params)
+    return await _get(conn, "network-monitoring/v1/tenant-client-health", params)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
@@ -35,7 +35,7 @@ async def central_get_insights(
     api_params: dict = {"limit": limit, "offset": offset}
     if filter:
         api_params["filter"] = filter
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-notifications/v1/insights",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_msp.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_msp.py
@@ -30,7 +30,7 @@ async def central_list_msp_tenants(
     """
     conn = get_central_conn(ctx)
     api_params: dict = {"limit": limit, "offset": offset}
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-msp/v1/list-tenants",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
@@ -46,7 +46,7 @@ async def central_get_reports(
     api_params: dict = {"limit": limit, "offset": offset}
     if filter:
         api_params["filter"] = filter
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-reporting/v1/reports",
@@ -78,7 +78,7 @@ async def central_get_report_runs(
     """
     conn = get_central_conn(ctx)
     api_params: dict = {"limit": limit, "offset": offset}
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=f"network-reporting/v1/reports/{report_id}/report-runs",
@@ -114,7 +114,7 @@ async def central_update_report(
     Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true`` and fires elicitation.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="PUT",
         api_path=f"network-reporting/v1/reports/{report_id}",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -27,8 +27,8 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -57,7 +57,7 @@ async def central_get_fco_resp_info(
     pre-shared-key / claim-code workflows.
     """
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-services/v1/fco-resp-info/{serial_number}")
+    return await _get(conn, f"network-services/v1/fco-resp-info/{serial_number}")
 
 
 @tool(annotations=READ_ONLY)
@@ -71,7 +71,7 @@ async def central_get_fco_resp_info_all(
     Paginated; use for bulk audits of factory-order state.
     """
     conn = get_central_conn(ctx)
-    return _get(conn, "network-services/v1/fco-resp-info-all", {"limit": limit, "offset": offset})
+    return await _get(conn, "network-services/v1/fco-resp-info-all", {"limit": limit, "offset": offset})
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ async def central_get_asset_tags(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-services/v1/asset-tags", params)
+    return await _get(conn, "network-services/v1/asset-tags", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -123,7 +123,7 @@ async def central_get_asset_tag(
     and the last-known location for the tracked tag.
     """
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-services/v1/asset-tags/{asset_tag_id}")
+    return await _get(conn, f"network-services/v1/asset-tags/{asset_tag_id}")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -166,7 +166,7 @@ async def central_manage_asset_tag_metadata(
     method = method_map[action_type]
     if action_type != "delete" and not payload:
         raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method,
         api_path=f"network-services/v1/asset-tags/{asset_tag_id}/metadata",
@@ -210,7 +210,7 @@ async def central_start_ap_ranging_scan(
     poll via ``central_get_ap_ranging_scan`` with the returned scan ID.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
         api_path="network-services/v1/ap-ranging-scans",
@@ -230,7 +230,7 @@ async def central_get_ap_ranging_scans(
 ) -> dict:
     """List AP ranging scans for a floor."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans",
     )
@@ -245,7 +245,7 @@ async def central_get_ap_ranging_scan(
 ) -> dict:
     """Get one AP ranging scan's results / status."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans/{scan_id}",
     )
@@ -260,7 +260,7 @@ async def central_delete_ap_ranging_scan(
 ) -> dict:
     """Delete an AP ranging scan record. Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``."""
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="DELETE",
         api_path=f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans/{scan_id}",
@@ -285,7 +285,7 @@ async def central_get_site_device_locations(
 ) -> dict:
     """List device locations placed at a site (across all floors)."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-services/v1/sites/{site_id}/device-locations",
         {"limit": limit, "offset": offset},
@@ -300,7 +300,7 @@ async def central_get_site_device_location(
 ) -> dict:
     """Get one device-location record."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-services/v1/sites/{site_id}/device-locations/{location_id}")
+    return await _get(conn, f"network-services/v1/sites/{site_id}/device-locations/{location_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -311,7 +311,7 @@ async def central_get_device_location(
 ) -> dict:
     """Get the placement (floor + coordinates) for a specific device at a site."""
     conn = get_central_conn(ctx)
-    return _get(
+    return await _get(
         conn,
         f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
     )
@@ -341,14 +341,14 @@ async def central_manage_device_location(
     if action_type == "set":
         if not payload:
             raise ToolError({"status_code": 400, "message": "``payload`` is required for set."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
             api_path=f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
             api_data=payload,
         )
     elif action_type == "delete":
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
@@ -388,7 +388,7 @@ async def central_get_wifi_clients_locations(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-services/v1/wifi-clients-locations", params)
+    return await _get(conn, "network-services/v1/wifi-clients-locations", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -411,7 +411,7 @@ async def central_get_location_analytics_trends(
         params["end"] = end
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-services/v1/location-analytics/trends", params)
+    return await _get(conn, "network-services/v1/location-analytics/trends", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -424,4 +424,4 @@ async def central_get_location_analytics_site_insights(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-services/v1/location-analytics/sites/insights", params)
+    return await _get(conn, "network-services/v1/location-analytics/sites/insights", params)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
@@ -25,8 +25,8 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict:
-    response = retry_central_command(
+async def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict:
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method,
         api_path=path,
@@ -51,7 +51,7 @@ async def central_get_sitemap_summary(
 ) -> dict:
     """Get high-level sitemap summary for a site (counts, floors, devices placed)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{site_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -62,7 +62,7 @@ async def central_get_catalogue_aps(
 ) -> dict:
     """List catalogue APs — the AP models available for placement on floor plans."""
     conn = get_central_conn(ctx)
-    return _call(
+    return await _call(
         conn,
         "GET",
         "network-monitoring/v1/catalogue-aps",
@@ -95,7 +95,7 @@ async def central_get_sitemap_devices(
     seen online at the placement.
     """
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/network-devices-{status}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/network-devices-{status}")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -136,7 +136,7 @@ async def central_manage_sitemap_devices(
     if action not in action_map:
         raise ToolError({"status_code": 400, "message": f"unknown action '{action}'."})
     method, segment = action_map[action]
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method,
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/{segment}",
@@ -161,7 +161,7 @@ async def central_get_floor(
 ) -> dict:
     """Get one floor's configuration (dimensions, scale, building, image ref)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -186,7 +186,7 @@ async def central_manage_floor(
     if action_type == "create":
         if not payload:
             raise ToolError({"status_code": 400, "message": "``payload`` is required for create."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors",
@@ -195,7 +195,7 @@ async def central_manage_floor(
     elif action_type == "update":
         if not floor_id or not payload:
             raise ToolError({"status_code": 400, "message": "``floor_id`` and ``payload`` are required for update."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="PUT",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}",
@@ -204,7 +204,7 @@ async def central_manage_floor(
     elif action_type == "delete":
         if not floor_id:
             raise ToolError({"status_code": 400, "message": "``floor_id`` is required for delete."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}",
@@ -229,7 +229,7 @@ async def central_set_floor_scale(
 ) -> dict:
     """Set the physical scale calibration for a floor (drives location accuracy)."""
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/scale",
@@ -249,7 +249,7 @@ async def central_get_floor_image(
 ) -> dict:
     """Get the floor-plan image reference / metadata."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -264,7 +264,7 @@ async def central_set_floor_image(
 ) -> dict:
     """Upload / replace the floor-plan image for a floor."""
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="PUT",
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image",
@@ -288,7 +288,7 @@ async def central_get_buildings(
 ) -> dict:
     """List buildings at a site."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/buildings")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/buildings")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -310,14 +310,14 @@ async def central_manage_building(
     if action_type == "update":
         if not payload:
             raise ToolError({"status_code": 400, "message": "``payload`` is required for update."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="PUT",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/buildings/{building_id}",
             api_data=payload,
         )
     elif action_type == "delete":
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-monitoring/v1/sitemaps/{site_id}/buildings/{building_id}",
@@ -348,7 +348,7 @@ async def central_import_sitemap(
 ) -> dict:
     """Kick off a sitemap import (bulk floor-plan upload). Poll status via ``central_get_sitemap_import_status``."""
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/import",
@@ -368,7 +368,7 @@ async def central_get_sitemap_import_status(
 ) -> dict:
     """Get the status / result of a sitemap import job."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/import/{import_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/import/{import_id}")
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +380,7 @@ async def central_get_sitemap_import_status(
 async def central_get_wall_types(ctx: Context) -> dict:
     """List the wall types configured at the tenant level (used in floor walls)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", "network-monitoring/v1/wall-types")
+    return await _call(conn, "GET", "network-monitoring/v1/wall-types")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -402,7 +402,7 @@ async def central_manage_wall_types(
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
         raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
         api_path="network-monitoring/v1/wall-types",
@@ -427,7 +427,7 @@ async def central_get_floor_walls(
 ) -> dict:
     """List walls placed on a floor (used by location services for signal attenuation modeling)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -451,7 +451,7 @@ async def central_manage_floor_walls(
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
         raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls",
@@ -471,7 +471,7 @@ async def central_get_floor_zones(
 ) -> dict:
     """List zones placed on a floor (named polygons used for location analytics)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones")
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -495,7 +495,7 @@ async def central_manage_floor_zones(
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
     if action_type != "delete" and not payload:
         raise ToolError({"status_code": 400, "message": f"``payload`` is required for {action_type}."})
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
         api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
@@ -16,8 +16,8 @@ from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-def _get(conn, path: str, params: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _get(conn, path: str, params: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=path,
@@ -45,7 +45,7 @@ async def central_get_switches(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/switches", params)
+    return await _get(conn, "network-monitoring/v1/switches", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -55,7 +55,7 @@ async def central_get_switch_lag(
 ) -> dict | str:
     """Get LAG (link-aggregation) state for a switch."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/switches/{serial_number}/lag")
+    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/lag")
 
 
 @tool(annotations=READ_ONLY)
@@ -65,7 +65,7 @@ async def central_get_switch_vlans(
 ) -> dict | str:
     """Get configured VLANs on a switch (runtime view)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/switches/{serial_number}/vlans")
+    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vlans")
 
 
 @tool(annotations=READ_ONLY)
@@ -75,7 +75,7 @@ async def central_get_switch_hardware_categories(
 ) -> dict | str:
     """Get available hardware-trend categories for a switch (drives the trend dimensions valid for this model)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/switches/{serial_number}/hardware-categories")
+    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/hardware-categories")
 
 
 @tool(annotations=READ_ONLY)
@@ -97,7 +97,7 @@ async def central_get_switch_interface_trends(
         params["start"] = start
     if end:
         params["end"] = end
-    return _get(conn, f"network-monitoring/v1/switches/{serial_number}/interface-trends", params)
+    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/interface-trends", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -111,7 +111,7 @@ async def central_get_switches_topn_interface_trends(
     params: dict = {"topN": top_n}
     if filter:
         params["filter"] = filter
-    return _get(conn, "network-monitoring/v1/switches/topn-interface-trends", params)
+    return await _get(conn, "network-monitoring/v1/switches/topn-interface-trends", params)
 
 
 @tool(annotations=READ_ONLY)
@@ -121,7 +121,7 @@ async def central_get_switch_vsx(
 ) -> dict | str:
     """Get the VSX pairing state for a switch (peer / status / sync info)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/switches/{serial_number}/vsx")
+    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vsx")
 
 
 @tool(annotations=READ_ONLY)
@@ -131,4 +131,4 @@ async def central_get_switch_stack_members(
 ) -> dict | str:
     """Get stack members for a stacked switch (returns members of the stack the conductor belongs to)."""
     conn = get_central_conn(ctx)
-    return _get(conn, f"network-monitoring/v1/stack/{serial_number}/members")
+    return await _get(conn, f"network-monitoring/v1/stack/{serial_number}/members")

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
@@ -24,8 +24,8 @@ WRITE_DELETE = ToolAnnotations(
 )
 
 
-def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
-    response = retry_central_command(
+async def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method,
         api_path=path,
@@ -45,7 +45,7 @@ async def central_get_topology(
 ) -> dict | str:
     """Get the network topology graph for a site (nodes + edges)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/topology/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/topology/{site_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -55,7 +55,7 @@ async def central_get_neighbours(
 ) -> dict | str:
     """Get LLDP / CDP neighbour records as seen by a specific device."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/neighbours/{serial_number}")
+    return await _call(conn, "GET", f"network-monitoring/v1/neighbours/{serial_number}")
 
 
 @tool(annotations=READ_ONLY)
@@ -65,7 +65,7 @@ async def central_get_unmanaged_device(
 ) -> dict | str:
     """Get details on an unmanaged device (seen on the network but not under Central management)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/unmanaged-device/{mac_address}")
+    return await _call(conn, "GET", f"network-monitoring/v1/unmanaged-device/{mac_address}")
 
 
 @tool(annotations=READ_ONLY)
@@ -75,7 +75,7 @@ async def central_get_isolated_devices(
 ) -> dict | str:
     """List isolated devices at a site (managed devices that lost connectivity to peers)."""
     conn = get_central_conn(ctx)
-    return _call(conn, "GET", f"network-monitoring/v1/isolated-devices/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/isolated-devices/{site_id}")
 
 
 @tool(annotations=READ_ONLY)
@@ -95,7 +95,7 @@ async def central_get_device_inventory(
     params: dict = {"limit": limit, "offset": offset}
     if filter:
         params["filter"] = filter
-    return _call(conn, "GET", "network-monitoring/v1/device-inventory", params=params)
+    return await _call(conn, "GET", "network-monitoring/v1/device-inventory", params=params)
 
 
 @tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
@@ -113,7 +113,7 @@ async def central_update_device(
     device, change its assigned site, update notes.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="PATCH",
         api_path=f"network-monitoring/v1/devices/{serial_number}",
@@ -138,7 +138,7 @@ async def central_delete_device(
     first if recommissioning.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="DELETE",
         api_path=f"network-monitoring/v1/devices/{serial_number}",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -49,9 +49,9 @@ DeviceFamilyApCx = Literal["aps", "cx"]
 DeviceFamilySwitchGw = Literal["aos-s", "cx", "gateways"]
 
 
-def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
+async def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
     try:
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method=method,
             api_path=path,
@@ -71,8 +71,8 @@ def _call(conn, method: str, path: str, params: dict | None = None, data: dict |
     raise ToolError({"status_code": code, "message": f"Central API error (HTTP {code}): {response.get('msg')}"})
 
 
-def _post_action(conn, family: str, serial: str, action: str, payload: dict | None) -> dict | str:
-    return _call(
+async def _post_action(conn, family: str, serial: str, action: str, payload: dict | None) -> dict | str:
+    return await _call(
         conn,
         "POST",
         f"network-troubleshooting/v1/{family}/{serial}/{action}",
@@ -114,7 +114,7 @@ async def central_get_troubleshooting_task_status(
     family, serial, and action name to fetch the completed result.
     """
     conn = get_central_conn(ctx)
-    return _call(
+    return await _call(
         conn,
         "GET",
         f"network-troubleshooting/v1/{device_family}/{serial_number}/{action}/async-operations/{task_id}",
@@ -132,7 +132,7 @@ async def central_list_troubleshooting_tasks(
 ) -> dict | str:
     """List recent troubleshooting tasks queued / running / completed on a device."""
     conn = get_central_conn(ctx)
-    return _call(
+    return await _call(
         conn,
         "GET",
         f"network-troubleshooting/v1/{device_family}/{serial_number}/list-tasks",
@@ -155,7 +155,7 @@ async def central_list_supported_show_commands(
     of allowed commands).
     """
     conn = get_central_conn(ctx)
-    return _call(
+    return await _call(
         conn,
         "GET",
         f"network-troubleshooting/v1/{device_family}/{serial_number}/show-commands",
@@ -181,7 +181,7 @@ async def central_get_event_extra_attributes(
     params: dict = {}
     if filter:
         params["filter"] = filter
-    return _call(
+    return await _call(
         conn,
         "GET",
         "network-troubleshooting/v1/event-extra-attributes",
@@ -208,7 +208,7 @@ async def central_probe_http(
 
     Returns a ``task_id`` to poll via ``central_get_troubleshooting_task_status``.
     """
-    return _post_action(get_central_conn(ctx), device_family, serial_number, "http", payload)
+    return await _post_action(get_central_conn(ctx), device_family, serial_number, "http", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -225,7 +225,7 @@ async def central_probe_https(
 
     Returns a ``task_id`` to poll via ``central_get_troubleshooting_task_status``.
     """
-    return _post_action(get_central_conn(ctx), device_family, serial_number, "https", payload)
+    return await _post_action(get_central_conn(ctx), device_family, serial_number, "https", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -238,7 +238,7 @@ async def central_probe_tcp(
     ],
 ) -> dict | str:
     """Initiate a TCP probe from an AP. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), "aps", serial_number, "tcp", payload)
+    return await _post_action(get_central_conn(ctx), "aps", serial_number, "tcp", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -251,7 +251,7 @@ async def central_iperf_test(
     ],
 ) -> dict | str:
     """Initiate an iperf bandwidth test from a gateway. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), "gateways", serial_number, "iperf", payload)
+    return await _post_action(get_central_conn(ctx), "gateways", serial_number, "iperf", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -264,7 +264,7 @@ async def central_speedtest(
     ] = None,
 ) -> dict | str:
     """Initiate an Internet speed test from an AP. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), "aps", serial_number, "speedtest", payload)
+    return await _post_action(get_central_conn(ctx), "aps", serial_number, "speedtest", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -277,7 +277,7 @@ async def central_nslookup(
     ],
 ) -> dict | str:
     """Initiate an nslookup from an AP. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), "aps", serial_number, "nslookup", payload)
+    return await _post_action(get_central_conn(ctx), "aps", serial_number, "nslookup", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -298,7 +298,7 @@ async def central_test_aaa(
     ],
 ) -> dict | str:
     """Initiate an AAA authentication test from an AP or CX switch. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), device_family, serial_number, "aaa", payload)
+    return await _post_action(get_central_conn(ctx), device_family, serial_number, "aaa", payload)
 
 
 @tool(annotations=READ_ONLY)
@@ -319,7 +319,7 @@ async def central_get_arp_table(
     ] = None,
 ) -> dict | str:
     """Retrieve the device's ARP table. Returns a ``task_id`` to poll."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         device_family,
         serial_number,
@@ -338,7 +338,7 @@ async def central_ping_sweep(
     ],
 ) -> dict | str:
     """Initiate a ping sweep across a subnet from a gateway. Returns a ``task_id`` to poll."""
-    return _post_action(get_central_conn(ctx), "gateways", serial_number, "pingSweep", payload)
+    return await _post_action(get_central_conn(ctx), "gateways", serial_number, "pingSweep", payload)
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +357,7 @@ async def central_reboot_device(
     ] = None,
 ) -> dict | str:
     """Reboot a device (operational — runs immediately, no confirmation). Returns a ``task_id`` to poll."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         device_family,
         serial_number,
@@ -376,7 +376,7 @@ async def central_reboot_swarm(
     ] = None,
 ) -> dict | str:
     """Reboot an entire IAP / Instant swarm (operational — runs immediately, no confirmation)."""
-    return _post_action(get_central_conn(ctx), "aps", serial_number, "rebootSwarm", payload)
+    return await _post_action(get_central_conn(ctx), "aps", serial_number, "rebootSwarm", payload)
 
 
 @tool(annotations=OPERATIONAL)
@@ -393,7 +393,7 @@ async def central_locate_device(
     ] = None,
 ) -> dict | str:
     """Blink a device's locator LED (operational). Returns a ``task_id`` to poll."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         device_family,
         serial_number,
@@ -412,7 +412,7 @@ async def central_halt_gateway(
     ] = None,
 ) -> dict | str:
     """Halt (graceful shutdown) a gateway (operational — runs immediately, no confirmation)."""
-    return _post_action(get_central_conn(ctx), "gateways", serial_number, "halt", payload)
+    return await _post_action(get_central_conn(ctx), "gateways", serial_number, "halt", payload)
 
 
 @tool(annotations=OPERATIONAL)
@@ -422,7 +422,7 @@ async def central_disconnect_user_by_network(
     network_name: Annotated[str, Field(description="Network name (SSID) to disconnect users from.")],
 ) -> dict | str:
     """Disconnect users on a specific network/SSID on an AP (operational — runs immediately, no confirmation)."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         "aps",
         serial_number,
@@ -438,7 +438,7 @@ async def central_disconnect_user_by_mac_on_ap(
     user_mac_address: Annotated[str, Field(description="MAC address of the user/client to disconnect.")],
 ) -> dict | str:
     """Disconnect a specific user/client by MAC address from an AP (operational — runs immediately, no confirmation)."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         "aps",
         serial_number,
@@ -457,7 +457,7 @@ async def central_disconnect_user_all_on_ap(
     Service-affecting — every associated client gets bounced. Use only
     during planned maintenance windows.
     """
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         "aps",
         serial_number,
@@ -476,7 +476,7 @@ async def central_disconnect_client_all_on_gateway(
     Service-affecting — every client connected through the gateway gets
     bounced. Use only during planned maintenance windows.
     """
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         "gateways",
         serial_number,
@@ -492,7 +492,7 @@ async def central_disconnect_client_by_mac_on_gateway(
     client_mac_address: Annotated[str, Field(description="MAC address of the client to disconnect.")],
 ) -> dict | str:
     """Disconnect a specific client by MAC address from a gateway (operational — runs immediately, no confirmation)."""
-    return _post_action(
+    return await _post_action(
         get_central_conn(ctx),
         "gateways",
         serial_number,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
@@ -42,7 +42,7 @@ async def central_get_webhooks(
     full configuration.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-services/v1/webhooks",
@@ -61,7 +61,7 @@ async def central_get_webhook(
 ) -> dict:
     """Get one webhook's full configuration by ID."""
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=f"network-services/v1/webhooks/{webhook_id}",
@@ -117,7 +117,7 @@ async def central_manage_webhook(
     if action_type == "create":
         if not payload:
             raise ToolError({"status_code": 400, "message": "``payload`` is required for create."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
             api_path="network-services/v1/webhooks",
@@ -129,7 +129,7 @@ async def central_manage_webhook(
         if not payload:
             raise ToolError({"status_code": 400, "message": "``payload`` is required for update."})
         method = "PUT" if replace_existing else "PATCH"
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method=method,
             api_path=f"network-services/v1/webhooks/{webhook_id}",
@@ -138,7 +138,7 @@ async def central_manage_webhook(
     elif action_type == "delete":
         if not webhook_id:
             raise ToolError({"status_code": 400, "message": "``webhook_id`` is required for delete."})
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
             api_path=f"network-services/v1/webhooks/{webhook_id}",
@@ -164,7 +164,7 @@ async def central_rotate_webhook_hmac_key(
     Requires ``ENABLE_CENTRAL_WRITE_TOOLS=true``.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
         api_path=f"network-services/v1/webhooks/{webhook_id}/rotate-hmac-key",

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -116,7 +116,7 @@ async def central_get_role_with_policy(
     role_path = f"network-config/v1alpha1/roles/{name}"
     role_body: dict = {}
     try:
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=role_path,
@@ -135,7 +135,7 @@ async def central_get_role_with_policy(
     for policy_name in _extract_policy_names(role_body):
         policy_path = f"network-config/v1alpha1/policies/{policy_name}"
         try:
-            response = retry_central_command(
+            response = await retry_central_command(
                 central_conn=conn,
                 api_method="GET",
                 api_path=policy_path,

--- a/src/hpe_networking_mcp/platforms/central/tools/scope.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope.py
@@ -57,7 +57,7 @@ async def central_get_scope_tree(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
         return tree_to_dict(tree, effective=(view == "effective"))
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
@@ -88,7 +88,7 @@ async def central_get_scope_resources(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
@@ -171,7 +171,7 @@ async def central_get_committed_config(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
@@ -241,7 +241,7 @@ async def central_get_effective_config(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
@@ -294,7 +294,7 @@ async def central_get_devices_in_scope(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
@@ -342,7 +342,7 @@ async def central_get_scope_diagram(
     """
     conn = get_central_conn(ctx)
     try:
-        tree = build_scope_tree(conn)
+        tree = await build_scope_tree(conn)
         return tree_to_mermaid(tree, scope_id, include_resources, include_devices)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error generating scope diagram: {e}"}) from e

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -39,7 +39,7 @@ async def _get_resource(ctx: Context, api_base: str, name: str | None) -> dict |
     """Generic GET for /network-config/v1alpha1/{api_base}[/{name}]."""
     conn = get_central_conn(ctx)
     api_path = f"network-config/v1alpha1/{api_base}/{name}" if name else f"network-config/v1alpha1/{api_base}"
-    response = retry_central_command(central_conn=conn, api_method="GET", api_path=api_path)
+    response = await retry_central_command(central_conn=conn, api_method="GET", api_path=api_path)
     code = response.get("code", 0)
     if code and not 200 <= code < 300:
         raise ToolError(
@@ -113,7 +113,7 @@ async def _manage_resource(
 
     logger.info("Central {}: {} '{}' — path: {}", resource_label, api_method, name, api_path)
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=api_method,
         api_path=api_path,
@@ -185,7 +185,7 @@ async def _operation_request(
 
     logger.info("Central operation: {} — path: {}", method, api_path)
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=method,
         api_path=api_path,

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -3,10 +3,10 @@ from typing import Annotated
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
-from pycentral.new_monitoring import MonitoringSites
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import SiteData
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
@@ -47,7 +47,7 @@ async def _scope_write(
         if guard is not None:
             return guard
     conn = get_central_conn(ctx)
-    response = retry_central_command(central_conn=conn, api_method=method, api_path=path, api_data=body)
+    response = await retry_central_command(central_conn=conn, api_method=method, api_path=path, api_data=body)
     code = response.get("code", 0)
     if not 200 <= code < 300:
         msg = response.get("msg", "unknown error")
@@ -89,7 +89,7 @@ async def central_get_sites(
     if sort:
         api_params["sort"] = sort
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-config/v1/sites",
@@ -123,7 +123,7 @@ async def central_get_site_health(
             (e.g. ["Owls Nest", "HQ"]). If omitted, all sites are returned (use sparingly).
     """
     wanted = normalize_site_name_filter(site_name)
-    sites_data = fetch_site_data_parallel(get_central_conn(ctx))
+    sites_data = await fetch_site_data_parallel(get_central_conn(ctx))
     if wanted:
         return [sites_data[name] for name in wanted if name in sites_data]
     return list(sites_data.values())
@@ -151,7 +151,7 @@ async def central_get_site_name_id_mapping(ctx: Context) -> dict:
     - total_clients: Total number of clients at the site.
     - total_alerts: Total number of alerts at the site.
     """
-    sites = MonitoringSites.get_all_sites(central_conn=get_central_conn(ctx))
+    sites = await monitoring_api.get_all_sites(central_conn=get_central_conn(ctx))
     mapping = {}
     for site in sites:
         health_obj = groups_to_map(site.get("health", {}))
@@ -184,7 +184,7 @@ async def central_get_global_scope(ctx: Context) -> dict | str:
     ``central_get_hierarchy`` at the tenant root.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-config/v1/global",
@@ -225,7 +225,7 @@ async def central_get_hierarchy(
     devices) beneath the resource identified by ``scope_id`` + ``scope_type``.
     """
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-config/v1/hierarchy",

--- a/src/hpe_networking_mcp/platforms/central/tools/stats.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/stats.py
@@ -2,9 +2,8 @@ from typing import Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.new_monitoring.aps import MonitoringAPs
-from pycentral.new_monitoring.gateways import MonitoringGateways
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
@@ -17,7 +16,7 @@ async def central_get_ap_stats(
     start_time: str | None = None,
     end_time: str | None = None,
     duration: str | None = None,
-) -> dict | str:
+) -> dict | list | str:
     """
     Get performance statistics for a specific access point.
 
@@ -35,14 +34,14 @@ async def central_get_ap_stats(
     conn = get_central_conn(ctx)
     kwargs: dict = {"central_conn": conn, "serial_number": serial_number}
     if start_time:
-        kwargs["from_timestamp"] = start_time
+        kwargs["start_time"] = start_time
     if end_time:
-        kwargs["to_timestamp"] = end_time
+        kwargs["end_time"] = end_time
     if duration:
         kwargs["duration"] = duration
 
     try:
-        resp = MonitoringAPs.get_ap_stats(**kwargs)
+        resp = await monitoring_api.get_ap_stats(**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching AP stats: {e}"}) from e
 
@@ -78,20 +77,20 @@ async def central_get_ap_utilization(
     conn = get_central_conn(ctx)
     kwargs: dict = {"central_conn": conn, "serial_number": serial_number}
     if start_time:
-        kwargs["from_timestamp"] = start_time
+        kwargs["start_time"] = start_time
     if end_time:
-        kwargs["to_timestamp"] = end_time
+        kwargs["end_time"] = end_time
     if duration:
         kwargs["duration"] = duration
 
     method_map = {
-        "cpu": MonitoringAPs.get_ap_cpu_utilization,
-        "memory": MonitoringAPs.get_ap_memory_utilization,
-        "poe": MonitoringAPs.get_ap_poe_utilization,
+        "cpu": monitoring_api.get_ap_cpu_utilization,
+        "memory": monitoring_api.get_ap_memory_utilization,
+        "poe": monitoring_api.get_ap_poe_utilization,
     }
 
     try:
-        resp = method_map[metric](**kwargs)
+        resp = await method_map[metric](**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching AP {metric} utilization: {e}"}) from e
 
@@ -107,7 +106,7 @@ async def central_get_gateway_stats(
     start_time: str | None = None,
     end_time: str | None = None,
     duration: str | None = None,
-) -> dict | str:
+) -> dict | list | str:
     """
     Get performance statistics for a specific gateway.
 
@@ -125,14 +124,14 @@ async def central_get_gateway_stats(
     conn = get_central_conn(ctx)
     kwargs: dict = {"central_conn": conn, "serial_number": serial_number}
     if start_time:
-        kwargs["from_timestamp"] = start_time
+        kwargs["start_time"] = start_time
     if end_time:
-        kwargs["to_timestamp"] = end_time
+        kwargs["end_time"] = end_time
     if duration:
         kwargs["duration"] = duration
 
     try:
-        resp = MonitoringGateways.get_gateway_stats(**kwargs)
+        resp = await monitoring_api.get_gateway_stats(**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching gateway stats: {e}"}) from e
 
@@ -168,19 +167,19 @@ async def central_get_gateway_utilization(
     conn = get_central_conn(ctx)
     kwargs: dict = {"central_conn": conn, "serial_number": serial_number}
     if start_time:
-        kwargs["from_timestamp"] = start_time
+        kwargs["start_time"] = start_time
     if end_time:
-        kwargs["to_timestamp"] = end_time
+        kwargs["end_time"] = end_time
     if duration:
         kwargs["duration"] = duration
 
     method_map = {
-        "cpu": MonitoringGateways.get_gateway_cpu_utilization,
-        "memory": MonitoringGateways.get_gateway_memory_utilization,
+        "cpu": monitoring_api.get_gateway_cpu_utilization,
+        "memory": monitoring_api.get_gateway_memory_utilization,
     }
 
     try:
-        resp = method_map[metric](**kwargs)
+        resp = await method_map[metric](**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching gateway {metric} utilization: {e}"}) from e
 
@@ -216,14 +215,14 @@ async def central_get_gateway_wan_availability(
     conn = get_central_conn(ctx)
     kwargs: dict = {"central_conn": conn, "serial_number": serial_number}
     if start_time:
-        kwargs["from_timestamp"] = start_time
+        kwargs["start_time"] = start_time
     if end_time:
-        kwargs["to_timestamp"] = end_time
+        kwargs["end_time"] = end_time
     if duration:
         kwargs["duration"] = duration
 
     try:
-        resp = MonitoringGateways.get_gateway_wan_availability(**kwargs)
+        resp = await monitoring_api.get_gateway_wan_availability(**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching gateway WAN availability: {e}"}) from e
 
@@ -251,7 +250,7 @@ async def central_get_tunnel_health(
     conn = get_central_conn(ctx)
 
     try:
-        resp = MonitoringGateways.get_tunnel_health_summary(
+        resp = await monitoring_api.get_tunnel_health_summary(
             central_conn=conn,
             serial_number=serial_number,
         )

--- a/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
@@ -31,7 +31,7 @@ async def central_get_switch_hardware_trends(
     conn = get_central_conn(ctx)
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
@@ -120,7 +120,7 @@ async def central_get_switch_poe(
     conn = get_central_conn(ctx)
 
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=(f"network-monitoring/v1/switches/{serial_number}/interface-poe"),

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -1,15 +1,15 @@
-from typing import Literal
+from typing import Any, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.troubleshooting.troubleshooting import Troubleshooting
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
 
 
-def _resolve_if_switch(conn, serial_number: str, device_type: str) -> str:
+async def _resolve_if_switch(conn, serial_number: str, device_type: str) -> str:
     """Resolve stack ID for switches (aos-s, cx). Returns serial unchanged for other types."""
     if device_type not in ("cx", "aos-s"):
         return serial_number
@@ -17,7 +17,7 @@ def _resolve_if_switch(conn, serial_number: str, device_type: str) -> str:
         _resolve_switch_id,
     )
 
-    return _resolve_switch_id(conn, serial_number)
+    return await _resolve_switch_id(conn, serial_number)
 
 
 @tool(annotations=READ_ONLY)
@@ -44,7 +44,7 @@ async def central_ping(
         packet_size: Ping packet size in bytes.
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_if_switch(conn, serial_number, device_type)
+    resolved_id = await _resolve_if_switch(conn, serial_number, device_type)
 
     kwargs: dict = {
         "central_conn": conn,
@@ -56,14 +56,14 @@ async def central_ping(
     if packet_size is not None:
         kwargs["packet_size"] = packet_size
 
-    method_map = {
-        "ap": Troubleshooting.ping_aps_test,
-        "cx": Troubleshooting.ping_cx_test,
-        "gateway": Troubleshooting.ping_gateways_test,
+    method_map: dict[str, Any] = {
+        "ap": monitoring_api.ping_aps_test,
+        "cx": monitoring_api.ping_cx_test,
+        "gateway": monitoring_api.ping_gateways_test,
     }
 
     try:
-        resp = method_map[device_type](**kwargs)
+        resp = await method_map[device_type](**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error running ping test: {e}"}) from e
 
@@ -91,16 +91,16 @@ async def central_traceroute(
         device_type: Type of device — "ap", "cx", or "gateway" (required).
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_if_switch(conn, serial_number, device_type)
+    resolved_id = await _resolve_if_switch(conn, serial_number, device_type)
 
-    method_map = {
-        "ap": Troubleshooting.traceroute_aps_test,
-        "cx": Troubleshooting.traceroute_cx_test,
-        "gateway": Troubleshooting.traceroute_gateways_test,
+    method_map: dict[str, Any] = {
+        "ap": monitoring_api.traceroute_aps_test,
+        "cx": monitoring_api.traceroute_cx_test,
+        "gateway": monitoring_api.traceroute_gateways_test,
     }
 
     try:
-        resp = method_map[device_type](
+        resp = await method_map[device_type](
             central_conn=conn,
             serial_number=resolved_id,
             destination=destination,
@@ -149,11 +149,11 @@ async def central_cable_test(
         raise ToolError({"status_code": 400, "message": f"poll_interval must be 1-10, got {poll_interval}"})
 
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_if_switch(conn, serial_number, device_type)
+    resolved_id = await _resolve_if_switch(conn, serial_number, device_type)
     port_list = [p.strip() for p in ports.split(",")]
 
     try:
-        resp = Troubleshooting.cable_test(
+        resp = await monitoring_api.cable_test(
             central_conn=conn,
             device_type=device_type,
             serial_number=resolved_id,
@@ -190,11 +190,11 @@ async def central_show_commands(
         commands: Comma-separated show commands, e.g. "show version,show interfaces" (required).
     """
     conn = get_central_conn(ctx)
-    resolved_id = _resolve_if_switch(conn, serial_number, device_type)
+    resolved_id = await _resolve_if_switch(conn, serial_number, device_type)
     command_list = [c.strip() for c in commands.split(",")]
 
     try:
-        resp = Troubleshooting.run_show_commands(
+        resp = await monitoring_api.run_show_commands(
             central_conn=conn,
             device_type=device_type,
             serial_number=resolved_id,

--- a/src/hpe_networking_mcp/platforms/central/tools/wids.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wids.py
@@ -154,7 +154,7 @@ async def central_get_wids_monitored_aps(
         api_params["filter"] = odata_filter
 
     conn = get_central_conn(ctx)
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path="network-services/v1alpha1/wids-monitored-aps",

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -50,7 +50,7 @@ async def central_get_wlan_profiles(
 
     api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}" if ssid else "network-config/v1alpha1/wlan-ssids"
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
         api_path=api_path,
@@ -222,7 +222,7 @@ async def central_manage_wlan_profile(
         ]
     else:
         action_wording = "patch (partial update of)"
-        diff_lines = _build_patch_diff(conn, api_path, payload)
+        diff_lines = await _build_patch_diff(conn, api_path, payload)
 
     # Confirm for update and delete only
     if action_type != "create" and not confirmed:
@@ -252,7 +252,7 @@ async def central_manage_wlan_profile(
 
     logger.info("Central WLAN: {} '{}' — path: {}", api_method, ssid, api_path)
 
-    response = retry_central_command(
+    response = await retry_central_command(
         central_conn=conn,
         api_method=api_method,
         api_path=api_path,
@@ -275,7 +275,7 @@ async def central_manage_wlan_profile(
     }
 
 
-def _build_patch_diff(conn: object, api_path: str, payload: dict) -> list[str]:
+async def _build_patch_diff(conn: object, api_path: str, payload: dict) -> list[str]:
     """Compute a human-readable diff of what a PATCH will change.
 
     Fetches the current profile and reports, per top-level key in the
@@ -284,7 +284,7 @@ def _build_patch_diff(conn: object, api_path: str, payload: dict) -> list[str]:
     message so the write isn't held up by a display-only helper.
     """
     try:
-        resp = retry_central_command(
+        resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=api_path,

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -2,8 +2,8 @@ from typing import Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from pycentral.new_monitoring.aps import MonitoringAPs
 
+from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, resolve_time_window, retry_central_command
@@ -48,7 +48,7 @@ async def central_get_wlans(
         if sort is not None:
             kwargs["sort"] = sort
 
-        resp = MonitoringAPs.get_wlans(**kwargs)
+        resp = await monitoring_api.get_wlans(**kwargs)
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching WLANs: {e}"}) from e
 
@@ -95,7 +95,7 @@ async def central_get_wlan_stats(
     conn = get_central_conn(ctx)
 
     try:
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=f"network-monitoring/v1/wlans/{wlan_name}/throughput-trends",

--- a/src/hpe_networking_mcp/platforms/central/utils.py
+++ b/src/hpe_networking_mcp/platforms/central/utils.py
@@ -1,5 +1,4 @@
-import time
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -145,7 +144,7 @@ def build_odata_filter(
 SITE_LIMIT = 100
 
 
-def fetch_site_data_parallel(
+async def fetch_site_data_parallel(
     central_conn: Any,
 ) -> dict[str, SiteData]:
     """
@@ -166,12 +165,9 @@ def fetch_site_data_parallel(
     # These endpoints are offset-paginated per the Aruba dev portal — they
     # accept ``limit`` + ``offset`` only. Default cursor pagination here
     # silently breaks for tenants with > SITE_LIMIT sites.
-    with ThreadPoolExecutor(max_workers=3) as executor:
-        futures = [
-            executor.submit(paginated_fetch, central_conn, endpoint, SITE_LIMIT, use_cursor=False)
-            for endpoint in endpoints
-        ]
-        results = [future.result() for future in futures]
+    results = await asyncio.gather(
+        *(paginated_fetch(central_conn, endpoint, SITE_LIMIT, use_cursor=False) for endpoint in endpoints)
+    )
 
     return process_site_health_data(*results)
 
@@ -210,7 +206,7 @@ def process_site_health_data(
     return processed_sites
 
 
-def paginated_fetch(
+async def paginated_fetch(
     central_conn: Any,
     api_path: str,
     limit: int,
@@ -249,7 +245,7 @@ def paginated_fetch(
                 "limit": limit,
                 "next": next_cursor,
             }
-            response = retry_central_command(
+            response = await retry_central_command(
                 central_conn,
                 api_method="GET",
                 api_path=api_path,
@@ -271,7 +267,7 @@ def paginated_fetch(
                 "limit": limit,
                 "offset": offset,
             }
-            response = retry_central_command(
+            response = await retry_central_command(
                 central_conn,
                 api_method="GET",
                 api_path=api_path,
@@ -329,7 +325,7 @@ def get_central_conn(ctx: Any) -> Any:
         ctx: The FastMCP request context.
 
     Returns:
-        The ``pycentral`` connection object.
+        The ``CentralClient`` instance.
 
     Raises:
         ToolError: 503 when Central is not configured or failed to start.
@@ -349,27 +345,7 @@ def get_central_conn(ctx: Any) -> Any:
     return conn
 
 
-def _log_transport_error(central_conn: Any, message: str) -> None:
-    """Log a transport error without assuming ``central_conn`` (or its logger) exists.
-
-    The original handler called ``central_conn.logger.error(...)`` directly; if
-    ``central_conn`` is ``None`` (issue #443) that raises a second
-    ``AttributeError`` inside the ``except`` block. Prefer the connection's own
-    logger when present, else fall back to the module logger. The message is
-    pre-formatted, so it's passed as a literal (``"{}"``) to loguru to avoid its
-    brace-format parser choking on braces in an exception string.
-    """
-    conn_logger = getattr(central_conn, "logger", None)
-    if conn_logger is not None:
-        try:
-            conn_logger.error(message)
-            return
-        except Exception:
-            pass
-    logger.error("{}", message)
-
-
-def retry_central_command(
+async def retry_central_command(
     central_conn: Any,
     api_method: str,
     api_path: str,
@@ -380,7 +356,7 @@ def retry_central_command(
     """Call central_conn.command and retry up to max_retries on transient errors.
 
     Args:
-        central_conn: pycentral connection object.
+        central_conn: ``CentralClient`` instance (from ``get_central_conn``).
         api_method: HTTP method (GET, POST, PUT, DELETE).
         api_path: API endpoint path.
         api_params: URL query parameters.
@@ -410,20 +386,20 @@ def retry_central_command(
     last_response: dict | None = None
     for attempt in range(1, max_retries + 1):
         try:
-            resp = central_conn.command(
+            resp = await central_conn.command(
                 api_method=api_method,
                 api_path=api_path,
                 api_params=api_params,
                 api_data=api_data,
             )
         except Exception as exc:
-            _log_transport_error(
-                central_conn,
+            logger.error(
+                "{}",
                 f"Central transport error attempt {attempt}/{max_retries} {api_method} {api_path}: {exc}",
             )
             last_response = {"code": 0, "msg": str(exc)}
             if attempt < max_retries:
-                time.sleep(_retry_backoff_secs(attempt))
+                await asyncio.sleep(_retry_backoff_secs(attempt))
             continue
 
         code = resp.get("code", 0)
@@ -441,8 +417,8 @@ def retry_central_command(
 
         # retry on server errors or rate limiting
         if code == 429 or 500 <= code < 600:
-            central_conn.logger.warning(
-                "Central transient response code=%s for %s %s (attempt %d/%d)",
+            logger.warning(
+                "Central transient response code={} for {} {} (attempt {}/{})",
                 code,
                 api_method,
                 api_path,
@@ -451,7 +427,7 @@ def retry_central_command(
             )
             last_response = resp
             if attempt < max_retries:
-                time.sleep(_retry_backoff_secs(attempt))
+                await asyncio.sleep(_retry_backoff_secs(attempt))
             continue
 
         # client errors -> raise immediately

--- a/src/hpe_networking_mcp/platforms/manage_wlan.py
+++ b/src/hpe_networking_mcp/platforms/manage_wlan.py
@@ -258,7 +258,7 @@ def register(mcp):
 
         # Check both platforms for the SSID
         mist_wlan = await _find_mist_wlan(ctx, ssid)
-        central_profile = _find_central_profile(ctx, ssid)
+        central_profile = await _find_central_profile(ctx, ssid)
 
         exists_mist = mist_wlan is not None
         exists_central = central_profile is not None
@@ -388,14 +388,14 @@ async def _find_mist_wlan(ctx: Context, ssid: str) -> dict | None:
     return None
 
 
-def _find_central_profile(ctx: Context, ssid: str) -> dict | None:
+async def _find_central_profile(ctx: Context, ssid: str) -> dict | None:
     """Check if an SSID exists in Central. Returns profile dict or None."""
     conn = ctx.lifespan_context.get("central_conn")
     if not conn:
         return None
 
     try:
-        response = retry_central_command(
+        response = await retry_central_command(
             central_conn=conn,
             api_method="GET",
             api_path=f"network-config/v1alpha1/wlan-ssids/{ssid}",

--- a/src/hpe_networking_mcp/platforms/site_health_check.py
+++ b/src/hpe_networking_mcp/platforms/site_health_check.py
@@ -204,9 +204,9 @@ async def _collect_central(ctx: Context, site_name: str, _window_hours: int) -> 
     summary = CentralSummary()
 
     try:
-        from pycentral.new_monitoring import MonitoringSites
+        from hpe_networking_mcp.platforms.central import monitoring_api
 
-        sites = await asyncio.to_thread(MonitoringSites.get_all_sites, central_conn=conn)
+        sites = await monitoring_api.get_all_sites(central_conn=conn)
         match = next((s for s in sites if s.get("siteName") == site_name), None)
         if not match:
             return summary
@@ -256,15 +256,15 @@ async def _collect_central(ctx: Context, site_name: str, _window_hours: int) -> 
     return summary
 
 
-def _extract_central_device_ips(ctx: Context, site_id: str) -> list[str]:
+async def _extract_central_device_ips(ctx: Context, site_id: str) -> list[str]:
     """Fetch devices at a Central site and return their management IPs."""
-    from pycentral.new_monitoring import MonitoringDevices
+    from hpe_networking_mcp.platforms.central import monitoring_api
 
     conn = ctx.lifespan_context.get("central_conn")
     if not conn:
         return []
     try:
-        devices = MonitoringDevices.get_all_device_inventory(
+        devices = await monitoring_api.get_all_device_inventory(
             central_conn=conn,
             filter_str=f"siteId eq '{site_id}'",
         )
@@ -702,7 +702,7 @@ def register(mcp: Any, config: Any) -> None:
 
         device_ips: list[str] = []
         if central_summary and central_summary.found and central_summary.site_id:
-            device_ips.extend(await asyncio.to_thread(_extract_central_device_ips, ctx, central_summary.site_id))
+            device_ips.extend(await _extract_central_device_ips(ctx, central_summary.site_id))
         if mist_summary and mist_summary.found and mist_summary.site_id:
             device_ips.extend(await _extract_mist_device_ips(ctx, mist_summary.site_id))
         device_ips = list(dict.fromkeys(device_ips))  # de-dupe preserving order

--- a/src/hpe_networking_mcp/platforms/site_rf_check.py
+++ b/src/hpe_networking_mcp/platforms/site_rf_check.py
@@ -318,14 +318,10 @@ async def _collect_central(
 
     summary = CentralRF()
 
-    try:
-        from pycentral.new_monitoring.aps import MonitoringAPs
-        from pycentral.new_monitoring.sites import MonitoringSites
-    except ImportError as e:
-        return CentralRF(error=f"pycentral not available: {e}"), []
+    from hpe_networking_mcp.platforms.central import monitoring_api
 
     try:
-        sites = await asyncio.to_thread(MonitoringSites.get_all_sites, central_conn=conn)
+        sites = await monitoring_api.get_all_sites(central_conn=conn)
         match = next((s for s in sites if s.get("siteName") == site_name), None)
         if not match:
             return summary, []
@@ -340,8 +336,7 @@ async def _collect_central(
     # details in parallel to get the radios array. Cap to max_aps to bound
     # cost on large sites — users can raise the cap via the tool param.
     try:
-        ap_list = await asyncio.to_thread(
-            MonitoringAPs.get_all_aps,
+        ap_list = await monitoring_api.get_all_aps(
             central_conn=conn,
             filter_str=f"siteId eq '{summary.site_id}'",
         )
@@ -361,10 +356,9 @@ async def _collect_central(
 
     details_list = await asyncio.gather(
         *[
-            asyncio.to_thread(
-                MonitoringAPs.get_ap_details,
+            monitoring_api.get_ap_details(
                 central_conn=conn,
-                serial_number=ap.get("serialNumber"),
+                serial_number=str(ap.get("serialNumber") or ""),
             )
             for ap in targets
         ],
@@ -592,18 +586,14 @@ async def _list_central_site_options(ctx: Context) -> list[SiteOption]:
     if not conn:
         return []
 
-    try:
-        from pycentral.new_monitoring.aps import MonitoringAPs
-        from pycentral.new_monitoring.sites import MonitoringSites
-    except ImportError:
-        return []
+    from hpe_networking_mcp.platforms.central import monitoring_api
 
     sites: Any = None
     aps: Any = None
     try:
         sites, aps = await asyncio.gather(
-            asyncio.to_thread(MonitoringSites.get_all_sites, central_conn=conn),
-            asyncio.to_thread(MonitoringAPs.get_all_aps, central_conn=conn),
+            monitoring_api.get_all_sites(central_conn=conn),
+            monitoring_api.get_all_aps(central_conn=conn),
             return_exceptions=True,
         )
     except Exception as e:

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -66,17 +66,11 @@ async def lifespan(server: FastMCP):
     # --- Central ---
     if config.central:
         try:
-            from pycentral import NewCentralBase
+            from hpe_networking_mcp.platforms.central.client import create_connection
 
-            context["central_conn"] = NewCentralBase(
-                token_info={
-                    "new_central": {
-                        "base_url": config.central.base_url,
-                        "client_id": config.central.client_id,
-                        "client_secret": config.central.client_secret,
-                    }
-                }
-            )
+            # Construction is non-blocking: the first API call triggers the
+            # initial OAuth2 token fetch via the shared AsyncTokenManager.
+            context["central_conn"] = create_connection(config.central)
         except Exception as e:
             logger.warning("Central: failed to initialize — {}", e)
             context["central_conn"] = None
@@ -215,6 +209,12 @@ async def lifespan(server: FastMCP):
         gl_tm = context.get("greenlake_token_manager")
         if gl_tm and hasattr(gl_tm, "close"):
             await gl_tm.close()
+        central = context.get("central_conn")
+        if central is not None:
+            try:
+                await central.aclose()
+            except Exception as e:  # noqa: BLE001 — shutdown must not raise
+                logger.warning("Central: aclose failed during shutdown — {}", e)
         mist_client_cleanup: Any = context.get("mist_client")
         if mist_client_cleanup is not None:
             try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,11 +31,16 @@ def _read_secret(name: str) -> str | None:
     return None
 
 
-@pytest.fixture(scope="session")
-def central_conn():
+@pytest.fixture
+async def central_conn():
     """Create a live Central connection from Docker secrets.
 
     Skips all tests if Central credentials are not available.
+
+    Function-scoped: ``CentralClient`` owns an ``httpx.AsyncClient`` bound to
+    the running event loop, and pytest-asyncio gives each test its own loop —
+    a session-scoped client would hit "Event loop is closed" on the second
+    test. The token fetch per test is the (acceptable) cost.
     """
     base_url = _read_secret("central_base_url")
     client_id = _read_secret("central_client_id")
@@ -44,21 +49,15 @@ def central_conn():
     if not all([base_url, client_id, client_secret]):
         pytest.skip("Central credentials not found — skipping live tests")
 
-    from pycentral import NewCentralBase
+    from hpe_networking_mcp.config import CentralSecrets
+    from hpe_networking_mcp.platforms.central.client import create_connection
 
-    conn = NewCentralBase(
-        token_info={
-            "new_central": {
-                "base_url": base_url,
-                "client_id": client_id,
-                "client_secret": client_secret,
-            }
-        }
-    )
-    return conn
+    conn = create_connection(CentralSecrets(base_url=base_url, client_id=client_id, client_secret=client_secret))
+    yield conn
+    await conn.aclose()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def live_ctx(central_conn):
     """Create a mock Context with a live Central connection.
 

--- a/tests/unit/test_central_cable_test.py
+++ b/tests/unit/test_central_cable_test.py
@@ -1,15 +1,15 @@
 """Unit tests for ``central_cable_test`` poll-budget parameters.
 
-Regression coverage for issue #382: the tool is fire-and-poll (pycentral's
-``cable_test`` blocks up to ``max_attempts * poll_interval`` seconds), which
+Regression coverage for issue #382: the tool is fire-and-poll (the ported
+``cable_test`` polls up to ``max_attempts * poll_interval`` seconds), which
 can breach the code-mode sandbox wall-clock budget. The tool now exposes
 ``max_attempts`` / ``poll_interval`` (validated, 1-10) and forwards them to
-pycentral.
+the async monitoring_api port.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -18,7 +18,7 @@ from hpe_networking_mcp.platforms.central.tools.troubleshooting import central_c
 
 pytestmark = pytest.mark.unit
 
-_TS = "hpe_networking_mcp.platforms.central.tools.troubleshooting.Troubleshooting"
+_CABLE = "hpe_networking_mcp.platforms.central.tools.troubleshooting.monitoring_api.cable_test"
 _RESOLVE = "hpe_networking_mcp.platforms.central.tools.troubleshooting._resolve_if_switch"
 
 
@@ -29,23 +29,23 @@ def _ctx() -> MagicMock:
 
 
 class TestCableTestPolling:
-    @patch(_RESOLVE, return_value="SW1")
-    @patch(_TS)
-    async def test_defaults_forward_5_by_5(self, mock_ts, _mock_resolve):
-        mock_ts.cable_test.return_value = {"ports": []}
+    @patch(_RESOLVE, new_callable=AsyncMock, return_value="SW1")
+    @patch(_CABLE, new_callable=AsyncMock)
+    async def test_defaults_forward_5_by_5(self, mock_cable, _mock_resolve):
+        mock_cable.return_value = {"ports": []}
         await central_cable_test(_ctx(), serial_number="SW1", device_type="cx", ports="1/1/1")
-        kw = mock_ts.cable_test.call_args.kwargs
+        kw = mock_cable.call_args.kwargs
         assert kw["max_attempts"] == 5
         assert kw["poll_interval"] == 5
 
-    @patch(_RESOLVE, return_value="SW1")
-    @patch(_TS)
-    async def test_custom_poll_params_forwarded(self, mock_ts, _mock_resolve):
-        mock_ts.cable_test.return_value = {"ports": []}
+    @patch(_RESOLVE, new_callable=AsyncMock, return_value="SW1")
+    @patch(_CABLE, new_callable=AsyncMock)
+    async def test_custom_poll_params_forwarded(self, mock_cable, _mock_resolve):
+        mock_cable.return_value = {"ports": []}
         await central_cable_test(
             _ctx(), serial_number="SW1", device_type="cx", ports="1/1/1", max_attempts=2, poll_interval=1
         )
-        kw = mock_ts.cable_test.call_args.kwargs
+        kw = mock_cable.call_args.kwargs
         assert kw["max_attempts"] == 2
         assert kw["poll_interval"] == 1
 
@@ -65,9 +65,9 @@ class TestCableTestPolling:
             )
         assert exc.value.args[0]["status_code"] == 400
 
-    @patch(_RESOLVE, return_value="SW1")
-    @patch(_TS)
-    async def test_empty_result_returns_info_string(self, mock_ts, _mock_resolve):
-        mock_ts.cable_test.return_value = None
+    @patch(_RESOLVE, new_callable=AsyncMock, return_value="SW1")
+    @patch(_CABLE, new_callable=AsyncMock)
+    async def test_empty_result_returns_info_string(self, mock_cable, _mock_resolve):
+        mock_cable.return_value = None
         result = await central_cable_test(_ctx(), serial_number="SW1", device_type="cx", ports="1/1/1")
         assert result == "Cable test returned no results."

--- a/tests/unit/test_central_client.py
+++ b/tests/unit/test_central_client.py
@@ -1,0 +1,245 @@
+"""Unit tests for CentralClient — the pycentral-compatible async replacement.
+
+Pins the ``command()`` contract that all ~660 Central tools rely on through
+``retry_central_command``: the ``{code, msg, headers}`` return dict, None
+param stripping, empty-body omission, JSON serialization, Bearer auth, and
+the 401 → refresh-once → retry flow.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from hpe_networking_mcp.config import CentralSecrets
+from hpe_networking_mcp.platforms.central.client import (
+    CentralClient,
+    create_connection,
+    verify_connection,
+)
+
+
+@pytest.mark.unit
+class TestNoPycentralAnywhere:
+    """The pycentral SDK was removed in v3.3.11.0 — no module under src/ may import it."""
+
+    def test_no_pycentral_imports_in_src(self):
+        import ast
+        import pathlib
+
+        import hpe_networking_mcp
+
+        root = pathlib.Path(hpe_networking_mcp.__file__).parent
+        offenders: list[str] = []
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    if any(a.name.split(".")[0] == "pycentral" for a in node.names):
+                        offenders.append(f"{path}:{node.lineno}")
+                elif isinstance(node, ast.ImportFrom) and node.module and node.module.split(".")[0] == "pycentral":
+                    offenders.append(f"{path}:{node.lineno}")
+        assert not offenders, f"pycentral imports found (SDK was removed): {offenders}"
+
+
+def _make_secrets(**overrides) -> CentralSecrets:
+    base = {
+        "base_url": "https://central.example.test",
+        "client_id": "central-client-id",
+        "client_secret": "central-client-secret",
+    }
+    base.update(overrides)
+    return CentralSecrets(**base)
+
+
+def _make_client(handler, token: str = "test-token") -> CentralClient:
+    """Build a CentralClient with a MockTransport and a primed token."""
+    client = CentralClient(_make_secrets())
+    client._http = httpx.AsyncClient(
+        base_url="https://central.example.test",
+        transport=httpx.MockTransport(handler),
+    )
+    client._tokens.prime(token, expires_in=3600)
+    return client
+
+
+@pytest.mark.unit
+class TestCommandContract:
+    async def test_returns_pycentral_shaped_dict(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"items": [1, 2]}, headers={"X-Request-Id": "abc"})
+
+        client = _make_client(handler)
+        resp = await client.command(api_method="GET", api_path="network-monitoring/v1/aps")
+        assert resp["code"] == 200
+        assert resp["msg"] == {"items": [1, 2]}
+        assert resp["headers"]["x-request-id"] == "abc"
+        await client.aclose()
+
+    async def test_non_json_body_returned_as_text(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(502, text="<html>bad gateway</html>")
+
+        client = _make_client(handler)
+        resp = await client.command(api_method="GET", api_path="x")
+        assert resp["code"] == 502
+        assert resp["msg"] == "<html>bad gateway</html>"
+        await client.aclose()
+
+    async def test_status_errors_not_raised(self):
+        """pycentral parity: 4xx/5xx come back in code, never raised."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"error": "not found"})
+
+        client = _make_client(handler)
+        resp = await client.command(api_method="GET", api_path="missing")
+        assert resp["code"] == 404
+        await client.aclose()
+
+    async def test_bearer_token_and_json_headers_sent(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler, token="tok-xyz")
+        await client.command(api_method="GET", api_path="network-monitoring/v1/aps")
+        request = captured[0]
+        assert request.headers["Authorization"] == "Bearer tok-xyz"
+        assert request.headers["Content-Type"] == "application/json"
+        assert request.headers["Accept"] == "application/json"
+        await client.aclose()
+
+    async def test_none_params_stripped(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.command(
+            api_method="GET",
+            api_path="network-monitoring/v1/aps",
+            api_params={"limit": 20, "filter": None, "sort": None},
+        )
+        assert captured[0].url.params.get("limit") == "20"
+        assert "filter" not in captured[0].url.params
+        assert "sort" not in captured[0].url.params
+        await client.aclose()
+
+    async def test_empty_body_not_sent(self):
+        """pycentral parity: api_data={} / None must not send a request body."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(202, json={})
+
+        client = _make_client(handler)
+        await client.command(api_method="POST", api_path="x", api_data={})
+        await client.command(api_method="POST", api_path="y", api_data=None)
+        assert captured[0].content == b""
+        assert captured[1].content == b""
+        await client.aclose()
+
+    async def test_dict_body_serialized_as_json(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.command(api_method="POST", api_path="x", api_data={"name": "HQ", "enabled": True})
+        assert json.loads(captured[0].content) == {"name": "HQ", "enabled": True}
+        await client.aclose()
+
+    async def test_path_appended_to_base_url(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.command(api_method="GET", api_path="network-monitoring/v1/sites-health")
+        assert str(captured[0].url) == "https://central.example.test/network-monitoring/v1/sites-health"
+        await client.aclose()
+
+
+@pytest.mark.unit
+class Test401Refresh:
+    async def test_401_refreshes_token_once_and_retries(self):
+        from hpe_networking_mcp.platforms._common.auth import TokenResult
+
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.headers["Authorization"])
+            if len(calls) == 1:
+                return httpx.Response(401, json={"error": "token expired"})
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(handler, token="stale-token")
+
+        async def fresh_fetch() -> TokenResult:
+            return TokenResult("fresh-token", expires_in=3600)
+
+        client._tokens._fetch = fresh_fetch
+        resp = await client.command(api_method="GET", api_path="x")
+        assert resp["code"] == 200
+        assert calls == ["Bearer stale-token", "Bearer fresh-token"]
+        await client.aclose()
+
+    async def test_second_401_returned_not_looped(self):
+        from hpe_networking_mcp.platforms._common.auth import TokenResult
+
+        count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal count
+            count += 1
+            return httpx.Response(401, json={"error": "still bad"})
+
+        client = _make_client(handler)
+
+        async def fetch() -> TokenResult:
+            return TokenResult("another-token", expires_in=3600)
+
+        client._tokens._fetch = fetch
+        resp = await client.command(api_method="GET", api_path="x")
+        assert resp["code"] == 401
+        assert count == 2  # original + exactly one retry
+        await client.aclose()
+
+
+@pytest.mark.unit
+class TestFactoriesAndHealth:
+    def test_create_connection_returns_client_without_network_io(self):
+        client = create_connection(_make_secrets())
+        assert isinstance(client, CentralClient)
+        assert client._tokens.token is None  # lazy: no token fetch at construction
+
+    async def test_health_check_true_on_200(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/network-monitoring/v1/sites-health"
+            assert request.url.params.get("limit") == "1"
+            return httpx.Response(200, json={"items": [], "total": 0})
+
+        client = _make_client(handler)
+        assert await client.health_check() is True
+        await client.aclose()
+
+    async def test_verify_connection_raises_runtime_error_on_failure(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, json={"error": "forbidden"})
+
+        client = _make_client(handler)
+        with pytest.raises(RuntimeError, match="connectivity check failed"):
+            await verify_connection(client)
+        await client.aclose()

--- a/tests/unit/test_central_disconnect_tools.py
+++ b/tests/unit/test_central_disconnect_tools.py
@@ -11,7 +11,7 @@ generic "Error calling tool" in code mode).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -28,7 +28,7 @@ def _ctx() -> MagicMock:
 
 
 class TestDisconnectBodies:
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_by_mac_on_ap_uses_user_mac_address(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_user_by_mac_on_ap,
@@ -41,7 +41,7 @@ class TestDisconnectBodies:
         assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserByMacAddress"
         assert kw["api_data"] == {"userMacAddress": "00:BD:3E:E4:8C:5D"}
 
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_by_network_uses_network_name(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_user_by_network,
@@ -53,7 +53,7 @@ class TestDisconnectBodies:
         assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserByNetwork"
         assert kw["api_data"] == {"networkName": "CORP-WIFI"}
 
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_by_mac_on_gateway_uses_client_mac_address(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_client_by_mac_on_gateway,
@@ -67,7 +67,7 @@ class TestDisconnectBodies:
         assert kw["api_path"] == "network-troubleshooting/v1/gateways/GW9/disconnectClientByMacAddress"
         assert kw["api_data"] == {"clientMacAddress": "aa:bb:cc:dd:ee:ff"}
 
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_all_on_ap_sends_empty_body(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_user_all_on_ap,
@@ -79,7 +79,7 @@ class TestDisconnectBodies:
         assert kw["api_path"] == "network-troubleshooting/v1/aps/CNT123/disconnectUserAll"
         assert kw["api_data"] == {}
 
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_all_on_gateway_sends_empty_body(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_client_all_on_gateway,
@@ -93,7 +93,7 @@ class TestDisconnectBodies:
 
 
 class TestCallErrorSurfacing:
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_non_2xx_raises_tool_error_with_detail(self, mock_cmd):
         """A 4xx body must surface as a ToolError carrying the real message —
         not be masked to a generic 'Error calling tool' in code mode."""
@@ -110,7 +110,7 @@ class TestCallErrorSurfacing:
         assert exc.value.args[0]["status_code"] == 400
         assert "Bad Request" in exc.value.args[0]["message"]
 
-    @patch(_CMD)
+    @patch(_CMD, new_callable=AsyncMock)
     async def test_upstream_exception_wrapped_as_tool_error(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.mrt_troubleshooting import (
             central_disconnect_user_by_mac_on_ap,

--- a/tests/unit/test_central_monitoring.py
+++ b/tests/unit/test_central_monitoring.py
@@ -1,6 +1,6 @@
 """Unit tests for central_get_aps empty-list contract.
 
-Pin the contract for issue #244: when ``MonitoringAPs.get_all_aps()`` returns
+Pin the contract for issue #244: when ``monitoring_api.get_all_aps()`` returns
 an empty result (None or []), ``central_get_aps`` must return ``[]`` so callers
 can iterate without ``None``-guards. Earlier behavior returned the human-string
 ``"No access points found matching the specified criteria."``, which broke
@@ -24,21 +24,21 @@ def _ctx() -> MagicMock:
 
 
 class TestCentralGetApsEmptyContract:
-    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.monitoring_api.get_all_aps", new_callable=AsyncMock)
     async def test_none_normalizes_to_empty_list(self, mock_get_all):
         from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
 
         mock_get_all.return_value = None
         assert await central_get_aps(_ctx()) == []
 
-    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.monitoring_api.get_all_aps", new_callable=AsyncMock)
     async def test_empty_list_passes_through_as_empty_list(self, mock_get_all):
         from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
 
         mock_get_all.return_value = []
         assert await central_get_aps(_ctx()) == []
 
-    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.monitoring_api.get_all_aps", new_callable=AsyncMock)
     async def test_populated_list_passes_through(self, mock_get_all):
         from hpe_networking_mcp.platforms.central.tools.monitoring import central_get_aps
 
@@ -46,7 +46,7 @@ class TestCentralGetApsEmptyContract:
         mock_get_all.return_value = sample
         assert await central_get_aps(_ctx()) == sample
 
-    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.MonitoringAPs.get_all_aps")
+    @patch("hpe_networking_mcp.platforms.central.tools.monitoring.monitoring_api.get_all_aps", new_callable=AsyncMock)
     async def test_sdk_exception_raises_tool_error(self, mock_get_all):
         """v3.2.1.0: SDK exceptions now raise ToolError(502) instead of
         returning an error string."""

--- a/tests/unit/test_central_mrt_ap_trend.py
+++ b/tests/unit/test_central_mrt_ap_trend.py
@@ -27,7 +27,7 @@ def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """Patch the module-level ``_get`` to record (path, params) and return {}."""
     captured: dict[str, Any] = {}
 
-    def fake_get(conn: Any, path: str, params: dict | None = None) -> dict:
+    async def fake_get(conn: Any, path: str, params: dict | None = None) -> dict:
         captured["path"] = path
         captured["params"] = params or {}
         return {}

--- a/tests/unit/test_central_retry.py
+++ b/tests/unit/test_central_retry.py
@@ -3,12 +3,12 @@
 Without backoff, all retries fire in <1s and a brief upstream flap (e.g. the
 degrading audit endpoint near its sunset) defeats every attempt. These tests
 pin the exponential backoff and the eventual-success behaviour, with
-``time.sleep`` patched so the suite stays fast.
+``asyncio.sleep`` patched so the suite stays fast.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -22,10 +22,9 @@ pytestmark = pytest.mark.unit
 
 
 def _conn(responses: list[dict]) -> MagicMock:
-    """A fake pycentral conn whose .command returns the given responses in order."""
+    """A fake CentralClient whose async .command returns the given responses in order."""
     conn = MagicMock()
-    conn.command.side_effect = responses
-    conn.logger = MagicMock()
+    conn.command = AsyncMock(side_effect=responses)
     return conn
 
 
@@ -39,8 +38,8 @@ class TestRetryBackoff:
         assert _retry_backoff_secs(5) == 5.0
         assert _retry_backoff_secs(10) == 5.0
 
-    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_transient_500_then_success(self, mock_sleep):
+    @patch("hpe_networking_mcp.platforms.central.utils.asyncio.sleep", new_callable=AsyncMock)
+    async def test_transient_500_then_success(self, mock_sleep):
         conn = _conn(
             [
                 {"code": 500, "msg": {"message": "flap"}},
@@ -48,34 +47,34 @@ class TestRetryBackoff:
                 {"code": 200, "msg": {"audits": [{"id": "x"}]}},
             ]
         )
-        resp = retry_central_command(conn, "GET", "network-services/v1/audits")
+        resp = await retry_central_command(conn, "GET", "network-services/v1/audits")
         assert resp["code"] == 200
         # rode out two flaps -> slept after attempts 1 and 2
         assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0]
 
-    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_429_is_retried_with_backoff(self, mock_sleep):
+    @patch("hpe_networking_mcp.platforms.central.utils.asyncio.sleep", new_callable=AsyncMock)
+    async def test_429_is_retried_with_backoff(self, mock_sleep):
         conn = _conn([{"code": 429, "msg": {}}, {"code": 200, "msg": {"ok": True}}])
-        resp = retry_central_command(conn, "GET", "network-monitoring/v1/devices/X")
+        resp = await retry_central_command(conn, "GET", "network-monitoring/v1/devices/X")
         assert resp["code"] == 200
         assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5]
 
-    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_exhausts_retries_then_raises_toolerror_without_sleeping_after_last(self, mock_sleep):
+    @patch("hpe_networking_mcp.platforms.central.utils.asyncio.sleep", new_callable=AsyncMock)
+    async def test_exhausts_retries_then_raises_toolerror_without_sleeping_after_last(self, mock_sleep):
         conn = _conn([{"code": 503, "msg": {"message": "down"}}] * 5)
         with pytest.raises(ToolError) as exc:
-            retry_central_command(conn, "GET", "network-services/v1/audits")
+            await retry_central_command(conn, "GET", "network-services/v1/audits")
         # exhaustion preserves the last transient code, not a generic 500
         assert exc.value.args[0]["status_code"] == 503
         assert "after 5 attempts" in exc.value.args[0]["message"]
         # 5 attempts -> sleeps after attempts 1..4 only (no sleep after the last)
         assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0, 2.0, 4.0]
 
-    @patch("hpe_networking_mcp.platforms.central.utils.time.sleep")
-    def test_4xx_raises_toolerror_immediately_no_sleep(self, mock_sleep):
+    @patch("hpe_networking_mcp.platforms.central.utils.asyncio.sleep", new_callable=AsyncMock)
+    async def test_4xx_raises_toolerror_immediately_no_sleep(self, mock_sleep):
         conn = _conn([{"code": 400, "msg": {"message": "bad"}}])
         with pytest.raises(ToolError) as exc:
-            retry_central_command(conn, "GET", "network-services/v1/audits")
+            await retry_central_command(conn, "GET", "network-services/v1/audits")
         # real 4xx code is preserved (not masked, not relabelled 502)
         assert exc.value.args[0]["status_code"] == 400
         assert "bad" in exc.value.args[0]["message"]

--- a/tests/unit/test_common_auth.py
+++ b/tests/unit/test_common_auth.py
@@ -212,6 +212,27 @@ class TestOAuth2ClientCredentials:
         with pytest.raises(AuthError, match="access_token"):
             await fetch()
 
+    async def test_basic_auth_style_uses_authorization_header(self):
+        """client_secret_basic: credentials in the Basic header, not the form body."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"access_token": "basic-tok", "expires_in": 900})
+
+        fetch = self._fetcher(handler, auth_style="basic")
+        result = await fetch()
+        assert result.token == "basic-tok"
+        request = captured[0]
+        assert request.headers["Authorization"].startswith("Basic ")
+        body = request.content.decode()
+        assert body == "grant_type=client_credentials"
+        assert "client_secret" not in body
+
+    def test_invalid_auth_style_raises_value_error(self):
+        with pytest.raises(ValueError, match="auth_style"):
+            oauth2_client_credentials("https://sso.example.com/t", "id", "sec", name="x", auth_style="header")
+
 
 @pytest.mark.unit
 class TestManagerWithOAuth2EndToEnd:

--- a/tests/unit/test_unavailable_platform_guards.py
+++ b/tests/unit/test_unavailable_platform_guards.py
@@ -51,27 +51,12 @@ class TestCentralUnavailableGuard:
         sentinel = object()
         assert get_central_conn(_ctx(central_conn=sentinel)) is sentinel
 
-    def test_retry_central_command_raises_503_when_conn_none(self) -> None:
+    async def test_retry_central_command_raises_503_when_conn_none(self) -> None:
         from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
         with pytest.raises(ToolError) as exc:
-            retry_central_command(None, "GET", "network-monitoring/v1/sites-health")
+            await retry_central_command(None, "GET", "network-monitoring/v1/sites-health")
         assert exc.value.args[0]["status_code"] == 503
-
-    def test_log_transport_error_does_not_crash_on_none_conn(self) -> None:
-        # The original handler dereferenced ``central_conn.logger`` and raised a
-        # second AttributeError when the conn was None. The safe logger must not.
-        from hpe_networking_mcp.platforms.central.utils import _log_transport_error
-
-        _log_transport_error(None, "transport error with no conn")  # must not raise
-
-    def test_log_transport_error_prefers_conn_logger(self) -> None:
-        from hpe_networking_mcp.platforms.central.utils import _log_transport_error
-
-        calls: list[str] = []
-        conn = SimpleNamespace(logger=SimpleNamespace(error=lambda msg: calls.append(msg)))
-        _log_transport_error(conn, "boom")
-        assert calls == ["boom"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Closes #464. Step 2 of the platform-standardization effort (References #466 — effort continues; per the release gate, no tag until all platforms are on the shared auth system).

Removes the pycentral SDK entirely and rebuilds the Central platform on `httpx.AsyncClient` + the shared `AsyncTokenManager` (#467).

### The client
- **`CentralClient`** mirrors pycentral 2.0a17's `command()` contract exactly — `{code, msg, headers}` return dict, JSON headers, `None`-param stripping, empty-body omission, one token refresh + retry on 401 — so the ~660 Central tools are untouched at the response-parsing layer. Verified against the SDK source line-by-line before writing.
- Token: same HPE SSO endpoint pycentral used, via a new `auth_style="basic"` (`client_secret_basic`) mode on the shared `oauth2_client_credentials` strategy. **Verified live** (the integration suite fetches real tokens). Unlike pycentral, expiry is tracked proactively from `expires_in`, and construction is lazy — pycentral did a blocking token fetch inside the lifespan handler.

### Async end-to-end (closes the event-loop blocking)
Previously every Central call blocked the loop. Now: `retry_central_command` / `paginated_fetch` / `fetch_site_data_parallel` / `build_scope_tree` are `async def` (~91 call sites across 35 files await them); `time.sleep` → `asyncio.sleep`; ThreadPoolExecutor → `asyncio.gather`; the `asyncio.to_thread` band-aids in `site_health_check`/`site_rf_check` are deleted. Retry layering also stops multiplying (pycentral's hidden 3-attempt transport retry under our 5-attempt wrapper is gone).

### SDK helper subset ported, not re-imagined
`platforms/central/monitoring_api.py` is a faithful async port of the helper subset we used: internal pagination loops (sites offset; aps/devices/clients integer-`next`), AP/gateway stats trend-merging, ping/traceroute/cable-test/show-commands initiate-and-poll flows, disconnect actions. Exception message formats are byte-identical — two call sites string-match them (e.g. the missing-client path).

### Bugs found and fixed along the way
- **Latent production bug**: `central_get_ap_stats`/`central_get_gateway_stats` passed `from_timestamp`/`to_timestamp` to SDK functions whose signatures only accept `start_time`/`end_time` — `TypeError` on every time-windowed stats call. Fixed; covered by the live suite.
- 13 MRT troubleshooting tools returned un-executed coroutines after the async flip (`return _post_action(...)` without await) — caught by an AST audit for un-awaited async calls run in the dev container.

### Guard rails
- `pycentral` removed from `pyproject.toml` (was pinned to alpha `2.0a17`).
- New permanent test `TestNoPycentralAnywhere` AST-scans `src/` and fails on any pycentral import — nothing can quietly depend on the SDK again.

## Tests

- New `tests/unit/test_central_client.py`: pycentral-compat contract (return shape, param/body semantics, headers, 401-refresh-once, second-401-not-looped, lazy construction, health probe).
- `client_secret_basic` coverage added to `test_common_auth.py`.
- Central fixtures converted to async mocks; live integration fixtures function-scoped (an `httpx.AsyncClient` cannot outlive its event loop).
- **Full suite in Docker: 1802 passed, 1 skipped — including live integration tests against a real tenant** (token fetch, WLAN/AP/site reads, pagination, time-windowed stats). ruff + format + mypy + bandit clean.

## Platform-standardization status after this PR

Shared auth adopters: UXI, Apstra, `_template`, **Central**. Remaining: ClearPass (#465), GreenLake, AOS8, Mist, Axis.