### PR TITLE
feat(clearpass)!: rebuild ClearPass on async httpx — remove pyclearpass SDK + full capability migration (v3.3.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.12.0] - 2026-06-11
+
+**Minor — ClearPass rebuilt on async httpx; pyclearpass SDK removed; full `capability=` migration.** Closes #441, #465. Step 3 of the platform-standardization effort (#466). No release/tag until the auth migration completes across all platforms.
+
+### Changed
+- **New `ClearPassClient`** (`platforms/clearpass/client.py`) replaces the pyclearpass SDK + `ClearPassTokenManager` + the `_send_request` monkey-patch. The response contract is pyclearpass-identical: decoded JSON with raw-text fallback, raw bytes for non-JSON accepts, and **error bodies returned, never raised**. Wire parity preserved down to pyclearpass's quirks: `""`-valued query params and top-level body keys are dropped, dict-valued params are compact-JSON encoded. Token lifecycle runs through the shared `AsyncTokenManager` (JSON `POST /oauth`, proactive 8-hour expiry tracking — the 403 storm after a token aged out structurally can't happen anymore); 401/403 auth-failure bodies trigger one refresh + replay, now first-class instead of monkey-patched.
+- **Every ClearPass call is now genuinely async** (closes #441): ~250 call sites across 36 files (35 tool modules + `site_health_check`) converted from sync SDK calls to `await client.request(...)`; the `clearpass_get` chokepoint (issue #126's isolation paid off) converted once for ~70 read sites; `asyncio.to_thread` band-aids removed.
+- **Full capability migration** (3/N of the annotation sequence): `_registry.py` on the shared `make_tool_decorator` factory; all 142 tools classified with `capability=` per the rubric (READ for reads, WRITE_DELETE for manage surfaces, OPERATIONAL+`enable_gated` for disruptive non-persistent actions like session disconnect/CoA, guest credential sends, and service start/stop). The derived `clearpass_write_delete` enable tag is byte-identical to the old hand-written tags — write gating is unchanged, and inline confirmation logic is untouched (the universal `requires_confirmation` gate lands in a later PR per the #415/#416 sequence).
+- `pyclearpass` removed from dependencies; permanent guard test (`TestNoPyclearpassAnywhere`) fails on any reappearing import. `server.py` lifespan now builds one lazy `clearpass_client` (replacing the `clearpass_config` + `clearpass_token_manager` pair); the health probe uses the client.
+
+### Fixed
+- **Several tools called pyclearpass methods that don't exist in the SDK** (e.g. `get_admin_user_by_admin_user_id`, `get_config_service_by_config_service_id`) — instant `AttributeError` on every invocation. Path-based calls fix them as a side effect.
+- Pre-existing hand-written endpoints that don't match the CPPM REST surface were **preserved verbatim** (behavior-preserving rebuild) and catalogued in #469 for live probing + fixes.
+
+### Tests
+- New `tests/unit/test_clearpass_client.py` (response contract incl. error-bodies-returned, auth-retry flow, token fetch, pyclearpass parity quirks) + updated health/visualizer/utils test fixtures to async mocks.
+- Full suite **1818 passed** in Docker; ruff + format + mypy + bandit clean. **Live-verified against a real CPPM**: token fetch, NAD/version reads (HAL envelope intact), and the 404-as-dict error contract.
+
 ## [3.3.11.0] - 2026-06-11
 
 **Minor — Central rebuilt on async httpx; pycentral SDK removed entirely.** Closes #464. Step 2 of the platform-standardization effort (#466). No release/tag until the auth migration completes across all platforms.

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ hpe-networking-mcp/
 │       ├── mist/                # 1037 Mist tools (spec-driven) + 2 prompts + API client
 │       ├── central/             # 660 Central tools + 12 prompts + API client
 │       ├── greenlake/           # 10 GreenLake tools + OAuth2 client
-│       ├── clearpass/           # 142 ClearPass tools + pyclearpass SDK client
+│       ├── clearpass/           # 142 ClearPass tools + async httpx client
 │       ├── apstra/              # 19 Apstra tools + async httpx client
 │       ├── axis/                # 25 Axis Atmos Cloud tools + httpx client (JWT bearer)
 │       ├── aos8/                # 48 AOS8 tools + 9 prompts + UIDARUBA session client

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1871,7 +1871,7 @@ All 10 GreenLake tools are read-only today. Write tools would follow the same ga
 
 ## Aruba ClearPass (142 tools)
 
-ClearPass tools use the `pyclearpass` SDK with OAuth2 client credentials. Write tools require
+ClearPass tools use an async httpx client with OAuth2 client credentials. Write tools require
 `ENABLE_CLEARPASS_WRITE_TOOLS=true`. Update/delete operations require user confirmation.
 
 ### Network Devices (4 read + 1 write)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.11.0"
+version = "3.3.12.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
@@ -31,8 +31,6 @@ dependencies = [
     "loguru>=0.7.3",
     # Tree data structure for Central scope hierarchy
     "treelib>=1.7.0",
-    # Aruba ClearPass API client
-    "pyclearpass>=1.0.0",
 ]
 
 [project.scripts]
@@ -95,7 +93,6 @@ disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
-    "pyclearpass.*",
     "fastmcp.tools.*",
 ]
 ignore_missing_imports = true

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -626,7 +626,7 @@ All GreenLake tools are read-only in v2.0. Use the standard dynamic-mode discove
 
 # ARUBA CLEARPASS (clearpass_* tools)
 
-ClearPass Policy Manager provides network access control (NAC), guest access management, device profiling, and policy enforcement. Tools use the pyclearpass SDK with OAuth2 client credentials authentication.
+ClearPass Policy Manager provides network access control (NAC), guest access management, device profiling, and policy enforcement. Tools use an async httpx client with OAuth2 client-credentials authentication.
 
 ## Starting a ClearPass Session
 No special ID resolution needed. ClearPass tools connect directly to the configured CPPM server. The API token is acquired automatically at startup.

--- a/src/hpe_networking_mcp/platforms/clearpass/_registry.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/_registry.py
@@ -1,62 +1,19 @@
-"""ClearPass tool registry -- module-level FastMCP holder + shared-registry shim.
+"""ClearPass tool registry — module-level FastMCP holder + shared-registry shim.
 
 Tool modules under ``platforms/clearpass/tools/`` decorate their functions with
-``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
-The shim mirrors the Apstra, Mist, and Central patterns: delegate to the real
-FastMCP decorator, merge the ``dynamic_managed`` tag so dynamic-mode
-``Visibility`` can hide individual tools, and record a ``ToolSpec`` into
-``REGISTRIES["clearpass"]`` so the three ClearPass meta-tools can dispatch by
-name at runtime.
+``@tool(...)`` (imported from here). The shim is built by the shared
+``make_tool_decorator`` factory — see ``platforms/_template/_registry.py`` for
+the canonical reference and ``docs/tool-annotation-rubric.md`` for how
+``capability=`` classifies a tool.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from fastmcp import FastMCP
 
-from hpe_networking_mcp.platforms._common.tool_registry import (
-    DYNAMIC_MANAGED_TAG,
-    ToolSpec,
-    record_tool,
-)
+from hpe_networking_mcp.platforms._common.tool_registry import make_tool_decorator
 
-# Set by platforms.clearpass.register_tools() before tool modules are imported.
+# Set by ``platforms.clearpass.register_tools()`` before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
 
-_PLATFORM = "clearpass"
-
-
-def _derive_category(func: Callable[..., Any]) -> str:
-    """Short module name as the registry category (e.g. ``sessions``)."""
-    module = getattr(func, "__module__", "")
-    return module.rsplit(".", 1)[-1] if "." in module else module
-
-
-def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
-        resolved_name: str = tool_kwargs.get("name") or func.__name__
-        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
-
-        record_tool(
-            ToolSpec(
-                name=resolved_name,
-                func=func,
-                platform=_PLATFORM,
-                category=_derive_category(func),
-                description=resolved_description,
-                tags=supplied_tags,
-            )
-        )
-
-        if mcp is None:
-            return func
-
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
-        return mcp.tool(**effective_kwargs)(func)
-
-    return decorator
+tool = make_tool_decorator("clearpass", lambda: mcp)

--- a/src/hpe_networking_mcp/platforms/clearpass/client.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/client.py
@@ -1,28 +1,46 @@
-"""ClearPass API session factory and helpers.
+"""ClearPass async API client (replaces the pyclearpass SDK).
 
-Unlike pycentral (single connection object), pyclearpass requires instantiating
-each API class independently — every class inherits ClearPassAPILogin.
+Tools obtain the client from the lifespan context via :func:`get_clearpass_client`.
 
-ClearPass OAuth2 tokens expire after 8 hours (28800s). pyclearpass only
-re-auths when its cached ``api_token`` is empty, so once the token ages out
-every subsequent call returns 403 Forbidden. We fix that by wrapping
-``_send_request`` on each API instance with a pycentral-style retry: on an
-auth failure, invalidate the cached token, fetch a fresh one, and replay the
-original request exactly once.
+The ``request()`` method preserves pyclearpass's response contract exactly —
+decoded JSON (dict/list) for JSON accepts with a raw-text fallback, raw bytes
+for non-JSON accepts, and **error bodies returned, never raised** (callers
+inspect ``{"status": 403, ...}`` dicts, exactly as they did against
+``ClearPassAPILogin._send_request``).
+
+Behavior intentionally mirrored from the previous pyclearpass-based layer:
+
+* OAuth2 client-credentials token from ``POST {server}/oauth`` with a JSON
+  body (ClearPass's token endpoint accepts JSON; this is what both
+  pyclearpass and our old ``ClearPassTokenManager`` sent).
+* ``Authorization: Bearer <token>`` + ``accept`` header per request.
+* On a 401/403 auth-failure body: invalidate, refresh, replay exactly once
+  (the behavior our ``_send_request`` monkey-patch added — now first-class).
+* ``verify_ssl`` honored from config (pyclearpass hardcoded ``False``; we
+  overrode it per-instance before).
+
+Tokens expire after 8 hours (28800 s); expiry is now tracked proactively from
+the token response via the shared :class:`AsyncTokenManager`, so the 403
+storm after a token aged out can no longer happen in the first place.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
 from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_context
 from loguru import logger
-from pyclearpass.common import ClearPassAPILogin
 
 from hpe_networking_mcp.config import ClearPassSecrets
+from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, AuthError, TokenResult
 from hpe_networking_mcp.utils.logging import mask_secret
+
+_REQUEST_TIMEOUT = 30.0
+_AUTH_TIMEOUT = 30.0
+_DEFAULT_TOKEN_TTL_SECS = 28800.0  # ClearPass default: 8 hours
 
 # ClearPass returns both 401 (invalid token) and 403 (insufficient perms /
 # expired client-credentials token). We retry on either since a stale token
@@ -30,35 +48,56 @@ from hpe_networking_mcp.utils.logging import mask_secret
 _AUTH_ERROR_STATUSES = frozenset({401, 403})
 
 
-class ClearPassAuthError(RuntimeError):
+class ClearPassAuthError(AuthError):
     """Raised when OAuth2 client-credentials authentication fails."""
 
 
-class ClearPassTokenManager:
-    """Acquires and caches ClearPass OAuth2 access tokens.
+def _is_auth_error(body: Any) -> bool:
+    """Detect a 401/403 auth-failure payload in a decoded response body.
 
-    The token is held until :meth:`invalidate` is called, at which point the
-    next :meth:`get_token` will fetch a fresh one from ``/oauth``.
+    ClearPass error bodies look like::
+
+        {"type": "...", "title": "Forbidden", "status": 403, "detail": "Forbidden"}
+    """
+    if not isinstance(body, dict):
+        return False
+    status = body.get("status")
+    return isinstance(status, int) and status in _AUTH_ERROR_STATUSES
+
+
+class ClearPassClient:
+    """Async ClearPass REST API client with pyclearpass-compatible responses.
+
+    Usage in tools::
+
+        client = await get_clearpass_client()
+        result = await client.request("get", "/guest", params={"limit": 25})
     """
 
     def __init__(self, config: ClearPassSecrets) -> None:
         self._config = config
-        self._token: str | None = None
+        self._tokens = AsyncTokenManager(self._fetch_token, name="ClearPass")
+        self._http = httpx.AsyncClient(
+            base_url=config.server,
+            verify=config.verify_ssl,
+            timeout=_REQUEST_TIMEOUT,
+        )
 
-    def get_token(self) -> str:
-        """Return the cached token, fetching a new one if none is held."""
-        if self._token is None:
-            self._refresh()
-        assert self._token is not None
-        return self._token
+    @property
+    def server(self) -> str:
+        """Return the configured ClearPass API base URL."""
+        return str(self._http.base_url)
 
-    def invalidate(self) -> None:
-        """Drop the cached token so the next ``get_token`` refreshes."""
-        self._token = None
+    async def aclose(self) -> None:
+        """Close the underlying httpx client. Called from ``server.py:lifespan``."""
+        await self._http.aclose()
 
-    def _refresh(self) -> None:
-        """Acquire a fresh access token via the client-credentials grant."""
-        url = f"{self._config.server}/oauth"
+    async def _fetch_token(self) -> TokenResult:
+        """Fetch strategy for :class:`AsyncTokenManager` — one ``/oauth`` POST.
+
+        Faithful port of the old ``ClearPassTokenManager._refresh`` (same JSON
+        body, same error messages).
+        """
         payload = {
             "grant_type": "client_credentials",
             "client_id": self._config.client_id,
@@ -66,12 +105,7 @@ class ClearPassTokenManager:
         }
         logger.info("ClearPass: requesting new OAuth2 access token")
         try:
-            response = httpx.post(
-                url,
-                json=payload,
-                verify=self._config.verify_ssl,
-                timeout=30.0,
-            )
+            response = await self._http.post("/oauth", json=payload, timeout=_AUTH_TIMEOUT)
         except httpx.HTTPError as e:
             raise ClearPassAuthError(f"ClearPass OAuth2 request failed: {e}") from e
 
@@ -88,147 +122,149 @@ class ClearPassTokenManager:
             detail = data.get("detail") or data.get("error_description") or data
             raise ClearPassAuthError(f"ClearPass OAuth2 response missing access_token: {detail}")
 
-        self._token = token
         logger.info("ClearPass: obtained token {}", mask_secret(token))
+        expires_in = float(data.get("expires_in", _DEFAULT_TOKEN_TTL_SECS))
+        return TokenResult(token=token, expires_in=expires_in)
 
+    @staticmethod
+    def _decode(response: httpx.Response, accept: str) -> Any:
+        """Mirror pyclearpass's response decoding exactly.
 
-def _is_auth_error(response: Any) -> bool:
-    """Detect a 401/403 auth-failure payload from pyclearpass.
+        JSON accepts: ``json.loads`` of the text with a raw-text fallback.
+        Anything else: raw bytes.
+        """
+        if "json" in accept:
+            try:
+                return json.loads(response.text)
+            except json.JSONDecodeError:
+                return response.text
+        return response.content
 
-    pyclearpass returns decoded dicts for JSON responses and raw text/bytes
-    otherwise. Error bodies look like::
-
-        {"type": "...", "title": "Forbidden", "status": 403, "detail": "Forbidden"}
-    """
-    if not isinstance(response, dict):
-        return False
-    status = response.get("status")
-    return isinstance(status, int) and status in _AUTH_ERROR_STATUSES
-
-
-_TOKEN_MANAGER_ATTR = "_hpe_token_manager"  # nosec B105 — attribute name, not a credential
-_PATCH_MARKER = "_hpe_auth_retry_patched"
-
-
-def _install_class_auth_retry() -> None:
-    """Patch :meth:`ClearPassAPILogin._send_request` once with refresh-on-auth-error.
-
-    pyclearpass API methods invoke ``ClearPassAPILogin._send_request(self, ...)``
-    directly against the class rather than the instance, so instance-level
-    monkey-patches never fire. We wrap the class method once at import time;
-    the wrapper looks up the token manager attached to each instance by
-    :func:`create_api_client` and uses it to refresh on 401/403.
-    """
-    if getattr(ClearPassAPILogin, _PATCH_MARKER, False):
-        return
-
-    original = ClearPassAPILogin._send_request
-
-    def send_with_retry(
-        self: ClearPassAPILogin,
-        url: str,
+    async def request(
+        self,
         method: str,
-        query: str = "",
-        content_response_type: str = "application/json",
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: Any = None,
+        accept: str = "application/json",
     ) -> Any:
-        response = original(self, url, method, query, content_response_type)
-        if not _is_auth_error(response):
-            return response
+        """Send an authenticated request; pyclearpass-compatible return contract.
 
-        token_manager: ClearPassTokenManager | None = getattr(self, _TOKEN_MANAGER_ATTR, None)
-        if token_manager is None:
-            return response
+        Args:
+            method: HTTP verb, lowercase or uppercase (``get``/``post``/...).
+            path: API path starting with ``/`` (e.g. ``/guest/{id}`` resolved),
+                appended to the configured server base URL.
+            params: Query-string parameters. pyclearpass parity: ``None`` and
+                ``""`` entries are dropped, and dict values are compact-JSON
+                encoded (how ClearPass ``filter`` params travel).
+            json_body: JSON request body (dict/list), omitted when ``None``.
+                pyclearpass parity: top-level ``""``-valued keys of dict
+                bodies are dropped before sending (``_remove_empty_keys``).
+            accept: ``accept`` header / response decoding mode.
+
+        Returns:
+            Decoded JSON (dict/list), raw text on JSON-decode failure, or raw
+            bytes for non-JSON accepts. **Error bodies are returned, not
+            raised** — callers inspect ``{"status": ..., "title": ...}`` dicts
+            exactly as they did with pyclearpass.
+
+        Raises:
+            ClearPassAuthError: When token acquisition itself fails.
+            httpx.HTTPError: On transport-level failures (connect, timeout).
+        """
+        token = await self._tokens.get_token()
+        body = await self._send(method, path, params, json_body, accept, token)
+        if not _is_auth_error(body):
+            return body
 
         logger.info(
             "ClearPass: auth error on {} {} — refreshing token and retrying once",
             method.upper(),
-            url,
+            path,
         )
-        token_manager.invalidate()
         try:
-            self.api_token = token_manager.get_token()
+            token = await self._tokens.refresh()
         except ClearPassAuthError as e:
             logger.warning("ClearPass: token refresh failed — {}", e)
-            return response
-        return original(self, url, method, query, content_response_type)
+            return body
+        return await self._send(method, path, params, json_body, accept, token)
 
-    ClearPassAPILogin._send_request = send_with_retry  # type: ignore[method-assign]
-    ClearPassAPILogin._hpe_auth_retry_patched = True  # type: ignore[attr-defined]
+    async def _send(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None,
+        json_body: Any,
+        accept: str,
+        token: str,
+    ) -> Any:
+        kwargs: dict[str, Any] = {
+            "headers": {
+                "Authorization": f"Bearer {token}",
+                "accept": accept,
+            }
+        }
+        if params:
+            cleaned = {k: v for k, v in params.items() if v is not None and v != ""}
+            kwargs["params"] = {
+                k: json.dumps(v, separators=(",", ":"), ensure_ascii=False) if isinstance(v, dict) else v
+                for k, v in cleaned.items()
+            }
+        if json_body is not None:
+            if isinstance(json_body, dict):
+                json_body = {k: v for k, v in json_body.items() if v != ""}
+            kwargs["json"] = json_body
+        response = await self._http.request(method.upper(), path, **kwargs)
+        return self._decode(response, accept)
+
+    async def health_check(self) -> bool:
+        """Probe credentials by acquiring a token. Returns True if it works."""
+        await self._tokens.get_token()
+        return True
 
 
-_install_class_auth_retry()
+def create_client(secrets: ClearPassSecrets) -> ClearPassClient:
+    """Build a new :class:`ClearPassClient` from config secrets.
 
-
-def create_api_client[T: ClearPassAPILogin](
-    api_class: type[T],
-    config: ClearPassSecrets,
-    token_manager: ClearPassTokenManager,
-) -> T:
-    """Create a pyclearpass API client wired up with the shared token manager.
-
-    The returned instance:
-      * uses the token manager's currently cached token
-      * honours ``config.verify_ssl`` (pyclearpass hardcodes ``False``)
-      * automatically refreshes the token and retries once on 401/403
-        (via the class-level :func:`_install_class_auth_retry` patch)
-
-    Args:
-        api_class: Any pyclearpass API class (e.g. ``ApiIdentities``).
-        config: ClearPass connection details from Docker secrets.
-        token_manager: Shared token manager for refresh-on-auth-error.
-
-    Returns:
-        Configured API class instance ready for calls.
+    Construction is cheap and non-blocking — the first API call triggers the
+    initial token fetch.
     """
-    instance = api_class(server=config.server, api_token=token_manager.get_token())
-    instance.verify_ssl = config.verify_ssl
-    setattr(instance, _TOKEN_MANAGER_ATTR, token_manager)
-    return instance
+    return ClearPassClient(secrets)
 
 
-async def get_clearpass_session[T: ClearPassAPILogin](api_class: type[T]) -> T:
-    """Get a pyclearpass API client from the lifespan context.
-
-    Usage in tools::
-
-        from pyclearpass.api_identities import ApiIdentities
-        client = await get_clearpass_session(ApiIdentities)
-        result = client.get_guest_by_guest_id(guest_id="42")
-
-    Args:
-        api_class: The pyclearpass API class to instantiate.
-
-    Returns:
-        Configured API client instance with auth-retry installed.
+async def get_clearpass_client() -> ClearPassClient:
+    """Retrieve the shared ClearPassClient from the lifespan context.
 
     Raises:
-        ToolError: If ClearPass is not configured or token acquisition fails.
+        ToolError: If ClearPass is not configured or the client is unavailable.
     """
     ctx = get_context()
-    config: ClearPassSecrets | None = ctx.lifespan_context.get("clearpass_config")
-    token_manager: ClearPassTokenManager | None = ctx.lifespan_context.get("clearpass_token_manager")
-
-    if config is None or token_manager is None:
+    client: ClearPassClient | None = ctx.lifespan_context.get("clearpass_client")
+    if client is None:
         raise ToolError(
             {
                 "status_code": 503,
-                "message": "ClearPass API session not available. Check your ClearPass credentials.",
+                "message": "ClearPass API client not available. Check your ClearPass credentials.",
             }
         )
+    return client
 
-    try:
-        token = token_manager.get_token()
-    except ClearPassAuthError as e:
-        raise ToolError(
-            {
-                "status_code": 503,
-                "message": f"ClearPass token refresh failed: {e}",
-            }
-        ) from e
 
-    logger.debug(
-        "ClearPass API request — server: {}, token: {}",
-        config.server,
-        mask_secret(token),
-    )
-    return create_api_client(api_class, config, token_manager)
+def format_http_error(exc: BaseException) -> dict[str, Any]:
+    """Shape any exception into a consistent dict for tool returns.
+
+    Surfaces status code and response body for ``httpx.HTTPStatusError``;
+    everything else falls back to a generic shape so call sites can use this
+    helper uniformly inside broad ``except Exception`` blocks. Same pattern
+    used by every other platform.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        text = exc.response.text[:500]
+        try:
+            body: Any = exc.response.json()
+        except (ValueError, json.JSONDecodeError):
+            body = text
+        return {"status_code": status, "message": str(exc), "body": body}
+    return {"status_code": 0, "message": str(exc), "body": None}

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/__init__.py
@@ -1,15 +1,8 @@
-from mcp.types import ToolAnnotations
+"""Tool modules for the Aruba ClearPass platform.
 
-READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
+Tools are classified with the ``capability=`` kwarg on the ``@tool`` decorator
+(see ``platforms/_common/annotations.py`` and ``docs/tool-annotation-rubric.md``).
+That single classification derives the MCP annotations, the
+``clearpass_write_delete`` enable tag, and the ``requires_confirmation`` gate
+tag — there are no hand-written ``ToolAnnotations`` constants.
+"""

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_audit_logs(
     ctx: Context,
     username: str,
@@ -24,17 +24,15 @@ async def clearpass_get_audit_logs(
         username: Admin username to retrieve audit logs for.
     """
     try:
-        from pyclearpass.api_logs import ApiLogs
-
-        client = await get_clearpass_session(ApiLogs)
-        return client.get_login_audit_by_name(name=username)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/login-audit/{username}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching audit logs: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_system_events(
     ctx: Context,
     filter: str | None = None,
@@ -57,18 +55,16 @@ async def clearpass_get_system_events(
     See: https://developer.arubanetworks.com/cppm/reference (Logs → /system-events)
     """
     try:
-        from pyclearpass.api_logs import ApiLogs
-
-        client = await get_clearpass_session(ApiLogs)
+        client = await get_clearpass_client()
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/system-event" + query)
+        return await clearpass_get(client, "/system-event" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching system events: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_insight_alerts(
     ctx: Context,
     alert_id: str | None = None,
@@ -94,22 +90,20 @@ async def clearpass_get_insight_alerts(
     https://developer.arubanetworks.com/cppm/reference (Insight → /alert)
     """
     try:
-        from pyclearpass.api_insight import ApiInsight
-
-        client = await get_clearpass_session(ApiInsight)
+        client = await get_clearpass_client()
         if alert_id:
-            return client.get_alert_by_id(id=alert_id)
+            return await client.request("get", f"/alert/{alert_id}")
         if name:
-            return client.get_alert_by_name(name=name)
+            return await client.request("get", f"/alert/{name}")
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
-        return clearpass_get(client, "/alert" + query)
+        return await clearpass_get(client, "/alert" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching insight alerts: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_insight_reports(
     ctx: Context,
     report_id: str | None = None,
@@ -135,22 +129,20 @@ async def clearpass_get_insight_reports(
     https://developer.arubanetworks.com/cppm/reference (Insight → /report)
     """
     try:
-        from pyclearpass.api_insight import ApiInsight
-
-        client = await get_clearpass_session(ApiInsight)
+        client = await get_clearpass_client()
         if report_id:
-            return client.get_report_by_id(id=report_id)
+            return await client.request("get", f"/report/{report_id}")
         if name:
-            return client.get_report_by_name(name=name)
+            return await client.request("get", f"/report/{name}")
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
-        return clearpass_get(client, "/report" + query)
+        return await clearpass_get(client, "/report" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching insight reports: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_endpoint_insights(
     ctx: Context,
     mac: str | None = None,
@@ -172,20 +164,15 @@ async def clearpass_get_endpoint_insights(
         to_time: End time for time-range query (ISO 8601 format, required with from_time).
     """
     try:
-        from pyclearpass.api_logs import ApiLogs
-
-        client = await get_clearpass_session(ApiLogs)
+        client = await get_clearpass_client()
         if mac:
-            return client.get_insight_endpoint_mac_by_mac(mac=mac)
+            return await client.request("get", f"/insight/endpoint/mac/{mac}")
         if ip:
-            return client.get_insight_endpoint_ip_by_ip(ip=ip)
+            return await client.request("get", f"/insight/endpoint/ip/{ip}")
         if ip_range:
-            return client.get_insight_endpoint_ip_range_by_ip_range(ip_range=ip_range)
+            return await client.request("get", f"/insight/endpoint/ip-range/{ip_range}")
         if from_time and to_time:
-            return client.get_insight_endpoint_time_range_by_from_time_to_time(
-                from_time=from_time,
-                to_time=to_time,
-            )
+            return await client.request("get", f"/insight/endpoint/time-range/{from_time}/{to_time}")
         raise ToolError(
             {
                 "status_code": 400,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_auth_sources(
     ctx: Context,
     auth_source_id: str | None = None,
@@ -36,13 +36,11 @@ async def clearpass_get_auth_sources(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if auth_source_id:
-            return client.get_auth_source_by_auth_source_id(auth_source_id=auth_source_id)
+            return await client.request("get", f"/auth-source/{auth_source_id}")
         if name:
-            return client.get_auth_source_name_by_name(name=name)
+            return await client.request("get", f"/auth-source/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -51,14 +49,14 @@ async def clearpass_get_auth_sources(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/auth-source" + query)
+        return await clearpass_get(client, "/auth-source" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching auth sources: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_auth_source_status(
     ctx: Context,
     auth_source_id: str,
@@ -72,17 +70,15 @@ async def clearpass_get_auth_source_status(
         auth_source_id: Numeric ID of the authentication source.
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        return client.get_auth_source_by_auth_source_id(auth_source_id=auth_source_id)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/auth-source/{auth_source_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching auth source status: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_test_auth_source(
     ctx: Context,
     auth_source_id: str,
@@ -97,10 +93,8 @@ async def clearpass_test_auth_source(
         auth_source_id: Numeric ID of the authentication source to test.
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        result = client.get_auth_source_by_auth_source_id(auth_source_id=auth_source_id)
+        client = await get_clearpass_client()
+        result = await client.request("get", f"/auth-source/{auth_source_id}")
         return {
             "auth_source": result,
             "note": "Actual connectivity testing (LDAP bind, AD join check) "
@@ -112,7 +106,7 @@ async def clearpass_test_auth_source(
         raise ToolError({"status_code": 502, "message": f"Error fetching auth source for testing: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_auth_methods(
     ctx: Context,
     auth_method_id: str | None = None,
@@ -137,13 +131,11 @@ async def clearpass_get_auth_methods(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if auth_method_id:
-            return client.get_auth_method_by_auth_method_id(auth_method_id=auth_method_id)
+            return await client.request("get", f"/auth-method/{auth_method_id}")
         if name:
-            return client.get_auth_method_name_by_name(name=name)
+            return await client.request("get", f"/auth-method/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -152,7 +144,7 @@ async def clearpass_get_auth_methods(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/auth-method" + query)
+        return await clearpass_get(client, "/auth-method" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_certificates(
     ctx: Context,
     certificate_id: str | None = None,
@@ -54,22 +54,20 @@ async def clearpass_get_certificates(
     (Certificate Authority → /certificate, /certificate/{id}, /certificate/{id}/chain)
     """
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
+        client = await get_clearpass_client()
         if certificate_id and chain:
-            return clearpass_get(client, f"/certificate/{certificate_id}/chain")
+            return await clearpass_get(client, f"/certificate/{certificate_id}/chain")
         if certificate_id:
-            return clearpass_get(client, f"/certificate/{certificate_id}")
+            return await clearpass_get(client, f"/certificate/{certificate_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/certificate" + query)
+        return await clearpass_get(client, "/certificate" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching CA certificates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_onboard_devices(
     ctx: Context,
     onboard_device_id: str | None = None,
@@ -103,13 +101,11 @@ async def clearpass_get_onboard_devices(
     See: https://developer.arubanetworks.com/cppm/reference (Certificate Authority → /onboard/device)
     """
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
+        client = await get_clearpass_client()
         if onboard_device_id:
-            return clearpass_get(client, f"/onboard/device/{onboard_device_id}")
+            return await clearpass_get(client, f"/onboard/device/{onboard_device_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/onboard/device" + query)
+        return await clearpass_get(client, "/onboard/device" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_trust_list(
     ctx: Context,
     cert_trust_list_id: str | None = None,
@@ -37,26 +37,20 @@ async def clearpass_get_trust_list(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
-
-        client = await get_clearpass_session(ApiPlatformCertificates)
+        client = await get_clearpass_client()
         if details_id:
-            return client.get_cert_trust_list_details_by_cert_trust_list_details_id(
-                cert_trust_list_details_id=details_id,
-            )
+            return await client.request("get", f"/cert-trust-list-details/{details_id}")
         if cert_trust_list_id:
-            return client.get_cert_trust_list_by_cert_trust_list_id(
-                cert_trust_list_id=cert_trust_list_id,
-            )
+            return await client.request("get", f"/cert-trust-list/{cert_trust_list_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/cert-trust-list" + query)
+        return await clearpass_get(client, "/cert-trust-list" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching trust list: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_client_certificates(
     ctx: Context,
     client_cert_id: str | None = None,
@@ -79,20 +73,18 @@ async def clearpass_get_client_certificates(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
-
-        client = await get_clearpass_session(ApiPlatformCertificates)
+        client = await get_clearpass_client()
         if client_cert_id:
-            return client.get_client_cert_by_client_cert_id(client_cert_id=client_cert_id)
+            return await client.request("get", f"/client-cert/{client_cert_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/client-cert" + query)
+        return await clearpass_get(client, "/client-cert" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching client certificates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_server_certificates(
     ctx: Context,
     service_id: str | None = None,
@@ -111,24 +103,19 @@ async def clearpass_get_server_certificates(
         service_name: Service name (required with server_uuid for lookup by name).
     """
     try:
-        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
-
-        client = await get_clearpass_session(ApiPlatformCertificates)
+        client = await get_clearpass_client()
         if service_id:
-            return client.get_server_cert_by_service_id(service_id=service_id)
+            return await client.request("get", f"/server-cert/{service_id}")
         if server_uuid and service_name:
-            return client.get_server_cert_name_by_server_uuid_service_name(
-                server_uuid=server_uuid,
-                service_name=service_name,
-            )
-        return clearpass_get(client, "/server-cert")
+            return await client.request("get", f"/server-cert/name/{server_uuid}/{service_name}")
+        return await clearpass_get(client, "/server-cert")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching server certificates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_service_certificates(
     ctx: Context,
     service_cert_id: str | None = None,
@@ -151,20 +138,18 @@ async def clearpass_get_service_certificates(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
-
-        client = await get_clearpass_session(ApiPlatformCertificates)
+        client = await get_clearpass_client()
         if service_cert_id:
-            return client.get_service_cert_by_service_cert_id(service_cert_id=service_cert_id)
+            return await client.request("get", f"/service-cert/{service_cert_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/service-cert" + query)
+        return await clearpass_get(client, "/service-cert" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching service certificates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_revocation_list(
     ctx: Context,
     revocation_list_id: str | None = None,
@@ -193,13 +178,11 @@ async def clearpass_get_revocation_list(
     See: https://developer.arubanetworks.com/cppm/reference (Platform Certificates → /revocation-list)
     """
     try:
-        from pyclearpass.api_platformcertificates import ApiPlatformCertificates
-
-        client = await get_clearpass_session(ApiPlatformCertificates)
+        client = await get_clearpass_client()
         if revocation_list_id:
-            return clearpass_get(client, f"/revocation-list/{revocation_list_id}")
+            return await clearpass_get(client, f"/revocation-list/{revocation_list_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/revocation-list" + query)
+        return await clearpass_get(client, "/revocation-list" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_onguard_activity(
     ctx: Context,
     activity_id: str | None = None,
@@ -46,22 +46,20 @@ async def clearpass_get_onguard_activity(
     See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /onguard-activity)
     """
     try:
-        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
-
-        client = await get_clearpass_session(ApiEndpointVisibility)
+        client = await get_clearpass_client()
         if activity_id:
-            return clearpass_get(client, f"/onguard-activity/{activity_id}")
+            return await clearpass_get(client, f"/onguard-activity/{activity_id}")
         if mac:
-            return clearpass_get(client, f"/onguard-activity/mac/{mac}")
+            return await clearpass_get(client, f"/onguard-activity/mac/{mac}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/onguard-activity" + query)
+        return await clearpass_get(client, "/onguard-activity" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching OnGuard activity: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_fingerprint_dictionary(
     ctx: Context,
     fingerprint_id: str | None = None,
@@ -91,20 +89,18 @@ async def clearpass_get_fingerprint_dictionary(
     See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /fingerprint-dictionary)
     """
     try:
-        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
-
-        client = await get_clearpass_session(ApiEndpointVisibility)
+        client = await get_clearpass_client()
         if fingerprint_id:
-            return clearpass_get(client, f"/fingerprint/{fingerprint_id}")
+            return await clearpass_get(client, f"/fingerprint/{fingerprint_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/fingerprint" + query)
+        return await clearpass_get(client, "/fingerprint" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching fingerprint dictionary: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_network_scan(
     ctx: Context,
     scan_id: str | None = None,
@@ -134,20 +130,18 @@ async def clearpass_get_network_scan(
     See: https://developer.arubanetworks.com/cppm/reference (Endpoint Visibility → /network-scan)
     """
     try:
-        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
-
-        client = await get_clearpass_session(ApiEndpointVisibility)
+        client = await get_clearpass_client()
         if scan_id:
-            return clearpass_get(client, f"/config/network-scan/{scan_id}")
+            return await clearpass_get(client, f"/config/network-scan/{scan_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/config/network-scan" + query)
+        return await clearpass_get(client, "/config/network-scan" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching network scans: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_onguard_settings(
     ctx: Context,
     global_settings: bool = False,
@@ -166,11 +160,9 @@ async def clearpass_get_onguard_settings(
     (Endpoint Visibility → /onguard/settings, /onguard/global-settings)
     """
     try:
-        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
-
-        client = await get_clearpass_session(ApiEndpointVisibility)
+        client = await get_clearpass_client()
         path = "/onguard/global-settings" if global_settings else "/onguard/settings"
-        return clearpass_get(client, path)
+        return await clearpass_get(client, path)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_endpoints(
     ctx: Context,
     endpoint_id: str | None = None,
@@ -41,13 +41,11 @@ async def clearpass_get_endpoints(
             details (DHCP, HTTP user-agent, device category). Off by default.
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if endpoint_id:
-            return client.get_endpoint_by_endpoint_id(endpoint_id=endpoint_id)
+            return await client.request("get", f"/endpoint/{endpoint_id}")
         if mac_address:
-            return client.get_endpoint_mac_address_by_mac_address(mac_address=mac_address)
+            return await client.request("get", f"/endpoint/mac-address/{mac_address}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -59,14 +57,14 @@ async def clearpass_get_endpoints(
             f"profile_details={'true' if profile_details else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/endpoint" + query)
+        return await clearpass_get(client, "/endpoint" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching endpoints: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_endpoint_profiler(
     ctx: Context,
     mac_or_ip: str,
@@ -80,10 +78,8 @@ async def clearpass_get_endpoint_profiler(
         mac_or_ip: MAC address or IP address of the endpoint to profile.
     """
     try:
-        from pyclearpass.api_endpointvisibility import ApiEndpointVisibility
-
-        client = await get_clearpass_session(ApiEndpointVisibility)
-        return client.get_device_profiler_device_fingerprint_by_mac_or_ip(mac_or_ip=mac_or_ip)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/device-profiler/device-fingerprint/{mac_or_ip}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_enforcement_policies(
     ctx: Context,
     policy_id: str | None = None,
@@ -39,13 +39,11 @@ async def clearpass_get_enforcement_policies(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if policy_id:
-            return client.get_enforcement_policy_by_enforcement_policy_id(enforcement_policy_id=policy_id)
+            return await client.request("get", f"/enforcement-policy/{policy_id}")
         if name:
-            return client.get_enforcement_policy_name_by_name(name=name)
+            return await client.request("get", f"/enforcement-policy/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -54,14 +52,14 @@ async def clearpass_get_enforcement_policies(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/enforcement-policy" + query)
+        return await clearpass_get(client, "/enforcement-policy" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching enforcement policies: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_enforcement_profiles(
     ctx: Context,
     profile_id: str | None = None,
@@ -89,13 +87,11 @@ async def clearpass_get_enforcement_profiles(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_enforcementprofile import ApiEnforcementProfile
-
-        client = await get_clearpass_session(ApiEnforcementProfile)
+        client = await get_clearpass_client()
         if profile_id:
-            return client.get_enforcement_profile_by_enforcement_profile_id(enforcement_profile_id=profile_id)
+            return await client.request("get", f"/enforcement-profile/{profile_id}")
         if name:
-            return client.get_enforcement_profile_name_by_name(name=name)
+            return await client.request("get", f"/enforcement-profile/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -104,14 +100,14 @@ async def clearpass_get_enforcement_profiles(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/enforcement-profile" + query)
+        return await clearpass_get(client, "/enforcement-profile" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching enforcement profiles: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_profile_templates(
     ctx: Context,
 ) -> dict | str:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_pass_templates(
     ctx: Context,
     template_id: str | None = None,
@@ -34,20 +34,18 @@ async def clearpass_get_pass_templates(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
         if template_id:
-            return client.get_template_pass_by_id(id=template_id)
+            return await client.request("get", f"/template/pass/{template_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/template/pass" + query)
+        return await clearpass_get(client, "/template/pass" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching pass templates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_print_templates(
     ctx: Context,
     template_id: str | None = None,
@@ -70,20 +68,18 @@ async def clearpass_get_print_templates(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
         if template_id:
-            return client.get_template_print_by_id(id=template_id)
+            return await client.request("get", f"/template/print/{template_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/template/print" + query)
+        return await clearpass_get(client, "/template/print" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching print templates: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_weblogin_pages(
     ctx: Context,
     page_id: str | None = None,
@@ -108,22 +104,20 @@ async def clearpass_get_weblogin_pages(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
         if page_id:
-            return client.get_weblogin_by_id(id=page_id)
+            return await client.request("get", f"/weblogin/{page_id}")
         if page_name:
-            return client.get_weblogin_page_name_by_page_name(page_name=page_name)
+            return await client.request("get", f"/weblogin/page-name/{page_name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/weblogin" + query)
+        return await clearpass_get(client, "/weblogin" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching web login pages: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_guest_auth_settings(
     ctx: Context,
 ) -> dict | str:
@@ -133,17 +127,15 @@ async def clearpass_get_guest_auth_settings(
     allowed authentication methods and session policies.
     """
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
-        return client.get_guest_authentication()
+        client = await get_clearpass_client()
+        return await client.request("get", "/guest/authentication")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching guest authentication settings: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_guest_manager_settings(
     ctx: Context,
 ) -> dict | str:
@@ -153,10 +145,8 @@ async def clearpass_get_guest_manager_settings(
     sponsor approval, and account lifetime policies.
     """
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
-        return client.get_guestmanager()
+        client = await get_clearpass_client()
+        return await client.request("get", "/guestmanager")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_guest_users(
     ctx: Context,
     guest_id: str | None = None,
@@ -36,13 +36,11 @@ async def clearpass_get_guest_users(
         limit: Max results per page (default 25). List mode only.
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if guest_id:
-            return client.get_guest_by_guest_id(guest_id=guest_id)
+            return await client.request("get", f"/guest/{guest_id}")
         if username:
-            return client.get_guest_username_by_username(username=username)
+            return await client.request("get", f"/guest/username/{username}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -51,7 +49,7 @@ async def clearpass_get_guest_users(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/guest" + query)
+        return await clearpass_get(client, "/guest" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_api_clients(
     ctx: Context,
     client_id: str | None = None,
@@ -34,20 +34,18 @@ async def clearpass_get_api_clients(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if client_id:
-            return client.get_api_client_by_client_id(client_id=client_id)
+            return await client.request("get", f"/api-client/{client_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/api-client" + query)
+        return await clearpass_get(client, "/api-client" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching API clients: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_local_users(
     ctx: Context,
     local_user_id: str | None = None,
@@ -73,22 +71,20 @@ async def clearpass_get_local_users(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if local_user_id:
-            return client.get_local_user_by_local_user_id(local_user_id=local_user_id)
+            return await client.request("get", f"/local-user/{local_user_id}")
         if user_id:
-            return client.get_local_user_user_id_by_user_id(user_id=user_id)
+            return await client.request("get", f"/local-user/user-id/{user_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/local-user" + query)
+        return await clearpass_get(client, "/local-user" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching local users: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_static_host_lists(
     ctx: Context,
     static_host_list_id: str | None = None,
@@ -113,24 +109,20 @@ async def clearpass_get_static_host_lists(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if static_host_list_id:
-            return client.get_static_host_list_by_static_host_list_id(
-                static_host_list_id=static_host_list_id,
-            )
+            return await client.request("get", f"/static-host-list/{static_host_list_id}")
         if name:
-            return client.get_static_host_list_name_by_name(name=name)
+            return await client.request("get", f"/static-host-list/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/static-host-list" + query)
+        return await clearpass_get(client, "/static-host-list" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching static host lists: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_devices(
     ctx: Context,
     device_id: str | None = None,
@@ -155,22 +147,20 @@ async def clearpass_get_devices(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if device_id:
-            return client.get_device_by_device_id(device_id=device_id)
+            return await client.request("get", f"/device/{device_id}")
         if macaddr:
-            return client.get_device_mac_by_macaddr(macaddr=macaddr)
+            return await client.request("get", f"/device/mac/{macaddr}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/device" + query)
+        return await clearpass_get(client, "/device" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching devices: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_deny_listed_users(
     ctx: Context,
     deny_listed_users_id: str | None = None,
@@ -193,22 +183,18 @@ async def clearpass_get_deny_listed_users(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if deny_listed_users_id:
-            return client.get_deny_listed_users_by_deny_listed_users_id(
-                deny_listed_users_id=deny_listed_users_id,
-            )
+            return await client.request("get", f"/deny-listed-users/{deny_listed_users_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/deny-listed-users" + query)
+        return await clearpass_get(client, "/deny-listed-users" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching deny-listed users: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_external_accounts(
     ctx: Context,
     external_account_id: str | None = None,
@@ -241,15 +227,13 @@ async def clearpass_get_external_accounts(
     See: https://developer.arubanetworks.com/cppm/reference (Identities → /external-account)
     """
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if external_account_id:
-            return clearpass_get(client, f"/external-account/{external_account_id}")
+            return await clearpass_get(client, f"/external-account/{external_account_id}")
         if name:
-            return clearpass_get(client, f"/external-account/name/{name}")
+            return await clearpass_get(client, f"/external-account/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/external-account" + query)
+        return await clearpass_get(client, "/external-account" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_extensions(
     ctx: Context,
     extension_id: str | None = None,
@@ -37,22 +37,20 @@ async def clearpass_get_extensions(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if extension_id and show_config:
-            return client.get_extension_instance_by_id_config(id=extension_id)
+            return await client.request("get", f"/extension/instance/{extension_id}/config")
         if extension_id:
-            return client.get_extension_instance_by_id(id=extension_id)
+            return await client.request("get", f"/extension/instance/{extension_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/extension/instance" + query)
+        return await clearpass_get(client, "/extension/instance" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching extensions: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_syslog_targets(
     ctx: Context,
     syslog_target_id: str | None = None,
@@ -75,20 +73,18 @@ async def clearpass_get_syslog_targets(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if syslog_target_id:
-            return client.get_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
+            return await client.request("get", f"/syslog-target/{syslog_target_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/syslog-target" + query)
+        return await clearpass_get(client, "/syslog-target" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching syslog targets: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_syslog_export_filters(
     ctx: Context,
     syslog_export_filter_id: str | None = None,
@@ -111,22 +107,18 @@ async def clearpass_get_syslog_export_filters(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if syslog_export_filter_id:
-            return client.get_syslog_export_filter_by_syslog_export_filter_id(
-                syslog_export_filter_id=syslog_export_filter_id,
-            )
+            return await client.request("get", f"/syslog-export-filter/{syslog_export_filter_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/syslog-export-filter" + query)
+        return await clearpass_get(client, "/syslog-export-filter" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching syslog export filters: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_event_sources(
     ctx: Context,
     event_sources_id: str | None = None,
@@ -149,20 +141,18 @@ async def clearpass_get_event_sources(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if event_sources_id:
-            return client.get_event_sources_by_event_sources_id(event_sources_id=event_sources_id)
+            return await client.request("get", f"/event-sources/{event_sources_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/event-sources" + query)
+        return await clearpass_get(client, "/event-sources" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching event sources: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_context_servers(
     ctx: Context,
     context_server_action_id: str | None = None,
@@ -185,22 +175,18 @@ async def clearpass_get_context_servers(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if context_server_action_id:
-            return client.get_context_server_action_by_context_server_action_id(
-                context_server_action_id=context_server_action_id,
-            )
+            return await client.request("get", f"/context-server-action/{context_server_action_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/context-server-action" + query)
+        return await clearpass_get(client, "/context-server-action" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching context server actions: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_endpoint_context_servers(
     ctx: Context,
     endpoint_context_server_id: str | None = None,
@@ -223,22 +209,18 @@ async def clearpass_get_endpoint_context_servers(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if endpoint_context_server_id:
-            return client.get_endpoint_context_server_by_endpoint_context_server_id(
-                endpoint_context_server_id=endpoint_context_server_id,
-            )
+            return await client.request("get", f"/endpoint-context-server/{endpoint_context_server_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/endpoint-context-server" + query)
+        return await clearpass_get(client, "/endpoint-context-server" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching endpoint context servers: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_extension_log(
     ctx: Context,
     extension_id: str,
@@ -256,13 +238,11 @@ async def clearpass_get_extension_log(
     See: https://developer.arubanetworks.com/cppm/reference (Integrations → /extension-instance/{id}/log)
     """
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         path = f"/extension-instance/{extension_id}/log"
         if tail is not None:
             path += f"?tail={tail}"
-        return clearpass_get(client, path)
+        return await clearpass_get(client, path)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_access_controls(
     ctx: Context,
     server_uuid: str,
@@ -26,22 +26,17 @@ async def clearpass_get_access_controls(
         resource_name: Specific resource name for single-item lookup.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if resource_name:
-            return client.get_server_access_control_by_server_uuid_resource_name(
-                server_uuid=server_uuid,
-                resource_name=resource_name,
-            )
-        return client.get_server_access_control_by_server_uuid(server_uuid=server_uuid)
+            return await client.request("get", f"/server/access-control/{server_uuid}/{resource_name}")
+        return await client.request("get", f"/server/access-control/{server_uuid}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching access controls: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_ad_domains(
     ctx: Context,
     server_uuid: str,
@@ -57,22 +52,17 @@ async def clearpass_get_ad_domains(
         netbios_name: NetBIOS name for single-domain lookup.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if netbios_name:
-            return client.get_ad_domain_by_server_uuid_netbios_name_netbios_name(
-                server_uuid=server_uuid,
-                netbios_name=netbios_name,
-            )
-        return client.get_ad_domain_by_server_uuid(server_uuid=server_uuid)
+            return await client.request("get", f"/ad-domain/{server_uuid}/netbios-name/{netbios_name}")
+        return await client.request("get", f"/ad-domain/{server_uuid}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching AD domains: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_server_version(
     ctx: Context,
     uuid: str | None = None,
@@ -86,14 +76,12 @@ async def clearpass_get_server_version(
         uuid: Cluster member UUID for specific server lookup.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if uuid:
-            return client.get_cluster_server_by_uuid(uuid=uuid)
+            return await client.request("get", f"/cluster/server/{uuid}")
         return {
-            "cppm_version": client.get_cppm_version(),
-            "server_version": client.get_server_version(),
+            "cppm_version": await client.request("get", "/cppm-version"),
+            "server_version": await client.request("get", "/server/version"),
         }
     except ToolError:
         raise
@@ -101,7 +89,7 @@ async def clearpass_get_server_version(
         raise ToolError({"status_code": 502, "message": f"Error fetching server version: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_fips_status(
     ctx: Context,
 ) -> dict | str:
@@ -110,17 +98,15 @@ async def clearpass_get_fips_status(
     Returns whether FIPS mode is enabled or disabled on the ClearPass server.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
-        return client.get_server_fips()
+        client = await get_clearpass_client()
+        return await client.request("get", "/server/fips")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching FIPS status: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_server_services(
     ctx: Context,
     server_uuid: str,
@@ -136,22 +122,17 @@ async def clearpass_get_server_services(
         service_name: Service name for single-service lookup.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if service_name:
-            return client.get_server_service_by_server_uuid_service_name(
-                server_uuid=server_uuid,
-                service_name=service_name,
-            )
-        return client.get_server_service_by_server_uuid(server_uuid=server_uuid)
+            return await client.request("get", f"/server/service/{server_uuid}/{service_name}")
+        return await client.request("get", f"/server/service/{server_uuid}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching server services: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_server_snmp(
     ctx: Context,
     server_uuid: str,
@@ -165,17 +146,15 @@ async def clearpass_get_server_snmp(
         server_uuid: UUID of the ClearPass server node.
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
-        return client.get_server_snmp_by_server_uuid(server_uuid=server_uuid)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/server/snmp/{server_uuid}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching server SNMP config: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_cluster_servers(
     ctx: Context,
 ) -> dict | str:
@@ -196,10 +175,8 @@ async def clearpass_get_cluster_servers(
     See: https://developer.arubanetworks.com/cppm/reference (Local Server Configuration → /server)
     """
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
-        return client.get_cluster_server()
+        client = await get_clearpass_client()
+        return await client.request("get", "/cluster/server")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _ALERT_ACTIONS = ("create", "update", "delete", "enable", "disable", "mute", "unmute")
 _REPORT_ACTIONS = ("create", "delete", "enable", "disable", "run")
@@ -28,7 +28,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_insight_alert(
     ctx: Context,
     action_type: Annotated[
@@ -64,21 +64,21 @@ async def clearpass_manage_insight_alert(
             return decline
 
     try:
-        from pyclearpass.api_insight import ApiInsight
-
-        client = await get_clearpass_session(ApiInsight)
-        return _execute_alert_action(client, action_type, payload, alert_id)
+        client = await get_clearpass_client()
+        return await _execute_alert_action(client, action_type, payload, alert_id)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing insight alert: {e}"}) from e
 
 
-def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str | None) -> dict | str:
+async def _execute_alert_action(
+    client: ClearPassClient, action_type: str, payload: dict, alert_id: str | None
+) -> dict | str:
     """Execute the resolved insight alert action.
 
     Args:
-        client: pyclearpass ApiInsight instance.
+        client: ClearPass API client.
         action_type: Alert operation to perform.
         payload: Configuration payload.
         alert_id: Alert ID for non-create actions.
@@ -87,25 +87,25 @@ def _execute_alert_action(client, action_type: str, payload: dict, alert_id: str
         API response dict or error string.
     """
     if action_type == "create":
-        return client._send_request("/alert", "post", query=payload)
+        return await client.request("post", "/alert", json_body=payload)
     if not alert_id:
         raise ToolError({"status_code": 400, "message": "alert_id is required for this action."})
     if action_type == "update":
-        return client._send_request(f"/alert/{alert_id}", "patch", query=payload)
+        return await client.request("patch", f"/alert/{alert_id}", json_body=payload)
     if action_type == "delete":
-        return client.delete_alert_by_id(id=alert_id)
+        return await client.request("delete", f"/alert/{alert_id}")
     if action_type == "enable":
-        return client.update_alert_by_id_enable(id=alert_id)
+        return await client.request("patch", f"/alert/{alert_id}/enable")
     if action_type == "disable":
-        return client.update_alert_by_id_disable(id=alert_id)
+        return await client.request("patch", f"/alert/{alert_id}/disable")
     if action_type == "mute":
-        return client._send_request(f"/alert/{alert_id}/mute", "patch", query={})
+        return await client.request("patch", f"/alert/{alert_id}/mute", json_body={})
     if action_type == "unmute":
-        return client._send_request(f"/alert/{alert_id}/unmute", "patch", query={})
+        return await client.request("patch", f"/alert/{alert_id}/unmute", json_body={})
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_insight_report(
     ctx: Context,
     action_type: Annotated[
@@ -141,21 +141,21 @@ async def clearpass_manage_insight_report(
             return decline
 
     try:
-        from pyclearpass.api_insight import ApiInsight
-
-        client = await get_clearpass_session(ApiInsight)
-        return _execute_report_action(client, action_type, payload, report_id)
+        client = await get_clearpass_client()
+        return await _execute_report_action(client, action_type, payload, report_id)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing insight report: {e}"}) from e
 
 
-def _execute_report_action(client, action_type: str, payload: dict, report_id: str | None) -> dict | str:
+async def _execute_report_action(
+    client: ClearPassClient, action_type: str, payload: dict, report_id: str | None
+) -> dict | str:
     """Execute the resolved insight report action.
 
     Args:
-        client: pyclearpass ApiInsight instance.
+        client: ClearPass API client.
         action_type: Report operation to perform.
         payload: Configuration payload.
         report_id: Report ID for non-create actions.
@@ -164,21 +164,21 @@ def _execute_report_action(client, action_type: str, payload: dict, report_id: s
         API response dict or error string.
     """
     if action_type == "create":
-        return client._send_request("/report", "post", query=payload)
+        return await client.request("post", "/report", json_body=payload)
     if not report_id:
         raise ToolError({"status_code": 400, "message": "report_id is required for this action."})
     if action_type == "delete":
-        return client.delete_report_by_id(id=report_id)
+        return await client.request("delete", f"/report/{report_id}")
     if action_type == "enable":
-        return client.update_report_by_id_enable(id=report_id)
+        return await client.request("patch", f"/report/{report_id}/enable")
     if action_type == "disable":
-        return client.update_report_by_id_disable(id=report_id)
+        return await client.request("patch", f"/report/{report_id}/disable")
     if action_type == "run":
-        return client.new_report_by_id_run(id=report_id)
+        return await client.request("post", f"/report/{report_id}/run")
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE, tags={"clearpass_write_delete"})
 async def clearpass_create_system_event(
     ctx: Context,
     source: Annotated[str, Field(description="Event source (e.g. 'MCP Server', 'Admin').")],
@@ -212,9 +212,7 @@ async def clearpass_create_system_event(
             return decline
 
     try:
-        from pyclearpass.api_logs import ApiLogs
-
-        client = await get_clearpass_session(ApiLogs)
+        client = await get_clearpass_client()
         payload = {
             "source": source,
             "level": level,
@@ -222,7 +220,7 @@ async def clearpass_create_system_event(
             "action": action,
             "description": description,
         }
-        return client._send_request("/system-event", "post", query=payload)
+        return await client.request("post", "/system-event", json_body=payload)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _SOURCE_ACTIONS = ("create", "update", "delete", "configure_backup", "configure_filters", "configure_radius_attrs")
 
@@ -27,7 +27,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_auth_source(
     ctx: Context,
     action_type: Annotated[
@@ -76,23 +76,21 @@ async def clearpass_manage_auth_source(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        return _execute_auth_source_action(client, action_type, payload, auth_source_id, name)
+        client = await get_clearpass_client()
+        return await _execute_auth_source_action(client, action_type, payload, auth_source_id, name)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing auth source: {e}"}) from e
 
 
-def _execute_auth_source_action(
-    client, action_type: str, payload: dict, auth_source_id: str | None, name: str | None
+async def _execute_auth_source_action(
+    client: ClearPassClient, action_type: str, payload: dict, auth_source_id: str | None, name: str | None
 ) -> dict | str:
     """Execute the resolved auth source action.
 
     Args:
-        client: pyclearpass ApiPolicyElements instance.
+        client: ClearPass API client.
         action_type: Operation to perform.
         payload: Configuration payload.
         auth_source_id: Auth source ID.
@@ -102,23 +100,23 @@ def _execute_auth_source_action(
         API response dict or error string.
     """
     if action_type == "create":
-        return client._send_request("/auth-source", "post", query=payload)
+        return await client.request("post", "/auth-source", json_body=payload)
 
     if not auth_source_id and not name:
         raise ToolError({"status_code": 400, "message": "Either auth_source_id or name is required for this action."})
 
     if action_type == "delete":
         if auth_source_id:
-            return client.delete_auth_source_by_auth_source_id(auth_source_id=auth_source_id)
-        return client.delete_auth_source_name_by_name(name=name)
+            return await client.request("delete", f"/auth-source/{auth_source_id}")
+        return await client.request("delete", f"/auth-source/name/{name}")
 
     # update, configure_backup, configure_filters, configure_radius_attrs — all PATCH
     if auth_source_id:
-        return client._send_request(f"/auth-source/{auth_source_id}", "patch", query=payload)
-    return client._send_request(f"/auth-source/name/{name}", "patch", query=payload)
+        return await client.request("patch", f"/auth-source/{auth_source_id}", json_body=payload)
+    return await client.request("patch", f"/auth-source/name/{name}", json_body=payload)
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_auth_method(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -153,24 +151,22 @@ async def clearpass_manage_auth_method(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/auth-method", "post", query=payload)
+            return await client.request("post", "/auth-method", json_body=payload)
         if not auth_method_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either auth_method_id or name is required for update/delete."}
             )
         if action_type == "update":
             if auth_method_id:
-                return client._send_request(f"/auth-method/{auth_method_id}", "patch", query=payload)
-            return client._send_request(f"/auth-method/name/{name}", "patch", query=payload)
+                return await client.request("patch", f"/auth-method/{auth_method_id}", json_body=payload)
+            return await client.request("patch", f"/auth-method/name/{name}", json_body=payload)
         # delete
         if auth_method_id:
-            return client.delete_auth_method_by_auth_method_id(auth_method_id=auth_method_id)
-        return client.delete_auth_method_name_by_name(name=name)
+            return await client.request("delete", f"/auth-method/{auth_method_id}")
+        return await client.request("delete", f"/auth-method/name/{name}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
@@ -20,9 +20,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 _CA_ACTIONS = (
     "import",
@@ -36,7 +36,7 @@ _CA_ACTIONS = (
 )
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_certificate_authority(
     ctx: Context,
     action_type: Annotated[
@@ -102,20 +102,18 @@ async def clearpass_manage_certificate_authority(
         return decline
 
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
+        client = await get_clearpass_client()
 
         if action_type == "import":
-            return client._send_request("/certificate/import", "post", query=payload)
+            return await client.request("post", "/certificate/import", json_body=payload)
         if action_type == "new":
-            return client._send_request("/certificate/new", "post", query=payload)
+            return await client.request("post", "/certificate/new", json_body=payload)
         if action_type == "request":
-            return client._send_request("/certificate/request", "post", query=payload)
+            return await client.request("post", "/certificate/request", json_body=payload)
         if action_type == "delete":
-            return client._send_request(f"/certificate/{certificate_id}", "delete")
+            return await client.request("delete", f"/certificate/{certificate_id}")
         # sign / revoke / reject / export
-        return client._send_request(f"/certificate/{certificate_id}/{action_type}", "post", query=payload)
+        return await client.request("post", f"/certificate/{certificate_id}/{action_type}", json_body=payload)
     except ToolError:
         raise
     except Exception as e:
@@ -125,7 +123,7 @@ async def clearpass_manage_certificate_authority(
 _ONBOARD_ACTIONS = ("update", "delete")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_onboard_device(
     ctx: Context,
     action_type: Annotated[
@@ -171,14 +169,12 @@ async def clearpass_manage_onboard_device(
         return decline
 
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
+        client = await get_clearpass_client()
         path = f"/onboard/device/{record_id}"
         if action_type == "delete":
-            return client._send_request(path, "delete")
+            return await client.request("delete", path)
         body: Any = payload if payload is not None else {}
-        return client._send_request(path, "patch", query=body)
+        return await client.request("patch", path, json_body=body)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _CERT_ACTIONS = (
     "import_trust_list",
@@ -33,7 +33,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} certificate '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_certificate(
     ctx: Context,
     action_type: Annotated[
@@ -93,18 +93,16 @@ async def clearpass_manage_certificate(
             return decline
 
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
-        return _execute_cert_action(client, action_type, payload, cert_id, server_uuid, service_name)
+        client = await get_clearpass_client()
+        return await _execute_cert_action(client, action_type, payload, cert_id, server_uuid, service_name)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing certificate: {e}"}) from e
 
 
-def _execute_cert_action(
-    client,
+async def _execute_cert_action(
+    client: ClearPassClient,
     action_type: str,
     payload: dict,
     cert_id: str | None,
@@ -114,7 +112,7 @@ def _execute_cert_action(
     """Execute the resolved certificate action.
 
     Args:
-        client: pyclearpass ApiCertificateAuthority instance.
+        client: ClearPassClient instance.
         action_type: Certificate operation to perform.
         payload: Certificate data payload.
         cert_id: Certificate ID for delete operations.
@@ -125,17 +123,17 @@ def _execute_cert_action(
         API response dict or error string.
     """
     if action_type == "import_trust_list":
-        return client._send_request("/cert-trust-list", "post", query=payload)
+        return await client.request("post", "/cert-trust-list", json_body=payload)
 
     if action_type == "delete_trust_list":
         if not cert_id:
             raise ToolError({"status_code": 400, "message": "cert_id is required for delete_trust_list."})
-        return client.delete_cert_trust_list_by_cert_trust_list_id(cert_trust_list_id=cert_id)
+        return await client.request("delete", f"/cert-trust-list/{cert_id}")
 
     if action_type == "delete_client_cert":
         if not cert_id:
             raise ToolError({"status_code": 400, "message": "cert_id is required for delete_client_cert."})
-        return client.delete_client_cert_by_client_cert_id(client_cert_id=cert_id)
+        return await client.request("delete", f"/client-cert/{cert_id}")
 
     if action_type in ("enable_server_cert", "disable_server_cert"):
         if not server_uuid or not service_name:
@@ -147,12 +145,12 @@ def _execute_cert_action(
             )
         action = "enable" if action_type == "enable_server_cert" else "disable"
         path = f"/server-cert/name/{server_uuid}/{service_name}/{action}"
-        return client._send_request(path, "patch", query={})
+        return await client.request("patch", path, json_body={})
 
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_create_csr(
     ctx: Context,
     payload: Annotated[
@@ -182,10 +180,8 @@ async def clearpass_create_csr(
             return decline
 
     try:
-        from pyclearpass.api_certificateauthority import ApiCertificateAuthority
-
-        client = await get_clearpass_session(ApiCertificateAuthority)
-        return client._send_request("/certificate/csr", "post", query=payload)
+        client = await get_clearpass_client()
+        return await client.request("post", "/certificate/csr", json_body=payload)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
@@ -9,12 +9,12 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_endpoint(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -54,12 +54,10 @@ async def clearpass_manage_endpoint(
             return decline
 
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/endpoint", "post", query=payload)
+            return await client.request("post", "/endpoint", json_body=payload)
 
         if not endpoint_id and not mac_address:
             raise ToolError(
@@ -68,13 +66,13 @@ async def clearpass_manage_endpoint(
 
         if action_type == "update":
             if endpoint_id:
-                return client._send_request(f"/endpoint/{endpoint_id}", "patch", query=payload)
-            return client._send_request(f"/endpoint/mac-address/{mac_address}", "patch", query=payload)
+                return await client.request("patch", f"/endpoint/{endpoint_id}", json_body=payload)
+            return await client.request("patch", f"/endpoint/mac-address/{mac_address}", json_body=payload)
 
         # delete
         if endpoint_id:
-            return client.delete_endpoint_by_endpoint_id(endpoint_id=endpoint_id)
-        return client.delete_endpoint_mac_address_by_mac_address(mac_address=mac_address)
+            return await client.request("delete", f"/endpoint/{endpoint_id}")
+        return await client.request("delete", f"/endpoint/mac-address/{mac_address}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
@@ -25,7 +25,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_enforcement_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -60,29 +60,27 @@ async def clearpass_manage_enforcement_policy(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/enforcement-policy", "post", query=payload)
+            return await client.request("post", "/enforcement-policy", json_body=payload)
         if not policy_id and not name:
             raise ToolError({"status_code": 400, "message": "Either policy_id or name is required for update/delete."})
         if action_type == "update":
             if policy_id:
-                return client._send_request(f"/enforcement-policy/{policy_id}", "patch", query=payload)
-            return client._send_request(f"/enforcement-policy/name/{name}", "patch", query=payload)
+                return await client.request("patch", f"/enforcement-policy/{policy_id}", json_body=payload)
+            return await client.request("patch", f"/enforcement-policy/name/{name}", json_body=payload)
         # delete
         if policy_id:
-            return client.delete_enforcement_policy_by_enforcement_policy_id(enforcement_policy_id=policy_id)
-        return client.delete_enforcement_policy_name_by_name(name=name)
+            return await client.request("delete", f"/enforcement-policy/{policy_id}")
+        return await client.request("delete", f"/enforcement-policy/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing enforcement policy: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_enforcement_profile(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -117,22 +115,20 @@ async def clearpass_manage_enforcement_profile(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/enforcement-profile", "post", query=payload)
+            return await client.request("post", "/enforcement-profile", json_body=payload)
         if not profile_id and not name:
             raise ToolError({"status_code": 400, "message": "Either profile_id or name is required for update/delete."})
         if action_type == "update":
             if profile_id:
-                return client._send_request(f"/enforcement-profile/{profile_id}", "patch", query=payload)
-            return client._send_request(f"/enforcement-profile/name/{name}", "patch", query=payload)
+                return await client.request("patch", f"/enforcement-profile/{profile_id}", json_body=payload)
+            return await client.request("patch", f"/enforcement-profile/name/{name}", json_body=payload)
         # delete
         if profile_id:
-            return client.delete_enforcement_profile_by_enforcement_profile_id(enforcement_profile_id=profile_id)
-        return client.delete_enforcement_profile_name_by_name(name=name)
+            return await client.request("delete", f"/enforcement-profile/{profile_id}")
+        return await client.request("delete", f"/enforcement-profile/name/{name}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
@@ -25,7 +25,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} guest config '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_pass_template(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -58,26 +58,24 @@ async def clearpass_manage_pass_template(
             return decline
 
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/template/pass", "post", query=payload)
+            return await client.request("post", "/template/pass", json_body=payload)
         if not template_id:
             raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
-            return client._send_request(f"/template/pass/{template_id}", "patch", query=payload)
+            return await client.request("patch", f"/template/pass/{template_id}", json_body=payload)
         if action_type == "replace":
-            return client._send_request(f"/template/pass/{template_id}", "put", query=payload)
-        return client.delete_template_pass_by_id(id=template_id)
+            return await client.request("put", f"/template/pass/{template_id}", json_body=payload)
+        return await client.request("delete", f"/template/pass/{template_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing pass template: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_print_template(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -109,26 +107,24 @@ async def clearpass_manage_print_template(
             return decline
 
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/template/print", "post", query=payload)
+            return await client.request("post", "/template/print", json_body=payload)
         if not template_id:
             raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
-            return client._send_request(f"/template/print/{template_id}", "patch", query=payload)
+            return await client.request("patch", f"/template/print/{template_id}", json_body=payload)
         if action_type == "replace":
-            return client._send_request(f"/template/print/{template_id}", "put", query=payload)
-        return client.delete_template_print_by_id(id=template_id)
+            return await client.request("put", f"/template/print/{template_id}", json_body=payload)
+        return await client.request("delete", f"/template/print/{template_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing print template: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_weblogin_page(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
@@ -162,31 +158,29 @@ async def clearpass_manage_weblogin_page(
             return decline
 
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/weblogin", "post", query=payload)
+            return await client.request("post", "/weblogin", json_body=payload)
         if not page_id and not page_name:
             raise ToolError(
                 {"status_code": 400, "message": "Either page_id or page_name is required for update/replace/delete."}
             )
         if action_type == "delete":
             if page_id:
-                return client.delete_weblogin_by_id(id=page_id)
-            return client.delete_weblogin_page_name_by_page_name(page_name=page_name)
+                return await client.request("delete", f"/weblogin/{page_id}")
+            return await client.request("delete", f"/weblogin/page-name/{page_name}")
         # update or replace
         path_suffix = f"/{page_id}" if page_id else f"/page-name/{page_name}"
         method = "patch" if action_type == "update" else "put"
-        return client._send_request(f"/weblogin{path_suffix}", method, query=payload)
+        return await client.request(method, f"/weblogin{path_suffix}", json_body=payload)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing weblogin page: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_guest_settings(
     ctx: Context,
     setting_type: Annotated[str, Field(description="Setting type: 'authentication' or 'manager'.")],
@@ -214,13 +208,11 @@ async def clearpass_manage_guest_settings(
             return decline
 
     try:
-        from pyclearpass.api_guestconfiguration import ApiGuestConfiguration
-
-        client = await get_clearpass_session(ApiGuestConfiguration)
+        client = await get_clearpass_client()
 
         if setting_type == "authentication":
-            return client._send_request("/guest/authentication", "patch", query=payload)
-        return client._send_request("/guestmanager", "patch", query=payload)
+            return await client.request("patch", "/guest/authentication", json_body=payload)
+        return await client.request("patch", "/guestmanager", json_body=payload)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
@@ -25,7 +25,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} guest '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_guest_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -57,31 +57,29 @@ async def clearpass_manage_guest_user(
             return decline
 
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/guest", "post", query=payload)
+            return await client.request("post", "/guest", json_body=payload)
         if not guest_id and not username:
             raise ToolError(
                 {"status_code": 400, "message": "Either guest_id or username is required for update/delete."}
             )
         if action_type == "update":
             if guest_id:
-                return client._send_request(f"/guest/{guest_id}", "patch", query=payload)
-            return client._send_request(f"/guest/username/{username}", "patch", query=payload)
+                return await client.request("patch", f"/guest/{guest_id}", json_body=payload)
+            return await client.request("patch", f"/guest/username/{username}", json_body=payload)
         # delete
         if guest_id:
-            return client.delete_guest_by_guest_id(guest_id=guest_id)
-        return client.delete_guest_username_by_username(username=username)
+            return await client.request("delete", f"/guest/{guest_id}")
+        return await client.request("delete", f"/guest/username/{username}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing guest user: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def clearpass_send_guest_credentials(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to send credentials for.")],
@@ -106,17 +104,15 @@ async def clearpass_send_guest_credentials(
             return decline
 
     try:
-        from pyclearpass.api_guestactions import ApiGuestActions
-
-        client = await get_clearpass_session(ApiGuestActions)
-        return client._send_request(f"/guest/{guest_id}/send-{delivery_method}", "post", query={})
+        client = await get_clearpass_client()
+        return await client.request("post", f"/guest/{guest_id}/send-{delivery_method}", json_body={})
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error sending guest credentials: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def clearpass_generate_guest_pass(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to generate pass for.")],
@@ -141,18 +137,16 @@ async def clearpass_generate_guest_pass(
             return decline
 
     try:
-        from pyclearpass.api_guestactions import ApiGuestActions
-
-        client = await get_clearpass_session(ApiGuestActions)
+        client = await get_clearpass_client()
         endpoint = "pass" if pass_type == "digital" else "receipt"  # nosec B105 — API path, not a password
-        return client._send_request(f"/guest/{guest_id}/{endpoint}", "post", query={})
+        return await client.request("post", f"/guest/{guest_id}/{endpoint}", json_body={})
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error generating guest pass: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_process_sponsor_action(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to process sponsor action for.")],
@@ -175,10 +169,8 @@ async def clearpass_process_sponsor_action(
             return decline
 
     try:
-        from pyclearpass.api_guestactions import ApiGuestActions
-
-        client = await get_clearpass_session(ApiGuestActions)
-        return client._send_request(f"/guest/{guest_id}/sponsor/{action}", "post", query={})
+        client = await get_clearpass_client()
+        return await client.request("post", f"/guest/{guest_id}/sponsor/{action}", json_body={})
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(
@@ -27,7 +27,7 @@ async def _confirm_write(
     return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_api_client(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -54,23 +54,21 @@ async def clearpass_manage_api_client(
     if decline:
         return decline
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/api-client", "post", query=payload)
+            return await client.request("post", "/api-client", json_body=payload)
         if not client_id:
             raise ToolError({"status_code": 400, "message": "client_id is required for update/delete."})
         if action_type == "update":
-            return client._send_request(f"/api-client/{client_id}", "patch", query=payload)
-        return client.delete_api_client_by_client_id(client_id=client_id)
+            return await client.request("patch", f"/api-client/{client_id}", json_body=payload)
+        return await client.request("delete", f"/api-client/{client_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing API client: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_local_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -99,28 +97,26 @@ async def clearpass_manage_local_user(
     if decline:
         return decline
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/local-user", "post", query=payload)
+            return await client.request("post", "/local-user", json_body=payload)
         if not local_user_id and not user_id:
             raise ToolError(
                 {"status_code": 400, "message": "Either local_user_id or user_id is required for update/delete."}
             )
         if action_type == "update":
             path = f"/local-user/{local_user_id}" if local_user_id else f"/local-user/user-id/{user_id}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if local_user_id:
-            return client.delete_local_user_by_local_user_id(local_user_id=local_user_id)
-        return client.delete_local_user_user_id_by_user_id(user_id=user_id)
+            return await client.request("delete", f"/local-user/{local_user_id}")
+        return await client.request("delete", f"/local-user/user-id/{user_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing local user: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_static_host_list(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -151,11 +147,9 @@ async def clearpass_manage_static_host_list(
     if decline:
         return decline
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/static-host-list", "post", query=payload)
+            return await client.request("post", "/static-host-list", json_body=payload)
         if not static_host_list_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either static_host_list_id or name is required for update/delete."}
@@ -164,17 +158,17 @@ async def clearpass_manage_static_host_list(
             path = (
                 f"/static-host-list/{static_host_list_id}" if static_host_list_id else f"/static-host-list/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if static_host_list_id:
-            return client.delete_static_host_list_by_static_host_list_id(static_host_list_id=static_host_list_id)
-        return client.delete_static_host_list_name_by_name(name=name)
+            return await client.request("delete", f"/static-host-list/{static_host_list_id}")
+        return await client.request("delete", f"/static-host-list/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing static host list: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_device(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -203,28 +197,26 @@ async def clearpass_manage_device(
     if decline:
         return decline
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/device", "post", query=payload)
+            return await client.request("post", "/device", json_body=payload)
         if not device_id and not macaddr:
             raise ToolError(
                 {"status_code": 400, "message": "Either device_id or macaddr is required for update/delete."}
             )
         if action_type == "update":
             path = f"/device/{device_id}" if device_id else f"/device/mac/{macaddr}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if device_id:
-            return client.delete_device_by_device_id(device_id=device_id)
-        return client.delete_device_mac_by_macaddr(macaddr=macaddr)
+            return await client.request("delete", f"/device/{device_id}")
+        return await client.request("delete", f"/device/mac/{macaddr}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing device: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_deny_listed_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create' or 'delete'.")],
@@ -248,14 +240,12 @@ async def clearpass_manage_deny_listed_user(
     if decline:
         return decline
     try:
-        from pyclearpass.api_identities import ApiIdentities
-
-        client = await get_clearpass_session(ApiIdentities)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/deny-listed-users", "post", query=payload)
+            return await client.request("post", "/deny-listed-users", json_body=payload)
         if not deny_listed_users_id:
             raise ToolError({"status_code": 400, "message": "deny_listed_users_id is required for delete."})
-        return client.delete_deny_listed_users_by_deny_listed_users_id(deny_listed_users_id=deny_listed_users_id)
+        return await client.request("delete", f"/deny-listed-users/{deny_listed_users_id}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(
@@ -27,7 +27,7 @@ async def _confirm_write(
     return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_extension(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'start', 'stop', 'restart', or 'delete'.")],
@@ -50,23 +50,21 @@ async def clearpass_manage_extension(
     if decline:
         return decline
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if action_type == "start":
-            return client.new_extension_instance_by_id_start(id=extension_id)
+            return await client.request("post", f"/extension/instance/{extension_id}/start")
         if action_type == "stop":
-            return client.new_extension_instance_by_id_stop(id=extension_id)
+            return await client.request("post", f"/extension/instance/{extension_id}/stop")
         if action_type == "restart":
-            return client.new_extension_instance_by_id_restart(id=extension_id)
-        return client.delete_extension_instance_by_id(id=extension_id)
+            return await client.request("post", f"/extension/instance/{extension_id}/restart")
+        return await client.request("delete", f"/extension/instance/{extension_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing extension: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_syslog_target(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -95,28 +93,26 @@ async def clearpass_manage_syslog_target(
     if decline:
         return decline
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/syslog-target", "post", query=payload)
+            return await client.request("post", "/syslog-target", json_body=payload)
         if not syslog_target_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either syslog_target_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/syslog-target/{syslog_target_id}" if syslog_target_id else f"/syslog-target/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if syslog_target_id:
-            return client.delete_syslog_target_by_syslog_target_id(syslog_target_id=syslog_target_id)
-        return client._send_request(f"/syslog-target/name/{name}", "delete")
+            return await client.request("delete", f"/syslog-target/{syslog_target_id}")
+        return await client.request("delete", f"/syslog-target/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing syslog target: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_syslog_export_filter(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -147,11 +143,9 @@ async def clearpass_manage_syslog_export_filter(
     if decline:
         return decline
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/syslog-export-filter", "post", query=payload)
+            return await client.request("post", "/syslog-export-filter", json_body=payload)
         if not syslog_export_filter_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either syslog_export_filter_id or name is required for update/delete."}
@@ -162,19 +156,17 @@ async def clearpass_manage_syslog_export_filter(
                 if syslog_export_filter_id
                 else f"/syslog-export-filter/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if syslog_export_filter_id:
-            return client.delete_syslog_export_filter_by_syslog_export_filter_id(
-                syslog_export_filter_id=syslog_export_filter_id
-            )
-        return client._send_request(f"/syslog-export-filter/name/{name}", "delete")
+            return await client.request("delete", f"/syslog-export-filter/{syslog_export_filter_id}")
+        return await client.request("delete", f"/syslog-export-filter/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing syslog export filter: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_endpoint_context_server(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', or 'trigger_poll'.")],
@@ -205,11 +197,9 @@ async def clearpass_manage_endpoint_context_server(
     if decline:
         return decline
     try:
-        from pyclearpass.api_integrations import ApiIntegrations
-
-        client = await get_clearpass_session(ApiIntegrations)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/endpoint-context-server", "post", query=payload)
+            return await client.request("post", "/endpoint-context-server", json_body=payload)
         if not endpoint_context_server_id and not name:
             raise ToolError({"status_code": 400, "message": "Either endpoint_context_server_id or name is required."})
         if action_type == "update":
@@ -218,18 +208,14 @@ async def clearpass_manage_endpoint_context_server(
                 if endpoint_context_server_id
                 else f"/endpoint-context-server/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if not endpoint_context_server_id:
             raise ToolError(
                 {"status_code": 400, "message": "endpoint_context_server_id is required for delete/trigger_poll."}
             )
         if action_type == "trigger_poll":
-            return client.update_endpoint_context_server_by_endpoint_context_server_id_trigger_poll(
-                endpoint_context_server_id=endpoint_context_server_id
-            )
-        return client.delete_endpoint_context_server_by_endpoint_context_server_id(
-            endpoint_context_server_id=endpoint_context_server_id
-        )
+            return await client.request("patch", f"/endpoint-context-server/{endpoint_context_server_id}/trigger-poll")
+        return await client.request("delete", f"/endpoint-context-server/{endpoint_context_server_id}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(
@@ -27,7 +27,7 @@ async def _confirm_write(
     return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_access_control(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'update' or 'delete'.")],
@@ -53,21 +53,19 @@ async def clearpass_manage_access_control(
     if decline:
         return decline
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "update":
-            return client._send_request(f"/server/access-control/{server_uuid}/{resource_name}", "patch", query=payload)
-        return client.delete_server_access_control_by_server_uuid_resource_name(
-            server_uuid=server_uuid, resource_name=resource_name
-        )
+            return await client.request(
+                "patch", f"/server/access-control/{server_uuid}/{resource_name}", json_body=payload
+            )
+        return await client.request("delete", f"/server/access-control/{server_uuid}/{resource_name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing access control: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_ad_domain(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'join', 'leave', or 'configure_password_servers'.")],
@@ -96,17 +94,15 @@ async def clearpass_manage_ad_domain(
     if decline:
         return decline
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "join":
-            return client._send_request(f"/ad-domain/{server_uuid}/join", "put", query=payload)
+            return await client.request("put", f"/ad-domain/{server_uuid}/join", json_body=payload)
         if action_type == "leave":
-            return client._send_request(f"/ad-domain/{server_uuid}/leave", "put", query=payload)
+            return await client.request("put", f"/ad-domain/{server_uuid}/leave", json_body=payload)
         if not netbios_name:
             raise ToolError({"status_code": 400, "message": "netbios_name is required for configure_password_servers."})
-        return client._send_request(
-            f"/ad-domain/{server_uuid}/netbios-name/{netbios_name}/password-servers", "patch", query=payload
+        return await client.request(
+            "patch", f"/ad-domain/{server_uuid}/netbios-name/{netbios_name}/password-servers", json_body=payload
         )
     except ToolError:
         raise
@@ -114,7 +110,7 @@ async def clearpass_manage_ad_domain(
         raise ToolError({"status_code": 502, "message": f"Error managing AD domain: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_cluster_server(
     ctx: Context,
     server_uuid: Annotated[str, Field(description="Server UUID to update.")],
@@ -132,17 +128,15 @@ async def clearpass_manage_cluster_server(
     if decline:
         return decline
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
-        return client._send_request(f"/cluster/server/{server_uuid}", "patch", query=payload)
+        client = await get_clearpass_client()
+        return await client.request("patch", f"/cluster/server/{server_uuid}", json_body=payload)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing cluster server: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def clearpass_manage_server_service(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'start' or 'stop'.")],
@@ -166,23 +160,17 @@ async def clearpass_manage_server_service(
     if decline:
         return decline
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "start":
-            return client.update_server_service_by_server_uuid_service_name_start(
-                server_uuid=server_uuid, service_name=service_name
-            )
-        return client.update_server_service_by_server_uuid_service_name_stop(
-            server_uuid=server_uuid, service_name=service_name
-        )
+            return await client.request("patch", f"/server/service/{server_uuid}/{service_name}/start")
+        return await client.request("patch", f"/server/service/{server_uuid}/{service_name}/stop")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing server service: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_service_params(
     ctx: Context,
     server_uuid: Annotated[str, Field(description="UUID of the ClearPass server node.")],
@@ -232,11 +220,8 @@ async def clearpass_manage_service_params(
     if decline:
         return decline
     try:
-        from pyclearpass.api_localserverconfiguration import ApiLocalServerConfiguration
-
-        client = await get_clearpass_session(ApiLocalServerConfiguration)
-        path = f"/server/{server_uuid}/service/{service_id}"
-        return client._send_request(path, "patch", query=param_values)
+        client = await get_clearpass_client()
+        return await client.request("patch", f"/server/{server_uuid}/service/{service_id}", json_body=param_values)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _VALID_ACTIONS = (
     "create",
@@ -25,11 +25,11 @@ _VALID_ACTIONS = (
 )
 
 
-async def _resolve_device_id(client, device_id: str | None, name: str | None) -> str | None:
+async def _resolve_device_id(client: ClearPassClient, device_id: str | None, name: str | None) -> str | None:
     """Resolve a network device ID from device_id or name.
 
     Args:
-        client: pyclearpass ApiPolicyElements instance.
+        client: ClearPass API client.
         device_id: Numeric device ID (returned as-is if provided).
         name: Device name to look up.
 
@@ -39,7 +39,7 @@ async def _resolve_device_id(client, device_id: str | None, name: str | None) ->
     if device_id:
         return device_id
     if name:
-        result = client.get_network_device_name_by_name(name=name)
+        result = await client.request("get", f"/network-device/name/{name}")
         if isinstance(result, dict) and "id" in result:
             return str(result["id"])
     return None
@@ -56,7 +56,7 @@ async def _confirm_action(ctx: Context, action_type: str, device_id: str | None,
     return await confirm_write(ctx, f"ClearPass: {action_type} network device '{identifier}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_network_device(
     ctx: Context,
     action_type: Annotated[
@@ -106,9 +106,7 @@ async def clearpass_manage_network_device(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         return await _execute_device_action(client, action_type, payload, device_id, name, source_device_id)
     except ToolError:
         raise
@@ -117,12 +115,17 @@ async def clearpass_manage_network_device(
 
 
 async def _execute_device_action(
-    client, action_type: str, payload: dict, device_id: str | None, name: str | None, source_device_id: str | None
+    client: ClearPassClient,
+    action_type: str,
+    payload: dict,
+    device_id: str | None,
+    name: str | None,
+    source_device_id: str | None,
 ) -> dict | str:
     """Execute the resolved network device action.
 
     Args:
-        client: pyclearpass ApiPolicyElements instance.
+        client: ClearPass API client.
         action_type: Operation to perform.
         payload: Configuration payload.
         device_id: Device ID for update/delete/configure.
@@ -133,28 +136,28 @@ async def _execute_device_action(
         API response dict or error string.
     """
     if action_type == "create":
-        return client._send_request("/network-device", "post", query=payload)
+        return await client.request("post", "/network-device", json_body=payload)
 
     if action_type == "clone":
         if not source_device_id:
             raise ToolError({"status_code": 400, "message": "source_device_id is required for clone action."})
-        source = client.get_network_device_by_network_device_id(network_device_id=source_device_id)
+        source = await client.request("get", f"/network-device/{source_device_id}")
         if not isinstance(source, dict):
             raise ToolError({"status_code": 404, "message": f"Failed to retrieve source device {source_device_id}."})
         source.pop("id", None)
         source.update(payload)
-        return client._send_request("/network-device", "post", query=source)
+        return await client.request("post", "/network-device", json_body=source)
 
     resolved_id = await _resolve_device_id(client, device_id, name)
     if not resolved_id and action_type == "delete" and name:
-        return client.delete_network_device_name_by_name(name=name)
+        return await client.request("delete", f"/network-device/name/{name}")
     if not resolved_id:
         raise ToolError({"status_code": 400, "message": "Either device_id or name is required for this action."})
 
     if action_type == "update":
-        return client._send_request(f"/network-device/{resolved_id}", "patch", query=payload)
+        return await client.request("patch", f"/network-device/{resolved_id}", json_body=payload)
     if action_type == "delete":
-        return client.delete_network_device_by_network_device_id(network_device_id=resolved_id)
+        return await client.request("delete", f"/network-device/{resolved_id}")
 
     # configure_snmp, configure_radsec, configure_cli, configure_onconnect
-    return client._send_request(f"/network-device/{resolved_id}", "patch", query=payload)
+    return await client.request("patch", f"/network-device/{resolved_id}", json_body=payload)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(
@@ -27,7 +27,7 @@ async def _confirm_write(
     return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_service(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', 'enable', or 'disable'.")],
@@ -54,35 +54,33 @@ async def clearpass_manage_service(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/config/service", "post", query=payload)
+            return await client.request("post", "/config/service", json_body=payload)
         if not config_service_id and not name:
             raise ToolError({"status_code": 400, "message": "Either config_service_id or name is required."})
         if action_type == "update":
             path = f"/config/service/{config_service_id}" if config_service_id else f"/config/service/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if action_type == "enable":
             if not config_service_id:
                 raise ToolError({"status_code": 400, "message": "config_service_id is required for enable."})
-            return client.update_config_service_by_config_service_id_enable(config_service_id=config_service_id)
+            return await client.request("patch", f"/config/service/{config_service_id}/enable")
         if action_type == "disable":
             if not config_service_id:
                 raise ToolError({"status_code": 400, "message": "config_service_id is required for disable."})
-            return client.update_config_service_by_config_service_id_disable(config_service_id=config_service_id)
+            return await client.request("patch", f"/config/service/{config_service_id}/disable")
         # delete
         if config_service_id:
-            return client.delete_config_service_by_config_service_id(config_service_id=config_service_id)
-        return client.delete_config_service_name_by_name(name=name)
+            return await client.request("delete", f"/config/service/{config_service_id}")
+        return await client.request("delete", f"/config/service/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing service: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_device_group(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -113,11 +111,9 @@ async def clearpass_manage_device_group(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/network-device-group", "post", query=payload)
+            return await client.request("post", "/network-device-group", json_body=payload)
         if not network_device_group_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either network_device_group_id or name is required for update/delete."}
@@ -128,19 +124,17 @@ async def clearpass_manage_device_group(
                 if network_device_group_id
                 else f"/network-device-group/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if network_device_group_id:
-            return client.delete_network_device_group_by_network_device_group_id(
-                network_device_group_id=network_device_group_id
-            )
-        return client.delete_network_device_group_name_by_name(name=name)
+            return await client.request("delete", f"/network-device-group/{network_device_group_id}")
+        return await client.request("delete", f"/network-device-group/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing device group: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_posture_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -171,28 +165,26 @@ async def clearpass_manage_posture_policy(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/posture-policy", "post", query=payload)
+            return await client.request("post", "/posture-policy", json_body=payload)
         if not posture_policy_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either posture_policy_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/posture-policy/{posture_policy_id}" if posture_policy_id else f"/posture-policy/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if posture_policy_id:
-            return client.delete_posture_policy_by_posture_policy_id(posture_policy_id=posture_policy_id)
-        return client.delete_posture_policy_name_by_name(name=name)
+            return await client.request("delete", f"/posture-policy/{posture_policy_id}")
+        return await client.request("delete", f"/posture-policy/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing posture policy: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_proxy_target(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -221,28 +213,26 @@ async def clearpass_manage_proxy_target(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/proxy-target", "post", query=payload)
+            return await client.request("post", "/proxy-target", json_body=payload)
         if not proxy_target_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either proxy_target_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/proxy-target/{proxy_target_id}" if proxy_target_id else f"/proxy-target/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if proxy_target_id:
-            return client.delete_proxy_target_by_proxy_target_id(proxy_target_id=proxy_target_id)
-        return client.delete_proxy_target_name_by_name(name=name)
+            return await client.request("delete", f"/proxy-target/{proxy_target_id}")
+        return await client.request("delete", f"/proxy-target/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing proxy target: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_radius_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'delete', 'enable', or 'disable'.")],
@@ -271,11 +261,9 @@ async def clearpass_manage_radius_dictionary(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/radius-dictionary", "post", query=payload)
+            return await client.request("post", "/radius-dictionary", json_body=payload)
         if not radius_dictionary_id and not name:
             raise ToolError({"status_code": 400, "message": "Either radius_dictionary_id or name is required."})
         if action_type == "update":
@@ -284,30 +272,26 @@ async def clearpass_manage_radius_dictionary(
                 if radius_dictionary_id
                 else f"/radius-dictionary/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if action_type == "enable":
             if not radius_dictionary_id:
                 raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for enable."})
-            return client.update_radius_dictionary_by_radius_dictionary_id_enable(
-                radius_dictionary_id=radius_dictionary_id
-            )
+            return await client.request("patch", f"/radius-dictionary/{radius_dictionary_id}/enable")
         if action_type == "disable":
             if not radius_dictionary_id:
                 raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for disable."})
-            return client.update_radius_dictionary_by_radius_dictionary_id_disable(
-                radius_dictionary_id=radius_dictionary_id
-            )
+            return await client.request("patch", f"/radius-dictionary/{radius_dictionary_id}/disable")
         # delete
         if radius_dictionary_id:
-            return client._send_request(f"/radius-dictionary/{radius_dictionary_id}", "delete")
-        return client._send_request(f"/radius-dictionary/name/{name}", "delete")
+            return await client.request("delete", f"/radius-dictionary/{radius_dictionary_id}")
+        return await client.request("delete", f"/radius-dictionary/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing RADIUS dictionary: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_tacacs_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -338,11 +322,9 @@ async def clearpass_manage_tacacs_dictionary(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/tacacs-dictionary", "post", query=payload)
+            return await client.request("post", "/tacacs-dictionary", json_body=payload)
         if not tacacs_dictionary_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either tacacs_dictionary_id or name is required for update/delete."}
@@ -353,17 +335,17 @@ async def clearpass_manage_tacacs_dictionary(
                 if tacacs_dictionary_id
                 else f"/tacacs-dictionary/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if tacacs_dictionary_id:
-            return client._send_request(f"/tacacs-dictionary/{tacacs_dictionary_id}", "delete")
-        return client._send_request(f"/tacacs-dictionary/name/{name}", "delete")
+            return await client.request("delete", f"/tacacs-dictionary/{tacacs_dictionary_id}")
+        return await client.request("delete", f"/tacacs-dictionary/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing TACACS dictionary: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_application_dictionary(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -396,11 +378,9 @@ async def clearpass_manage_application_dictionary(
     if decline:
         return decline
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/application-dictionary", "post", query=payload)
+            return await client.request("post", "/application-dictionary", json_body=payload)
         if not application_dictionary_id and not name:
             raise ToolError(
                 {
@@ -414,10 +394,10 @@ async def clearpass_manage_application_dictionary(
                 if application_dictionary_id
                 else f"/application-dictionary/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if application_dictionary_id:
-            return client._send_request(f"/application-dictionary/{application_dictionary_id}", "delete")
-        return client._send_request(f"/application-dictionary/name/{name}", "delete")
+            return await client.request("delete", f"/application-dictionary/{application_dictionary_id}")
+        return await client.request("delete", f"/application-dictionary/name/{name}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
@@ -25,7 +25,7 @@ async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> d
     return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_role(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -61,29 +61,27 @@ async def clearpass_manage_role(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/role", "post", query=payload)
+            return await client.request("post", "/role", json_body=payload)
         if not role_id and not name:
             raise ToolError({"status_code": 400, "message": "Either role_id or name is required for update/delete."})
         if action_type == "update":
             if role_id:
-                return client._send_request(f"/role/{role_id}", "patch", query=payload)
-            return client._send_request(f"/role/name/{name}", "patch", query=payload)
+                return await client.request("patch", f"/role/{role_id}", json_body=payload)
+            return await client.request("patch", f"/role/name/{name}", json_body=payload)
         # delete
         if role_id:
-            return client.delete_role_by_role_id(role_id=role_id)
-        return client.delete_role_name_by_name(name=name)
+            return await client.request("delete", f"/role/{role_id}")
+        return await client.request("delete", f"/role/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing role: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_role_mapping(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -118,24 +116,22 @@ async def clearpass_manage_role_mapping(
             return decline
 
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
 
         if action_type == "create":
-            return client._send_request("/role-mapping", "post", query=payload)
+            return await client.request("post", "/role-mapping", json_body=payload)
         if not role_mapping_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either role_mapping_id or name is required for update/delete."}
             )
         if action_type == "update":
             if role_mapping_id:
-                return client._send_request(f"/role-mapping/{role_mapping_id}", "patch", query=payload)
-            return client._send_request(f"/role-mapping/name/{name}", "patch", query=payload)
+                return await client.request("patch", f"/role-mapping/{role_mapping_id}", json_body=payload)
+            return await client.request("patch", f"/role-mapping/name/{name}", json_body=payload)
         # delete
         if role_mapping_id:
-            return client.delete_role_mapping_by_role_mapping_id(role_mapping_id=role_mapping_id)
-        return client.delete_role_mapping_name_by_name(name=name)
+            return await client.request("delete", f"/role-mapping/{role_mapping_id}")
+        return await client.request("delete", f"/role-mapping/name/{name}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
 async def _confirm_write(
@@ -27,7 +27,7 @@ async def _confirm_write(
     return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_admin_user(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -48,28 +48,26 @@ async def clearpass_manage_admin_user(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/admin-user", "post", query=payload)
+            return await client.request("post", "/admin-user", json_body=payload)
         if not admin_user_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either admin_user_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/admin-user/{admin_user_id}" if admin_user_id else f"/admin-user/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if admin_user_id:
-            return client.delete_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
-        return client._send_request(f"/admin-user/name/{name}", "delete")
+            return await client.request("delete", f"/admin-user/{admin_user_id}")
+        return await client.request("delete", f"/admin-user/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing admin user: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_admin_privilege(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -90,28 +88,26 @@ async def clearpass_manage_admin_privilege(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/admin-privilege", "post", query=payload)
+            return await client.request("post", "/admin-privilege", json_body=payload)
         if not admin_privilege_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either admin_privilege_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/admin-privilege/{admin_privilege_id}" if admin_privilege_id else f"/admin-privilege/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if admin_privilege_id:
-            return client.delete_admin_privilege_by_admin_privilege_id(admin_privilege_id=admin_privilege_id)
-        return client._send_request(f"/admin-privilege/name/{name}", "delete")
+            return await client.request("delete", f"/admin-privilege/{admin_privilege_id}")
+        return await client.request("delete", f"/admin-privilege/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing admin privilege: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_operator_profile(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -134,11 +130,9 @@ async def clearpass_manage_operator_profile(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/operator-profile", "post", query=payload)
+            return await client.request("post", "/operator-profile", json_body=payload)
         if not operator_profile_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either operator_profile_id or name is required for update/delete."}
@@ -147,17 +141,17 @@ async def clearpass_manage_operator_profile(
             path = (
                 f"/operator-profile/{operator_profile_id}" if operator_profile_id else f"/operator-profile/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if operator_profile_id:
-            return client.delete_operator_profile_by_operator_profile_id(operator_profile_id=operator_profile_id)
-        return client._send_request(f"/operator-profile/name/{name}", "delete")
+            return await client.request("delete", f"/operator-profile/{operator_profile_id}")
+        return await client.request("delete", f"/operator-profile/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing operator profile: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_license(
     ctx: Context,
     action_type: Annotated[
@@ -177,25 +171,23 @@ async def clearpass_manage_license(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/application-license", "post", query=payload)
+            return await client.request("post", "/application-license", json_body=payload)
         if not license_id:
             raise ToolError({"status_code": 400, "message": "license_id is required for delete/activate operations."})
         if action_type == "delete":
-            return client.delete_application_license_by_license_id(license_id=license_id)
+            return await client.request("delete", f"/application-license/{license_id}")
         if action_type == "activate_online":
-            return client.update_application_license_activate_online_by_license_id(license_id=license_id)
-        return client.update_application_license_activate_offline_by_license_id(license_id=license_id)
+            return await client.request("patch", f"/application-license/activate-online/{license_id}")
+        return await client.request("patch", f"/application-license/activate-offline/{license_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing license: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_cluster_params(
     ctx: Context,
     payload: Annotated[dict, Field(description="Cluster parameters config payload.")],
@@ -206,17 +198,15 @@ async def clearpass_manage_cluster_params(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        return client._send_request("/cluster/parameters", "patch", query=payload)
+        client = await get_clearpass_client()
+        return await client.request("patch", "/cluster/parameters", json_body=payload)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing cluster parameters: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_password_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'update_admin' or 'update_local'.")],
@@ -233,18 +223,16 @@ async def clearpass_manage_password_policy(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         path = "/admin-user/password-policy" if action_type == "update_admin" else "/local-user/password-policy"
-        return client._send_request(path, "patch", query=payload)
+        return await client.request("patch", path, json_body=payload)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing password policy: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_attribute(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -265,28 +253,26 @@ async def clearpass_manage_attribute(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/attribute", "post", query=payload)
+            return await client.request("post", "/attribute", json_body=payload)
         if not attribute_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either attribute_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/attribute/{attribute_id}" if attribute_id else f"/attribute/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if attribute_id:
-            return client.delete_attribute_by_attribute_id(attribute_id=attribute_id)
-        return client._send_request(f"/attribute/name/{name}", "delete")
+            return await client.request("delete", f"/attribute/{attribute_id}")
+        return await client.request("delete", f"/attribute/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing attribute: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_data_filter(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -307,28 +293,26 @@ async def clearpass_manage_data_filter(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/data-filter", "post", query=payload)
+            return await client.request("post", "/data-filter", json_body=payload)
         if not data_filter_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either data_filter_id or name is required for update/delete."}
             )
         if action_type == "update":
             path = f"/data-filter/{data_filter_id}" if data_filter_id else f"/data-filter/name/{name}"
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if data_filter_id:
-            return client.delete_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
-        return client._send_request(f"/data-filter/name/{name}", "delete")
+            return await client.request("delete", f"/data-filter/{data_filter_id}")
+        return await client.request("delete", f"/data-filter/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing data filter: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_file_backup_server(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -351,11 +335,9 @@ async def clearpass_manage_file_backup_server(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/file-backup-server", "post", query=payload)
+            return await client.request("post", "/file-backup-server", json_body=payload)
         if not file_backup_server_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either file_backup_server_id or name is required for update/delete."}
@@ -366,19 +348,17 @@ async def clearpass_manage_file_backup_server(
                 if file_backup_server_id
                 else f"/file-backup-server/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if file_backup_server_id:
-            return client.delete_file_backup_server_by_file_backup_server_id(
-                file_backup_server_id=file_backup_server_id
-            )
-        return client._send_request(f"/file-backup-server/name/{name}", "delete")
+            return await client.request("delete", f"/file-backup-server/{file_backup_server_id}")
+        return await client.request("delete", f"/file-backup-server/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing file backup server: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_messaging_setup(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -397,21 +377,19 @@ async def clearpass_manage_messaging_setup(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/messaging-setup", "post", query=payload)
+            return await client.request("post", "/messaging-setup", json_body=payload)
         if action_type == "update":
-            return client._send_request("/messaging-setup", "patch", query=payload)
-        return client.delete_messaging_setup()
+            return await client.request("patch", "/messaging-setup", json_body=payload)
+        return await client.request("delete", "/messaging-setup")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing messaging setup: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_snmp_trap_receiver(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -434,11 +412,9 @@ async def clearpass_manage_snmp_trap_receiver(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/snmp-trap-receiver", "post", query=payload)
+            return await client.request("post", "/snmp-trap-receiver", json_body=payload)
         if not snmp_trap_receiver_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either snmp_trap_receiver_id or name is required for update/delete."}
@@ -449,19 +425,17 @@ async def clearpass_manage_snmp_trap_receiver(
                 if snmp_trap_receiver_id
                 else f"/snmp-trap-receiver/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if snmp_trap_receiver_id:
-            return client.delete_snmp_trap_receiver_by_snmp_trap_receiver_id(
-                snmp_trap_receiver_id=snmp_trap_receiver_id
-            )
-        return client._send_request(f"/snmp-trap-receiver/name/{name}", "delete")
+            return await client.request("delete", f"/snmp-trap-receiver/{snmp_trap_receiver_id}")
+        return await client.request("delete", f"/snmp-trap-receiver/name/{name}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error managing SNMP trap receiver: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_policy_manager_zone(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
@@ -484,11 +458,9 @@ async def clearpass_manage_policy_manager_zone(
     if decline:
         return decline
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if action_type == "create":
-            return client._send_request("/server/policy-manager-zones", "post", query=payload)
+            return await client.request("post", "/server/policy-manager-zones", json_body=payload)
         if not policy_manager_zones_id and not name:
             raise ToolError(
                 {"status_code": 400, "message": "Either policy_manager_zones_id or name is required for update/delete."}
@@ -499,12 +471,10 @@ async def clearpass_manage_policy_manager_zone(
                 if policy_manager_zones_id
                 else f"/server/policy-manager-zones/name/{name}"
             )
-            return client._send_request(path, "patch", query=payload)
+            return await client.request("patch", path, json_body=payload)
         if policy_manager_zones_id:
-            return client.delete_server_policy_manager_zones_by_policy_manager_zones_id(
-                policy_manager_zones_id=policy_manager_zones_id
-            )
-        return client._send_request(f"/server/policy-manager-zones/name/{name}", "delete")
+            return await client.request("delete", f"/server/policy-manager-zones/{policy_manager_zones_id}")
+        return await client.request("delete", f"/server/policy-manager-zones/name/{name}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
@@ -9,9 +9,9 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import WRITE_DELETE
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 _VALID_TARGETS = ("session_id", "username", "mac", "ip", "bulk")
 
@@ -27,7 +27,7 @@ async def _confirm_session_action(ctx: Context, action: str, target_type: str, t
     return await confirm_write(ctx, f"ClearPass: {action} session for {label}. Confirm?")
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def clearpass_disconnect_session(
     ctx: Context,
     target_type: Annotated[str, Field(description="Target type: 'session_id', 'username', 'mac', 'ip', or 'bulk'.")],
@@ -76,25 +76,23 @@ async def clearpass_disconnect_session(
             return decline
 
     try:
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        client = await get_clearpass_session(ApiSessionControl)
+        client = await get_clearpass_client()
 
         if target_type == "session_id":
-            return client._send_request(f"/session/{target_value}/disconnect", "post", query={})
+            return await client.request("post", f"/session/{target_value}/disconnect", json_body={})
         if target_type == "bulk":
-            return client._send_request("/session/disconnect", "post", query=filter)
+            return await client.request("post", "/session/disconnect", json_body=filter)
         # username, mac, ip — use filtered disconnect
         filter_map = {"username": "username", "mac": "mac_address", "ip": "framedipaddress"}
-        query = {filter_map[target_type]: target_value}
-        return client._send_request("/session/disconnect", "post", query=query)
+        body = {filter_map[target_type]: target_value}
+        return await client.request("post", "/session/disconnect", json_body=body)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error disconnecting session: {e}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"clearpass_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def clearpass_perform_coa(
     ctx: Context,
     target_type: Annotated[str, Field(description="Target type: 'session_id', 'username', 'mac', 'ip', or 'bulk'.")],
@@ -146,18 +144,16 @@ async def clearpass_perform_coa(
             return decline
 
     try:
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        client = await get_clearpass_session(ApiSessionControl)
+        client = await get_clearpass_client()
 
         if target_type == "session_id":
-            return client.get_session_by_id_reauthorize(id=target_value)
+            return await client.request("get", f"/session/{target_value}/reauthorize")
         if target_type == "bulk":
-            return client._send_request("/session/reauthorize", "post", query=filter)
+            return await client.request("post", "/session/reauthorize", json_body=filter)
         # username, mac, ip — use filtered reauthorize
         filter_map = {"username": "username", "mac": "mac_address", "ip": "framedipaddress"}
-        query = {filter_map[target_type]: target_value}
-        return client._send_request("/session/reauthorize", "post", query=query)
+        body = {filter_map[target_type]: target_value}
+        return await client.request("post", "/session/reauthorize", json_body=body)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_network_devices(
     ctx: Context,
     device_id: str | None = None,
@@ -36,22 +36,20 @@ async def clearpass_get_network_devices(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if device_id:
-            return client.get_network_device_by_network_device_id(network_device_id=device_id)
+            return await client.request("get", f"/network-device/{device_id}")
         if name:
-            return client.get_network_device_name_by_name(name=name)
+            return await client.request("get", f"/network-device/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/network-device" + query)
+        return await clearpass_get(client, "/network-device" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching network devices: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_network_device_stats(
     ctx: Context,
     device_id: str,
@@ -65,17 +63,15 @@ async def clearpass_get_network_device_stats(
         device_id: Numeric ID of the network device.
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        return client.get_network_device_by_network_device_id(network_device_id=device_id)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/network-device/{device_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching network device stats: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_test_device_connectivity(
     ctx: Context,
     device_id: str,
@@ -90,10 +86,8 @@ async def clearpass_test_device_connectivity(
         device_id: Numeric ID of the network device to check.
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        result = client.get_network_device_by_network_device_id(network_device_id=device_id)
+        client = await get_clearpass_client()
+        result = await client.request("get", f"/network-device/{device_id}")
         return {
             "device": result,
             "note": "Actual connectivity testing requires ClearPass server-side capabilities.",
@@ -104,7 +98,7 @@ async def clearpass_test_device_connectivity(
         raise ToolError({"status_code": 502, "message": f"Error fetching device for connectivity review: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_validate_device_config(
     ctx: Context,
     device_id: str,
@@ -118,10 +112,8 @@ async def clearpass_validate_device_config(
         device_id: Numeric ID of the network device to validate.
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
-        device = client.get_network_device_by_network_device_id(network_device_id=device_id)
+        client = await get_clearpass_client()
+        device = await client.request("get", f"/network-device/{device_id}")
 
         issues: list[str] = []
         if isinstance(device, dict):

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_services(
     ctx: Context,
     config_service_id: str | None = None,
@@ -36,22 +36,20 @@ async def clearpass_get_services(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if config_service_id:
-            return client.get_config_service_by_config_service_id(config_service_id=config_service_id)
+            return await client.request("get", f"/config/service/{config_service_id}")
         if name:
-            return client.get_config_service_name_by_name(name=name)
+            return await client.request("get", f"/config/service/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/config/service" + query)
+        return await clearpass_get(client, "/config/service" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching services: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_posture_policies(
     ctx: Context,
     posture_policy_id: str | None = None,
@@ -76,22 +74,20 @@ async def clearpass_get_posture_policies(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if posture_policy_id:
-            return client.get_posture_policy_by_posture_policy_id(posture_policy_id=posture_policy_id)
+            return await client.request("get", f"/posture-policy/{posture_policy_id}")
         if name:
-            return client.get_posture_policy_name_by_name(name=name)
+            return await client.request("get", f"/posture-policy/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/posture-policy" + query)
+        return await clearpass_get(client, "/posture-policy" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching posture policies: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_device_groups(
     ctx: Context,
     network_device_group_id: str | None = None,
@@ -116,24 +112,20 @@ async def clearpass_get_device_groups(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if network_device_group_id:
-            return client.get_network_device_group_by_network_device_group_id(
-                network_device_group_id=network_device_group_id,
-            )
+            return await client.request("get", f"/network-device-group/{network_device_group_id}")
         if name:
-            return client.get_network_device_group_name_by_name(name=name)
+            return await client.request("get", f"/network-device-group/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/network-device-group" + query)
+        return await clearpass_get(client, "/network-device-group" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching device groups: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_proxy_targets(
     ctx: Context,
     proxy_target_id: str | None = None,
@@ -158,22 +150,20 @@ async def clearpass_get_proxy_targets(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if proxy_target_id:
-            return client.get_proxy_target_by_proxy_target_id(proxy_target_id=proxy_target_id)
+            return await client.request("get", f"/proxy-target/{proxy_target_id}")
         if name:
-            return client.get_proxy_target_name_by_name(name=name)
+            return await client.request("get", f"/proxy-target/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/proxy-target" + query)
+        return await clearpass_get(client, "/proxy-target" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching proxy targets: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_radius_dictionaries(
     ctx: Context,
     radius_dictionary_id: str | None = None,
@@ -198,24 +188,20 @@ async def clearpass_get_radius_dictionaries(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if radius_dictionary_id:
-            return client.get_radius_dictionary_by_radius_dictionary_id(
-                radius_dictionary_id=radius_dictionary_id,
-            )
+            return await client.request("get", f"/radius-dictionary/{radius_dictionary_id}")
         if name:
-            return client.get_radius_dictionary_name_by_name(name=name)
+            return await client.request("get", f"/radius-dictionary/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/radius-dictionary" + query)
+        return await clearpass_get(client, "/radius-dictionary" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching RADIUS dictionaries: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_tacacs_dictionaries(
     ctx: Context,
     tacacs_service_dictionary_id: str | None = None,
@@ -240,24 +226,20 @@ async def clearpass_get_tacacs_dictionaries(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if tacacs_service_dictionary_id:
-            return client.get_tacacs_service_dictionary_by_tacacs_service_dictionary_id(
-                tacacs_service_dictionary_id=tacacs_service_dictionary_id,
-            )
+            return await client.request("get", f"/tacacs-service-dictionary/{tacacs_service_dictionary_id}")
         if name:
-            return client.get_tacacs_service_dictionary_name_by_name(name=name)
+            return await client.request("get", f"/tacacs-service-dictionary/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/tacacs-service-dictionary" + query)
+        return await clearpass_get(client, "/tacacs-service-dictionary" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching TACACS+ dictionaries: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_application_dictionaries(
     ctx: Context,
     application_dictionary_id: str | None = None,
@@ -282,24 +264,20 @@ async def clearpass_get_application_dictionaries(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if application_dictionary_id:
-            return client.get_application_dictionary_by_application_dictionary_id(
-                application_dictionary_id=application_dictionary_id,
-            )
+            return await client.request("get", f"/application-dictionary/{application_dictionary_id}")
         if name:
-            return client.get_application_dictionary_name_by_name(name=name)
+            return await client.request("get", f"/application-dictionary/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/application-dictionary" + query)
+        return await clearpass_get(client, "/application-dictionary" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching application dictionaries: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_radius_dynamic_authorization_template(
     ctx: Context,
     template_id: str | None = None,
@@ -331,15 +309,13 @@ async def clearpass_get_radius_dynamic_authorization_template(
     See: https://developer.arubanetworks.com/cppm/reference (Policy Elements → /radius-dynamic-authorization-template)
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if template_id:
-            return clearpass_get(client, f"/radius-dynamic-authorization-template/{template_id}")
+            return await clearpass_get(client, f"/radius-dynamic-authorization-template/{template_id}")
         if name:
-            return clearpass_get(client, f"/radius-dynamic-authorization-template/name/{name}")
+            return await clearpass_get(client, f"/radius-dynamic-authorization-template/name/{name}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/radius-dynamic-authorization-template" + query)
+        return await clearpass_get(client, "/radius-dynamic-authorization-template" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_visualizer.py
@@ -23,14 +23,14 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
+from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.api_adapter import adapt
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.flow_graph import compile_service
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.mermaid_render import format_mermaid
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_details import build_details
 from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_model import build
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 # High default fan-out limit for the compile path. ClearPass tenants
@@ -56,13 +56,13 @@ def _unwrap_items(response: Any) -> list[dict]:
     return []
 
 
-def _bulk_get(client: Any, path: str) -> list[dict]:
+async def _bulk_get(client: ClearPassClient, path: str) -> list[dict]:
     """Fetch a full collection in one call (no pagination loop in v1)."""
     query = build_query_string(filter=None, sort=None, offset=0, limit=_BULK_LIMIT, calculate_count=False)
-    return _unwrap_items(clearpass_get(client, path + query))
+    return _unwrap_items(await clearpass_get(client, path + query))
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_list_policy_services(
     ctx: Context,
     filter: str | None = None,
@@ -85,11 +85,9 @@ async def clearpass_list_policy_services(
         offset: Pagination offset (default 0).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         query = build_query_string(filter, sort, offset, limit, calculate_count=False)
-        items = _unwrap_items(clearpass_get(client, "/config/service" + query))
+        items = _unwrap_items(await clearpass_get(client, "/config/service" + query))
         return [
             {
                 "id": s.get("id"),
@@ -165,7 +163,7 @@ def _resolve_service_name(
     return (None, [])
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_compile_policy_flow(
     ctx: Context,
     service_id: int | None = None,
@@ -259,19 +257,15 @@ async def clearpass_compile_policy_flow(
         raise ToolError({"status_code": 400, "message": "Error: provide exactly one of service_id or service_name"})
 
     try:
-        from pyclearpass.api_enforcementprofile import ApiEnforcementProfile
-        from pyclearpass.api_policyelements import ApiPolicyElements
+        client = await get_clearpass_client()
 
-        client_pe = await get_clearpass_session(ApiPolicyElements)
-        client_ep = await get_clearpass_session(ApiEnforcementProfile)
-
-        services = _bulk_get(client_pe, "/config/service")
-        role_mappings = _bulk_get(client_pe, "/role-mapping")
-        enforcement_policies = _bulk_get(client_pe, "/enforcement-policy")
-        enforcement_profiles = _bulk_get(client_ep, "/enforcement-profile")
-        roles = _bulk_get(client_pe, "/role")
-        auth_methods = _bulk_get(client_pe, "/auth-method")
-        auth_sources = _bulk_get(client_pe, "/auth-source")
+        services = await _bulk_get(client, "/config/service")
+        role_mappings = await _bulk_get(client, "/role-mapping")
+        enforcement_policies = await _bulk_get(client, "/enforcement-policy")
+        enforcement_profiles = await _bulk_get(client, "/enforcement-profile")
+        roles = await _bulk_get(client, "/role")
+        auth_methods = await _bulk_get(client, "/auth-method")
+        auth_sources = await _bulk_get(client, "/auth-source")
 
         target_name, candidates = _resolve_service_name(services, service_id, service_name)
         if candidates:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_roles(
     ctx: Context,
     role_id: str | None = None,
@@ -36,13 +36,11 @@ async def clearpass_get_roles(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if role_id:
-            return client.get_role_by_role_id(role_id=role_id)
+            return await client.request("get", f"/role/{role_id}")
         if name:
-            return client.get_role_name_by_name(name=name)
+            return await client.request("get", f"/role/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -51,14 +49,14 @@ async def clearpass_get_roles(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/role" + query)
+        return await clearpass_get(client, "/role" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching roles: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_role_mappings(
     ctx: Context,
     role_mapping_id: str | None = None,
@@ -86,13 +84,11 @@ async def clearpass_get_role_mappings(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-
-        client = await get_clearpass_session(ApiPolicyElements)
+        client = await get_clearpass_client()
         if role_mapping_id:
-            return client.get_role_mapping_by_role_mapping_id(role_mapping_id=role_mapping_id)
+            return await client.request("get", f"/role-mapping/{role_mapping_id}")
         if name:
-            return client.get_role_mapping_name_by_name(name=name)
+            return await client.request("get", f"/role-mapping/name/{name}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -101,7 +97,7 @@ async def clearpass_get_role_mappings(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/role-mapping" + query)
+        return await clearpass_get(client, "/role-mapping" + query)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_admin_users(
     ctx: Context,
     admin_user_id: str | None = None,
@@ -34,20 +34,18 @@ async def clearpass_get_admin_users(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if admin_user_id:
-            return client.get_admin_user_by_admin_user_id(admin_user_id=admin_user_id)
+            return await client.request("get", f"/admin-user/{admin_user_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/admin-user" + query)
+        return await clearpass_get(client, "/admin-user" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching admin users: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_admin_privileges(
     ctx: Context,
     admin_privilege_id: str | None = None,
@@ -70,22 +68,18 @@ async def clearpass_get_admin_privileges(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if admin_privilege_id:
-            return client.get_admin_privilege_by_admin_privilege_id(
-                admin_privilege_id=admin_privilege_id,
-            )
+            return await client.request("get", f"/admin-privilege/{admin_privilege_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/admin-privilege" + query)
+        return await clearpass_get(client, "/admin-privilege" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching admin privileges: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_operator_profiles(
     ctx: Context,
     filter: str | None = None,
@@ -105,18 +99,16 @@ async def clearpass_get_operator_profiles(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/operator-profile" + query)
+        return await clearpass_get(client, "/operator-profile" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching operator profiles: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_licenses(
     ctx: Context,
     license_id: str | None = None,
@@ -130,19 +122,17 @@ async def clearpass_get_licenses(
         license_id: Numeric ID for single license lookup.
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if license_id:
-            return client.get_application_license_by_license_id(license_id=license_id)
-        return client.get_application_license_summary()
+            return await client.request("get", f"/application-license/{license_id}")
+        return await client.request("get", "/application-license/summary")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching licenses: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_cluster_params(
     ctx: Context,
 ) -> dict | str:
@@ -152,17 +142,15 @@ async def clearpass_get_cluster_params(
     and replication parameters.
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        return client.get_cluster_parameters()
+        client = await get_clearpass_client()
+        return await client.request("get", "/cluster/parameters")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching cluster parameters: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_password_policies(
     ctx: Context,
 ) -> dict | str:
@@ -171,11 +159,9 @@ async def clearpass_get_password_policies(
     Returns both the admin password policy and the local user password policy.
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        admin_policy = client.get_admin_password_policy()
-        local_user_policy = client.get_local_user_password_policy()
+        client = await get_clearpass_client()
+        admin_policy = await client.request("get", "/admin-user/password-policy")
+        local_user_policy = await client.request("get", "/local-user/password-policy")
         return {
             "admin_password_policy": admin_policy,
             "local_user_password_policy": local_user_policy,
@@ -186,7 +172,7 @@ async def clearpass_get_password_policies(
         raise ToolError({"status_code": 502, "message": f"Error fetching password policies: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_attributes(
     ctx: Context,
     attribute_id: str | None = None,
@@ -209,20 +195,18 @@ async def clearpass_get_attributes(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if attribute_id:
-            return client.get_attribute_by_attribute_id(attribute_id=attribute_id)
+            return await client.request("get", f"/attribute/{attribute_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/attribute" + query)
+        return await clearpass_get(client, "/attribute" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching attributes: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_data_filters(
     ctx: Context,
     data_filter_id: str | None = None,
@@ -245,20 +229,18 @@ async def clearpass_get_data_filters(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if data_filter_id:
-            return client.get_data_filter_by_data_filter_id(data_filter_id=data_filter_id)
+            return await client.request("get", f"/data-filter/{data_filter_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/data-filter" + query)
+        return await clearpass_get(client, "/data-filter" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching data filters: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_file_backup_servers(
     ctx: Context,
     file_backup_server_id: str | None = None,
@@ -281,22 +263,18 @@ async def clearpass_get_file_backup_servers(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if file_backup_server_id:
-            return client.get_file_backup_server_by_file_backup_server_id(
-                file_backup_server_id=file_backup_server_id,
-            )
+            return await client.request("get", f"/file-backup-server/{file_backup_server_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/file-backup-server" + query)
+        return await clearpass_get(client, "/file-backup-server" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching file backup servers: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_messaging_setup(
     ctx: Context,
 ) -> dict | str:
@@ -306,17 +284,15 @@ async def clearpass_get_messaging_setup(
     and guest account provisioning.
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        return client.get_messaging_setup()
+        client = await get_clearpass_client()
+        return await client.request("get", "/messaging-setup")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching messaging setup: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_snmp_trap_receivers(
     ctx: Context,
     snmp_trap_receiver_id: str | None = None,
@@ -339,22 +315,18 @@ async def clearpass_get_snmp_trap_receivers(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if snmp_trap_receiver_id:
-            return client.get_snmp_trap_receiver_by_snmp_trap_receiver_id(
-                snmp_trap_receiver_id=snmp_trap_receiver_id,
-            )
+            return await client.request("get", f"/snmp-trap-receiver/{snmp_trap_receiver_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/snmp-trap-receiver" + query)
+        return await clearpass_get(client, "/snmp-trap-receiver" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching SNMP trap receivers: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_policy_manager_zones(
     ctx: Context,
     policy_manager_zones_id: str | None = None,
@@ -377,22 +349,18 @@ async def clearpass_get_policy_manager_zones(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
+        client = await get_clearpass_client()
         if policy_manager_zones_id:
-            return client.get_server_policy_manager_zones_by_policy_manager_zones_id(
-                policy_manager_zones_id=policy_manager_zones_id,
-            )
+            return await client.request("get", f"/server/policy-manager-zones/{policy_manager_zones_id}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
-        return clearpass_get(client, "/server/policy-manager-zones" + query)
+        return await clearpass_get(client, "/server/policy-manager-zones" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching Policy Manager zones: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_oauth_privileges(
     ctx: Context,
 ) -> dict | str:
@@ -402,10 +370,8 @@ async def clearpass_get_oauth_privileges(
     assigned to API clients.
     """
     try:
-        from pyclearpass.api_globalserverconfiguration import ApiGlobalServerConfiguration
-
-        client = await get_clearpass_session(ApiGlobalServerConfiguration)
-        return clearpass_get(client, "/oauth/all-privileges")
+        client = await get_clearpass_client()
+        return await clearpass_get(client, "/oauth/all-privileges")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_sessions(
     ctx: Context,
     session_id: str | None = None,
@@ -34,11 +34,9 @@ async def clearpass_get_sessions(
         limit: Max results per page (default 25).
     """
     try:
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        client = await get_clearpass_session(ApiSessionControl)
+        client = await get_clearpass_client()
         if session_id:
-            return client.get_session_by_id(id=session_id)
+            return await client.request("get", f"/session/{session_id}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -47,14 +45,14 @@ async def clearpass_get_sessions(
             f"calculate_count={'true' if calculate_count else 'false'}",
         ]
         query = "?" + "&".join(p for p in params if p)
-        return clearpass_get(client, "/session" + query)
+        return await clearpass_get(client, "/session" + query)
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching sessions: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_session_action_status(
     ctx: Context,
     action_id: str,
@@ -68,17 +66,15 @@ async def clearpass_get_session_action_status(
         action_id: The action ID returned from a session action request.
     """
     try:
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        client = await get_clearpass_session(ApiSessionControl)
-        return client.get_session_action_by_action_id(action_id=action_id)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/session-action/{action_id}")
     except ToolError:
         raise
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching session action status: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_get_reauth_profiles(
     ctx: Context,
     session_id: str,
@@ -92,10 +88,8 @@ async def clearpass_get_reauth_profiles(
         session_id: Session ID to retrieve reauthorization profiles for.
     """
     try:
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        client = await get_clearpass_session(ApiSessionControl)
-        return client.get_session_by_id_reauthorize(id=session_id)
+        client = await get_clearpass_client()
+        return await client.request("get", f"/session/{session_id}/reauthorize")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/utilities.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
-from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-from hpe_networking_mcp.platforms.clearpass.tools import READ_ONLY
+from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def clearpass_generate_random_password(
     ctx: Context,
     type: str = "password",
@@ -24,12 +24,10 @@ async def clearpass_generate_random_password(
         type: Type of random string to generate. Either "password" or "mpsk".
     """
     try:
-        from pyclearpass.api_toolsandutilities import ApiToolsAndUtilities
-
-        client = await get_clearpass_session(ApiToolsAndUtilities)
+        client = await get_clearpass_client()
         if type == "mpsk":
-            return client.get_random_mpsk()
-        return client.get_random_password()
+            return await client.request("get", "/random-mpsk")
+        return await client.request("get", "/random-password")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/utils.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/utils.py
@@ -4,10 +4,10 @@ Exposes:
 - ``build_query_string`` — formats the five list-endpoint pagination /
   filter parameters (filter, sort, offset, limit, calculate_count) into
   a query string. Consolidated from 10 file-local copies (issue #125).
-- ``clearpass_get`` — single-purpose wrapper for ``ClearPassAPILogin._send_request(path, "get")``.
-  Centralizes the use of pyclearpass's private transport method so a
-  future SDK change (e.g. addition of a public list method) only needs
-  updating in one place rather than ~70 call sites (issue #126).
+- ``clearpass_get`` — single-purpose GET wrapper. Originally isolated
+  pyclearpass's private ``_send_request`` (issue #126); the isolation paid
+  off — the SDK removal updated exactly this one function for ~70 read
+  call sites.
 """
 
 from __future__ import annotations
@@ -15,25 +15,19 @@ from __future__ import annotations
 from typing import Any
 
 
-def clearpass_get(client: Any, path: str) -> Any:
-    """Send a GET request via pyclearpass's transport layer.
-
-    pyclearpass does not expose a public list method for most resource
-    types — list and single-item reads have to use the private
-    ``ClearPassAPILogin._send_request(path, "get")`` method. This wrapper
-    isolates the dependency so a future SDK change only requires
-    updating a single call site.
+async def clearpass_get(client: Any, path: str) -> Any:
+    """Send a GET request via the ClearPass client.
 
     Args:
-        client: A ``ClearPassAPILogin`` instance returned by
-            ``get_clearpass_session()``.
+        client: A ``ClearPassClient`` returned by ``get_clearpass_client()``.
         path: API path (including any pre-built query string from
             ``build_query_string``).
 
     Returns:
-        The decoded JSON body returned by pyclearpass.
+        The decoded JSON body (pyclearpass-compatible contract — error
+        bodies are returned, not raised).
     """
-    return client._send_request(path, "get")
+    return await client.request("get", path)
 
 
 def build_query_string(

--- a/src/hpe_networking_mcp/platforms/health.py
+++ b/src/hpe_networking_mcp/platforms/health.py
@@ -127,14 +127,13 @@ async def _probe_greenlake(ctx: Context) -> dict[str, Any]:
 
 
 async def _probe_clearpass(ctx: Context) -> dict[str, Any]:
-    tm = ctx.lifespan_context.get("clearpass_token_manager")
-    if tm is None:
+    client = ctx.lifespan_context.get("clearpass_client")
+    if client is None:
         return {"status": "unavailable", "message": "ClearPass is not configured or failed to initialize"}
     try:
-        token = tm.get_token()
-        if token:
+        if await client.health_check():
             return {"status": "ok", "message": "ClearPass OAuth2 token active"}
-        return {"status": "degraded", "message": "ClearPass token manager returned empty token"}
+        return {"status": "degraded", "message": "ClearPass token acquisition returned no token"}
     except Exception as e:
         return {"status": "degraded", "message": f"ClearPass probe failed: {e}"}
 

--- a/src/hpe_networking_mcp/platforms/site_health_check.py
+++ b/src/hpe_networking_mcp/platforms/site_health_check.py
@@ -386,21 +386,11 @@ async def _collect_clearpass(
 
     summary = ClearPassSummary(queried=True)
 
-    try:
-        from pyclearpass.api_policyelements import ApiPolicyElements
-        from pyclearpass.api_sessioncontrol import ApiSessionControl
-
-        from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_session
-    except ImportError as e:
-        return ClearPassSummary(queried=False, error=f"pyclearpass not available: {e}")
+    from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
     try:
-        nad_client = await get_clearpass_session(ApiPolicyElements)
-        nad_resp = await asyncio.to_thread(
-            nad_client._send_request,
-            "/network-device?limit=1000",
-            "get",
-        )
+        client = await get_clearpass_client()
+        nad_resp = await client.request("get", "/network-device?limit=1000")
         all_nads = nad_resp.get("_embedded", {}).get("items", []) if isinstance(nad_resp, dict) else []
     except Exception as e:
         logger.warning("site_health_check: ClearPass NAD fetch failed — {}", e)
@@ -436,13 +426,8 @@ async def _collect_clearpass(
     # device inventory.
     cutoff = int(time.time()) - window_hours * 3600
     try:
-        session_client = await get_clearpass_session(ApiSessionControl)
         sess_filter = json.dumps({"acctstarttime": {"$gt": cutoff}})
-        sess_resp = await asyncio.to_thread(
-            session_client._send_request,
-            f"/session?filter={sess_filter}&limit=500",
-            "get",
-        )
+        sess_resp = await client.request("get", f"/session?filter={sess_filter}&limit=500")
         items = sess_resp.get("_embedded", {}).get("items", []) if isinstance(sess_resp, dict) else []
         matched_count = sum(1 for s in items if _ip_in_any(s.get("nasipaddress", ""), site_nad_matchers))
         summary.active_sessions = matched_count
@@ -459,11 +444,7 @@ async def _collect_clearpass(
     # auth-failure counter over REST.
     try:
         event_filter = json.dumps({"timestamp_utc": {"$gt": cutoff}, "level": "ERROR"})
-        events_resp = await asyncio.to_thread(
-            session_client._send_request,
-            f"/system-event?filter={event_filter}&limit=500",
-            "get",
-        )
+        events_resp = await client.request("get", f"/system-event?filter={event_filter}&limit=500")
         event_items = events_resp.get("_embedded", {}).get("items", []) if isinstance(events_resp, dict) else []
         name_set = {n.lower() for n in site_nad_names}
         if name_set:

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -104,17 +104,16 @@ async def lifespan(server: FastMCP):
     # --- ClearPass ---
     if config.clearpass:
         try:
-            from hpe_networking_mcp.platforms.clearpass.client import ClearPassTokenManager
+            from hpe_networking_mcp.platforms.clearpass.client import create_client
 
-            context["clearpass_token_manager"] = ClearPassTokenManager(config.clearpass)
-            context["clearpass_config"] = config.clearpass
+            # Construction is non-blocking: the first API call triggers the
+            # initial OAuth2 token fetch via the shared AsyncTokenManager.
+            context["clearpass_client"] = create_client(config.clearpass)
         except Exception as e:
             logger.warning("ClearPass: failed to initialize — {}", e)
-            context["clearpass_config"] = None
-            context["clearpass_token_manager"] = None
+            context["clearpass_client"] = None
     else:
-        context["clearpass_config"] = None
-        context["clearpass_token_manager"] = None
+        context["clearpass_client"] = None
 
     # --- Apstra ---
     if config.apstra:
@@ -215,6 +214,12 @@ async def lifespan(server: FastMCP):
                 await central.aclose()
             except Exception as e:  # noqa: BLE001 — shutdown must not raise
                 logger.warning("Central: aclose failed during shutdown — {}", e)
+        clearpass = context.get("clearpass_client")
+        if clearpass is not None:
+            try:
+                await clearpass.aclose()
+            except Exception as e:  # noqa: BLE001 — shutdown must not raise
+                logger.warning("ClearPass: aclose failed during shutdown — {}", e)
         mist_client_cleanup: Any = context.get("mist_client")
         if mist_client_cleanup is not None:
             try:

--- a/tests/unit/test_clearpass_client.py
+++ b/tests/unit/test_clearpass_client.py
@@ -176,6 +176,44 @@ class TestRequestContract:
 
 
 @pytest.mark.unit
+class TestBasePathJoining:
+    """The configured server URL carries a path component (e.g. ``/api``).
+
+    httpx keeps the base path as a prefix when joining request paths —
+    load-bearing for every call now that raw paths go straight to httpx.
+    Pins both the API-call path and the ``/oauth`` token path.
+    """
+
+    async def test_api_paths_land_under_the_base_path(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.request("get", "/guest/42")
+        assert captured[0].url.path == "/api/guest/42"
+        await client.aclose()
+
+    async def test_oauth_token_path_lands_under_the_base_path(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"access_token": "t", "expires_in": 28800})
+
+        client = ClearPassClient(_make_secrets())
+        client._http = httpx.AsyncClient(
+            base_url="https://clearpass.example.test:443/api",
+            transport=httpx.MockTransport(handler),
+        )
+        await client._fetch_token()
+        assert captured[0].url.path == "/api/oauth"
+        await client.aclose()
+
+
+@pytest.mark.unit
 class TestAuthRetry:
     async def test_403_body_refreshes_and_replays_once(self):
         calls: list[str] = []

--- a/tests/unit/test_clearpass_client.py
+++ b/tests/unit/test_clearpass_client.py
@@ -1,0 +1,288 @@
+"""Unit tests for ClearPassClient — the pyclearpass-compatible async replacement.
+
+Pins the response contract the ~142 ClearPass tools rely on: decoded JSON
+with raw-text fallback, raw bytes for non-JSON accepts, error bodies
+RETURNED (never raised), and the 401/403 → refresh-once → replay flow that
+previously lived in the ``_send_request`` monkey-patch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from hpe_networking_mcp.config import ClearPassSecrets
+from hpe_networking_mcp.platforms._common.auth import TokenResult
+from hpe_networking_mcp.platforms.clearpass.client import (
+    ClearPassAuthError,
+    ClearPassClient,
+    create_client,
+)
+
+
+def _make_secrets(**overrides) -> ClearPassSecrets:
+    base = {
+        "server": "https://clearpass.example.test:443/api",
+        "client_id": "cp-client-id",
+        "client_secret": "cp-client-secret",
+        "verify_ssl": True,
+    }
+    base.update(overrides)
+    return ClearPassSecrets(**base)
+
+
+def _make_client(handler, token: str = "cp-token") -> ClearPassClient:
+    client = ClearPassClient(_make_secrets())
+    client._http = httpx.AsyncClient(
+        base_url="https://clearpass.example.test:443/api",
+        transport=httpx.MockTransport(handler),
+    )
+    client._tokens.prime(token, expires_in=28800)
+    return client
+
+
+@pytest.mark.unit
+class TestNoPyclearpassAnywhere:
+    """The pyclearpass SDK was removed — no module under src/ may import it."""
+
+    def test_no_pyclearpass_imports_in_src(self):
+        import ast
+        import pathlib
+
+        import hpe_networking_mcp
+
+        root = pathlib.Path(hpe_networking_mcp.__file__).parent
+        offenders: list[str] = []
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    if any(a.name.split(".")[0] == "pyclearpass" for a in node.names):
+                        offenders.append(f"{path}:{node.lineno}")
+                elif isinstance(node, ast.ImportFrom) and node.module and node.module.split(".")[0] == "pyclearpass":
+                    offenders.append(f"{path}:{node.lineno}")
+        assert not offenders, f"pyclearpass imports found (SDK was removed): {offenders}"
+
+
+@pytest.mark.unit
+class TestRequestContract:
+    async def test_json_response_decoded(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"items": [{"id": 1}]})
+
+        client = _make_client(handler)
+        body = await client.request("get", "/guest")
+        assert body == {"items": [{"id": 1}]}
+        await client.aclose()
+
+    async def test_non_json_text_falls_back_to_raw_text(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="plain text payload")
+
+        client = _make_client(handler)
+        body = await client.request("get", "/guest")
+        assert body == "plain text payload"
+        await client.aclose()
+
+    async def test_non_json_accept_returns_bytes(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"\x00\x01CERTDATA")
+
+        client = _make_client(handler)
+        body = await client.request("get", "/cert-file", accept="application/octet-stream")
+        assert body == b"\x00\x01CERTDATA"
+        await client.aclose()
+
+    async def test_error_bodies_returned_not_raised(self):
+        """pyclearpass parity: a 404 body comes back as a dict, no exception."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"status": 404, "title": "Not Found", "detail": "no such guest"})
+
+        client = _make_client(handler)
+        body = await client.request("get", "/guest/999")
+        assert body["status"] == 404
+        assert body["title"] == "Not Found"
+        await client.aclose()
+
+    async def test_bearer_and_accept_headers_sent(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler, token="tok-abc")
+        await client.request("get", "/guest")
+        assert captured[0].headers["Authorization"] == "Bearer tok-abc"
+        assert captured[0].headers["accept"] == "application/json"
+        await client.aclose()
+
+    async def test_empty_string_params_and_body_keys_dropped(self):
+        """pyclearpass parity: '' query params and '' top-level body keys never reach the API."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.request(
+            "post",
+            "/guest",
+            params={"change_of_authorization": "", "limit": 10},
+            json_body={"username": "visitor@example.com", "notes": "", "role_id": 2},
+        )
+        request = captured[0]
+        assert "change_of_authorization" not in request.url.params
+        assert request.url.params.get("limit") == "10"
+        assert json.loads(request.content) == {"username": "visitor@example.com", "role_id": 2}
+        await client.aclose()
+
+    async def test_dict_param_json_encoded(self):
+        """pyclearpass parity: dict-valued query params (filter) travel as compact JSON."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.request("get", "/guest", params={"filter": {"username": "visitor@example.com"}})
+        assert captured[0].url.params.get("filter") == '{"username":"visitor@example.com"}'
+        await client.aclose()
+
+    async def test_params_stripped_and_body_passed(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={})
+
+        client = _make_client(handler)
+        await client.request(
+            "post",
+            "/guest",
+            params={"limit": 25, "filter": None},
+            json_body={"username": "visitor@example.com"},
+        )
+        request = captured[0]
+        assert request.url.params.get("limit") == "25"
+        assert "filter" not in request.url.params
+        assert json.loads(request.content) == {"username": "visitor@example.com"}
+        await client.aclose()
+
+
+@pytest.mark.unit
+class TestAuthRetry:
+    async def test_403_body_refreshes_and_replays_once(self):
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.headers["Authorization"])
+            if len(calls) == 1:
+                return httpx.Response(403, json={"status": 403, "title": "Forbidden", "detail": "Forbidden"})
+            return httpx.Response(200, json={"ok": True})
+
+        client = _make_client(handler, token="stale")
+
+        async def fresh() -> TokenResult:
+            return TokenResult("fresh", expires_in=28800)
+
+        client._tokens._fetch = fresh
+        body = await client.request("get", "/guest")
+        assert body == {"ok": True}
+        assert calls == ["Bearer stale", "Bearer fresh"]
+        await client.aclose()
+
+    async def test_second_403_returned_not_looped(self):
+        count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal count
+            count += 1
+            return httpx.Response(403, json={"status": 403, "title": "Forbidden"})
+
+        client = _make_client(handler)
+
+        async def fetch() -> TokenResult:
+            return TokenResult("again", expires_in=28800)
+
+        client._tokens._fetch = fetch
+        body = await client.request("get", "/guest")
+        assert body["status"] == 403
+        assert count == 2
+        await client.aclose()
+
+    async def test_refresh_failure_returns_original_error_body(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, json={"status": 403, "title": "Forbidden"})
+
+        client = _make_client(handler)
+
+        async def failing_fetch() -> TokenResult:
+            raise ClearPassAuthError("ClearPass OAuth2 failed with HTTP 400: bad client")
+
+        client._tokens._fetch = failing_fetch
+        body = await client.request("get", "/guest")
+        assert body["status"] == 403  # original error body surfaced, not an exception
+        await client.aclose()
+
+
+@pytest.mark.unit
+class TestTokenFetch:
+    async def test_oauth_post_sends_json_client_credentials(self):
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"access_token": "fresh-tok", "expires_in": 28800})
+
+        client = ClearPassClient(_make_secrets())
+        client._http = httpx.AsyncClient(
+            base_url="https://clearpass.example.test:443/api",
+            transport=httpx.MockTransport(handler),
+        )
+        result = await client._fetch_token()
+        assert result.token == "fresh-tok"
+        assert result.expires_in == 28800
+        request = captured[0]
+        assert request.url.path.endswith("/oauth")
+        assert json.loads(request.content) == {
+            "grant_type": "client_credentials",
+            "client_id": "cp-client-id",
+            "client_secret": "cp-client-secret",
+        }
+        await client.aclose()
+
+    async def test_non_200_raises_auth_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="invalid client")
+
+        client = ClearPassClient(_make_secrets())
+        client._http = httpx.AsyncClient(
+            base_url="https://clearpass.example.test:443/api",
+            transport=httpx.MockTransport(handler),
+        )
+        with pytest.raises(ClearPassAuthError, match="HTTP 400"):
+            await client._fetch_token()
+        await client.aclose()
+
+    async def test_missing_access_token_raises_auth_error(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"error_description": "scope rejected"})
+
+        client = ClearPassClient(_make_secrets())
+        client._http = httpx.AsyncClient(
+            base_url="https://clearpass.example.test:443/api",
+            transport=httpx.MockTransport(handler),
+        )
+        with pytest.raises(ClearPassAuthError, match="missing access_token"):
+            await client._fetch_token()
+        await client.aclose()
+
+    def test_create_client_is_lazy(self):
+        client = create_client(_make_secrets())
+        assert client._tokens.token is None

--- a/tests/unit/test_clearpass_policy_visualizer_tools.py
+++ b/tests/unit/test_clearpass_policy_visualizer_tools.py
@@ -1,6 +1,6 @@
 """Unit tests for the ClearPass policy-visualizer MCP tools.
 
-Mocks ``get_clearpass_session`` + ``clearpass_get`` at the import site
+Mocks ``get_clearpass_client`` + ``clearpass_get`` at the import site
 so the tools never reach the network. Verifies endpoint paths, parameter
 validation, and the fan-out shape for the compile path.
 """
@@ -27,9 +27,9 @@ def _hal(items: list[dict]) -> dict:
 
 
 class TestListPolicyServices:
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_returns_slim_summary(self, mock_session, mock_get):
@@ -67,9 +67,9 @@ class TestListPolicyServices:
         # extra unrelated fields are dropped
         assert "this_should_be_dropped" not in entry
 
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_hits_config_service_endpoint(self, mock_session, mock_get):
@@ -198,9 +198,9 @@ class TestResolveServiceName:
 
 
 class TestCompilePolicyFlowAmbiguousResponse:
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_substring_matching_multiple_services_returns_ambiguous_with_names_only(self, mock_session, mock_get):
@@ -232,9 +232,9 @@ class TestCompilePolicyFlowAmbiguousResponse:
 
 
 class TestCompilePolicyFlowFanout:
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_service_not_found_returns_available_list(self, mock_session, mock_get):
@@ -250,9 +250,9 @@ class TestCompilePolicyFlowFanout:
         assert result["status"] == "service_not_found"
         assert "[Existing Service]" in result["available_services"]
 
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_fans_out_to_seven_endpoints(self, mock_session, mock_get):
@@ -275,9 +275,9 @@ class TestCompilePolicyFlowFanout:
         assert paths.count("/auth-source") == 1
         assert len(paths) == 7
 
-    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get")
+    @patch("hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.clearpass_get", new_callable=AsyncMock)
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_session",
+        "hpe_networking_mcp.platforms.clearpass.tools.policy_visualizer.get_clearpass_client",
         new_callable=AsyncMock,
     )
     async def test_end_to_end_compiles_a_minimal_service(self, mock_session, mock_get):

--- a/tests/unit/test_clearpass_utils.py
+++ b/tests/unit/test_clearpass_utils.py
@@ -1,13 +1,15 @@
 """Unit tests for the shared ClearPass utility helpers.
 
 Pins the contract for ``build_query_string`` (consolidated from 10 file-local
-copies in issue #125) and ``clearpass_get`` (the centralized wrapper around
-pyclearpass's private ``_send_request`` method, issue #126).
+copies in issue #125) and ``clearpass_get`` (the centralized GET wrapper —
+formerly around pyclearpass's ``_send_request``, now around
+``ClearPassClient.request``; the isolation from issue #126 made the SDK
+removal a one-function change).
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -20,24 +22,25 @@ pytestmark = pytest.mark.unit
 
 
 class TestClearPassGet:
-    def test_delegates_to_send_request_with_get_method(self):
+    async def test_delegates_to_client_request_with_get_method(self):
         client = MagicMock()
-        client._send_request.return_value = {"items": []}
-        result = clearpass_get(client, "/network-device?offset=0&limit=25")
-        client._send_request.assert_called_once_with("/network-device?offset=0&limit=25", "get")
+        client.request = AsyncMock(return_value={"items": []})
+        result = await clearpass_get(client, "/network-device?offset=0&limit=25")
+        client.request.assert_awaited_once_with("get", "/network-device?offset=0&limit=25")
         assert result == {"items": []}
 
-    def test_passes_path_through_unchanged(self):
+    async def test_passes_path_through_unchanged(self):
         client = MagicMock()
-        clearpass_get(client, "/cert-trust-list/42")
+        client.request = AsyncMock(return_value={})
+        await clearpass_get(client, "/cert-trust-list/42")
         # Single-item lookups (no query string) work the same way.
-        client._send_request.assert_called_once_with("/cert-trust-list/42", "get")
+        client.request.assert_awaited_once_with("get", "/cert-trust-list/42")
 
-    def test_returns_whatever_the_sdk_returns(self):
+    async def test_returns_whatever_the_client_returns(self):
         client = MagicMock()
         sentinel = object()
-        client._send_request.return_value = sentinel
-        assert clearpass_get(client, "/anything") is sentinel
+        client.request = AsyncMock(return_value=sentinel)
+        assert await clearpass_get(client, "/anything") is sentinel
 
 
 class TestBuildQueryString:

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -94,21 +94,21 @@ class TestRunProbes:
         assert results["apstra"]["status"] == "unavailable"
 
     async def test_clearpass_ok_when_token_returns(self):
-        tm = MagicMock()
-        tm.get_token = MagicMock(return_value="fake-token-abc")
+        client = MagicMock()
+        client.health_check = AsyncMock(return_value=True)
 
         ctx = MagicMock()
-        ctx.lifespan_context = {"clearpass_token_manager": tm}
+        ctx.lifespan_context = {"clearpass_client": client}
 
         results = await run_probes(ctx, ["clearpass"])
         assert results["clearpass"]["status"] == "ok"
 
     async def test_clearpass_degraded_on_refresh_failure(self):
-        tm = MagicMock()
-        tm.get_token = MagicMock(side_effect=RuntimeError("OAuth2 rejected"))
+        client = MagicMock()
+        client.health_check = AsyncMock(side_effect=RuntimeError("OAuth2 rejected"))
 
         ctx = MagicMock()
-        ctx.lifespan_context = {"clearpass_token_manager": tm}
+        ctx.lifespan_context = {"clearpass_client": client}
 
         results = await run_probes(ctx, ["clearpass"])
         assert results["clearpass"]["status"] == "degraded"


### PR DESCRIPTION
## What

Closes #441 (blocking HTTP from async paths). Closes #465. Step 3 of the platform-standardization effort (References #466 — release stays gated until all platforms are on the shared auth system).

The bundled per-file sweep #465 called for: pyclearpass removal + `capability=` migration in one pass over the ~36 affected files, so each file was touched once. Net diff is **negative** (−72 lines) despite adding a full client.

### The client
- **`ClearPassClient`** preserves the pyclearpass response contract exactly: decoded JSON with raw-text fallback, raw bytes for non-JSON accepts, and **error bodies returned, never raised** (tools inspect `{"status": 403, ...}` dicts — verified against `ClearPassAPILogin._send_request`'s source line-by-line). Wire parity includes pyclearpass's quirks: `""`-valued query params and top-level body keys are dropped, dict-valued params travel as compact JSON (`filter` semantics).
- Token lifecycle on the shared `AsyncTokenManager` (JSON `POST /oauth`, same error messages as the old `ClearPassTokenManager`). Expiry is now tracked proactively from `expires_in` (8 h) — the post-expiry 403 storm the old code worked around **structurally cannot happen**. The 401/403 refresh-once-and-replay that previously lived in a class-level `_send_request` monkey-patch is now first-class client behavior.

### Conversion mechanics (for reviewer confidence)
- The SDK's 796 methods were mapped **mechanically** (AST/regex extraction of verb + path template + param placement from the SDK source) rather than hand-transcribed; every converted call site was checked against that map, and divergences were flagged, not silently "fixed".
- The `clearpass_get` chokepoint (issue #126's isolation) converted ~70 read sites in one function.
- Post-sweep gates: compile pass, un-awaited-coroutine AST audit (clean), no-pyclearpass guard test (permanent), full suite, live CPPM verification.

### Capability migration (3/N of the annotation sequence)
- `_registry.py` on the shared `make_tool_decorator` factory; all 142 tools classified per `docs/tool-annotation-rubric.md`.
- Gating is **byte-identical**: `Capability.WRITE_DELETE` (and `OPERATIONAL`/`WRITE` with explicit gating where flagged) derives exactly the old hand-written `clearpass_write_delete` enable tag. The existing dynamic-mode test asserting that tag passes unchanged — a free regression check on the classification.
- **Deviation from #465's text, deliberate:** inline confirmation machinery is NOT removed here. The universal `requires_confirmation` gate (#415/#416 step 3) doesn't exist yet — removing inline confirms now would leave writes unguarded. They go in the gate PR.

### Bugs surfaced
- **Fixed as a side effect**: several tools called pyclearpass methods that don't exist in the SDK (e.g. `get_admin_user_by_admin_user_id`) — `AttributeError` on every invocation, i.e. those code paths never worked.
- **Preserved + catalogued**: ~14 hand-written endpoints that don't match the CPPM REST surface (guest send/sponsor actions, bulk session disconnect/CoA routing, several `/name/{name}` routes, AD-domain path order, extension log path). All preserved byte-for-byte per the behavior-preserving rule and filed as #469 for live probing.

## Tests & verification
- New `tests/unit/test_clearpass_client.py`: response contract (error-bodies-returned, decode rules, parity quirks), auth-retry flow (403→refresh→replay, no loops, refresh-failure fallback), token fetch contract, lazy construction, plus the permanent no-pyclearpass import guard.
- Full suite in Docker: **1818 passed, 1 skipped**; ruff + format + mypy + bandit clean.
- **Live-verified against a real CPPM** through the new client: OAuth2 token fetch, NAD list read (HAL envelope intact), `cppm-version` read, and the 404-error-body-as-dict contract.

## Platform-standardization status after this PR

Shared auth adopters: UXI, Apstra, `_template`, Central, **ClearPass**. Capability-migrated: Axis, AOS8, **ClearPass**. Both vendor SDKs are now gone from the dependency tree. Remaining: GreenLake, AOS8 (client conformance), Mist, Axis adoptions.