### PR TITLE
refactor(annotations): Apstra/UXI/GreenLake capability migration (4-6/N) + AOS8 client conformance (v3.3.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.12.2] - 2026-06-11
+
+**Patch — capability migrations 4–6/N (Apstra, UXI, GreenLake) + AOS8 client conformance.** Advances the annotation sequence toward the universal confirmation gate (#415/#416, tracked in #466). The `requires_confirmation` tag remains inert until the gate PR; all visibility gating is byte-equivalent.
+
+### Changed
+- **Apstra (19), UXI (21), GreenLake (10) tools migrated to `capability=`** per `docs/tool-annotation-rubric.md`; their registries moved onto the shared `make_tool_decorator` factory and the per-platform `ToolAnnotations` constants were deleted. Notable classifications: `apstra_deploy_blueprint` → OPERATIONAL + `enable_gated=True` (applies staged config — the axis-commit pattern); UXI delete tools drop the redundant `uxi_write` tag alongside `uxi_write_delete` (gating-neutral: the Visibility transform hides on either). 7 of 9 platform registries are now on the factory — only the generated Mist/Central surfaces remain.
+- **AOS8 client conformance** (#466): template-style `get_aos8_client(ctx)` accessor + `format_http_error()` added.
+
+### Fixed
+- **AOS8 tools crashed with an opaque `AttributeError` when AOS 8 was not configured** — 55 call sites dereferenced `lifespan_context["aos8_client"]` unguarded (the #443/#444 bug class, previously fixed for Central/GreenLake only). All routed through the new accessor, which raises a clear 503 ToolError instead.
+
+### Tests
+- Full suite **1802 passed** in Docker; ruff + format + mypy + bandit clean.
+
 ## [3.3.12.1] - 2026-06-11
 
 **Patch — final shared-auth adoptions: GreenLake, AOS8, Mist, Axis. The auth migration is COMPLETE — all 8 platforms (+ `_template`) now run token lifecycle through `AsyncTokenManager`.** Pure refactor, no tool changes. This closes the release gate: this version is the tag candidate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.12.1"
+version = "3.3.12.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/aos8/client.py
+++ b/src/hpe_networking_mcp/platforms/aos8/client.py
@@ -14,17 +14,19 @@ References:
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, Literal
 
 import httpx
+from fastmcp.exceptions import ToolError
 from loguru import logger
 
 from hpe_networking_mcp.config import AOS8Secrets
 from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, AuthError, TokenResult
 from hpe_networking_mcp.utils.logging import mask_secret
 
-__all__ = ["AOS8Client", "AOS8AuthError", "AOS8APIError"]
+__all__ = ["AOS8APIError", "AOS8AuthError", "AOS8Client", "format_http_error", "get_aos8_client"]
 
 _AUTH_TIMEOUT = 15.0
 _REQUEST_TIMEOUT = 30.0
@@ -350,3 +352,48 @@ class AOS8Client:
             finally:
                 self._tokens.invalidate()
         await self._http.aclose()
+
+
+def get_aos8_client(ctx: Any) -> AOS8Client:
+    """Return the AOS8Client from the request context, or raise a clear 503.
+
+    Takes ``ctx`` explicitly (the ``get_central_conn`` pattern) so tests can
+    pass a fake context directly.
+
+    Raises:
+        ToolError: 503 when AOS 8 is not configured or failed to initialize —
+            the same guard pattern as every other platform (issues #443/#444),
+            so a disabled integration produces a recoverable "not configured"
+            response instead of an opaque ``AttributeError`` on ``None``.
+    """
+    client: AOS8Client | None = ctx.lifespan_context.get("aos8_client")
+    if client is None:
+        raise ToolError(
+            {
+                "status_code": 503,
+                "message": (
+                    "AOS 8 API client not available. Provide the AOS 8 Docker secrets "
+                    "(aos8_host, aos8_username, aos8_password) and restart the server."
+                ),
+            }
+        )
+    return client
+
+
+def format_http_error(exc: BaseException) -> dict[str, Any]:
+    """Shape any exception into a consistent dict for tool returns.
+
+    Surfaces status code and response body for ``httpx.HTTPStatusError``;
+    everything else falls back to a generic shape so call sites can use this
+    helper uniformly inside broad ``except Exception`` blocks. Same pattern
+    used by every other platform.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        text = exc.response.text[:500]
+        try:
+            body: Any = exc.response.json()
+        except (ValueError, json.JSONDecodeError):
+            body = text
+        return {"status_code": status, "message": str(exc), "body": body}
+    return {"status_code": 0, "message": str(exc), "body": None}

--- a/src/hpe_networking_mcp/platforms/aos8/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/alerts.py
@@ -20,6 +20,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     run_show,
@@ -37,7 +38,7 @@ async def aos8_get_alarms(ctx: Context, config_path: str = "/md") -> dict[str, A
     """List active alarms reported by the AOS8 controller.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -46,7 +47,7 @@ async def aos8_get_alarms(ctx: Context, config_path: str = "/md") -> dict[str, A
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show alarms", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -58,14 +59,14 @@ async def aos8_get_audit_trail(ctx: Context) -> dict[str, Any] | str:
     """Fetch the AOS8 controller-wide audit trail.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
 
     Returns:
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show audit-trail")
     except Exception as exc:  # noqa: BLE001
@@ -77,7 +78,7 @@ async def aos8_get_events(ctx: Context, config_path: str = "/md") -> dict[str, A
     """Fetch recent events logged by the AOS8 controller.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -86,7 +87,7 @@ async def aos8_get_events(ctx: Context, config_path: str = "/md") -> dict[str, A
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show events", config_path=config_path)
     except Exception as exc:  # noqa: BLE001

--- a/src/hpe_networking_mcp/platforms/aos8/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/clients.py
@@ -21,6 +21,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     run_show,
@@ -38,7 +39,7 @@ async def aos8_get_clients(ctx: Context, config_path: str = "/md") -> dict[str, 
     Returns:
         Cleaned showcommand body, or an error string when the request fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show user-table", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -81,7 +82,7 @@ async def aos8_find_client(
         # username is not None by elimination
         command = f"show user-table name {username}"
 
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, command, config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -104,7 +105,7 @@ async def aos8_get_client_detail(
     Returns:
         Cleaned showcommand body, or an error string when the request fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(
             client,
@@ -129,7 +130,7 @@ async def aos8_get_client_history(ctx: Context, mac: str) -> dict[str, Any] | st
     Returns:
         Cleaned showcommand body, or an error string when the request fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"show ap association history client-mac {mac}")
     except Exception as exc:  # noqa: BLE001

--- a/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/differentiators.py
@@ -22,6 +22,7 @@ from fastmcp import Context
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
 from hpe_networking_mcp.platforms.aos8.cli_parser import parse_aos8_cli
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     get_object,
@@ -58,7 +59,7 @@ async def aos8_get_md_hierarchy(ctx: Context) -> dict[str, Any] | str:
         Dict with the AOS8 ``Configuration node hierarchy`` table on success;
         error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show configuration node-hierarchy")
     except Exception as exc:  # noqa: BLE001
@@ -94,7 +95,7 @@ async def aos8_get_effective_config(
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await get_object(
             client,
@@ -166,7 +167,7 @@ async def aos8_get_pending_changes(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show configuration pending")
     except Exception as exc:  # noqa: BLE001
@@ -194,7 +195,7 @@ async def aos8_get_rf_neighbors(
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(
             client,
@@ -220,7 +221,7 @@ async def aos8_get_cluster_state(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show lc-cluster group-membership")
     except Exception as exc:  # noqa: BLE001
@@ -242,7 +243,7 @@ async def aos8_get_air_monitors(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap monitor active-laser-beams")
     except Exception as exc:  # noqa: BLE001
@@ -268,7 +269,7 @@ async def aos8_get_ap_wired_ports(
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"show ap port status ap-name {ap_name}")
     except Exception as exc:  # noqa: BLE001
@@ -290,7 +291,7 @@ async def aos8_get_ipsec_tunnels(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show crypto ipsec sa")
     except Exception as exc:  # noqa: BLE001
@@ -323,7 +324,7 @@ async def aos8_get_md_health_check(
         Dict with keys ``config_path``, ``aps``, ``clients``, ``alarms``,
         ``firmware``. On full failure returns an error string.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         results: Any = await asyncio.gather(
             run_show(client, "show ap active", config_path=config_path),

--- a/src/hpe_networking_mcp/platforms/aos8/tools/health.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/health.py
@@ -16,6 +16,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     run_show,
@@ -35,7 +36,7 @@ async def aos8_get_controllers(ctx: Context) -> dict[str, Any] | str:
         Parsed JSON body (``_meta`` / ``_global_result`` stripped) on success;
         error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show switches")
     except Exception as exc:  # noqa: BLE001
@@ -55,7 +56,7 @@ async def aos8_get_ap_database(ctx: Context, config_path: str = "/md") -> dict[s
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap database", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -75,7 +76,7 @@ async def aos8_get_active_aps(ctx: Context, config_path: str = "/md") -> dict[st
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap active", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -106,7 +107,7 @@ async def aos8_get_ap_detail(
     if (ap_name is None) == (ap_mac is None):
         return "Must provide exactly one of ap_name or ap_mac"
     selector = f"ap-name {ap_name}" if ap_name else f"ap-mac {ap_mac}"
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"show ap details {selector}", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -126,7 +127,7 @@ async def aos8_get_bss_table(ctx: Context, config_path: str = "/md") -> dict[str
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap bss-table", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -146,7 +147,7 @@ async def aos8_get_radio_summary(ctx: Context, config_path: str = "/md") -> dict
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap radio-summary", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -165,7 +166,7 @@ async def aos8_get_version(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show version")
     except Exception as exc:  # noqa: BLE001
@@ -184,7 +185,7 @@ async def aos8_get_licenses(ctx: Context) -> dict[str, Any] | str:
     Returns:
         Parsed JSON body on success; error string on failure.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show license")
     except Exception as exc:  # noqa: BLE001

--- a/src/hpe_networking_mcp/platforms/aos8/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/troubleshooting.py
@@ -23,6 +23,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     run_show,
@@ -45,7 +46,7 @@ async def aos8_ping(ctx: Context, dest: str) -> dict[str, Any] | str:
     """Ping a target from the controller via the showcommand endpoint.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         dest: Destination host or IP to ping (e.g. ``"8.8.8.8"``).
 
@@ -53,7 +54,7 @@ async def aos8_ping(ctx: Context, dest: str) -> dict[str, Any] | str:
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"ping {dest}")
     except Exception as exc:  # noqa: BLE001
@@ -65,7 +66,7 @@ async def aos8_traceroute(ctx: Context, dest: str) -> dict[str, Any] | str:
     """Traceroute to a target from the controller via the showcommand endpoint.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         dest: Destination host or IP to traceroute (e.g. ``"8.8.8.8"``).
 
@@ -73,7 +74,7 @@ async def aos8_traceroute(ctx: Context, dest: str) -> dict[str, Any] | str:
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"traceroute {dest}")
     except Exception as exc:  # noqa: BLE001
@@ -91,7 +92,7 @@ async def aos8_show_command(ctx: Context, command: str) -> dict[str, Any] | str:
     wrapped as ``{"output": <text>}``.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         command: Full CLI string starting with ``"show "``.
 
@@ -103,7 +104,7 @@ async def aos8_show_command(ctx: Context, command: str) -> dict[str, Any] | str:
     normalized = command.strip()
     if not normalized.lower().startswith("show "):
         return f"Only 'show' commands are permitted. Received: {command!r}"
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         response = await client.request(
             "GET",
@@ -124,7 +125,7 @@ async def aos8_get_logs(ctx: Context, count: int = 100) -> dict[str, Any] | str:
     """Return the last ``count`` lines of the controller system log.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         count: Number of recent log lines to return. Capped at 1000 to keep
             responses manageable; oversized requests are rejected with an
@@ -137,7 +138,7 @@ async def aos8_get_logs(ctx: Context, count: int = 100) -> dict[str, Any] | str:
     """
     if count > 1000:
         return "count must be <= 1000"
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, f"show log system {count}")
     except Exception as exc:  # noqa: BLE001
@@ -154,14 +155,14 @@ async def aos8_get_controller_stats(ctx: Context) -> dict[str, Any] | str:
     three is treated as a single failure for the aggregate.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
 
     Returns:
         Dict with ``cpu``, ``memory``, and ``uptime`` keys, or a formatted
         error string when any of the underlying API calls fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         cpu = await run_show(client, "show cpuload")
         memory = await run_show(client, "show memory")
@@ -176,7 +177,7 @@ async def aos8_get_arm_history(ctx: Context, config_path: str = "/md") -> dict[s
     """Fetch ARM (Adaptive Radio Management) channel/power change history.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``,
             ``"/md/branch1"``). Defaults to ``"/md"``.
@@ -185,7 +186,7 @@ async def aos8_get_arm_history(ctx: Context, config_path: str = "/md") -> dict[s
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap arm history", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -197,7 +198,7 @@ async def aos8_get_rf_monitor(ctx: Context, config_path: str = "/md") -> dict[st
     """Fetch RF monitor statistics across the AP fleet.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``,
             ``"/md/branch1"``). Defaults to ``"/md"``.
@@ -206,7 +207,7 @@ async def aos8_get_rf_monitor(ctx: Context, config_path: str = "/md") -> dict[st
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await run_show(client, "show ap monitor stats", config_path=config_path)
     except Exception as exc:  # noqa: BLE001

--- a/src/hpe_networking_mcp/platforms/aos8/tools/wlan.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/wlan.py
@@ -19,6 +19,7 @@ from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
+from hpe_networking_mcp.platforms.aos8.client import get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import (
     format_aos8_error,
     get_object,
@@ -37,7 +38,7 @@ async def aos8_get_ssid_profiles(ctx: Context, config_path: str = "/md") -> dict
     """Fetch SSID profiles defined at the given configuration node.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -46,7 +47,7 @@ async def aos8_get_ssid_profiles(ctx: Context, config_path: str = "/md") -> dict
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await get_object(client, "ssid_prof", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -58,7 +59,7 @@ async def aos8_get_virtual_aps(ctx: Context, config_path: str = "/md") -> dict[s
     """Fetch virtual-AP profiles defined at the given configuration node.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -67,7 +68,7 @@ async def aos8_get_virtual_aps(ctx: Context, config_path: str = "/md") -> dict[s
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await get_object(client, "virtual_ap", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -79,7 +80,7 @@ async def aos8_get_ap_groups(ctx: Context, config_path: str = "/md") -> dict[str
     """Fetch AP-group definitions at the given configuration node.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -88,7 +89,7 @@ async def aos8_get_ap_groups(ctx: Context, config_path: str = "/md") -> dict[str
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await get_object(client, "ap_group", config_path=config_path)
     except Exception as exc:  # noqa: BLE001
@@ -100,7 +101,7 @@ async def aos8_get_user_roles(ctx: Context, config_path: str = "/md") -> dict[st
     """Fetch user-role definitions at the given configuration node.
 
     Args:
-        ctx: FastMCP request context; ``ctx.lifespan_context["aos8_client"]``
+        ctx: FastMCP request context (client resolved via ``get_aos8_client()``
             must hold an authenticated ``AOS8Client``.
         config_path: Hierarchy node to query (e.g. ``"/md"``, ``"/md/branch1"``).
             Defaults to ``"/md"``.
@@ -109,7 +110,7 @@ async def aos8_get_user_roles(ctx: Context, config_path: str = "/md") -> dict[st
         Parsed JSON body with ``_meta`` and ``_global_result`` stripped, or a
         formatted error string when the API call fails.
     """
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         return await get_object(client, "role", config_path=config_path)
     except Exception as exc:  # noqa: BLE001

--- a/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
@@ -27,7 +27,7 @@ from pydantic import Field
 from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
-from hpe_networking_mcp.platforms.aos8.client import AOS8APIError, AOS8AuthError
+from hpe_networking_mcp.platforms.aos8.client import AOS8APIError, AOS8AuthError, get_aos8_client
 from hpe_networking_mcp.platforms.aos8.tools._helpers import format_aos8_error, post_object, strip_meta
 
 _ACTION_MAP = {"create": "add", "update": "modify", "delete": "delete"}
@@ -77,7 +77,7 @@ async def _post_managed_object(
             return decision  # type: ignore[return-value]
 
     body = {object_name: {**payload, "_action": action}}
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         result = await post_object(client, object_name, body, config_path=config_path)
     except (AOS8APIError, AOS8AuthError, httpx.HTTPError) as exc:
@@ -352,7 +352,7 @@ async def aos8_disconnect_client(
             return decision  # type: ignore[return-value]
 
     body = {"aaa_user_delete": {"mac": mac}}
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         result = await post_object(client, "aaa_user_delete", body)
     except (AOS8APIError, AOS8AuthError, httpx.HTTPError) as exc:
@@ -379,7 +379,7 @@ async def aos8_reboot_ap(
             return decision  # type: ignore[return-value]
 
     body = {"apboot": {"ap-name": ap_name}}
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         result = await post_object(client, "apboot", body)
     except (AOS8APIError, AOS8AuthError, httpx.HTTPError) as exc:
@@ -416,7 +416,7 @@ async def aos8_write_memory(
         if decision is not None:
             return decision  # type: ignore[return-value]
 
-    client = ctx.lifespan_context["aos8_client"]
+    client = get_aos8_client(ctx)
     try:
         response = await client.request(
             "POST",

--- a/src/hpe_networking_mcp/platforms/apstra/_registry.py
+++ b/src/hpe_networking_mcp/platforms/apstra/_registry.py
@@ -1,78 +1,19 @@
-"""Apstra tool registry -- module-level FastMCP holder + shared-registry shim.
+"""Apstra tool registry — module-level FastMCP holder + shared-registry shim.
 
 Tool modules under ``platforms/apstra/tools/`` decorate their functions with
-``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
-The shim:
-
-1. Delegates to the underlying FastMCP ``mcp.tool(...)`` so the tool is
-   registered with the server the same way it was pre-v2.
-2. Merges the ``dynamic_managed`` tag onto every registered tool so the
-   ``Visibility(False, tags={"dynamic_managed"})`` transform can hide all
-   these tools when ``MCP_TOOL_MODE=dynamic``.
-3. Populates ``REGISTRIES["apstra"]`` so the three Apstra meta-tools can
-   dispatch by name at runtime.
-
-Both modes work from the same decorator — no per-mode branching in tool files.
+``@tool(...)`` (imported from here). The shim is built by the shared
+``make_tool_decorator`` factory — see ``platforms/_template/_registry.py`` for
+the canonical reference and ``docs/tool-annotation-rubric.md`` for how
+``capability=`` classifies a tool.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from fastmcp import FastMCP
 
-from hpe_networking_mcp.platforms._common.tool_registry import (
-    DYNAMIC_MANAGED_TAG,
-    ToolSpec,
-    record_tool,
-)
+from hpe_networking_mcp.platforms._common.tool_registry import make_tool_decorator
 
-# Set by platforms.apstra.register_tools() before tool modules are imported.
+# Set by ``platforms.apstra.register_tools()`` before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
 
-_PLATFORM = "apstra"
-
-
-def _derive_category(func: Callable[..., Any]) -> str:
-    """Short module name as the registry category (e.g. ``manage_networks``)."""
-    module = getattr(func, "__module__", "")
-    return module.rsplit(".", 1)[-1] if "." in module else module
-
-
-def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry.
-
-    Accepts every keyword ``FastMCP.tool`` accepts — forwards them unchanged
-    except for ``tags``, which gets ``dynamic_managed`` merged in so the
-    Visibility transform in ``server.py`` can hide these tools when the
-    server is running in dynamic mode.
-    """
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
-        resolved_name: str = tool_kwargs.get("name") or func.__name__
-        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
-
-        record_tool(
-            ToolSpec(
-                name=resolved_name,
-                func=func,
-                platform=_PLATFORM,
-                category=_derive_category(func),
-                description=resolved_description,
-                tags=supplied_tags,
-            )
-        )
-
-        if mcp is None:
-            # register_tools() not yet called — likely an import during test
-            # collection before the platform is wired. Leaving the function
-            # undecorated is fine: tests that need FastMCP registration set
-            # up a real mcp before import (see tests/conftest.py stubs).
-            return func
-
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
-        return mcp.tool(**effective_kwargs)(func)
-
-    return decorator
+tool = make_tool_decorator("apstra", lambda: mcp)

--- a/src/hpe_networking_mcp/platforms/apstra/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/__init__.py
@@ -1,22 +1,8 @@
-from mcp.types import ToolAnnotations
+"""Tool modules for the Juniper Apstra platform.
 
-READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
-
-WRITE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
+Tools are classified with the ``capability=`` kwarg on the ``@tool`` decorator
+(see ``platforms/_common/annotations.py`` and ``docs/tool-annotation-rubric.md``).
+That single classification derives the MCP annotations, the
+``apstra_write[_delete]`` enable tag, and the ``requires_confirmation`` gate
+tag — there are no hand-written ``ToolAnnotations`` constants.
+"""

--- a/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all racks in a blueprint.
 
@@ -33,7 +33,7 @@ async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
         raise ToolError({"status_code": 502, "message": f"Error fetching racks: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all routing zones (security zones) in a blueprint.
 
@@ -52,7 +52,7 @@ async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str,
         raise ToolError({"status_code": 502, "message": f"Error fetching routing zones: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_system_info(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get systems (devices) inside a blueprint.
 

--- a/src/hpe_networking_mcp/platforms/apstra/tools/blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/blueprints.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_blueprints(ctx: Context) -> dict[str, Any]:
     """Get list of all Apstra blueprints.
 
@@ -33,7 +33,7 @@ async def apstra_get_blueprints(ctx: Context) -> dict[str, Any]:
         raise ToolError({"status_code": 502, "message": f"Error fetching blueprints: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_templates(ctx: Context) -> dict[str, Any]:
     """Get list of available design templates for blueprint creation."""
     try:

--- a/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get connectivity templates (endpoint policies) in a blueprint.
 
@@ -34,7 +34,7 @@ async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> 
         raise ToolError({"status_code": 502, "message": f"Error fetching connectivity templates: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_application_endpoints(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all possible application endpoints for connectivity templates.
 

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
@@ -8,13 +8,13 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import WRITE, WRITE_DELETE
 
 
-@tool(annotations=WRITE_DELETE, tags={"apstra_write_delete"})
+@tool(capability=Capability.OPERATIONAL, enable_gated=True)
 async def apstra_deploy(
     ctx: Context,
     blueprint_id: str,
@@ -55,7 +55,7 @@ async def apstra_deploy(
         raise ToolError({"status_code": 502, "message": f"Error deploying blueprint: {detail}"}) from e
 
 
-@tool(annotations=WRITE_DELETE, tags={"apstra_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def apstra_delete_blueprint(
     ctx: Context,
     blueprint_id: str,
@@ -95,7 +95,7 @@ async def apstra_delete_blueprint(
         raise ToolError({"status_code": 502, "message": f"Error deleting blueprint: {detail}"}) from e
 
 
-@tool(annotations=WRITE, tags={"apstra_write"})
+@tool(capability=Capability.WRITE)
 async def apstra_create_datacenter_blueprint(
     ctx: Context,
     blueprint_name: str,
@@ -138,7 +138,7 @@ async def apstra_create_datacenter_blueprint(
         raise ToolError({"status_code": 502, "message": f"Error creating datacenter blueprint: {detail}"}) from e
 
 
-@tool(annotations=WRITE, tags={"apstra_write"})
+@tool(capability=Capability.WRITE)
 async def apstra_create_freeform_blueprint(
     ctx: Context,
     blueprint_name: str,

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
@@ -8,14 +8,14 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
 from hpe_networking_mcp.platforms.apstra.models import normalize_application_points
-from hpe_networking_mcp.platforms.apstra.tools import WRITE
 
 
-@tool(annotations=WRITE, tags={"apstra_write"})
+@tool(capability=Capability.WRITE)
 async def apstra_apply_ct_policies(
     ctx: Context,
     blueprint_id: str,

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -17,11 +18,10 @@ from hpe_networking_mcp.platforms.apstra.models import (
     normalize_to_string_list,
     parse_bool,
 )
-from hpe_networking_mcp.platforms.apstra.tools import WRITE
 from hpe_networking_mcp.platforms.apstra.topology import get_individual_leafs_from_system_ids
 
 
-@tool(annotations=WRITE, tags={"apstra_write"})
+@tool(capability=Capability.WRITE)
 async def apstra_create_virtual_network(
     ctx: Context,
     blueprint_id: str,
@@ -182,7 +182,7 @@ async def apstra_create_virtual_network(
         raise ToolError({"status_code": 502, "message": f"Error creating virtual network: {detail}"}) from e
 
 
-@tool(annotations=WRITE, tags={"apstra_write"})
+@tool(capability=Capability.WRITE)
 async def apstra_create_remote_gateway(
     ctx: Context,
     blueprint_id: str,

--- a/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get virtual networks in a blueprint, including bound systems and VLAN IDs.
 
@@ -32,7 +32,7 @@ async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[s
         raise ToolError({"status_code": 502, "message": f"Error fetching virtual networks: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_remote_gateways(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all remote EVPN gateways in a blueprint.
 

--- a/src/hpe_networking_mcp/platforms/apstra/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/status.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
-from hpe_networking_mcp.platforms.apstra.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get anomalies for a blueprint.
 
@@ -32,7 +32,7 @@ async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any
         raise ToolError({"status_code": 502, "message": f"Error fetching anomalies: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get configuration diff status (staging vs active) for a blueprint.
 
@@ -54,7 +54,7 @@ async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, A
         raise ToolError({"status_code": 502, "message": f"Error fetching diff status: {detail}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def apstra_get_protocol_sessions(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """Get all protocol (e.g. BGP) sessions in a blueprint.
 

--- a/src/hpe_networking_mcp/platforms/greenlake/_registry.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/_registry.py
@@ -1,61 +1,19 @@
-"""GreenLake tool registry -- module-level FastMCP holder + shared-registry shim.
+"""GreenLake tool registry — module-level FastMCP holder + shared-registry shim.
 
 Tool modules under ``platforms/greenlake/tools/`` decorate their functions with
-``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
-The shim mirrors the other four platforms: delegate to the real FastMCP
-decorator, merge the ``dynamic_managed`` tag so dynamic-mode ``Visibility`` can
-hide individual tools, and record a ``ToolSpec`` into ``REGISTRIES["greenlake"]``
-so the three GreenLake meta-tools can dispatch by name at runtime.
+``@tool(...)`` (imported from here). The shim is built by the shared
+``make_tool_decorator`` factory — see ``platforms/_template/_registry.py`` for
+the canonical reference and ``docs/tool-annotation-rubric.md`` for how
+``capability=`` classifies a tool.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from fastmcp import FastMCP
 
-from hpe_networking_mcp.platforms._common.tool_registry import (
-    DYNAMIC_MANAGED_TAG,
-    ToolSpec,
-    record_tool,
-)
+from hpe_networking_mcp.platforms._common.tool_registry import make_tool_decorator
 
-# Set by platforms.greenlake.register_tools() before tool modules are imported.
+# Set by ``platforms.greenlake.register_tools()`` before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
 
-_PLATFORM = "greenlake"
-
-
-def _derive_category(func: Callable[..., Any]) -> str:
-    """Short module name as the registry category (e.g. ``devices``)."""
-    module = getattr(func, "__module__", "")
-    return module.rsplit(".", 1)[-1] if "." in module else module
-
-
-def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
-        resolved_name: str = tool_kwargs.get("name") or func.__name__
-        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
-
-        record_tool(
-            ToolSpec(
-                name=resolved_name,
-                func=func,
-                platform=_PLATFORM,
-                category=_derive_category(func),
-                description=resolved_description,
-                tags=supplied_tags,
-            )
-        )
-
-        if mcp is None:
-            return func
-
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
-        return mcp.tool(**effective_kwargs)(func)
-
-    return decorator
+tool = make_tool_decorator("greenlake", lambda: mcp)

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
@@ -16,6 +16,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -50,13 +51,7 @@ def _coerce_int(value: Any, name: str) -> int:
         "workspace/workspaceName, application/id, region, hasDetails."
     ),
     tags={"greenlake", "audit_logs"},
-    annotations={
-        "title": "Get GreenLake audit logs",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_audit_logs(
     ctx: Context,
@@ -137,13 +132,7 @@ async def greenlake_get_audit_logs(
     name="greenlake_get_audit_log_details",
     description=("Get additional detail of an HPE GreenLake audit log entry."),
     tags={"greenlake", "audit_logs"},
-    annotations={
-        "title": "Get GreenLake audit log details",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_audit_log_details(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
@@ -16,6 +16,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -52,13 +53,7 @@ def _coerce_int(value: Any, name: str) -> int:
         "warranty."
     ),
     tags={"greenlake", "devices"},
-    annotations={
-        "title": "Get GreenLake devices",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_devices(
     ctx: Context,
@@ -151,13 +146,7 @@ async def greenlake_get_devices(
         "Rate limit: 40 requests/min per workspace."
     ),
     tags={"greenlake", "devices"},
-    annotations={
-        "title": "Get GreenLake device by ID",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_device_by_id(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
@@ -16,6 +16,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -52,13 +53,7 @@ def _coerce_int(value: Any, name: str) -> int:
         "updatedAt."
     ),
     tags={"greenlake", "subscriptions"},
-    annotations={
-        "title": "Get GreenLake subscriptions",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_subscriptions(
     ctx: Context,
@@ -152,13 +147,7 @@ async def greenlake_get_subscriptions(
         "Rate limit: 20 requests/min per workspace."
     ),
     tags={"greenlake", "subscriptions"},
-    annotations={
-        "title": "Get GreenLake subscription details",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_subscription_details(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
@@ -17,6 +17,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -51,13 +52,7 @@ def _coerce_int(value: Any, name: str) -> int:
         "Rate limit: 300 requests/min per workspace."
     ),
     tags={"greenlake", "users"},
-    annotations={
-        "title": "Get GreenLake users",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_users(
     ctx: Context,
@@ -118,13 +113,7 @@ async def greenlake_get_users(
     name="greenlake_get_user_details",
     description=("Retrieve a single HPE GreenLake user by user ID."),
     tags={"greenlake", "users"},
-    annotations={
-        "title": "Get GreenLake user details",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_user_details(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
@@ -17,6 +17,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -29,13 +30,7 @@ from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
     name="greenlake_get_workspace",
     description=("Retrieve basic workspace information for a given HPE GreenLake workspace ID."),
     tags={"greenlake", "workspaces"},
-    annotations={
-        "title": "Get GreenLake workspace",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_workspace(
     ctx: Context,
@@ -68,13 +63,7 @@ async def greenlake_get_workspace(
     name="greenlake_get_workspace_details",
     description=("Retrieve detailed contact information for an HPE GreenLake workspace."),
     tags={"greenlake", "workspaces"},
-    annotations={
-        "title": "Get GreenLake workspace details",
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": True,
-    },
+    capability=Capability.READ,
 )
 async def greenlake_get_workspace_details(
     ctx: Context,

--- a/src/hpe_networking_mcp/platforms/uxi/_registry.py
+++ b/src/hpe_networking_mcp/platforms/uxi/_registry.py
@@ -1,59 +1,19 @@
 """UXI tool registry — module-level FastMCP holder + shared-registry shim.
 
-Tool modules under ``platforms/uxi/tools/`` decorate their functions
-with ``@tool(...)`` (imported from here) instead of directly with
-``@mcp.tool(...)``. Same shim shape as every other platform — see
-``platforms/_template/_registry.py`` for the canonical reference.
+Tool modules under ``platforms/uxi/tools/`` decorate their functions with
+``@tool(...)`` (imported from here). The shim is built by the shared
+``make_tool_decorator`` factory — see ``platforms/_template/_registry.py`` for
+the canonical reference and ``docs/tool-annotation-rubric.md`` for how
+``capability=`` classifies a tool.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from fastmcp import FastMCP
 
-from hpe_networking_mcp.platforms._common.tool_registry import (
-    DYNAMIC_MANAGED_TAG,
-    ToolSpec,
-    record_tool,
-)
+from hpe_networking_mcp.platforms._common.tool_registry import make_tool_decorator
 
 # Set by ``platforms.uxi.register_tools()`` before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
 
-_PLATFORM = "uxi"
-
-
-def _derive_category(func: Callable[..., Any]) -> str:
-    """Short module name as the registry category (e.g. ``sensors``)."""
-    module = getattr(func, "__module__", "")
-    return module.rsplit(".", 1)[-1] if "." in module else module
-
-
-def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
-        resolved_name: str = tool_kwargs.get("name") or func.__name__
-        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
-
-        record_tool(
-            ToolSpec(
-                name=resolved_name,
-                func=func,
-                platform=_PLATFORM,
-                category=_derive_category(func),
-                description=resolved_description,
-                tags=supplied_tags,
-            )
-        )
-
-        if mcp is None:
-            return func
-
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
-        return mcp.tool(**effective_kwargs)(func)
-
-    return decorator
+tool = make_tool_decorator("uxi", lambda: mcp)

--- a/src/hpe_networking_mcp/platforms/uxi/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/__init__.py
@@ -1,27 +1,8 @@
-"""Shared ToolAnnotations constants for UXI tools.
+"""Tool modules for the Aruba UXI platform.
 
-Apply via the @tool decorator's ``annotations`` kwarg.
+Tools are classified with the ``capability=`` kwarg on the ``@tool`` decorator
+(see ``platforms/_common/annotations.py`` and ``docs/tool-annotation-rubric.md``).
+That single classification derives the MCP annotations, the
+``uxi_write[_delete]`` enable tag, and the ``requires_confirmation`` gate tag —
+there are no hand-written ``ToolAnnotations`` constants.
 """
-
-from mcp.types import ToolAnnotations
-
-READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
-
-WRITE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)

--- a/src/hpe_networking_mcp/platforms/uxi/tools/agents.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/agents.py
@@ -7,12 +7,12 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_agents(
     ctx: Context,
     next_cursor: str | None = None,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/assignments.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/assignments.py
@@ -7,12 +7,12 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_agent_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
@@ -35,7 +35,7 @@ async def uxi_list_agent_group_assignments(
         return format_http_error(e)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_sensor_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
@@ -58,7 +58,7 @@ async def uxi_list_sensor_group_assignments(
         return format_http_error(e)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_network_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
@@ -81,7 +81,7 @@ async def uxi_list_network_group_assignments(
         return format_http_error(e)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_service_test_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/groups.py
@@ -7,12 +7,12 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_groups(
     ctx: Context,
     next_cursor: str | None = None,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/networks.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/networks.py
@@ -7,12 +7,12 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_wired_networks(
     ctx: Context,
     next_cursor: str | None = None,
@@ -36,7 +36,7 @@ async def uxi_list_wired_networks(
         return format_http_error(e)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_wireless_networks(
     ctx: Context,
     next_cursor: str | None = None,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
@@ -7,13 +7,13 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_sensors(
     ctx: Context,
     next_cursor: str | None = None,
@@ -37,7 +37,7 @@ async def uxi_list_sensors(
         return format_http_error(e)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_get_sensor_status(
     ctx: Context,
     sensor_id: str,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/service_tests.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/service_tests.py
@@ -7,12 +7,12 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import READ_ONLY
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def uxi_list_service_tests(
     ctx: Context,
     next_cursor: str | None = None,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
@@ -13,15 +13,15 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import WRITE, WRITE_DELETE
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
 
 _VALID_PCAP_MODES = {"light", "full", "off"}
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_update_agent(
     ctx: Context,
     agent_id: str,
@@ -75,7 +75,7 @@ async def uxi_update_agent(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE_DELETE, tags={"uxi_write", "uxi_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def uxi_delete_agent(
     ctx: Context,
     agent_id: str,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
@@ -18,13 +18,13 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import WRITE, WRITE_DELETE
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_assign_agent_to_group(
     ctx: Context,
     agent_id: str,
@@ -58,7 +58,7 @@ async def uxi_assign_agent_to_group(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE_DELETE, tags={"uxi_write", "uxi_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def uxi_remove_agent_from_group(
     ctx: Context,
     assignment_id: str,
@@ -89,7 +89,7 @@ async def uxi_remove_agent_from_group(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_assign_sensor_to_group(
     ctx: Context,
     sensor_id: str,
@@ -123,7 +123,7 @@ async def uxi_assign_sensor_to_group(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE_DELETE, tags={"uxi_write", "uxi_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def uxi_remove_sensor_from_group(
     ctx: Context,
     assignment_id: str,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
@@ -13,13 +13,13 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import WRITE, WRITE_DELETE
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_create_group(
     ctx: Context,
     name: str,
@@ -53,7 +53,7 @@ async def uxi_create_group(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_update_group(
     ctx: Context,
     group_id: str,
@@ -84,7 +84,7 @@ async def uxi_update_group(
         return format_http_error(e)
 
 
-@tool(annotations=WRITE_DELETE, tags={"uxi_write", "uxi_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def uxi_delete_group(
     ctx: Context,
     group_id: str,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
@@ -13,15 +13,15 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
-from hpe_networking_mcp.platforms.uxi.tools import WRITE
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
 
 _VALID_PCAP_MODES = {"light", "full", "off"}
 
 
-@tool(annotations=WRITE, tags={"uxi_write"})
+@tool(capability=Capability.WRITE)
 async def uxi_update_sensor(
     ctx: Context,
     sensor_id: str,


### PR DESCRIPTION
## What

Advances the annotation sequence toward the universal confirmation gate. References #466 (its capability-migration items for these three platforms + the AOS8 client-conformance item); advances the #415/#416 sequence. Behavior-preserving: `requires_confirmation` remains inert until the gate PR, and all write-visibility gating is byte-equivalent.

### Capability migrations (50 tools)
- **Apstra (19)**: 12 READ, 5 WRITE, 1 WRITE_DELETE, and `apstra_deploy_blueprint` → **OPERATIONAL + `enable_gated=True`** (applies staged config — the rubric's axis-commit pattern). Apstra's Visibility transform hides both `apstra_write` and `apstra_write_delete`, so WRITE/WRITE_DELETE both stay enable-gated exactly as before.
- **UXI (21)**: 11 READ, 6 WRITE, 4 WRITE_DELETE (the write surface lives under `tools/writes/`). Delete tools drop the redundant `uxi_write` tag alongside `uxi_write_delete` — gating-neutral (Visibility hides on either tag); the existing write-tool tag tests pass unchanged.
- **GreenLake (10)**: all READ (verified per-function: `client.get` only). Legacy dict-hints matched what `classify(READ)` derives, so hints are unchanged.
- All three registries moved to the shared `make_tool_decorator` factory and the per-platform `ToolAnnotations` constants deleted. **7 of 9 platform registries are now on the factory** — only the generated Mist/Central surfaces remain (next PRs).

### AOS8 client conformance + hardening
- Template-style `get_aos8_client(ctx)` accessor (the testable `get_central_conn` pattern) and `format_http_error()` added.
- **Bug fixed along the way**: 55 call sites dereferenced `lifespan_context["aos8_client"]` unguarded — `AttributeError` on `None` whenever AOS 8 isn't configured (the #443/#444 class, previously fixed for Central/GreenLake only). All now raise a clear 503.

## Tests
Full suite in Docker: **1802 passed, 1 skipped**; ruff + format + mypy + bandit clean. Existing per-platform tag/registry tests pass unchanged — they double as gating-equivalence regression checks.

## Remaining before the gate PR
Central capability migration (regen generator + hand-curated + the #416 mis-annotations) and Mist generator capability emission (bundling #368/#436). Then the universal gate (closes #415/#416).