### PR TITLE
refactor(annotations): all 660 Central tools to capability classification (7/N) (v3.3.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.12.3] - 2026-06-11
+
+**Patch — Central capability migration (7/N): all 660 Central tools classified; #416 mis-annotations corrected.** The largest annotation migration; one platform remains (Mist, generator-side) before the universal confirmation gate.
+
+### Changed
+- **All 660 Central tools migrated to `capability=`** (381 READ, ~250 WRITE_DELETE, 23 OPERATIONAL, plus the scope writes); registry on the shared `make_tool_decorator` factory; all per-file `ToolAnnotations` constants deleted. Visibility gating byte-equivalent. 8 of 9 platform registries on the factory.
+- **The formerly-ungated MRT/alert write surface (#416) now derives `requires_confirmation`** — OPERATIONAL's gated default and WRITE_DELETE classification cover the ~20 destructive tools that previously had no confirmation pathway; the tag activates when the universal gate lands.
+- Benign operational tools (`central_clear_alerts`, `central_defer_alerts`, `central_reactivate_alerts`, `central_set_alert_priority`, `central_locate_device`) classify `OPERATIONAL, gated=False` — no prompt, per the rubric.
+- Scope-membership writes keep an explicit `central_write_delete` tag on top of `Capability.WRITE` (Central's visibility transform only hides `_write_delete` — the documented footgun; gating preserved exactly).
+- NOTE for #429 (future auto-regen): the regenerated config tool files are source-of-truth since #423; any future generator must emit `capability=` in this form.
+
+### Fixed
+- **`central_start_ap_ranging_scan` reclassified WRITE_DELETE → DIAGNOSTIC** (#416's mis-annotation call-out): it triggers a calibration scan returning results with no persistent change; it no longer hides behind the write-enable flag.
+
+### Tests
+- Runtime tag-derivation verified (gated/ungated/diagnostic samples). Full suite **1802 passed**; ruff + format + mypy + bandit clean.
+
 ## [3.3.12.2] - 2026-06-11
 
 **Patch — capability migrations 4–6/N (Apstra, UXI, GreenLake) + AOS8 client conformance.** Advances the annotation sequence toward the universal confirmation gate (#415/#416, tracked in #466). The `requires_confirmation` tag remains inert until the gate PR; all visibility gating is byte-equivalent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.12.2"
+version = "3.3.12.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/_registry.py
+++ b/src/hpe_networking_mcp/platforms/central/_registry.py
@@ -1,61 +1,19 @@
-"""Central tool registry -- module-level FastMCP holder + shared-registry shim.
+"""Central tool registry — module-level FastMCP holder + shared-registry shim.
 
 Tool modules under ``platforms/central/tools/`` decorate their functions with
-``@tool(...)`` (imported from here) instead of directly with ``@mcp.tool(...)``.
-The shim mirrors the Apstra and Mist patterns: delegate to the real FastMCP
-decorator, merge the ``dynamic_managed`` tag so dynamic-mode ``Visibility`` can
-hide individual tools, and record a ``ToolSpec`` into ``REGISTRIES["central"]``
-so the three Central meta-tools can dispatch by name at runtime.
+``@tool(...)`` (imported from here). The shim is built by the shared
+``make_tool_decorator`` factory — see ``platforms/_template/_registry.py`` for
+the canonical reference and ``docs/tool-annotation-rubric.md`` for how
+``capability=`` classifies a tool.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
-
 from fastmcp import FastMCP
 
-from hpe_networking_mcp.platforms._common.tool_registry import (
-    DYNAMIC_MANAGED_TAG,
-    ToolSpec,
-    record_tool,
-)
+from hpe_networking_mcp.platforms._common.tool_registry import make_tool_decorator
 
-# Set by platforms.central.register_tools() before tool modules are imported.
+# Set by ``platforms.central.register_tools()`` before tool modules are imported.
 mcp: FastMCP = None  # type: ignore[assignment]
 
-_PLATFORM = "central"
-
-
-def _derive_category(func: Callable[..., Any]) -> str:
-    """Short module name as the registry category (e.g. ``sites``)."""
-    module = getattr(func, "__module__", "")
-    return module.rsplit(".", 1)[-1] if "." in module else module
-
-
-def tool(**tool_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Drop-in replacement for ``@mcp.tool(...)`` that also populates the registry."""
-
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        supplied_tags: set[str] = set(tool_kwargs.get("tags") or set())
-        resolved_name: str = tool_kwargs.get("name") or func.__name__
-        resolved_description: str = tool_kwargs.get("description") or func.__doc__ or ""
-
-        record_tool(
-            ToolSpec(
-                name=resolved_name,
-                func=func,
-                platform=_PLATFORM,
-                category=_derive_category(func),
-                description=resolved_description,
-                tags=supplied_tags,
-            )
-        )
-
-        if mcp is None:
-            return func
-
-        effective_kwargs = {**tool_kwargs, "tags": supplied_tags | {DYNAMIC_MANAGED_TAG, _PLATFORM}}
-        return mcp.tool(**effective_kwargs)(func)
-
-    return decorator
+tool = make_tool_decorator("central", lambda: mcp)

--- a/src/hpe_networking_mcp/platforms/central/tools/__init__.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/__init__.py
@@ -1,8 +1,13 @@
-from mcp.types import ToolAnnotations
+"""Tool modules for the Aruba Central platform.
 
-READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
+Tools are classified with the ``capability=`` kwarg on the ``@tool`` decorator
+(see ``platforms/_common/annotations.py`` and ``docs/tool-annotation-rubric.md``).
+That single classification derives the MCP annotations, the
+``central_write[_delete]`` enable tag, and the ``requires_confirmation`` gate
+tag — there are no hand-written ``ToolAnnotations`` constants.
+
+NOTE: scope-membership writes carry an explicit ``central_write_delete``
+functional tag on top of ``Capability.WRITE`` because Central's visibility
+transform only hides ``central_write_delete`` (the bare ``central_write``
+tag gates nothing — see the gating footgun note in the rubric rollout).
+"""

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -2,18 +2,11 @@ from typing import Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
-
-OPERATIONAL = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
 
 
 async def _resolve_switch_id(conn, serial_number: str) -> str:
@@ -46,7 +39,7 @@ async def _resolve_switch_id(conn, serial_number: str) -> str:
 # ── Disconnect Tools ─────────────────────────────────────────────
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_users_ssid(
     ctx: Context,
     serial_number: str,
@@ -82,7 +75,7 @@ async def central_disconnect_users_ssid(
     return resp
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_users_ap(
     ctx: Context,
     serial_number: str,
@@ -114,7 +107,7 @@ async def central_disconnect_users_ap(
     return resp
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_client_switch(
     ctx: Context,
     serial_number: str,
@@ -151,7 +144,7 @@ async def central_disconnect_client_switch(
     return resp
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_client_gateway(
     ctx: Context,
     serial_number: str,
@@ -184,7 +177,7 @@ async def central_disconnect_client_gateway(
     return resp
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_clients_gateway(
     ctx: Context,
     serial_number: str,
@@ -265,7 +258,7 @@ async def _get_switch_ports(conn, serial_number: str) -> dict:
 # ── Port / PoE Bounce Tools ──────────────────────────────────────
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_port_bounce_switch(
     ctx: Context,
     serial_number: str,
@@ -330,7 +323,7 @@ async def central_port_bounce_switch(
     }
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_poe_bounce_switch(
     ctx: Context,
     serial_number: str,
@@ -410,7 +403,7 @@ async def central_poe_bounce_switch(
     }
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_port_bounce_gateway(
     ctx: Context,
     serial_number: str,
@@ -446,7 +439,7 @@ async def central_port_bounce_gateway(
     return resp
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_poe_bounce_gateway(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
@@ -32,18 +32,10 @@ profiles.
 from typing import Literal
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 ScopeType = Literal["GLOBAL", "SITE", "DEVICE"]
 
@@ -63,7 +55,7 @@ def _typed_scope_query_params(type_id: str, scope_id: str, scope_type: ScopeType
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_alert_configs(
     ctx: Context,
     scope_id: str,
@@ -113,7 +105,7 @@ async def central_get_alert_configs(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_create_alert_config(
     ctx: Context,
     type_id: str,
@@ -188,7 +180,7 @@ async def central_create_alert_config(
     return msg if msg else f"Alert config create submitted for typeId={type_id}; response was empty"
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_update_alert_config(
     ctx: Context,
     type_id: str,
@@ -241,7 +233,7 @@ async def central_update_alert_config(
     return msg if msg else f"Alert config update submitted for typeId={type_id}; response was empty"
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_reset_alert_config(
     ctx: Context,
     type_id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -2,11 +2,10 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import PaginatedAlerts
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     build_odata_filter,
@@ -26,6 +25,7 @@ ALERT_FILTER_FIELDS: dict[str, FilterField] = {
     "site_id": FilterField("siteId"),
 }
 
+
 # Operational annotation for state-transition actions on alerts (clear,
 # defer, reactivate, set_priority). Mirrors the pattern in actions.py:
 # not read-only (changes alert state), not destructive (every transition
@@ -34,15 +34,7 @@ ALERT_FILTER_FIELDS: dict[str, FilterField] = {
 # `central_write_delete` — alert state transitions are operational
 # actions, not config changes, so they ride alongside reboot/AP-action
 # tools rather than gated behind ENABLE_CENTRAL_WRITE_TOOLS.
-OPERATIONAL = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
-
-
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_alerts(
     ctx: Context,
     site_id: str,
@@ -139,7 +131,7 @@ async def central_get_alerts(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_alert_classification(
     ctx: Context,
     classify_by: Literal[
@@ -197,7 +189,7 @@ async def central_get_alert_classification(
     return msg
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_alert_action_status(
     ctx: Context,
     task_id: str,
@@ -238,7 +230,7 @@ async def central_get_alert_action_status(
 # central_get_alert_action_status to confirm completion.
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL, gated=False)
 async def central_clear_alerts(
     ctx: Context,
     keys: list[str],
@@ -287,7 +279,7 @@ async def central_clear_alerts(
     return msg or f"Clear request submitted for {len(keys)} alert(s); response was empty"
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL, gated=False)
 async def central_defer_alerts(
     ctx: Context,
     keys: list[str],
@@ -325,7 +317,7 @@ async def central_defer_alerts(
     return msg or f"Defer request submitted for {len(keys)} alert(s); response was empty"
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL, gated=False)
 async def central_reactivate_alerts(
     ctx: Context,
     keys: list[str],
@@ -358,7 +350,7 @@ async def central_reactivate_alerts(
     return msg or f"Reactivate request submitted for {len(keys)} alert(s); response was empty"
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL, gated=False)
 async def central_set_alert_priority(
     ctx: Context,
     keys: list[str],

--- a/src/hpe_networking_mcp/platforms/central/tools/application_experience.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/application_experience.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- app-bandwidth-contracts -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_app_bandwidth_contracts(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_app_bandwidth_contracts(
     return await _get_resource(ctx, "app-bandwidth-contracts", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_app_bandwidth_contracts(
     ctx: Context,
     name: Annotated[str, Field(description="``app-bandwidth-contracts`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_app_bandwidth_contracts(
 # ----- arc -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_arc(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_arc(
     return await _get_resource(ctx, "arc", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_arc(
     ctx: Context,
     name: Annotated[str, Field(description="``arc`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/applications.py
@@ -3,8 +3,8 @@ from datetime import UTC, datetime
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -86,7 +86,7 @@ def _normalize_sort(value: str) -> str:
     return s
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_applications(
     ctx: Context,
     site_id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -1,12 +1,12 @@
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import deprecation_notice, get_central_conn, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_audit_logs(
     ctx: Context,
     start_at: str,
@@ -72,7 +72,7 @@ async def central_get_audit_logs(
     return body
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_audit_log_detail(
     ctx: Context,
     id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/central_nac.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/central_nac.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- airpass-approval -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_airpass_approval(
     ctx: Context,
     name: str | None = None,
@@ -60,7 +52,7 @@ async def central_get_airpass_approval(
 # ----- auth-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_auth_profiles(
     ctx: Context,
     auth_profile_id: str | None = None,
@@ -75,7 +67,7 @@ async def central_get_auth_profiles(
     return await _get_resource(ctx, "auth-profiles", auth_profile_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_auth_profiles(
     ctx: Context,
     auth_profile_id: Annotated[
@@ -118,7 +110,7 @@ async def central_manage_auth_profiles(
 # ----- authz-policies -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_authz_policies(
     ctx: Context,
     policy_id: str | None = None,
@@ -133,7 +125,7 @@ async def central_get_authz_policies(
     return await _get_resource(ctx, "authz-policies", policy_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_authz_policies(
     ctx: Context,
     policy_id: Annotated[str, Field(description="``authz-policies`` identifier (OpenAPI path param: ``policy-id``).")],
@@ -174,7 +166,7 @@ async def central_manage_authz_policies(
 # ----- custom-messages -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_custom_messages(
     ctx: Context,
     message_id: str | None = None,
@@ -189,7 +181,7 @@ async def central_get_custom_messages(
     return await _get_resource(ctx, "custom-messages", message_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_custom_messages(
     ctx: Context,
     message_id: Annotated[
@@ -232,7 +224,7 @@ async def central_manage_custom_messages(
 # ----- default-custom-messages -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_default_custom_messages(
     ctx: Context,
     message_id: str | None = None,
@@ -247,7 +239,7 @@ async def central_get_default_custom_messages(
     return await _get_resource(ctx, "default-custom-messages", message_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_default_custom_messages(
     ctx: Context,
     message_id: Annotated[
@@ -290,7 +282,7 @@ async def central_manage_default_custom_messages(
 # ----- identity-stores -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_identity_stores(
     ctx: Context,
     id: str | None = None,
@@ -305,7 +297,7 @@ async def central_get_identity_stores(
     return await _get_resource(ctx, "identity-stores", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_identity_stores(
     ctx: Context,
     id: Annotated[str, Field(description="``identity-stores`` identifier (OpenAPI path param: ``id``).")],
@@ -346,7 +338,7 @@ async def central_manage_identity_stores(
 # ----- message-providers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_message_providers(
     ctx: Context,
     provider_id: str | None = None,
@@ -361,7 +353,7 @@ async def central_get_message_providers(
     return await _get_resource(ctx, "message-providers", provider_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_message_providers(
     ctx: Context,
     provider_id: Annotated[
@@ -404,7 +396,7 @@ async def central_manage_message_providers(
 # ----- overrides -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_overrides(
     ctx: Context,
     override_id: str | None = None,
@@ -419,7 +411,7 @@ async def central_get_overrides(
     return await _get_resource(ctx, "overrides", override_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_overrides(
     ctx: Context,
     override_id: Annotated[str, Field(description="``overrides`` identifier (OpenAPI path param: ``override-id``).")],
@@ -460,7 +452,7 @@ async def central_manage_overrides(
 # ----- portals -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_portals(
     ctx: Context,
     portal_id: str | None = None,
@@ -475,7 +467,7 @@ async def central_get_portals(
     return await _get_resource(ctx, "portals", portal_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_portals(
     ctx: Context,
     portal_id: Annotated[str, Field(description="``portals`` identifier (OpenAPI path param: ``portal-id``).")],
@@ -516,7 +508,7 @@ async def central_manage_portals(
 # ----- skins -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_skins(
     ctx: Context,
     skin_id: str | None = None,
@@ -531,7 +523,7 @@ async def central_get_skins(
     return await _get_resource(ctx, "skins", skin_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_skins(
     ctx: Context,
     skin_id: Annotated[str, Field(description="``skins`` identifier (OpenAPI path param: ``skin-id``).")],
@@ -572,7 +564,7 @@ async def central_manage_skins(
 # ----- static-tag -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_static_tag(
     ctx: Context,
     tag_id: str | None = None,
@@ -587,7 +579,7 @@ async def central_get_static_tag(
     return await _get_resource(ctx, "static-tag", tag_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_static_tag(
     ctx: Context,
     tag_id: Annotated[str, Field(description="``static-tag`` identifier (OpenAPI path param: ``tag-id``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/central_nac_service.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/central_nac_service.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -33,17 +32,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _operation_request,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- cnac-certificate -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_certificate(
     ctx: Context,
 ) -> dict | list | str:
@@ -57,7 +49,7 @@ async def central_get_cnac_certificate(
 # ----- cnac-dpp-reg -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_dpp_reg(
     ctx: Context,
     id: str | None = None,
@@ -72,7 +64,7 @@ async def central_get_cnac_dpp_reg(
     return await _get_resource(ctx, "cnac-dpp-reg", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_dpp_reg(
     ctx: Context,
     id: Annotated[str, Field(description="``cnac-dpp-reg`` identifier (OpenAPI path param: ``id``).")],
@@ -113,7 +105,7 @@ async def central_manage_cnac_dpp_reg(
 # ----- cnac-image -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_image(
     ctx: Context,
     image_id: str | None = None,
@@ -131,7 +123,7 @@ async def central_get_cnac_image(
 # ----- cnac-job -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_job(
     ctx: Context,
     job_id: str | None = None,
@@ -146,7 +138,7 @@ async def central_get_cnac_job(
     return await _get_resource(ctx, "cnac-job", job_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_job(
     ctx: Context,
     job_id: Annotated[str, Field(description="``cnac-job`` identifier (OpenAPI path param: ``job-id``).")],
@@ -187,7 +179,7 @@ async def central_manage_cnac_job(
 # ----- cnac-mac-reg -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_mac_reg(
     ctx: Context,
     id: str | None = None,
@@ -202,7 +194,7 @@ async def central_get_cnac_mac_reg(
     return await _get_resource(ctx, "cnac-mac-reg", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_mac_reg(
     ctx: Context,
     id: Annotated[str, Field(description="``cnac-mac-reg`` identifier (OpenAPI path param: ``id``).")],
@@ -243,7 +235,7 @@ async def central_manage_cnac_mac_reg(
 # ----- cnac-named-mpsk-reg -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_named_mpsk_reg(
     ctx: Context,
     id: str | None = None,
@@ -258,7 +250,7 @@ async def central_get_cnac_named_mpsk_reg(
     return await _get_resource(ctx, "cnac-named-mpsk-reg", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_named_mpsk_reg(
     ctx: Context,
     id: Annotated[str, Field(description="``cnac-named-mpsk-reg`` identifier (OpenAPI path param: ``id``).")],
@@ -299,7 +291,7 @@ async def central_manage_cnac_named_mpsk_reg(
 # ----- cnac-visitor -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_visitor(
     ctx: Context,
     id: str | None = None,
@@ -314,7 +306,7 @@ async def central_get_cnac_visitor(
     return await _get_resource(ctx, "cnac-visitor", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_visitor(
     ctx: Context,
     id: Annotated[str, Field(description="``cnac-visitor`` identifier (OpenAPI path param: ``id``).")],
@@ -355,7 +347,7 @@ async def central_manage_cnac_visitor(
 # ----- operation: cnac-certificate/revoke -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_cnac_certificate_revoke(
     ctx: Context,
     payload: Annotated[
@@ -380,7 +372,7 @@ async def central_cnac_certificate_revoke(
 # ----- operation: cnac-image/upload -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_cnac_image_upload(
     ctx: Context,
     payload: Annotated[
@@ -405,7 +397,7 @@ async def central_cnac_image_upload(
 # ----- operation: cnac-mac-reg/import -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_cnac_mac_reg_import(
     ctx: Context,
     payload: Annotated[
@@ -430,7 +422,7 @@ async def central_cnac_mac_reg_import(
 # ----- operation: cnac-named-mpsk-reg/import -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_cnac_named_mpsk_reg_import(
     ctx: Context,
     payload: Annotated[
@@ -455,7 +447,7 @@ async def central_cnac_named_mpsk_reg_import(
 # ----- operation: cnac-image/download/{image-id} -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_image_download(
     ctx: Context,
     image_id: Annotated[str, Field(description="Path parameter (OpenAPI: ``image-id``).")],
@@ -474,7 +466,7 @@ async def central_get_cnac_image_download(
 # ----- operation: cnac-job/{job-id}/error -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_job_error(
     ctx: Context,
     job_id: Annotated[str, Field(description="Path parameter (OpenAPI: ``job-id``).")],
@@ -493,7 +485,7 @@ async def central_get_cnac_job_error(
 # ----- operation: cnac-job/{job-id}/input -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_job_input(
     ctx: Context,
     job_id: Annotated[str, Field(description="Path parameter (OpenAPI: ``job-id``).")],
@@ -512,7 +504,7 @@ async def central_get_cnac_job_input(
 # ----- operation: cnac-job/{job-id}/status -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_job_status(
     ctx: Context,
     job_id: Annotated[str, Field(description="Path parameter (OpenAPI: ``job-id``).")],
@@ -531,7 +523,7 @@ async def central_get_cnac_job_status(
 # ----- operation: cnac-mac-reg/export -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_mac_reg_export(
     ctx: Context,
 ) -> dict | str:
@@ -546,7 +538,7 @@ async def central_get_cnac_mac_reg_export(
 # ----- operation: cnac-named-mpsk-reg/export -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_named_mpsk_reg_export(
     ctx: Context,
 ) -> dict | str:
@@ -561,7 +553,7 @@ async def central_get_cnac_named_mpsk_reg_export(
 # ----- operation: cnac-visitor/export -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cnac_visitor_export(
     ctx: Context,
 ) -> dict | str:
@@ -576,7 +568,7 @@ async def central_get_cnac_visitor_export(
 # ----- operation: cnac-static-tags/usage -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cnac_static_tags_usage(
     ctx: Context,
     payload: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/clients.py
@@ -3,10 +3,10 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Client
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     build_odata_filter,
@@ -28,7 +28,7 @@ CLIENT_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_clients(
     ctx: Context,
     site_id: str | None = None,
@@ -99,7 +99,7 @@ async def central_get_clients(
     return clean_client_data(clients)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_find_client(
     ctx: Context,
     mac_address: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -17,16 +17,9 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = {
-    "readOnlyHint": False,
-    "destructiveHint": True,
-    "idempotentHint": False,
-    "openWorldHint": True,
-}
 
 # Valid device-function values from the API schema
 VALID_DEVICE_FUNCTIONS = {
@@ -51,7 +44,7 @@ VALID_DEVICE_FUNCTIONS = {
 }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_config_assignments(
     ctx: Context,
     scope_id: Annotated[
@@ -108,7 +101,7 @@ async def central_get_config_assignments(
     return response.get("msg", {})
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_config_assignment(
     ctx: Context,
     action_type: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/config_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_health.py
@@ -12,29 +12,21 @@ from typing import Any
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 # Per the upstream OpenAPI: search must be 3-128 chars when supplied.
 _SEARCH_MIN_CHARS = 3
 _SEARCH_MAX_CHARS = 128
 
+
 # Resync is operational, not a config edit: it re-pushes the *intended*
 # config (idempotent, non-destructive). Like the disconnect/reboot tools it
 # runs immediately without elicitation and isn't gated behind
 # ENABLE_CENTRAL_WRITE_TOOLS.
-OPERATIONAL = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
-
-
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_config_issues(
     ctx: Context,
     serial: str,
@@ -67,7 +59,7 @@ async def central_get_device_config_issues(
     return response.get("msg", {})
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devices_config_health(
     ctx: Context,
     limit: int = 100,
@@ -129,7 +121,7 @@ async def central_get_devices_config_health(
     return response.get("msg", {})
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_resync_device_config(
     ctx: Context,
     serials: list[str],

--- a/src/hpe_networking_mcp/platforms/central/tools/config_management.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_management.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- config-checkpoint -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_config_checkpoint(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_config_checkpoint(
     return await _get_resource(ctx, "config-checkpoint", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_config_checkpoint(
     ctx: Context,
     name: Annotated[str, Field(description="``config-checkpoint`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_config_checkpoint(
 # ----- device-persona-mapping -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_persona_mapping(
     ctx: Context,
     device_type: str | None = None,
@@ -116,7 +108,7 @@ async def central_get_device_persona_mapping(
 # ----- persona-assignment -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_persona_assignment(
     ctx: Context,
     target_device_function: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -11,19 +11,12 @@ from typing import Annotated
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 
 class ActionType(Enum):
@@ -45,7 +38,7 @@ class CollectionActionType(Enum):
 # ------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_site(
     ctx: Context,
     action_type: Annotated[
@@ -111,7 +104,7 @@ async def central_manage_site(
 # ------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_site_collection(
     ctx: Context,
     action_type: Annotated[
@@ -189,7 +182,7 @@ async def central_manage_site_collection(
 # ------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_group(
     ctx: Context,
     action_type: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/devices.py
@@ -3,10 +3,10 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import Device
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     as_comma_separated,
@@ -27,7 +27,7 @@ DEVICE_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devices(
     ctx: Context,
     site_id: str | None = None,
@@ -104,7 +104,7 @@ async def central_get_devices(
     return clean_device_data(devices)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_find_device(
     ctx: Context,
     serial_number: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/events.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/events.py
@@ -3,13 +3,13 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import (
     Event,
     EventFilters,
     PaginatedEvents,
 )
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     clean_event_filters,
     compute_time_window,
@@ -53,7 +53,7 @@ def _resolve_time_window(
     return fmt(start_dt), fmt(end_dt)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_events(
     ctx: Context,
     context_type: CONTEXT_TYPE,
@@ -134,7 +134,7 @@ async def central_get_events(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_events_count(
     ctx: Context,
     context_type: CONTEXT_TYPE,

--- a/src/hpe_networking_mcp/platforms/central/tools/extensions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/extensions.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- psm -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_psm(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_psm(
     return await _get_resource(ctx, "psm", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_psm(
     ctx: Context,
     name: Annotated[str, Field(description="``psm`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_psm(
 # ----- splunk-instances -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_splunk_instances(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_splunk_instances(
     return await _get_resource(ctx, "splunk-instances", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_splunk_instances(
     ctx: Context,
     name: Annotated[str, Field(description="``splunk-instances`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_splunk_instances(
 # ----- vsphere-instances -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vsphere_instances(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_vsphere_instances(
     return await _get_resource(ctx, "vsphere-instances", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vsphere_instances(
     ctx: Context,
     name: Annotated[str, Field(description="``vsphere-instances`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware.py
@@ -23,8 +23,8 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import BaseModel, Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -220,7 +220,7 @@ def _build_filter(
     return " and ".join(parts) if parts else None
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_recommend_firmware(
     ctx: Context,
     serial_number: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/firmware_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/firmware_policy.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- firmware-compliance -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_firmware_compliance(
     ctx: Context,
 ) -> dict | list | str:
@@ -53,7 +45,7 @@ async def central_get_firmware_compliance(
     return await _get_resource(ctx, "firmware-compliance", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_firmware_compliance(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/gateway_clustering_orchestration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/gateway_clustering_orchestration.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- gw-cluster-intent-config -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gw_cluster_intent_config(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_gw_cluster_intent_config(
     return await _get_resource(ctx, "gw-cluster-intent-config", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_gw_cluster_intent_config(
     ctx: Context,
     name: Annotated[str, Field(description="``gw-cluster-intent-config`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/high_availability.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/high_availability.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- gateway-clusters -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_clusters(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_gateway_clusters(
     return await _get_resource(ctx, "gateway-clusters", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_gateway_clusters(
     ctx: Context,
     name: Annotated[str, Field(description="``gateway-clusters`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_gateway_clusters(
 # ----- stacks -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_stacks(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_stacks(
     return await _get_resource(ctx, "stacks", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_stacks(
     ctx: Context,
     name: Annotated[str, Field(description="``stacks`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_stacks(
 # ----- vsf-templates -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vsf_templates(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_vsf_templates(
     return await _get_resource(ctx, "vsf-templates", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vsf_templates(
     ctx: Context,
     name: Annotated[str, Field(description="``vsf-templates`` identifier (OpenAPI path param: ``name``).")],
@@ -210,7 +202,7 @@ async def central_manage_vsf_templates(
 # ----- vsx-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vsx_profiles(
     ctx: Context,
     name: str | None = None,
@@ -225,7 +217,7 @@ async def central_get_vsx_profiles(
     return await _get_resource(ctx, "vsx-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vsx_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``vsx-profiles`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/interfaces.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/interfaces.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- ap-port-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_port_profiles(
     ctx: Context,
     profile_name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_ap_port_profiles(
     return await _get_resource(ctx, "ap-port-profiles", profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ap_port_profiles(
     ctx: Context,
     profile_name: Annotated[
@@ -100,7 +92,7 @@ async def central_manage_ap_port_profiles(
 # ----- ap-uplinks -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_uplinks(
     ctx: Context,
     name: str | None = None,
@@ -115,7 +107,7 @@ async def central_get_ap_uplinks(
     return await _get_resource(ctx, "ap-uplinks", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ap_uplinks(
     ctx: Context,
     name: Annotated[str, Field(description="``ap-uplinks`` identifier (OpenAPI path param: ``name``).")],
@@ -156,7 +148,7 @@ async def central_manage_ap_uplinks(
 # ----- cdp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cdp(
     ctx: Context,
     name: str | None = None,
@@ -171,7 +163,7 @@ async def central_get_cdp(
     return await _get_resource(ctx, "cdp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_cdp(
     ctx: Context,
     name: Annotated[str, Field(description="``cdp`` identifier (OpenAPI path param: ``name``).")],
@@ -212,7 +204,7 @@ async def central_manage_cdp(
 # ----- device-profile -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_profile(
     ctx: Context,
     name: str | None = None,
@@ -227,7 +219,7 @@ async def central_get_device_profile(
     return await _get_resource(ctx, "device-profile", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_profile(
     ctx: Context,
     name: Annotated[str, Field(description="``device-profile`` identifier (OpenAPI path param: ``name``).")],
@@ -268,7 +260,7 @@ async def central_manage_device_profile(
 # ----- dhcp-client -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_client(
     ctx: Context,
     name: str | None = None,
@@ -283,7 +275,7 @@ async def central_get_dhcp_client(
     return await _get_resource(ctx, "dhcp-client", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_client(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-client`` identifier (OpenAPI path param: ``name``).")],
@@ -324,7 +316,7 @@ async def central_manage_dhcp_client(
 # ----- ethernet-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ethernet_interfaces(
     ctx: Context,
     name: str | None = None,
@@ -339,7 +331,7 @@ async def central_get_ethernet_interfaces(
     return await _get_resource(ctx, "ethernet-interfaces", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ethernet_interfaces(
     ctx: Context,
     name: Annotated[str, Field(description="``ethernet-interfaces`` identifier (OpenAPI path param: ``name``).")],
@@ -380,7 +372,7 @@ async def central_manage_ethernet_interfaces(
 # ----- fault-monitor -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_fault_monitor(
     ctx: Context,
     name: str | None = None,
@@ -395,7 +387,7 @@ async def central_get_fault_monitor(
     return await _get_resource(ctx, "fault-monitor", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_fault_monitor(
     ctx: Context,
     name: Annotated[str, Field(description="``fault-monitor`` identifier (OpenAPI path param: ``name``).")],
@@ -436,7 +428,7 @@ async def central_manage_fault_monitor(
 # ----- gw-port-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gw_port_profiles(
     ctx: Context,
     profile_name: str | None = None,
@@ -451,7 +443,7 @@ async def central_get_gw_port_profiles(
     return await _get_resource(ctx, "gw-port-profiles", profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_gw_port_profiles(
     ctx: Context,
     profile_name: Annotated[
@@ -494,7 +486,7 @@ async def central_manage_gw_port_profiles(
 # ----- interface-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_interface_profiles(
     ctx: Context,
     name: str | None = None,
@@ -509,7 +501,7 @@ async def central_get_interface_profiles(
     return await _get_resource(ctx, "interface-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_interface_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``interface-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -550,7 +542,7 @@ async def central_manage_interface_profiles(
 # ----- lacp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_lacp(
     ctx: Context,
 ) -> dict | list | str:
@@ -561,7 +553,7 @@ async def central_get_lacp(
     return await _get_resource(ctx, "lacp", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_lacp(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -600,7 +592,7 @@ async def central_manage_lacp(
 # ----- lldp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_lldp(
     ctx: Context,
     name: str | None = None,
@@ -615,7 +607,7 @@ async def central_get_lldp(
     return await _get_resource(ctx, "lldp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_lldp(
     ctx: Context,
     name: Annotated[str, Field(description="``lldp`` identifier (OpenAPI path param: ``name``).")],
@@ -656,7 +648,7 @@ async def central_manage_lldp(
 # ----- loopback-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_loopback_interfaces(
     ctx: Context,
     id: str | None = None,
@@ -671,7 +663,7 @@ async def central_get_loopback_interfaces(
     return await _get_resource(ctx, "loopback-interfaces", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_loopback_interfaces(
     ctx: Context,
     id: Annotated[str, Field(description="``loopback-interfaces`` identifier (OpenAPI path param: ``id``).")],
@@ -712,7 +704,7 @@ async def central_manage_loopback_interfaces(
 # ----- mgmt-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mgmt_interfaces(
     ctx: Context,
     name: str | None = None,
@@ -727,7 +719,7 @@ async def central_get_mgmt_interfaces(
     return await _get_resource(ctx, "mgmt-interfaces", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mgmt_interfaces(
     ctx: Context,
     name: Annotated[str, Field(description="``mgmt-interfaces`` identifier (OpenAPI path param: ``name``).")],
@@ -768,7 +760,7 @@ async def central_manage_mgmt_interfaces(
 # ----- mirror-endpoint -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mirror_endpoint(
     ctx: Context,
     name: str | None = None,
@@ -783,7 +775,7 @@ async def central_get_mirror_endpoint(
     return await _get_resource(ctx, "mirror-endpoint", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mirror_endpoint(
     ctx: Context,
     name: Annotated[str, Field(description="``mirror-endpoint`` identifier (OpenAPI path param: ``name``).")],
@@ -824,7 +816,7 @@ async def central_manage_mirror_endpoint(
 # ----- mirrors -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mirrors(
     ctx: Context,
     name: str | None = None,
@@ -839,7 +831,7 @@ async def central_get_mirrors(
     return await _get_resource(ctx, "mirrors", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mirrors(
     ctx: Context,
     name: Annotated[str, Field(description="``mirrors`` identifier (OpenAPI path param: ``name``).")],
@@ -880,7 +872,7 @@ async def central_manage_mirrors(
 # ----- portchannels -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_portchannels(
     ctx: Context,
     name: str | None = None,
@@ -895,7 +887,7 @@ async def central_get_portchannels(
     return await _get_resource(ctx, "portchannels", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_portchannels(
     ctx: Context,
     name: Annotated[str, Field(description="``portchannels`` identifier (OpenAPI path param: ``name``).")],
@@ -936,7 +928,7 @@ async def central_manage_portchannels(
 # ----- sflow -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sflow(
     ctx: Context,
     name: str | None = None,
@@ -951,7 +943,7 @@ async def central_get_sflow(
     return await _get_resource(ctx, "sflow", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_sflow(
     ctx: Context,
     name: Annotated[str, Field(description="``sflow`` identifier (OpenAPI path param: ``name``).")],
@@ -992,7 +984,7 @@ async def central_manage_sflow(
 # ----- static-macs -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_static_macs(
     ctx: Context,
     name: str | None = None,
@@ -1007,7 +999,7 @@ async def central_get_static_macs(
     return await _get_resource(ctx, "static-macs", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_static_macs(
     ctx: Context,
     name: Annotated[str, Field(description="``static-macs`` identifier (OpenAPI path param: ``name``).")],
@@ -1048,7 +1040,7 @@ async def central_manage_static_macs(
 # ----- sub-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sub_interfaces(
     ctx: Context,
     parent_name_id: str | None = None,
@@ -1063,7 +1055,7 @@ async def central_get_sub_interfaces(
     return await _get_resource(ctx, "sub-interfaces", parent_name_id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_sub_interfaces(
     ctx: Context,
     parent_name_id: Annotated[
@@ -1106,7 +1098,7 @@ async def central_manage_sub_interfaces(
 # ----- sw-port-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sw_port_profiles(
     ctx: Context,
     profile_name: str | None = None,
@@ -1121,7 +1113,7 @@ async def central_get_sw_port_profiles(
     return await _get_resource(ctx, "sw-port-profiles", profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_sw_port_profiles(
     ctx: Context,
     profile_name: Annotated[
@@ -1164,7 +1156,7 @@ async def central_manage_sw_port_profiles(
 # ----- ufd -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ufd(
     ctx: Context,
     name: str | None = None,
@@ -1179,7 +1171,7 @@ async def central_get_ufd(
     return await _get_resource(ctx, "ufd", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ufd(
     ctx: Context,
     name: Annotated[str, Field(description="``ufd`` identifier (OpenAPI path param: ``name``).")],
@@ -1220,7 +1212,7 @@ async def central_manage_ufd(
 # ----- vlan-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vlan_interfaces(
     ctx: Context,
     id: str | None = None,
@@ -1235,7 +1227,7 @@ async def central_get_vlan_interfaces(
     return await _get_resource(ctx, "vlan-interfaces", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vlan_interfaces(
     ctx: Context,
     id: Annotated[str, Field(description="``vlan-interfaces`` identifier (OpenAPI path param: ``id``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/iot.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/iot.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- usb -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_usb(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_usb(
     return await _get_resource(ctx, "usb", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_usb(
     ctx: Context,
     name: Annotated[str, Field(description="``usb`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/miscellaneous.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/miscellaneous.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- device-firmware -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_firmware(
     ctx: Context,
 ) -> dict | list | str:
@@ -53,7 +45,7 @@ async def central_get_device_firmware(
     return await _get_resource(ctx, "device-firmware", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_firmware(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -92,7 +84,7 @@ async def central_manage_device_firmware(
 # ----- dsm -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dsm(
     ctx: Context,
     name: str | None = None,
@@ -107,7 +99,7 @@ async def central_get_dsm(
     return await _get_resource(ctx, "dsm", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dsm(
     ctx: Context,
     name: Annotated[str, Field(description="``dsm`` identifier (OpenAPI path param: ``name``).")],
@@ -148,7 +140,7 @@ async def central_manage_dsm(
 # ----- features -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_features(
     ctx: Context,
 ) -> dict | list | str:
@@ -159,7 +151,7 @@ async def central_get_features(
     return await _get_resource(ctx, "features", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_features(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -198,7 +190,7 @@ async def central_manage_features(
 # ----- node-operations -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_node_operations(
     ctx: Context,
     xpath: str | None = None,
@@ -213,7 +205,7 @@ async def central_get_node_operations(
     return await _get_resource(ctx, "node-operations", xpath)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_node_operations(
     ctx: Context,
     xpath: Annotated[str, Field(description="``node-operations`` identifier (OpenAPI path param: ``xpath``).")],
@@ -254,7 +246,7 @@ async def central_manage_node_operations(
 # ----- overlay-wlan -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_overlay_wlan(
     ctx: Context,
     profile: str | None = None,
@@ -269,7 +261,7 @@ async def central_get_overlay_wlan(
     return await _get_resource(ctx, "overlay-wlan", profile)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_overlay_wlan(
     ctx: Context,
     profile: Annotated[str, Field(description="``overlay-wlan`` identifier (OpenAPI path param: ``profile``).")],
@@ -310,7 +302,7 @@ async def central_manage_overlay_wlan(
 # ----- vsx-config -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vsx_config(
     ctx: Context,
     name: str | None = None,
@@ -325,7 +317,7 @@ async def central_get_vsx_config(
     return await _get_resource(ctx, "vsx-config", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vsx_config(
     ctx: Context,
     name: Annotated[str, Field(description="``vsx-config`` identifier (OpenAPI path param: ``name``).")],
@@ -366,7 +358,7 @@ async def central_manage_vsx_config(
 # ----- vxlan -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vxlan(
     ctx: Context,
     name: str | None = None,
@@ -381,7 +373,7 @@ async def central_get_vxlan(
     return await _get_resource(ctx, "vxlan", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vxlan(
     ctx: Context,
     name: Annotated[str, Field(description="``vxlan`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -3,9 +3,9 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     FilterField,
     as_comma_separated,
@@ -30,7 +30,7 @@ _AP_FILTER_FIELDS: dict[str, FilterField] = {
 }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_aps(
     ctx: Context,
     site_id: str | None = None,
@@ -93,7 +93,7 @@ async def central_get_aps(
     return aps or []
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_wlans(
     ctx: Context,
     serial_number: str,
@@ -128,7 +128,7 @@ async def central_get_ap_wlans(
     return items
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_details(
     ctx: Context,
     serial_number: str,
@@ -158,7 +158,7 @@ async def central_get_ap_details(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_details(
     ctx: Context,
     serial_number: str,
@@ -242,7 +242,7 @@ async def central_get_switch_details(
     return result
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_details(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -12,8 +12,8 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import coerce_enum, get_central_conn, retry_central_command
 
 
@@ -47,7 +47,7 @@ def _time_params(start: str | None, end: str | None) -> dict:
 _ApTrendDimension = Literal["throughput", "cpu", "memory", "power"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -107,7 +107,7 @@ async def central_get_ap_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_radios(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -120,7 +120,7 @@ async def central_get_ap_radios(
 _RadioTrendDimension = Literal["throughput", "channel-utilization", "channel-quality", "noise-floor", "frames"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_radio_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -158,7 +158,7 @@ async def central_get_ap_radio_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_ports(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -171,7 +171,7 @@ async def central_get_ap_ports(
 _PortTrendDimension = Literal["throughput", "frames", "crc", "collisions"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_port_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -203,7 +203,7 @@ async def central_get_ap_port_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_tunnels(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -213,7 +213,7 @@ async def central_get_ap_tunnels(
     return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_tunnel(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -227,7 +227,7 @@ async def central_get_ap_tunnel(
 _TunnelTrendDimension = Literal["throughput", "packet-loss", "mos", "jitter", "latency"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_tunnel_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -265,7 +265,7 @@ async def central_get_ap_tunnel_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_wlans_monitoring(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -280,7 +280,7 @@ async def central_get_ap_wlans_monitoring(
     return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/wlans")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_wlan_throughput(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -305,7 +305,7 @@ async def central_get_ap_wlan_throughput(
 _UsageMetric = Literal["wireless", "wired", "usage"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_top_aps_by_usage(
     ctx: Context,
     metric: Annotated[
@@ -346,7 +346,7 @@ async def central_get_top_aps_by_usage(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_radios(
     ctx: Context,
     filter: str | None = None,
@@ -361,7 +361,7 @@ async def central_get_radios(
     return await _get(conn, "network-monitoring/v1/radios", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_bssids(
     ctx: Context,
     filter: str | None = None,
@@ -376,7 +376,7 @@ async def central_get_bssids(
     return await _get(conn, "network-monitoring/v1/bssids", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wlans_monitoring(
     ctx: Context,
     filter: str | None = None,
@@ -396,7 +396,7 @@ async def central_get_wlans_monitoring(
     return await _get(conn, "network-monitoring/v1/wlans", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wlan_monitoring_detail(
     ctx: Context,
     wlan_name: Annotated[str, Field(description="WLAN / SSID name.")],
@@ -406,7 +406,7 @@ async def central_get_wlan_monitoring_detail(
     return await _get(conn, f"network-monitoring/v1/wlans/{wlan_name}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_swarms(
     ctx: Context,
     filter: str | None = None,
@@ -421,7 +421,7 @@ async def central_get_swarms(
     return await _get(conn, "network-monitoring/v1/swarms", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_swarm(
     ctx: Context,
     cluster_id: Annotated[str, Field(description="Swarm / cluster identifier.")],
@@ -431,7 +431,7 @@ async def central_get_swarm(
     return await _get(conn, f"network-monitoring/v1/swarms/{cluster_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_applications_v1(
     ctx: Context,
     filter: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
@@ -10,8 +10,8 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -33,7 +33,7 @@ async def _get(conn, path: str, params: dict | None = None) -> dict | str:
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_clients_trend(
     ctx: Context,
     start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
@@ -52,7 +52,7 @@ async def central_get_clients_trend(
     return await _get(conn, "network-monitoring/v1/clients-trend", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_clients_topn_usage(
     ctx: Context,
     top_n: Annotated[int, Field(ge=1, le=100, description="Number of top-clients to return (default 10).")] = 10,
@@ -66,7 +66,7 @@ async def central_get_clients_topn_usage(
     return await _get(conn, "network-monitoring/v1/clients-topn-usage", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_mobility_trail(
     ctx: Context,
     mac_address: Annotated[str, Field(description="Client MAC address.")],
@@ -83,7 +83,7 @@ async def central_get_client_mobility_trail(
     return await _get(conn, f"network-monitoring/v1/clients/{mac_address}/mobility-trail", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_detail(
     ctx: Context,
     mac_address: Annotated[str, Field(description="Client MAC address.")],
@@ -98,7 +98,7 @@ async def central_get_client_detail(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_onboarding_score(
     ctx: Context,
     filter: str | None = None,
@@ -111,7 +111,7 @@ async def central_get_client_onboarding_score(
     return await _get(conn, "network-monitoring/v1/client-onboarding-score", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_export(
     ctx: Context,
     filter: str | None = None,
@@ -129,7 +129,7 @@ async def central_get_client_onboarding_stage_export(
     return await _get(conn, "network-monitoring/v1/client-onboarding-stage/export", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_reasons(
     ctx: Context,
     filter: str | None = None,
@@ -142,7 +142,7 @@ async def central_get_client_onboarding_stage_reasons(
     return await _get(conn, "network-monitoring/v1/client-onboarding-stage/reasons", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_count(
     ctx: Context,
     filter: str | None = None,
@@ -163,7 +163,7 @@ async def central_get_client_onboarding_stage_count(
 _FirewallScope = Literal["site", "client", "firewall-clients"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_firewall_sessions(
     ctx: Context,
     scope: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
@@ -12,8 +12,8 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -44,7 +44,7 @@ def _time_params(start: str | None, end: str | None) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateways(
     ctx: Context,
     filter: str | None = None,
@@ -62,7 +62,7 @@ async def central_get_gateways(
 _GwTrendDimension = Literal["cpu", "memory", "hardware-temperature", "wan-availability", "vpn-availability"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -100,7 +100,7 @@ async def central_get_gateway_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_ports(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -110,7 +110,7 @@ async def central_get_gateway_ports(
     return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_port(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -124,7 +124,7 @@ async def central_get_gateway_port(
 _GwPortTrendDimension = Literal["throughput", "frames", "frames-errors", "frames-packets"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_port_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -158,7 +158,7 @@ async def central_get_gateway_port_trend(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_tunnels(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -168,7 +168,7 @@ async def central_get_gateway_tunnels(
     return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_tunnel(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -182,7 +182,7 @@ async def central_get_gateway_tunnel(
 _GwTunnelTrendDimension = Literal["throughput", "status", "dropped-packet"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_tunnel_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -211,7 +211,7 @@ async def central_get_gateway_tunnel_trend(
 _TunnelHealthScope = Literal["lan", "wan"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_tunnels_health_summary(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -230,7 +230,7 @@ async def central_get_gateway_tunnels_health_summary(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_vlans_runtime(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -240,7 +240,7 @@ async def central_get_gateway_vlans_runtime(
     return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_vlan_runtime(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -256,7 +256,7 @@ async def central_get_gateway_vlan_runtime(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplinks(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -266,7 +266,7 @@ async def central_get_gateway_uplinks(
     return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplink(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -280,7 +280,7 @@ async def central_get_gateway_uplink(
 _UplinkTrendDimension = Literal["throughput", "wan-compression", "wan-availability"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplink_trend(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -306,7 +306,7 @@ async def central_get_gateway_uplink_trend(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplink_probes(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -317,7 +317,7 @@ async def central_get_gateway_uplink_probes(
     return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplink_probe_performance(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -335,7 +335,7 @@ async def central_get_gateway_uplink_probe_performance(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_uplink_vpn_availability(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -367,7 +367,7 @@ async def central_get_gateway_uplink_vpn_availability(
 _DhcpView = Literal["pools", "clients"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_dhcp(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -386,7 +386,7 @@ async def central_get_gateway_dhcp(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cluster_members(
     ctx: Context,
     cluster_name: Annotated[str, Field(description="Cluster name.")],
@@ -405,7 +405,7 @@ _ClusterSummaryKind = Literal[
 ]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cluster_summary(
     ctx: Context,
     cluster_name: Annotated[str, Field(description="Cluster name.")],
@@ -426,7 +426,7 @@ async def central_get_cluster_summary(
     return await _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/{kind}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_cluster_capacity_trends(
     ctx: Context,
     cluster_name: Annotated[str, Field(description="Cluster name.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
@@ -12,8 +12,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -30,7 +30,7 @@ async def _get(conn, path: str, params: dict | None = None) -> dict | str:
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_site_health_detail(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -45,7 +45,7 @@ async def central_get_site_health_detail(
     return await _get(conn, f"network-monitoring/v1/site-health/{site_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sites_client_health(
     ctx: Context,
     filter: str | None = None,
@@ -60,7 +60,7 @@ async def central_get_sites_client_health(
     return await _get(conn, "network-monitoring/v1/sites-client-health", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tenant_device_health(
     ctx: Context,
     filter: str | None = None,
@@ -73,7 +73,7 @@ async def central_get_tenant_device_health(
     return await _get(conn, "network-monitoring/v1/tenant-device-health", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tenant_client_health(
     ctx: Context,
     filter: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
@@ -7,12 +7,12 @@ recommendation-style observations Central surfaces alongside hard alerts.
 
 from fastmcp import Context
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_insights(
     ctx: Context,
     filter: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_msp.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_msp.py
@@ -7,12 +7,12 @@ empty / 403 responses.
 
 from fastmcp import Context
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_list_msp_tenants(
     ctx: Context,
     limit: int = 100,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
@@ -9,22 +9,14 @@ report has zero or more report-runs (one per generation cycle).
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
-
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_reports(
     ctx: Context,
     filter: str | None = None,
@@ -58,7 +50,7 @@ async def central_get_reports(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_report_runs(
     ctx: Context,
     report_id: Annotated[str, Field(description="Report identifier (from ``central_get_reports``).")],
@@ -90,7 +82,7 @@ async def central_get_report_runs(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_update_report(
     ctx: Context,
     report_id: Annotated[str, Field(description="Report identifier to update.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -12,19 +12,11 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 
 async def _get(conn, path: str, params: dict | None = None) -> dict:
@@ -45,7 +37,7 @@ async def _get(conn, path: str, params: dict | None = None) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_fco_resp_info(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Device serial number.")],
@@ -60,7 +52,7 @@ async def central_get_fco_resp_info(
     return await _get(conn, f"network-services/v1/fco-resp-info/{serial_number}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_fco_resp_info_all(
     ctx: Context,
     limit: int = 100,
@@ -79,7 +71,7 @@ async def central_get_fco_resp_info_all(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_asset_tags(
     ctx: Context,
     filter: str | None = None,
@@ -109,7 +101,7 @@ async def central_get_asset_tags(
     return await _get(conn, "network-services/v1/asset-tags", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_asset_tag(
     ctx: Context,
     asset_tag_id: Annotated[
@@ -126,7 +118,7 @@ async def central_get_asset_tag(
     return await _get(conn, f"network-services/v1/asset-tags/{asset_tag_id}")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_asset_tag_metadata(
     ctx: Context,
     asset_tag_id: Annotated[str, Field(description="Asset-tag identifier.")],
@@ -188,7 +180,7 @@ async def central_manage_asset_tag_metadata(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.DIAGNOSTIC)
 async def central_start_ap_ranging_scan(
     ctx: Context,
     payload: Annotated[
@@ -222,7 +214,7 @@ async def central_start_ap_ranging_scan(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_ranging_scans(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -236,7 +228,7 @@ async def central_get_ap_ranging_scans(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_ranging_scan(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -251,7 +243,7 @@ async def central_get_ap_ranging_scan(
     )
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_delete_ap_ranging_scan(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -276,7 +268,7 @@ async def central_delete_ap_ranging_scan(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_site_device_locations(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -292,7 +284,7 @@ async def central_get_site_device_locations(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_site_device_location(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -303,7 +295,7 @@ async def central_get_site_device_location(
     return await _get(conn, f"network-services/v1/sites/{site_id}/device-locations/{location_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_location(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -317,7 +309,7 @@ async def central_get_device_location(
     )
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_location(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -371,7 +363,7 @@ async def central_manage_device_location(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wifi_clients_locations(
     ctx: Context,
     filter: str | None = None,
@@ -391,7 +383,7 @@ async def central_get_wifi_clients_locations(
     return await _get(conn, "network-services/v1/wifi-clients-locations", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_location_analytics_trends(
     ctx: Context,
     start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
@@ -414,7 +406,7 @@ async def central_get_location_analytics_trends(
     return await _get(conn, "network-services/v1/location-analytics/trends", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_location_analytics_site_insights(
     ctx: Context,
     filter: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
@@ -10,19 +10,11 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 
 async def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict:
@@ -44,7 +36,7 @@ async def _call(conn, method: str, path: str, params: dict | None = None, data: 
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sitemap_summary(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -54,7 +46,7 @@ async def central_get_sitemap_summary(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{site_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_catalogue_aps(
     ctx: Context,
     limit: int = 100,
@@ -78,7 +70,7 @@ async def central_get_catalogue_aps(
 _DeviceStatus = Literal["deployed", "assigned", "planned"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sitemap_devices(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -98,7 +90,7 @@ async def central_get_sitemap_devices(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/network-devices-{status}")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_sitemap_devices(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -153,7 +145,7 @@ async def central_manage_sitemap_devices(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_floor(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -164,7 +156,7 @@ async def central_get_floor(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_floor(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -217,7 +209,7 @@ async def central_manage_floor(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_set_floor_scale(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -241,7 +233,7 @@ async def central_set_floor_scale(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_floor_image(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -252,7 +244,7 @@ async def central_get_floor_image(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_set_floor_image(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -281,7 +273,7 @@ async def central_set_floor_image(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_buildings(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -291,7 +283,7 @@ async def central_get_buildings(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/buildings")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_building(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -335,7 +327,7 @@ async def central_manage_building(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_import_sitemap(
     ctx: Context,
     site_id: Annotated[str, Field(description="Target site identifier.")],
@@ -360,7 +352,7 @@ async def central_import_sitemap(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sitemap_import_status(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -376,14 +368,14 @@ async def central_get_sitemap_import_status(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wall_types(ctx: Context) -> dict:
     """List the wall types configured at the tenant level (used in floor walls)."""
     conn = get_central_conn(ctx)
     return await _call(conn, "GET", "network-monitoring/v1/wall-types")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_wall_types(
     ctx: Context,
     action_type: Annotated[
@@ -419,7 +411,7 @@ async def central_manage_wall_types(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_floor_walls(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -430,7 +422,7 @@ async def central_get_floor_walls(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_floor_walls(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -463,7 +455,7 @@ async def central_manage_floor_walls(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_floor_zones(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -474,7 +466,7 @@ async def central_get_floor_zones(
     return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones")
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_floor_zones(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
@@ -11,8 +11,8 @@ from typing import Annotated
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -29,7 +29,7 @@ async def _get(conn, path: str, params: dict | None = None) -> dict | str:
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switches(
     ctx: Context,
     filter: str | None = None,
@@ -48,7 +48,7 @@ async def central_get_switches(
     return await _get(conn, "network-monitoring/v1/switches", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_lag(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Switch serial number.")],
@@ -58,7 +58,7 @@ async def central_get_switch_lag(
     return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/lag")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_vlans(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Switch serial number.")],
@@ -68,7 +68,7 @@ async def central_get_switch_vlans(
     return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vlans")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_hardware_categories(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Switch serial number.")],
@@ -78,7 +78,7 @@ async def central_get_switch_hardware_categories(
     return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/hardware-categories")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_interface_trends(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Switch serial number.")],
@@ -100,7 +100,7 @@ async def central_get_switch_interface_trends(
     return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/interface-trends", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switches_topn_interface_trends(
     ctx: Context,
     top_n: Annotated[int, Field(ge=1, le=100, description="Number of top interfaces to return (default 10).")] = 10,
@@ -114,7 +114,7 @@ async def central_get_switches_topn_interface_trends(
     return await _get(conn, "network-monitoring/v1/switches/topn-interface-trends", params)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_vsx(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Switch serial number.")],
@@ -124,7 +124,7 @@ async def central_get_switch_vsx(
     return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vsx")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_stack_members(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Conductor switch serial number.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
@@ -9,19 +9,11 @@ write surface.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
 
 async def _call(conn, method: str, path: str, params: dict | None = None, data: dict | None = None) -> dict | str:
@@ -38,7 +30,7 @@ async def _call(conn, method: str, path: str, params: dict | None = None, data: 
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_topology(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -48,7 +40,7 @@ async def central_get_topology(
     return await _call(conn, "GET", f"network-monitoring/v1/topology/{site_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_neighbours(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Device serial number.")],
@@ -58,7 +50,7 @@ async def central_get_neighbours(
     return await _call(conn, "GET", f"network-monitoring/v1/neighbours/{serial_number}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_unmanaged_device(
     ctx: Context,
     mac_address: Annotated[str, Field(description="MAC address of the unmanaged device.")],
@@ -68,7 +60,7 @@ async def central_get_unmanaged_device(
     return await _call(conn, "GET", f"network-monitoring/v1/unmanaged-device/{mac_address}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_isolated_devices(
     ctx: Context,
     site_id: Annotated[str, Field(description="Site identifier.")],
@@ -78,7 +70,7 @@ async def central_get_isolated_devices(
     return await _call(conn, "GET", f"network-monitoring/v1/isolated-devices/{site_id}")
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_inventory(
     ctx: Context,
     filter: str | None = None,
@@ -98,7 +90,7 @@ async def central_get_device_inventory(
     return await _call(conn, "GET", "network-monitoring/v1/device-inventory", params=params)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_update_device(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Device serial number to update.")],
@@ -125,7 +117,7 @@ async def central_update_device(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_delete_device(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Device serial number to delete from the inventory.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -28,19 +28,11 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-OPERATIONAL = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
-)
 
 DeviceFamilyAll = Literal["aos-s", "aps", "cx", "gateways"]
 DeviceFamilyApGwSw = Literal["aps", "cx", "gateways"]
@@ -85,7 +77,7 @@ async def _post_action(conn, family: str, serial: str, action: str, payload: dic
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_troubleshooting_task_status(
     ctx: Context,
     device_family: Annotated[
@@ -121,7 +113,7 @@ async def central_get_troubleshooting_task_status(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_list_troubleshooting_tasks(
     ctx: Context,
     device_family: Annotated[
@@ -139,7 +131,7 @@ async def central_list_troubleshooting_tasks(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_list_supported_show_commands(
     ctx: Context,
     device_family: Annotated[
@@ -167,7 +159,7 @@ async def central_list_supported_show_commands(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_event_extra_attributes(
     ctx: Context,
     filter: str | None = None,
@@ -194,7 +186,7 @@ async def central_get_event_extra_attributes(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_probe_http(
     ctx: Context,
     device_family: Annotated[DeviceFamilyApGwSw, Field(description="``'aps'``, ``'cx'``, or ``'gateways'``.")],
@@ -211,7 +203,7 @@ async def central_probe_http(
     return await _post_action(get_central_conn(ctx), device_family, serial_number, "http", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_probe_https(
     ctx: Context,
     device_family: Annotated[DeviceFamilyApGwSw, Field(description="``'aps'``, ``'cx'``, or ``'gateways'``.")],
@@ -228,7 +220,7 @@ async def central_probe_https(
     return await _post_action(get_central_conn(ctx), device_family, serial_number, "https", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_probe_tcp(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number (TCP probe is only offered on APs).")],
@@ -241,7 +233,7 @@ async def central_probe_tcp(
     return await _post_action(get_central_conn(ctx), "aps", serial_number, "tcp", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_iperf_test(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number (iperf is only offered on gateways).")],
@@ -254,7 +246,7 @@ async def central_iperf_test(
     return await _post_action(get_central_conn(ctx), "gateways", serial_number, "iperf", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_speedtest(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number (speedtest is only offered on APs).")],
@@ -267,7 +259,7 @@ async def central_speedtest(
     return await _post_action(get_central_conn(ctx), "aps", serial_number, "speedtest", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_nslookup(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number (nslookup is only offered on APs).")],
@@ -280,7 +272,7 @@ async def central_nslookup(
     return await _post_action(get_central_conn(ctx), "aps", serial_number, "nslookup", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_test_aaa(
     ctx: Context,
     device_family: Annotated[DeviceFamilyApCx, Field(description="``'aps'`` or ``'cx'``.")],
@@ -301,7 +293,7 @@ async def central_test_aaa(
     return await _post_action(get_central_conn(ctx), device_family, serial_number, "aaa", payload)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_arp_table(
     ctx: Context,
     device_family: Annotated[
@@ -328,7 +320,7 @@ async def central_get_arp_table(
     )
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_ping_sweep(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number (pingSweep is only offered on gateways).")],
@@ -346,7 +338,7 @@ async def central_ping_sweep(
 # ---------------------------------------------------------------------------
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_reboot_device(
     ctx: Context,
     device_family: Annotated[DeviceFamilyAll, Field(description="Device family.")],
@@ -366,7 +358,7 @@ async def central_reboot_device(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_reboot_swarm(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Swarm conductor AP serial number.")],
@@ -379,7 +371,7 @@ async def central_reboot_swarm(
     return await _post_action(get_central_conn(ctx), "aps", serial_number, "rebootSwarm", payload)
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL, gated=False)
 async def central_locate_device(
     ctx: Context,
     device_family: Annotated[
@@ -402,7 +394,7 @@ async def central_locate_device(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_halt_gateway(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -415,7 +407,7 @@ async def central_halt_gateway(
     return await _post_action(get_central_conn(ctx), "gateways", serial_number, "halt", payload)
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_user_by_network(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -431,7 +423,7 @@ async def central_disconnect_user_by_network(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_user_by_mac_on_ap(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -447,7 +439,7 @@ async def central_disconnect_user_by_mac_on_ap(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_user_all_on_ap(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
@@ -466,7 +458,7 @@ async def central_disconnect_user_all_on_ap(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_client_all_on_gateway(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
@@ -485,7 +477,7 @@ async def central_disconnect_client_all_on_gateway(
     )
 
 
-@tool(annotations=OPERATIONAL)
+@tool(capability=Capability.OPERATIONAL)
 async def central_disconnect_client_by_mac_on_gateway(
     ctx: Context,
     serial_number: Annotated[str, Field(description="Gateway serial number.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
@@ -14,22 +14,14 @@ from typing import Annotated, Literal
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
-
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_webhooks(
     ctx: Context,
     limit: int = 100,
@@ -54,7 +46,7 @@ async def central_get_webhooks(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_webhook(
     ctx: Context,
     webhook_id: Annotated[str, Field(description="Webhook identifier.")],
@@ -72,7 +64,7 @@ async def central_get_webhook(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_webhook(
     ctx: Context,
     action_type: Annotated[
@@ -152,7 +144,7 @@ async def central_manage_webhook(
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_rotate_webhook_hmac_key(
     ctx: Context,
     webhook_id: Annotated[str, Field(description="Webhook identifier to rotate.")],

--- a/src/hpe_networking_mcp/platforms/central/tools/named_object.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/named_object.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- aliases -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_aliases(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_aliases(
     return await _get_resource(ctx, "aliases", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_aliases(
     ctx: Context,
     name: Annotated[str, Field(description="``aliases`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_aliases(
 # ----- named-conditions -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_named_conditions(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_named_conditions(
     return await _get_resource(ctx, "named-conditions", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_named_conditions(
     ctx: Context,
     name: Annotated[str, Field(description="``named-conditions`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_named_conditions(
 # ----- net-services -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_net_services(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_net_services(
     return await _get_resource(ctx, "net-services", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_net_services(
     ctx: Context,
     name: Annotated[str, Field(description="``net-services`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/network_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/network_services.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- dhcp-pool -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_pool(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_dhcp_pool(
     return await _get_resource(ctx, "dhcp-pool", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_pool(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-pool`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_dhcp_pool(
 # ----- dhcp-relay -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_relay(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_dhcp_relay(
     return await _get_resource(ctx, "dhcp-relay", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_relay(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-relay`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_dhcp_relay(
 # ----- dhcp-server -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_server(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_dhcp_server(
     return await _get_resource(ctx, "dhcp-server", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_server(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-server`` identifier (OpenAPI path param: ``name``).")],
@@ -210,7 +202,7 @@ async def central_manage_dhcp_server(
 # ----- dhcp-snooping -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_snooping(
     ctx: Context,
     name: str | None = None,
@@ -225,7 +217,7 @@ async def central_get_dhcp_snooping(
     return await _get_resource(ctx, "dhcp-snooping", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_snooping(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-snooping`` identifier (OpenAPI path param: ``name``).")],
@@ -266,7 +258,7 @@ async def central_manage_dhcp_snooping(
 # ----- dhcp-snooping-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dhcp_snooping_interface(
     ctx: Context,
     name: str | None = None,
@@ -281,7 +273,7 @@ async def central_get_dhcp_snooping_interface(
     return await _get_resource(ctx, "dhcp-snooping-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dhcp_snooping_interface(
     ctx: Context,
     name: Annotated[str, Field(description="``dhcp-snooping-interface`` identifier (OpenAPI path param: ``name``).")],
@@ -322,7 +314,7 @@ async def central_manage_dhcp_snooping_interface(
 # ----- dynamic-arp-inspection-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dynamic_arp_inspection_interface(
     ctx: Context,
     name: str | None = None,
@@ -337,7 +329,7 @@ async def central_get_dynamic_arp_inspection_interface(
     return await _get_resource(ctx, "dynamic-arp-inspection-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dynamic_arp_inspection_interface(
     ctx: Context,
     name: Annotated[
@@ -380,7 +372,7 @@ async def central_manage_dynamic_arp_inspection_interface(
 # ----- external-storage -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_external_storage(
     ctx: Context,
     name: str | None = None,
@@ -395,7 +387,7 @@ async def central_get_external_storage(
     return await _get_resource(ctx, "external-storage", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_external_storage(
     ctx: Context,
     name: Annotated[str, Field(description="``external-storage`` identifier (OpenAPI path param: ``name``).")],
@@ -436,7 +428,7 @@ async def central_manage_external_storage(
 # ----- ip-source-lockdown -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ip_source_lockdown(
     ctx: Context,
     name: str | None = None,
@@ -451,7 +443,7 @@ async def central_get_ip_source_lockdown(
     return await _get_resource(ctx, "ip-source-lockdown", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ip_source_lockdown(
     ctx: Context,
     name: Annotated[str, Field(description="``ip-source-lockdown`` identifier (OpenAPI path param: ``name``).")],
@@ -492,7 +484,7 @@ async def central_manage_ip_source_lockdown(
 # ----- ip-source-lockdown-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ip_source_lockdown_interface(
     ctx: Context,
     name: str | None = None,
@@ -507,7 +499,7 @@ async def central_get_ip_source_lockdown_interface(
     return await _get_resource(ctx, "ip-source-lockdown-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ip_source_lockdown_interface(
     ctx: Context,
     name: Annotated[
@@ -550,7 +542,7 @@ async def central_manage_ip_source_lockdown_interface(
 # ----- ipsla -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ipsla(
     ctx: Context,
     name: str | None = None,
@@ -565,7 +557,7 @@ async def central_get_ipsla(
     return await _get_resource(ctx, "ipsla", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ipsla(
     ctx: Context,
     name: Annotated[str, Field(description="``ipsla`` identifier (OpenAPI path param: ``name``).")],
@@ -606,7 +598,7 @@ async def central_manage_ipsla(
 # ----- mgmd-global -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mgmd_global(
     ctx: Context,
     name: str | None = None,
@@ -621,7 +613,7 @@ async def central_get_mgmd_global(
     return await _get_resource(ctx, "mgmd-global", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mgmd_global(
     ctx: Context,
     name: Annotated[str, Field(description="``mgmd-global`` identifier (OpenAPI path param: ``name``).")],
@@ -662,7 +654,7 @@ async def central_manage_mgmd_global(
 # ----- multicast-dns -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_multicast_dns(
     ctx: Context,
     name: str | None = None,
@@ -677,7 +669,7 @@ async def central_get_multicast_dns(
     return await _get_resource(ctx, "multicast-dns", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_multicast_dns(
     ctx: Context,
     name: Annotated[str, Field(description="``multicast-dns`` identifier (OpenAPI path param: ``name``).")],
@@ -718,7 +710,7 @@ async def central_manage_multicast_dns(
 # ----- nae-lite -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nae_lite(
     ctx: Context,
     name: str | None = None,
@@ -733,7 +725,7 @@ async def central_get_nae_lite(
     return await _get_resource(ctx, "nae-lite", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nae_lite(
     ctx: Context,
     name: Annotated[str, Field(description="``nae-lite`` identifier (OpenAPI path param: ``name``).")],
@@ -774,7 +766,7 @@ async def central_manage_nae_lite(
 # ----- nd-snooping -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nd_snooping(
     ctx: Context,
     name: str | None = None,
@@ -789,7 +781,7 @@ async def central_get_nd_snooping(
     return await _get_resource(ctx, "nd-snooping", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nd_snooping(
     ctx: Context,
     name: Annotated[str, Field(description="``nd-snooping`` identifier (OpenAPI path param: ``name``).")],
@@ -830,7 +822,7 @@ async def central_manage_nd_snooping(
 # ----- nd-snooping-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nd_snooping_interface(
     ctx: Context,
     name: str | None = None,
@@ -845,7 +837,7 @@ async def central_get_nd_snooping_interface(
     return await _get_resource(ctx, "nd-snooping-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nd_snooping_interface(
     ctx: Context,
     name: Annotated[str, Field(description="``nd-snooping-interface`` identifier (OpenAPI path param: ``name``).")],
@@ -886,7 +878,7 @@ async def central_manage_nd_snooping_interface(
 # ----- ptp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ptp(
     ctx: Context,
     name: str | None = None,
@@ -901,7 +893,7 @@ async def central_get_ptp(
     return await _get_resource(ctx, "ptp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ptp(
     ctx: Context,
     name: Annotated[str, Field(description="``ptp`` identifier (OpenAPI path param: ``name``).")],
@@ -942,7 +934,7 @@ async def central_manage_ptp(
 # ----- qos-global -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_qos_global(
     ctx: Context,
     name: str | None = None,
@@ -957,7 +949,7 @@ async def central_get_qos_global(
     return await _get_resource(ctx, "qos-global", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_qos_global(
     ctx: Context,
     name: Annotated[str, Field(description="``qos-global`` identifier (OpenAPI path param: ``name``).")],
@@ -998,7 +990,7 @@ async def central_manage_qos_global(
 # ----- qos-queues -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_qos_queues(
     ctx: Context,
     q_profile_name: str | None = None,
@@ -1013,7 +1005,7 @@ async def central_get_qos_queues(
     return await _get_resource(ctx, "qos-queues", q_profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_qos_queues(
     ctx: Context,
     q_profile_name: Annotated[
@@ -1056,7 +1048,7 @@ async def central_manage_qos_queues(
 # ----- qos-schedules -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_qos_schedules(
     ctx: Context,
     sched_profile_name: str | None = None,
@@ -1071,7 +1063,7 @@ async def central_get_qos_schedules(
     return await _get_resource(ctx, "qos-schedules", sched_profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_qos_schedules(
     ctx: Context,
     sched_profile_name: Annotated[
@@ -1114,7 +1106,7 @@ async def central_manage_qos_schedules(
 # ----- qos-thresholds -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_qos_thresholds(
     ctx: Context,
     thresh_profile_name: str | None = None,
@@ -1129,7 +1121,7 @@ async def central_get_qos_thresholds(
     return await _get_resource(ctx, "qos-thresholds", thresh_profile_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_qos_thresholds(
     ctx: Context,
     thresh_profile_name: Annotated[
@@ -1172,7 +1164,7 @@ async def central_manage_qos_thresholds(
 # ----- source-ip-bindings -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_source_ip_bindings(
     ctx: Context,
     ip_version_vlan_client_address: str | None = None,
@@ -1187,7 +1179,7 @@ async def central_get_source_ip_bindings(
     return await _get_resource(ctx, "source-ip-bindings", ip_version_vlan_client_address)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_source_ip_bindings(
     ctx: Context,
     ip_version_vlan_client_address: Annotated[
@@ -1233,7 +1225,7 @@ async def central_manage_source_ip_bindings(
 # ----- udp-broadcast-forwarders -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_udp_broadcast_forwarders(
     ctx: Context,
     name: str | None = None,
@@ -1248,7 +1240,7 @@ async def central_get_udp_broadcast_forwarders(
     return await _get_resource(ctx, "udp-broadcast-forwarders", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_udp_broadcast_forwarders(
     ctx: Context,
     name: Annotated[str, Field(description="``udp-broadcast-forwarders`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -13,8 +13,8 @@ API: GET /network-config/v1alpha1/roles/{name},
 
 from fastmcp import Context
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
@@ -53,7 +53,7 @@ def _extract_policy_names(role_body: dict) -> list[str]:
     return names
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_role_with_policy(
     ctx: Context,
     name: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/roles_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles_policy.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- object-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_object_groups(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_object_groups(
     return await _get_resource(ctx, "object-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_object_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``object-groups`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_object_groups(
 # ----- policies -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_policies(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_policies(
     return await _get_resource(ctx, "policies", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_policies(
     ctx: Context,
     name: Annotated[str, Field(description="``policies`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_policies(
 # ----- policy-group-list -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_policy_group_list(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_policy_group_list(
     return await _get_resource(ctx, "policy-groups/policy-group/policy-group-list", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_policy_group_list(
     ctx: Context,
     name: Annotated[str, Field(description="``policy-group-list`` identifier (OpenAPI path param: ``name``).")],
@@ -210,7 +202,7 @@ async def central_manage_policy_group_list(
 # ----- policy-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_policy_groups(
     ctx: Context,
 ) -> dict | list | str:
@@ -221,7 +213,7 @@ async def central_get_policy_groups(
     return await _get_resource(ctx, "policy-groups", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_policy_groups(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -260,7 +252,7 @@ async def central_manage_policy_groups(
 # ----- role-acls -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_role_acls(
     ctx: Context,
     name: str | None = None,
@@ -275,7 +267,7 @@ async def central_get_role_acls(
     return await _get_resource(ctx, "role-acls", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_role_acls(
     ctx: Context,
     name: Annotated[str, Field(description="``role-acls`` identifier (OpenAPI path param: ``name``).")],
@@ -316,7 +308,7 @@ async def central_manage_role_acls(
 # ----- role-gpids -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_role_gpids(
     ctx: Context,
     name: str | None = None,
@@ -331,7 +323,7 @@ async def central_get_role_gpids(
     return await _get_resource(ctx, "role-gpids", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_role_gpids(
     ctx: Context,
     name: Annotated[str, Field(description="``role-gpids`` identifier (OpenAPI path param: ``name``).")],
@@ -372,7 +364,7 @@ async def central_manage_role_gpids(
 # ----- roles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_roles(
     ctx: Context,
     name: str | None = None,
@@ -387,7 +379,7 @@ async def central_get_roles(
     return await _get_resource(ctx, "roles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_roles(
     ctx: Context,
     name: Annotated[str, Field(description="``roles`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/routing_overlays.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/routing_overlays.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- advanced-intelligent-forwarding -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_advanced_intelligent_forwarding(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_advanced_intelligent_forwarding(
     return await _get_resource(ctx, "advanced-intelligent-forwarding", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_advanced_intelligent_forwarding(
     ctx: Context,
     name: Annotated[
@@ -100,7 +92,7 @@ async def central_manage_advanced_intelligent_forwarding(
 # ----- aspath-lists -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_aspath_lists(
     ctx: Context,
     aspath_list_name: str | None = None,
@@ -115,7 +107,7 @@ async def central_get_aspath_lists(
     return await _get_resource(ctx, "aspath-lists", aspath_list_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_aspath_lists(
     ctx: Context,
     aspath_list_name: Annotated[
@@ -158,7 +150,7 @@ async def central_manage_aspath_lists(
 # ----- bfd -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_bfd(
     ctx: Context,
     name: str | None = None,
@@ -173,7 +165,7 @@ async def central_get_bfd(
     return await _get_resource(ctx, "bfd", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_bfd(
     ctx: Context,
     name: Annotated[str, Field(description="``bfd`` identifier (OpenAPI path param: ``name``).")],
@@ -214,7 +206,7 @@ async def central_manage_bfd(
 # ----- bgp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_bgp(
     ctx: Context,
     name: str | None = None,
@@ -229,7 +221,7 @@ async def central_get_bgp(
     return await _get_resource(ctx, "bgp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_bgp(
     ctx: Context,
     name: Annotated[str, Field(description="``bgp`` identifier (OpenAPI path param: ``name``).")],
@@ -270,7 +262,7 @@ async def central_manage_bgp(
 # ----- community-lists -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_community_lists(
     ctx: Context,
     community_list_name_community_type: str | None = None,
@@ -285,7 +277,7 @@ async def central_get_community_lists(
     return await _get_resource(ctx, "community-lists", community_list_name_community_type)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_community_lists(
     ctx: Context,
     community_list_name_community_type: Annotated[
@@ -331,7 +323,7 @@ async def central_manage_community_lists(
 # ----- evpn -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_evpn(
     ctx: Context,
     name: str | None = None,
@@ -346,7 +338,7 @@ async def central_get_evpn(
     return await _get_resource(ctx, "evpn", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_evpn(
     ctx: Context,
     name: Annotated[str, Field(description="``evpn`` identifier (OpenAPI path param: ``name``).")],
@@ -387,7 +379,7 @@ async def central_manage_evpn(
 # ----- ip-routing -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ip_routing(
     ctx: Context,
     name: str | None = None,
@@ -402,7 +394,7 @@ async def central_get_ip_routing(
     return await _get_resource(ctx, "ip-routing", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ip_routing(
     ctx: Context,
     name: Annotated[str, Field(description="``ip-routing`` identifier (OpenAPI path param: ``name``).")],
@@ -443,7 +435,7 @@ async def central_manage_ip_routing(
 # ----- l3-route -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_l3_route(
     ctx: Context,
     name: str | None = None,
@@ -458,7 +450,7 @@ async def central_get_l3_route(
     return await _get_resource(ctx, "l3-route", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_l3_route(
     ctx: Context,
     name: Annotated[str, Field(description="``l3-route`` identifier (OpenAPI path param: ``name``).")],
@@ -499,7 +491,7 @@ async def central_manage_l3_route(
 # ----- mpls -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mpls(
     ctx: Context,
     name: str | None = None,
@@ -514,7 +506,7 @@ async def central_get_mpls(
     return await _get_resource(ctx, "mpls", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mpls(
     ctx: Context,
     name: Annotated[str, Field(description="``mpls`` identifier (OpenAPI path param: ``name``).")],
@@ -555,7 +547,7 @@ async def central_manage_mpls(
 # ----- msdp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_msdp(
     ctx: Context,
     name: str | None = None,
@@ -570,7 +562,7 @@ async def central_get_msdp(
     return await _get_resource(ctx, "msdp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_msdp(
     ctx: Context,
     name: Annotated[str, Field(description="``msdp`` identifier (OpenAPI path param: ``name``).")],
@@ -611,7 +603,7 @@ async def central_manage_msdp(
 # ----- multicast-global -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_multicast_global(
     ctx: Context,
     name: str | None = None,
@@ -626,7 +618,7 @@ async def central_get_multicast_global(
     return await _get_resource(ctx, "multicast-global", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_multicast_global(
     ctx: Context,
     name: Annotated[str, Field(description="``multicast-global`` identifier (OpenAPI path param: ``name``).")],
@@ -667,7 +659,7 @@ async def central_manage_multicast_global(
 # ----- multicast-static-route -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_multicast_static_route(
     ctx: Context,
     name: str | None = None,
@@ -682,7 +674,7 @@ async def central_get_multicast_static_route(
     return await _get_resource(ctx, "multicast-static-route", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_multicast_static_route(
     ctx: Context,
     name: Annotated[str, Field(description="``multicast-static-route`` identifier (OpenAPI path param: ``name``).")],
@@ -723,7 +715,7 @@ async def central_manage_multicast_static_route(
 # ----- nexthop-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nexthop_groups(
     ctx: Context,
     name: str | None = None,
@@ -738,7 +730,7 @@ async def central_get_nexthop_groups(
     return await _get_resource(ctx, "nexthop-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nexthop_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``nexthop-groups`` identifier (OpenAPI path param: ``name``).")],
@@ -779,7 +771,7 @@ async def central_manage_nexthop_groups(
 # ----- ospfv2 -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ospfv2(
     ctx: Context,
     name: str | None = None,
@@ -794,7 +786,7 @@ async def central_get_ospfv2(
     return await _get_resource(ctx, "ospfv2", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ospfv2(
     ctx: Context,
     name: Annotated[str, Field(description="``ospfv2`` identifier (OpenAPI path param: ``name``).")],
@@ -835,7 +827,7 @@ async def central_manage_ospfv2(
 # ----- ospfv3 -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ospfv3(
     ctx: Context,
     name: str | None = None,
@@ -850,7 +842,7 @@ async def central_get_ospfv3(
     return await _get_resource(ctx, "ospfv3", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ospfv3(
     ctx: Context,
     name: Annotated[str, Field(description="``ospfv3`` identifier (OpenAPI path param: ``name``).")],
@@ -891,7 +883,7 @@ async def central_manage_ospfv3(
 # ----- pim-router -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_pim_router(
     ctx: Context,
     name: str | None = None,
@@ -906,7 +898,7 @@ async def central_get_pim_router(
     return await _get_resource(ctx, "pim-router", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_pim_router(
     ctx: Context,
     name: Annotated[str, Field(description="``pim-router`` identifier (OpenAPI path param: ``name``).")],
@@ -947,7 +939,7 @@ async def central_manage_pim_router(
 # ----- prefix-lists -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_prefix_lists(
     ctx: Context,
     prefix_list_name_address_family: str | None = None,
@@ -962,7 +954,7 @@ async def central_get_prefix_lists(
     return await _get_resource(ctx, "prefix-lists", prefix_list_name_address_family)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_prefix_lists(
     ctx: Context,
     prefix_list_name_address_family: Annotated[
@@ -1005,7 +997,7 @@ async def central_manage_prefix_lists(
 # ----- rip -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_rip(
     ctx: Context,
     name: str | None = None,
@@ -1020,7 +1012,7 @@ async def central_get_rip(
     return await _get_resource(ctx, "rip", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_rip(
     ctx: Context,
     name: Annotated[str, Field(description="``rip`` identifier (OpenAPI path param: ``name``).")],
@@ -1061,7 +1053,7 @@ async def central_manage_rip(
 # ----- route-maps -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_route_maps(
     ctx: Context,
     route_map_name: str | None = None,
@@ -1076,7 +1068,7 @@ async def central_get_route_maps(
     return await _get_resource(ctx, "route-maps", route_map_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_route_maps(
     ctx: Context,
     route_map_name: Annotated[
@@ -1119,7 +1111,7 @@ async def central_manage_route_maps(
 # ----- static-route -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_static_route(
     ctx: Context,
     name: str | None = None,
@@ -1134,7 +1126,7 @@ async def central_get_static_route(
     return await _get_resource(ctx, "static-route", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_static_route(
     ctx: Context,
     name: Annotated[str, Field(description="``static-route`` identifier (OpenAPI path param: ``name``).")],
@@ -1175,7 +1167,7 @@ async def central_manage_static_route(
 # ----- tracking-object -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tracking_object(
     ctx: Context,
     identifier: str | None = None,
@@ -1190,7 +1182,7 @@ async def central_get_tracking_object(
     return await _get_resource(ctx, "tracking-object", identifier)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_tracking_object(
     ctx: Context,
     identifier: Annotated[
@@ -1233,7 +1225,7 @@ async def central_manage_tracking_object(
 # ----- vrfs -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vrfs(
     ctx: Context,
     name: str | None = None,
@@ -1248,7 +1240,7 @@ async def central_get_vrfs(
     return await _get_resource(ctx, "vrfs", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vrfs(
     ctx: Context,
     name: Annotated[str, Field(description="``vrfs`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/scope.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope.py
@@ -20,6 +20,7 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.scope_builder import (
     build_scope_tree,
@@ -31,11 +32,10 @@ from hpe_networking_mcp.platforms.central.scope_queries import (
     get_effective_resources_for_node,
     tree_to_mermaid,
 )
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_scope_tree(
     ctx: Context,
     view: Literal["committed", "effective"] = "committed",
@@ -63,7 +63,7 @@ async def central_get_scope_tree(
         raise ToolError({"status_code": 502, "message": f"Error building scope tree: {e}"}) from e
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_scope_resources(
     ctx: Context,
     scope_id: str,
@@ -130,7 +130,7 @@ async def central_get_scope_resources(
     }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_committed_config(
     ctx: Context,
     scope_id: str,
@@ -214,7 +214,7 @@ async def central_get_committed_config(
     }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_effective_config(
     ctx: Context,
     scope_id: str,
@@ -270,7 +270,7 @@ async def central_get_effective_config(
     }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devices_in_scope(
     ctx: Context,
     scope_id: str,
@@ -317,7 +317,7 @@ async def central_get_devices_in_scope(
     }
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_scope_diagram(
     ctx: Context,
     scope_id: str | None = None,

--- a/src/hpe_networking_mcp/platforms/central/tools/scope_management.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/scope_management.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -33,17 +32,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _operation_request,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- device-collection-add-devices -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_collection_add_devices(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -82,7 +74,7 @@ async def central_manage_device_collection_add_devices(
 # ----- device-collection-create-and-add-devices -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_collection_create_and_add_devices(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -121,7 +113,7 @@ async def central_manage_device_collection_create_and_add_devices(
 # ----- device-collection-remove-devices -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_collection_remove_devices(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -160,7 +152,7 @@ async def central_manage_device_collection_remove_devices(
 # ----- device-collections -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_collections(
     ctx: Context,
 ) -> dict | list | str:
@@ -171,7 +163,7 @@ async def central_get_device_collections(
     return await _get_resource(ctx, "device-collections", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_collections(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -210,7 +202,7 @@ async def central_manage_device_collections(
 # ----- operation: device-collections/bulk -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_device_collections_bulk_delete(
     ctx: Context,
     payload: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/security.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- aaa-profile -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_aaa_profile(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_aaa_profile(
     return await _get_resource(ctx, "aaa-profile", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_aaa_profile(
     ctx: Context,
     name: Annotated[str, Field(description="``aaa-profile`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_aaa_profile(
 # ----- auth-server-global-config -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_auth_server_global_config(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_auth_server_global_config(
     return await _get_resource(ctx, "auth-server-global-config", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_auth_server_global_config(
     ctx: Context,
     name: Annotated[str, Field(description="``auth-server-global-config`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_auth_server_global_config(
 # ----- auth-servers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_auth_servers(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_auth_servers(
     return await _get_resource(ctx, "auth-servers", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_auth_servers(
     ctx: Context,
     name: Annotated[str, Field(description="``auth-servers`` identifier (OpenAPI path param: ``name``).")],
@@ -210,7 +202,7 @@ async def central_manage_auth_servers(
 # ----- auth-survivability -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_auth_survivability(
     ctx: Context,
     name: str | None = None,
@@ -225,7 +217,7 @@ async def central_get_auth_survivability(
     return await _get_resource(ctx, "auth-survivability", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_auth_survivability(
     ctx: Context,
     name: Annotated[str, Field(description="``auth-survivability`` identifier (OpenAPI path param: ``name``).")],
@@ -266,7 +258,7 @@ async def central_manage_auth_survivability(
 # ----- bcn-rpt-req-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_bcn_rpt_req_profiles(
     ctx: Context,
     name: str | None = None,
@@ -281,7 +273,7 @@ async def central_get_bcn_rpt_req_profiles(
     return await _get_resource(ctx, "bcn-rpt-req-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_bcn_rpt_req_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``bcn-rpt-req-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -322,7 +314,7 @@ async def central_manage_bcn_rpt_req_profiles(
 # ----- captive-portal -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_captive_portal(
     ctx: Context,
     name: str | None = None,
@@ -337,7 +329,7 @@ async def central_get_captive_portal(
     return await _get_resource(ctx, "captive-portal", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_captive_portal(
     ctx: Context,
     name: Annotated[str, Field(description="``captive-portal`` identifier (OpenAPI path param: ``name``).")],
@@ -378,7 +370,7 @@ async def central_manage_captive_portal(
 # ----- certificate-rcp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_certificate_rcp(
     ctx: Context,
     name: str | None = None,
@@ -393,7 +385,7 @@ async def central_get_certificate_rcp(
     return await _get_resource(ctx, "certificate-rcp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_certificate_rcp(
     ctx: Context,
     name: Annotated[str, Field(description="``certificate-rcp`` identifier (OpenAPI path param: ``name``).")],
@@ -434,7 +426,7 @@ async def central_manage_certificate_rcp(
 # ----- certificate-store -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_certificate_store(
     ctx: Context,
     name: str | None = None,
@@ -449,7 +441,7 @@ async def central_get_certificate_store(
     return await _get_resource(ctx, "certificate-store", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_certificate_store(
     ctx: Context,
     name: Annotated[str, Field(description="``certificate-store`` identifier (OpenAPI path param: ``name``).")],
@@ -490,7 +482,7 @@ async def central_manage_certificate_store(
 # ----- certificate-usage -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_certificate_usage(
     ctx: Context,
     name: str | None = None,
@@ -505,7 +497,7 @@ async def central_get_certificate_usage(
     return await _get_resource(ctx, "certificate-usage", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_certificate_usage(
     ctx: Context,
     name: Annotated[str, Field(description="``certificate-usage`` identifier (OpenAPI path param: ``name``).")],
@@ -546,7 +538,7 @@ async def central_manage_certificate_usage(
 # ----- certificates -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_certificates(
     ctx: Context,
     name: str | None = None,
@@ -561,7 +553,7 @@ async def central_get_certificates(
     return await _get_resource(ctx, "certificates", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_certificates(
     ctx: Context,
     name: Annotated[str, Field(description="``certificates`` identifier (OpenAPI path param: ``name``).")],
@@ -602,7 +594,7 @@ async def central_manage_certificates(
 # ----- copp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_copp(
     ctx: Context,
     name: str | None = None,
@@ -617,7 +609,7 @@ async def central_get_copp(
     return await _get_resource(ctx, "copp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_copp(
     ctx: Context,
     name: Annotated[str, Field(description="``copp`` identifier (OpenAPI path param: ``name``).")],
@@ -658,7 +650,7 @@ async def central_manage_copp(
 # ----- device-certificates -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_device_certificates(
     ctx: Context,
     name: str | None = None,
@@ -673,7 +665,7 @@ async def central_get_device_certificates(
     return await _get_resource(ctx, "device-certificates", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_device_certificates(
     ctx: Context,
     name: Annotated[str, Field(description="``device-certificates`` identifier (OpenAPI path param: ``name``).")],
@@ -714,7 +706,7 @@ async def central_manage_device_certificates(
 # ----- dot11k-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dot11k_profiles(
     ctx: Context,
     name: str | None = None,
@@ -729,7 +721,7 @@ async def central_get_dot11k_profiles(
     return await _get_resource(ctx, "dot11k-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dot11k_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``dot11k-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -770,7 +762,7 @@ async def central_manage_dot11k_profiles(
 # ----- dot1xauth -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dot1xauth(
     ctx: Context,
     name: str | None = None,
@@ -785,7 +777,7 @@ async def central_get_dot1xauth(
     return await _get_resource(ctx, "dot1xauth", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dot1xauth(
     ctx: Context,
     name: Annotated[str, Field(description="``dot1xauth`` identifier (OpenAPI path param: ``name``).")],
@@ -826,7 +818,7 @@ async def central_manage_dot1xauth(
 # ----- dot1xsupp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dot1xsupp(
     ctx: Context,
     name: str | None = None,
@@ -841,7 +833,7 @@ async def central_get_dot1xsupp(
     return await _get_resource(ctx, "dot1xsupp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dot1xsupp(
     ctx: Context,
     name: Annotated[str, Field(description="``dot1xsupp`` identifier (OpenAPI path param: ``name``).")],
@@ -882,7 +874,7 @@ async def central_manage_dot1xsupp(
 # ----- est-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_est_profiles(
     ctx: Context,
     name: str | None = None,
@@ -897,7 +889,7 @@ async def central_get_est_profiles(
     return await _get_resource(ctx, "est-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_est_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``est-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -938,7 +930,7 @@ async def central_manage_est_profiles(
 # ----- firewall -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_firewall(
     ctx: Context,
     name: str | None = None,
@@ -953,7 +945,7 @@ async def central_get_firewall(
     return await _get_resource(ctx, "firewall", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_firewall(
     ctx: Context,
     name: Annotated[str, Field(description="``firewall`` identifier (OpenAPI path param: ``name``).")],
@@ -994,7 +986,7 @@ async def central_manage_firewall(
 # ----- gw-certificate-usage -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gw_certificate_usage(
     ctx: Context,
     name: str | None = None,
@@ -1009,7 +1001,7 @@ async def central_get_gw_certificate_usage(
     return await _get_resource(ctx, "gw-certificate-usage", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_gw_certificate_usage(
     ctx: Context,
     name: Annotated[str, Field(description="``gw-certificate-usage`` identifier (OpenAPI path param: ``name``).")],
@@ -1050,7 +1042,7 @@ async def central_manage_gw_certificate_usage(
 # ----- internal-user -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_internal_user(
     ctx: Context,
     name: str | None = None,
@@ -1065,7 +1057,7 @@ async def central_get_internal_user(
     return await _get_resource(ctx, "internal-user", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_internal_user(
     ctx: Context,
     name: Annotated[str, Field(description="``internal-user`` identifier (OpenAPI path param: ``name``).")],
@@ -1106,7 +1098,7 @@ async def central_manage_internal_user(
 # ----- keychains -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_keychains(
     ctx: Context,
     name: str | None = None,
@@ -1121,7 +1113,7 @@ async def central_get_keychains(
     return await _get_resource(ctx, "keychains", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_keychains(
     ctx: Context,
     name: Annotated[str, Field(description="``keychains`` identifier (OpenAPI path param: ``name``).")],
@@ -1162,7 +1154,7 @@ async def central_manage_keychains(
 # ----- mac-lockout -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mac_lockout(
     ctx: Context,
     name: str | None = None,
@@ -1177,7 +1169,7 @@ async def central_get_mac_lockout(
     return await _get_resource(ctx, "mac-lockout", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mac_lockout(
     ctx: Context,
     name: Annotated[str, Field(description="``mac-lockout`` identifier (OpenAPI path param: ``name``).")],
@@ -1218,7 +1210,7 @@ async def central_manage_mac_lockout(
 # ----- macauth -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_macauth(
     ctx: Context,
     name: str | None = None,
@@ -1233,7 +1225,7 @@ async def central_get_macauth(
     return await _get_resource(ctx, "macauth", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_macauth(
     ctx: Context,
     name: Annotated[str, Field(description="``macauth`` identifier (OpenAPI path param: ``name``).")],
@@ -1274,7 +1266,7 @@ async def central_manage_macauth(
 # ----- macsec -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_macsec(
     ctx: Context,
     name: str | None = None,
@@ -1289,7 +1281,7 @@ async def central_get_macsec(
     return await _get_resource(ctx, "macsec", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_macsec(
     ctx: Context,
     name: Annotated[str, Field(description="``macsec`` identifier (OpenAPI path param: ``name``).")],
@@ -1330,7 +1322,7 @@ async def central_manage_macsec(
 # ----- mka -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mka(
     ctx: Context,
     name: str | None = None,
@@ -1345,7 +1337,7 @@ async def central_get_mka(
     return await _get_resource(ctx, "mka", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mka(
     ctx: Context,
     name: Annotated[str, Field(description="``mka`` identifier (OpenAPI path param: ``name``).")],
@@ -1386,7 +1378,7 @@ async def central_manage_mka(
 # ----- net-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_net_groups(
     ctx: Context,
     name: str | None = None,
@@ -1401,7 +1393,7 @@ async def central_get_net_groups(
     return await _get_resource(ctx, "net-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_net_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``net-groups`` identifier (OpenAPI path param: ``name``).")],
@@ -1442,7 +1434,7 @@ async def central_manage_net_groups(
 # ----- passpoint-identity -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_passpoint_identity(
     ctx: Context,
     name: str | None = None,
@@ -1457,7 +1449,7 @@ async def central_get_passpoint_identity(
     return await _get_resource(ctx, "passpoint-identity", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_passpoint_identity(
     ctx: Context,
     name: Annotated[str, Field(description="``passpoint-identity`` identifier (OpenAPI path param: ``name``).")],
@@ -1498,7 +1490,7 @@ async def central_manage_passpoint_identity(
 # ----- port-security -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_port_security(
     ctx: Context,
     name: str | None = None,
@@ -1513,7 +1505,7 @@ async def central_get_port_security(
     return await _get_resource(ctx, "port-security", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_port_security(
     ctx: Context,
     name: Annotated[str, Field(description="``port-security`` identifier (OpenAPI path param: ``name``).")],
@@ -1554,7 +1546,7 @@ async def central_manage_port_security(
 # ----- radius-modifiers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_radius_modifiers(
     ctx: Context,
     name: str | None = None,
@@ -1569,7 +1561,7 @@ async def central_get_radius_modifiers(
     return await _get_resource(ctx, "radius-modifiers", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_radius_modifiers(
     ctx: Context,
     name: Annotated[str, Field(description="``radius-modifiers`` identifier (OpenAPI path param: ``name``).")],
@@ -1610,7 +1602,7 @@ async def central_manage_radius_modifiers(
 # ----- rrm-ie-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_rrm_ie_profiles(
     ctx: Context,
     name: str | None = None,
@@ -1625,7 +1617,7 @@ async def central_get_rrm_ie_profiles(
     return await _get_resource(ctx, "rrm-ie-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_rrm_ie_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``rrm-ie-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -1666,7 +1658,7 @@ async def central_manage_rrm_ie_profiles(
 # ----- server-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_server_groups(
     ctx: Context,
     name: str | None = None,
@@ -1681,7 +1673,7 @@ async def central_get_server_groups(
     return await _get_resource(ctx, "server-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_server_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``server-groups`` identifier (OpenAPI path param: ``name``).")],
@@ -1722,7 +1714,7 @@ async def central_manage_server_groups(
 # ----- stateful-dot1x-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_stateful_dot1x_profiles(
     ctx: Context,
     name: str | None = None,
@@ -1737,7 +1729,7 @@ async def central_get_stateful_dot1x_profiles(
     return await _get_resource(ctx, "stateful-dot1x-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_stateful_dot1x_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``stateful-dot1x-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -1778,7 +1770,7 @@ async def central_manage_stateful_dot1x_profiles(
 # ----- ubt -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ubt(
     ctx: Context,
     name: str | None = None,
@@ -1793,7 +1785,7 @@ async def central_get_ubt(
     return await _get_resource(ctx, "ubt", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ubt(
     ctx: Context,
     name: Annotated[str, Field(description="``ubt`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -16,19 +16,10 @@ All resources use the same CRUD pattern at /network-config/v1alpha1/.
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
-
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 
 # ---------------------------------------------------------------------------
 # Factory helpers — avoid repeating the same CRUD logic across resources

--- a/src/hpe_networking_mcp/platforms/central/tools/services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/services.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- airgroup-policies -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_airgroup_policies(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_airgroup_policies(
     return await _get_resource(ctx, "airgroup-policies", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_airgroup_policies(
     ctx: Context,
     name: Annotated[str, Field(description="``airgroup-policies`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_airgroup_policies(
 # ----- airgroup-servers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_airgroup_servers(
     ctx: Context,
     mac_address: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_airgroup_servers(
     return await _get_resource(ctx, "airgroup-servers", mac_address)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_airgroup_servers(
     ctx: Context,
     mac_address: Annotated[
@@ -156,7 +148,7 @@ async def central_manage_airgroup_servers(
 # ----- airgroup-service-definitions -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_airgroup_service_definitions(
     ctx: Context,
     name: str | None = None,
@@ -171,7 +163,7 @@ async def central_get_airgroup_service_definitions(
     return await _get_resource(ctx, "airgroup-service-definitions", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_airgroup_service_definitions(
     ctx: Context,
     name: Annotated[
@@ -214,7 +206,7 @@ async def central_manage_airgroup_service_definitions(
 # ----- airgroup-system -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_airgroup_system(
     ctx: Context,
 ) -> dict | list | str:
@@ -225,7 +217,7 @@ async def central_get_airgroup_system(
     return await _get_resource(ctx, "airgroup-system", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_airgroup_system(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -264,7 +256,7 @@ async def central_manage_airgroup_system(
 # ----- location -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_location(
     ctx: Context,
     name: str | None = None,
@@ -279,7 +271,7 @@ async def central_get_location(
     return await _get_resource(ctx, "location", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_location(
     ctx: Context,
     name: Annotated[str, Field(description="``location`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -2,14 +2,13 @@ from typing import Annotated
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import confirm_write
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import SiteData
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import (
     fetch_site_data_parallel,
     get_central_conn,
@@ -21,8 +20,6 @@ from hpe_networking_mcp.platforms.central.utils import (
 # Write annotations. Central's elicitation middleware enables the
 # ``central_write_delete`` tag when ENABLE_CENTRAL_WRITE_TOOLS=true, so ALL
 # central write tools carry that tag regardless of destructiveness.
-_WRITE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
-_WRITE_DELETE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=True)
 _CONFIRMED_FIELD = Field(default=False, description="Set to true when the user has confirmed the operation in chat.")
 
 
@@ -55,7 +52,7 @@ async def _scope_write(
     return response.get("msg", {})
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sites(
     ctx: Context,
     filter: str | None = None,
@@ -98,7 +95,7 @@ async def central_get_sites(
     return response.get("msg", {})
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_site_health(
     ctx: Context,
     site_name: str | list[str] | None = None,
@@ -129,7 +126,7 @@ async def central_get_site_health(
     return list(sites_data.values())
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_site_name_id_mapping(ctx: Context) -> dict:
     """
     Returns a lightweight mapping of all site names to their IDs and health
@@ -175,7 +172,7 @@ async def central_get_site_name_id_mapping(ctx: Context) -> dict:
     return mapping
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_global_scope(ctx: Context) -> dict | str:
     """Get the Global scope id for the tenant.
 
@@ -197,7 +194,7 @@ async def central_get_global_scope(ctx: Context) -> dict | str:
     return response.get("msg", {})
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_hierarchy(
     ctx: Context,
     scope_id: Annotated[
@@ -246,7 +243,7 @@ async def central_get_hierarchy(
 _DEVICES_FIELD = Field(description="List of device serial numbers to act on.")
 
 
-@tool(annotations=_WRITE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE, tags={"central_write_delete"})
 async def central_add_devices_to_device_group(
     ctx: Context,
     dest_scope_id: Annotated[
@@ -266,7 +263,7 @@ async def central_add_devices_to_device_group(
     )
 
 
-@tool(annotations=_WRITE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE, tags={"central_write_delete"})
 async def central_remove_devices_from_device_group(
     ctx: Context,
     devices: Annotated[list[str], _DEVICES_FIELD],
@@ -283,7 +280,7 @@ async def central_remove_devices_from_device_group(
     )
 
 
-@tool(annotations=_WRITE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE, tags={"central_write_delete"})
 async def central_create_device_group_with_devices(
     ctx: Context,
     scope_name: Annotated[str, Field(description="Name for the new device-group.")],
@@ -308,7 +305,7 @@ async def central_create_device_group_with_devices(
     )
 
 
-@tool(annotations=_WRITE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE, tags={"central_write_delete"})
 async def central_add_devices_to_site(
     ctx: Context,
     dest_scope_id: Annotated[
@@ -341,7 +338,7 @@ _BULK_ITEMS_FIELD = Field(
 )
 
 
-@tool(annotations=_WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_bulk_delete_device_groups(
     ctx: Context,
     items: Annotated[list[dict], _BULK_ITEMS_FIELD],
@@ -358,7 +355,7 @@ async def central_bulk_delete_device_groups(
     )
 
 
-@tool(annotations=_WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_bulk_delete_sites(
     ctx: Context,
     items: Annotated[list[dict], _BULK_ITEMS_FIELD],
@@ -375,7 +372,7 @@ async def central_bulk_delete_sites(
     )
 
 
-@tool(annotations=_WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_bulk_delete_site_collections(
     ctx: Context,
     items: Annotated[list[dict], _BULK_ITEMS_FIELD],

--- a/src/hpe_networking_mcp/platforms/central/tools/stats.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/stats.py
@@ -3,13 +3,13 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_stats(
     ctx: Context,
     serial_number: str,
@@ -50,7 +50,7 @@ async def central_get_ap_stats(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_utilization(
     ctx: Context,
     serial_number: str,
@@ -99,7 +99,7 @@ async def central_get_ap_utilization(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_stats(
     ctx: Context,
     serial_number: str,
@@ -140,7 +140,7 @@ async def central_get_gateway_stats(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_utilization(
     ctx: Context,
     serial_number: str,
@@ -190,7 +190,7 @@ async def central_get_gateway_utilization(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gateway_wan_availability(
     ctx: Context,
     serial_number: str,
@@ -231,7 +231,7 @@ async def central_get_gateway_wan_availability(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tunnel_health(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
@@ -3,12 +3,12 @@
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_hardware_trends(
     ctx: Context,
     serial_number: str,
@@ -99,7 +99,7 @@ async def central_get_switch_hardware_trends(
     return result
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_poe(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/system.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/system.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- ap-system -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ap_system(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_ap_system(
     return await _get_resource(ctx, "ap-system", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ap_system(
     ctx: Context,
     name: Annotated[str, Field(description="``ap-system`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_ap_system(
 # ----- container-networks -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_container_networks(
     ctx: Context,
     name_vrf: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_container_networks(
     return await _get_resource(ctx, "container-networks", name_vrf)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_container_networks(
     ctx: Context,
     name_vrf: Annotated[
@@ -156,7 +148,7 @@ async def central_manage_container_networks(
 # ----- containers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_containers(
     ctx: Context,
     name: str | None = None,
@@ -171,7 +163,7 @@ async def central_get_containers(
     return await _get_resource(ctx, "containers", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_containers(
     ctx: Context,
     name: Annotated[str, Field(description="``containers`` identifier (OpenAPI path param: ``name``).")],
@@ -212,7 +204,7 @@ async def central_manage_containers(
 # ----- countermon -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_countermon(
     ctx: Context,
     name: str | None = None,
@@ -227,7 +219,7 @@ async def central_get_countermon(
     return await _get_resource(ctx, "countermon", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_countermon(
     ctx: Context,
     name: Annotated[str, Field(description="``countermon`` identifier (OpenAPI path param: ``name``).")],
@@ -268,7 +260,7 @@ async def central_manage_countermon(
 # ----- custom-get-api -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_custom_get_api(
     ctx: Context,
 ) -> dict | list | str:
@@ -282,7 +274,7 @@ async def central_get_custom_get_api(
 # ----- db-observer -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_db_observer(
     ctx: Context,
     name: str | None = None,
@@ -297,7 +289,7 @@ async def central_get_db_observer(
     return await _get_resource(ctx, "db-observer", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_db_observer(
     ctx: Context,
     name: Annotated[str, Field(description="``db-observer`` identifier (OpenAPI path param: ``name``).")],
@@ -338,7 +330,7 @@ async def central_manage_db_observer(
 # ----- ddns -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ddns(
     ctx: Context,
     name: str | None = None,
@@ -353,7 +345,7 @@ async def central_get_ddns(
     return await _get_resource(ctx, "ddns", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ddns(
     ctx: Context,
     name: Annotated[str, Field(description="``ddns`` identifier (OpenAPI path param: ``name``).")],
@@ -394,7 +386,7 @@ async def central_manage_ddns(
 # ----- dns -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dns(
     ctx: Context,
     name: str | None = None,
@@ -409,7 +401,7 @@ async def central_get_dns(
     return await _get_resource(ctx, "dns", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dns(
     ctx: Context,
     name: Annotated[str, Field(description="``dns`` identifier (OpenAPI path param: ``name``).")],
@@ -450,7 +442,7 @@ async def central_manage_dns(
 # ----- dump-server -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_dump_server(
     ctx: Context,
     name: str | None = None,
@@ -465,7 +457,7 @@ async def central_get_dump_server(
     return await _get_resource(ctx, "dump-server", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_dump_server(
     ctx: Context,
     name: Annotated[str, Field(description="``dump-server`` identifier (OpenAPI path param: ``name``).")],
@@ -506,7 +498,7 @@ async def central_manage_dump_server(
 # ----- gw-system -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_gw_system(
     ctx: Context,
     name: str | None = None,
@@ -521,7 +513,7 @@ async def central_get_gw_system(
     return await _get_resource(ctx, "gw-system", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_gw_system(
     ctx: Context,
     name: Annotated[str, Field(description="``gw-system`` identifier (OpenAPI path param: ``name``).")],
@@ -562,7 +554,7 @@ async def central_manage_gw_system(
 # ----- hardware-modules -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_hardware_modules(
     ctx: Context,
     name: str | None = None,
@@ -577,7 +569,7 @@ async def central_get_hardware_modules(
     return await _get_resource(ctx, "hardware-modules", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_hardware_modules(
     ctx: Context,
     name: Annotated[str, Field(description="``hardware-modules`` identifier (OpenAPI path param: ``name``).")],
@@ -618,7 +610,7 @@ async def central_manage_hardware_modules(
 # ----- http-proxy-servers -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_http_proxy_servers(
     ctx: Context,
     name: str | None = None,
@@ -633,7 +625,7 @@ async def central_get_http_proxy_servers(
     return await _get_resource(ctx, "http-proxy-servers", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_http_proxy_servers(
     ctx: Context,
     name: Annotated[str, Field(description="``http-proxy-servers`` identifier (OpenAPI path param: ``name``).")],
@@ -674,7 +666,7 @@ async def central_manage_http_proxy_servers(
 # ----- ip-source-interfaces -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ip_source_interfaces(
     ctx: Context,
     name: str | None = None,
@@ -689,7 +681,7 @@ async def central_get_ip_source_interfaces(
     return await _get_resource(ctx, "ip-source-interfaces", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ip_source_interfaces(
     ctx: Context,
     name: Annotated[str, Field(description="``ip-source-interfaces`` identifier (OpenAPI path param: ``name``).")],
@@ -730,7 +722,7 @@ async def central_manage_ip_source_interfaces(
 # ----- ipm -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ipm(
     ctx: Context,
     name: str | None = None,
@@ -745,7 +737,7 @@ async def central_get_ipm(
     return await _get_resource(ctx, "ipm", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ipm(
     ctx: Context,
     name: Annotated[str, Field(description="``ipm`` identifier (OpenAPI path param: ``name``).")],
@@ -786,7 +778,7 @@ async def central_manage_ipm(
 # ----- job-scheduler -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_job_scheduler(
     ctx: Context,
     name: str | None = None,
@@ -801,7 +793,7 @@ async def central_get_job_scheduler(
     return await _get_resource(ctx, "job-scheduler", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_job_scheduler(
     ctx: Context,
     name: Annotated[str, Field(description="``job-scheduler`` identifier (OpenAPI path param: ``name``).")],
@@ -842,7 +834,7 @@ async def central_manage_job_scheduler(
 # ----- local-management -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_local_management(
     ctx: Context,
     name: str | None = None,
@@ -857,7 +849,7 @@ async def central_get_local_management(
     return await _get_resource(ctx, "local-management", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_local_management(
     ctx: Context,
     name: Annotated[str, Field(description="``local-management`` identifier (OpenAPI path param: ``name``).")],
@@ -898,7 +890,7 @@ async def central_manage_local_management(
 # ----- logging -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_logging(
     ctx: Context,
     name: str | None = None,
@@ -913,7 +905,7 @@ async def central_get_logging(
     return await _get_resource(ctx, "logging", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_logging(
     ctx: Context,
     name: Annotated[str, Field(description="``logging`` identifier (OpenAPI path param: ``name``).")],
@@ -954,7 +946,7 @@ async def central_manage_logging(
 # ----- management-server -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_management_server(
     ctx: Context,
     name: str | None = None,
@@ -969,7 +961,7 @@ async def central_get_management_server(
     return await _get_resource(ctx, "management-server", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_management_server(
     ctx: Context,
     name: Annotated[str, Field(description="``management-server`` identifier (OpenAPI path param: ``name``).")],
@@ -1010,7 +1002,7 @@ async def central_manage_management_server(
 # ----- management-user-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_management_user_groups(
     ctx: Context,
     name: str | None = None,
@@ -1025,7 +1017,7 @@ async def central_get_management_user_groups(
     return await _get_resource(ctx, "management-user-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_management_user_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``management-user-groups`` identifier (OpenAPI path param: ``name``).")],
@@ -1066,7 +1058,7 @@ async def central_manage_management_user_groups(
 # ----- management-users -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_management_users(
     ctx: Context,
     name: str | None = None,
@@ -1081,7 +1073,7 @@ async def central_get_management_users(
     return await _get_resource(ctx, "management-users", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_management_users(
     ctx: Context,
     name: Annotated[str, Field(description="``management-users`` identifier (OpenAPI path param: ``name``).")],
@@ -1122,7 +1114,7 @@ async def central_manage_management_users(
 # ----- nae-agents -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nae_agents(
     ctx: Context,
     agent_name: str | None = None,
@@ -1137,7 +1129,7 @@ async def central_get_nae_agents(
     return await _get_resource(ctx, "nae-agents", agent_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nae_agents(
     ctx: Context,
     agent_name: Annotated[str, Field(description="``nae-agents`` identifier (OpenAPI path param: ``agent-name``).")],
@@ -1178,7 +1170,7 @@ async def central_manage_nae_agents(
 # ----- nae-scripts -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_nae_scripts(
     ctx: Context,
     name: str | None = None,
@@ -1193,7 +1185,7 @@ async def central_get_nae_scripts(
     return await _get_resource(ctx, "nae-scripts", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_nae_scripts(
     ctx: Context,
     name: Annotated[str, Field(description="``nae-scripts`` identifier (OpenAPI path param: ``name``).")],
@@ -1234,7 +1226,7 @@ async def central_manage_nae_scripts(
 # ----- ntp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ntp(
     ctx: Context,
     name: str | None = None,
@@ -1249,7 +1241,7 @@ async def central_get_ntp(
     return await _get_resource(ctx, "ntp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ntp(
     ctx: Context,
     name: Annotated[str, Field(description="``ntp`` identifier (OpenAPI path param: ``name``).")],
@@ -1290,7 +1282,7 @@ async def central_manage_ntp(
 # ----- packet-capture -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_packet_capture(
     ctx: Context,
     name: str | None = None,
@@ -1305,7 +1297,7 @@ async def central_get_packet_capture(
     return await _get_resource(ctx, "packet-capture", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_packet_capture(
     ctx: Context,
     name: Annotated[str, Field(description="``packet-capture`` identifier (OpenAPI path param: ``name``).")],
@@ -1346,7 +1338,7 @@ async def central_manage_packet_capture(
 # ----- remote-management -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_remote_management(
     ctx: Context,
     name: str | None = None,
@@ -1361,7 +1353,7 @@ async def central_get_remote_management(
     return await _get_resource(ctx, "remote-management", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_remote_management(
     ctx: Context,
     name: Annotated[str, Field(description="``remote-management`` identifier (OpenAPI path param: ``name``).")],
@@ -1402,7 +1394,7 @@ async def central_manage_remote_management(
 # ----- rmon-alarms -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_rmon_alarms(
     ctx: Context,
     name: str | None = None,
@@ -1417,7 +1409,7 @@ async def central_get_rmon_alarms(
     return await _get_resource(ctx, "rmon-alarms", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_rmon_alarms(
     ctx: Context,
     name: Annotated[str, Field(description="``rmon-alarms`` identifier (OpenAPI path param: ``name``).")],
@@ -1458,7 +1450,7 @@ async def central_manage_rmon_alarms(
 # ----- snmp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_snmp(
     ctx: Context,
     name: str | None = None,
@@ -1473,7 +1465,7 @@ async def central_get_snmp(
     return await _get_resource(ctx, "snmp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_snmp(
     ctx: Context,
     name: Annotated[str, Field(description="``snmp`` identifier (OpenAPI path param: ``name``).")],
@@ -1514,7 +1506,7 @@ async def central_manage_snmp(
 # ----- snmp-trap -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_snmp_trap(
     ctx: Context,
     name: str | None = None,
@@ -1529,7 +1521,7 @@ async def central_get_snmp_trap(
     return await _get_resource(ctx, "snmp-trap", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_snmp_trap(
     ctx: Context,
     name: Annotated[str, Field(description="``snmp-trap`` identifier (OpenAPI path param: ``name``).")],
@@ -1570,7 +1562,7 @@ async def central_manage_snmp_trap(
 # ----- speed-test -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_speed_test(
     ctx: Context,
     name: str | None = None,
@@ -1585,7 +1577,7 @@ async def central_get_speed_test(
     return await _get_resource(ctx, "speed-test", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_speed_test(
     ctx: Context,
     name: Annotated[str, Field(description="``speed-test`` identifier (OpenAPI path param: ``name``).")],
@@ -1626,7 +1618,7 @@ async def central_manage_speed_test(
 # ----- switch-chassis -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_chassis(
     ctx: Context,
     chassis_name: str | None = None,
@@ -1641,7 +1633,7 @@ async def central_get_switch_chassis(
     return await _get_resource(ctx, "switch-chassis", chassis_name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_switch_chassis(
     ctx: Context,
     chassis_name: Annotated[
@@ -1684,7 +1676,7 @@ async def central_manage_switch_chassis(
 # ----- switch-profiles -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_profiles(
     ctx: Context,
     name: str | None = None,
@@ -1699,7 +1691,7 @@ async def central_get_switch_profiles(
     return await _get_resource(ctx, "switch-profiles", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_switch_profiles(
     ctx: Context,
     name: Annotated[str, Field(description="``switch-profiles`` identifier (OpenAPI path param: ``name``).")],
@@ -1740,7 +1732,7 @@ async def central_manage_switch_profiles(
 # ----- switch-system -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_switch_system(
     ctx: Context,
     name: str | None = None,
@@ -1755,7 +1747,7 @@ async def central_get_switch_system(
     return await _get_resource(ctx, "switch-system", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_switch_system(
     ctx: Context,
     name: Annotated[str, Field(description="``switch-system`` identifier (OpenAPI path param: ``name``).")],
@@ -1796,7 +1788,7 @@ async def central_manage_switch_system(
 # ----- sysmon -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_sysmon(
     ctx: Context,
     name: str | None = None,
@@ -1811,7 +1803,7 @@ async def central_get_sysmon(
     return await _get_resource(ctx, "sysmon", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_sysmon(
     ctx: Context,
     name: Annotated[str, Field(description="``sysmon`` identifier (OpenAPI path param: ``name``).")],
@@ -1852,7 +1844,7 @@ async def central_manage_sysmon(
 # ----- system-info -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_system_info(
     ctx: Context,
 ) -> dict | list | str:
@@ -1863,7 +1855,7 @@ async def central_get_system_info(
     return await _get_resource(ctx, "system-info", None)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_system_info(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -1902,7 +1894,7 @@ async def central_manage_system_info(
 # ----- telemetry -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_telemetry(
     ctx: Context,
     name: str | None = None,
@@ -1917,7 +1909,7 @@ async def central_get_telemetry(
     return await _get_resource(ctx, "telemetry", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_telemetry(
     ctx: Context,
     name: Annotated[str, Field(description="``telemetry`` identifier (OpenAPI path param: ``name``).")],
@@ -1958,7 +1950,7 @@ async def central_manage_telemetry(
 # ----- time-ranges -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_time_ranges(
     ctx: Context,
     name: str | None = None,
@@ -1973,7 +1965,7 @@ async def central_get_time_ranges(
     return await _get_resource(ctx, "time-ranges", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_time_ranges(
     ctx: Context,
     name: Annotated[str, Field(description="``time-ranges`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/telemetry.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/telemetry.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- client-insight -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_insight(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_client_insight(
     return await _get_resource(ctx, "client-insight", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_client_insight(
     ctx: Context,
     name: Annotated[str, Field(description="``client-insight`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_client_insight(
 # ----- client-iptracker -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_iptracker(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_client_iptracker(
     return await _get_resource(ctx, "client-iptracker", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_client_iptracker(
     ctx: Context,
     name: Annotated[str, Field(description="``client-iptracker`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_client_iptracker(
 # ----- client-iptracker-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_client_iptracker_interface(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_client_iptracker_interface(
     return await _get_resource(ctx, "client-iptracker-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_client_iptracker_interface(
     ctx: Context,
     name: Annotated[
@@ -212,7 +204,7 @@ async def central_manage_client_iptracker_interface(
 # ----- devicefingerprinting -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devicefingerprinting(
     ctx: Context,
     name: str | None = None,
@@ -227,7 +219,7 @@ async def central_get_devicefingerprinting(
     return await _get_resource(ctx, "devicefingerprinting", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_devicefingerprinting(
     ctx: Context,
     name: Annotated[str, Field(description="``devicefingerprinting`` identifier (OpenAPI path param: ``name``).")],
@@ -268,7 +260,7 @@ async def central_manage_devicefingerprinting(
 # ----- devicefingerprinting-interface -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devicefingerprinting_interface(
     ctx: Context,
     name: str | None = None,
@@ -283,7 +275,7 @@ async def central_get_devicefingerprinting_interface(
     return await _get_resource(ctx, "devicefingerprinting-interface", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_devicefingerprinting_interface(
     ctx: Context,
     name: Annotated[
@@ -326,7 +318,7 @@ async def central_manage_devicefingerprinting_interface(
 # ----- devicefingerprinting-profile -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_devicefingerprinting_profile(
     ctx: Context,
     name: str | None = None,
@@ -341,7 +333,7 @@ async def central_get_devicefingerprinting_profile(
     return await _get_resource(ctx, "devicefingerprinting-profile", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_devicefingerprinting_profile(
     ctx: Context,
     name: Annotated[
@@ -384,7 +376,7 @@ async def central_manage_devicefingerprinting_profile(
 # ----- flow-tracking -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_flow_tracking(
     ctx: Context,
     name: str | None = None,
@@ -399,7 +391,7 @@ async def central_get_flow_tracking(
     return await _get_resource(ctx, "flow-tracking", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_flow_tracking(
     ctx: Context,
     name: Annotated[str, Field(description="``flow-tracking`` identifier (OpenAPI path param: ``name``).")],
@@ -440,7 +432,7 @@ async def central_manage_flow_tracking(
 # ----- ipfix-flow-exporter -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ipfix_flow_exporter(
     ctx: Context,
     name: str | None = None,
@@ -455,7 +447,7 @@ async def central_get_ipfix_flow_exporter(
     return await _get_resource(ctx, "ipfix-flow-exporter", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ipfix_flow_exporter(
     ctx: Context,
     name: Annotated[str, Field(description="``ipfix-flow-exporter`` identifier (OpenAPI path param: ``name``).")],
@@ -496,7 +488,7 @@ async def central_manage_ipfix_flow_exporter(
 # ----- traffic-insight -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_traffic_insight(
     ctx: Context,
     name: str | None = None,
@@ -511,7 +503,7 @@ async def central_get_traffic_insight(
     return await _get_resource(ctx, "traffic-insight", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_traffic_insight(
     ctx: Context,
     name: Annotated[str, Field(description="``traffic-insight`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/translation_preview.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/translation_preview.py
@@ -38,8 +38,8 @@ from typing import Any
 
 from fastmcp import Context
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.translations import (
     EngineError,
     LoaderError,
@@ -139,7 +139,7 @@ def _target_object_keys(call: dict[str, Any]) -> list[tuple]:
     return [(call["method"], endpoint, json.dumps(call.get("query_params") or {}, sort_keys=True))]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_translation_preview(
     ctx: Context,
     translation_id: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/troubleshooting.py
@@ -3,9 +3,9 @@ from typing import Any, Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
 
 
@@ -20,7 +20,7 @@ async def _resolve_if_switch(conn, serial_number: str, device_type: str) -> str:
     return await _resolve_switch_id(conn, serial_number)
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_ping(
     ctx: Context,
     serial_number: str,
@@ -72,7 +72,7 @@ async def central_ping(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_traceroute(
     ctx: Context,
     serial_number: str,
@@ -113,7 +113,7 @@ async def central_traceroute(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_cable_test(
     ctx: Context,
     serial_number: str,
@@ -169,7 +169,7 @@ async def central_cable_test(
     return resp
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_show_commands(
     ctx: Context,
     serial_number: str,

--- a/src/hpe_networking_mcp/platforms/central/tools/tunnels.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/tunnels.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- tunnel -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tunnel(
     ctx: Context,
     id: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_tunnel(
     return await _get_resource(ctx, "tunnel", id)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_tunnel(
     ctx: Context,
     id: Annotated[str, Field(description="``tunnel`` identifier (OpenAPI path param: ``id``).")],
@@ -98,7 +90,7 @@ async def central_manage_tunnel(
 # ----- tunnel-groups -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_tunnel_groups(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_tunnel_groups(
     return await _get_resource(ctx, "tunnel-groups", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_tunnel_groups(
     ctx: Context,
     name: Annotated[str, Field(description="``tunnel-groups`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/vlans_networks.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/vlans_networks.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- erps -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_erps(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_erps(
     return await _get_resource(ctx, "erps", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_erps(
     ctx: Context,
     name: Annotated[str, Field(description="``erps`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_erps(
 # ----- layer2-vlan -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_layer2_vlan(
     ctx: Context,
     vlan: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_layer2_vlan(
     return await _get_resource(ctx, "layer2-vlan", vlan)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_layer2_vlan(
     ctx: Context,
     vlan: Annotated[str, Field(description="``layer2-vlan`` identifier (OpenAPI path param: ``vlan``).")],
@@ -154,7 +146,7 @@ async def central_manage_layer2_vlan(
 # ----- layer2-vlan-range -----
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_layer2_vlan_range(
     ctx: Context,
     action_type: Annotated[str, Field(description="``'create'``, ``'update'``, or ``'delete'``.")],
@@ -193,7 +185,7 @@ async def central_manage_layer2_vlan_range(
 # ----- loop-protect -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_loop_protect(
     ctx: Context,
     name: str | None = None,
@@ -208,7 +200,7 @@ async def central_get_loop_protect(
     return await _get_resource(ctx, "loop-protect", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_loop_protect(
     ctx: Context,
     name: Annotated[str, Field(description="``loop-protect`` identifier (OpenAPI path param: ``name``).")],
@@ -249,7 +241,7 @@ async def central_manage_loop_protect(
 # ----- mvrp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mvrp(
     ctx: Context,
     name: str | None = None,
@@ -264,7 +256,7 @@ async def central_get_mvrp(
     return await _get_resource(ctx, "mvrp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mvrp(
     ctx: Context,
     name: Annotated[str, Field(description="``mvrp`` identifier (OpenAPI path param: ``name``).")],
@@ -305,7 +297,7 @@ async def central_manage_mvrp(
 # ----- named-vlan -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_named_vlan(
     ctx: Context,
     name: str | None = None,
@@ -320,7 +312,7 @@ async def central_get_named_vlan(
     return await _get_resource(ctx, "named-vlan", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_named_vlan(
     ctx: Context,
     name: Annotated[str, Field(description="``named-vlan`` identifier (OpenAPI path param: ``name``).")],
@@ -361,7 +353,7 @@ async def central_manage_named_vlan(
 # ----- smartlink -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_smartlink(
     ctx: Context,
     name: str | None = None,
@@ -376,7 +368,7 @@ async def central_get_smartlink(
     return await _get_resource(ctx, "smartlink", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_smartlink(
     ctx: Context,
     name: Annotated[str, Field(description="``smartlink`` identifier (OpenAPI path param: ``name``).")],
@@ -417,7 +409,7 @@ async def central_manage_smartlink(
 # ----- static-neighbor -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_static_neighbor(
     ctx: Context,
     name: str | None = None,
@@ -432,7 +424,7 @@ async def central_get_static_neighbor(
     return await _get_resource(ctx, "static-neighbor", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_static_neighbor(
     ctx: Context,
     name: Annotated[str, Field(description="``static-neighbor`` identifier (OpenAPI path param: ``name``).")],
@@ -473,7 +465,7 @@ async def central_manage_static_neighbor(
 # ----- stp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_stp(
     ctx: Context,
     name: str | None = None,
@@ -488,7 +480,7 @@ async def central_get_stp(
     return await _get_resource(ctx, "stp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_stp(
     ctx: Context,
     name: Annotated[str, Field(description="``stp`` identifier (OpenAPI path param: ``name``).")],
@@ -529,7 +521,7 @@ async def central_manage_stp(
 # ----- stp-gw -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_stp_gw(
     ctx: Context,
     name: str | None = None,
@@ -544,7 +536,7 @@ async def central_get_stp_gw(
     return await _get_resource(ctx, "stp-gw", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_stp_gw(
     ctx: Context,
     name: Annotated[str, Field(description="``stp-gw`` identifier (OpenAPI path param: ``name``).")],
@@ -585,7 +577,7 @@ async def central_manage_stp_gw(
 # ----- vrrp -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vrrp(
     ctx: Context,
     name: str | None = None,
@@ -600,7 +592,7 @@ async def central_get_vrrp(
     return await _get_resource(ctx, "vrrp", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vrrp(
     ctx: Context,
     name: Annotated[str, Field(description="``vrrp`` identifier (OpenAPI path param: ``name``).")],
@@ -641,7 +633,7 @@ async def central_manage_vrrp(
 # ----- vrrp-global -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_vrrp_global(
     ctx: Context,
     name: str | None = None,
@@ -656,7 +648,7 @@ async def central_get_vrrp_global(
     return await _get_resource(ctx, "vrrp-global", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_vrrp_global(
     ctx: Context,
     name: Annotated[str, Field(description="``vrrp-global`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/wids.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wids.py
@@ -24,12 +24,12 @@ from typing import Annotated, Literal
 from fastmcp import Context
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wids_monitored_aps(
     ctx: Context,
     classification: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/wireless.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wireless.py
@@ -19,11 +19,10 @@ helpers used by the hand-curated Roles & Policy tools.
 from typing import Annotated
 
 from fastmcp import Context
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
     _DEVICE_FUNCTION_FIELD,
@@ -32,17 +31,10 @@ from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _manage_resource,
 )
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
-
 # ----- alg -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_alg(
     ctx: Context,
     name: str | None = None,
@@ -57,7 +49,7 @@ async def central_get_alg(
     return await _get_resource(ctx, "alg", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_alg(
     ctx: Context,
     name: Annotated[str, Field(description="``alg`` identifier (OpenAPI path param: ``name``).")],
@@ -98,7 +90,7 @@ async def central_manage_alg(
 # ----- ids -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_ids(
     ctx: Context,
     name: str | None = None,
@@ -113,7 +105,7 @@ async def central_get_ids(
     return await _get_resource(ctx, "ids", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_ids(
     ctx: Context,
     name: Annotated[str, Field(description="``ids`` identifier (OpenAPI path param: ``name``).")],
@@ -154,7 +146,7 @@ async def central_manage_ids(
 # ----- mesh -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mesh(
     ctx: Context,
     name: str | None = None,
@@ -169,7 +161,7 @@ async def central_get_mesh(
     return await _get_resource(ctx, "mesh", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mesh(
     ctx: Context,
     name: Annotated[str, Field(description="``mesh`` identifier (OpenAPI path param: ``name``).")],
@@ -210,7 +202,7 @@ async def central_manage_mesh(
 # ----- mpsk-local -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_mpsk_local(
     ctx: Context,
     name: str | None = None,
@@ -225,7 +217,7 @@ async def central_get_mpsk_local(
     return await _get_resource(ctx, "mpsk-local", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_mpsk_local(
     ctx: Context,
     name: Annotated[str, Field(description="``mpsk-local`` identifier (OpenAPI path param: ``name``).")],
@@ -266,7 +258,7 @@ async def central_manage_mpsk_local(
 # ----- passpoint -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_passpoint(
     ctx: Context,
     name: str | None = None,
@@ -281,7 +273,7 @@ async def central_get_passpoint(
     return await _get_resource(ctx, "passpoint", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_passpoint(
     ctx: Context,
     name: Annotated[str, Field(description="``passpoint`` identifier (OpenAPI path param: ``name``).")],
@@ -322,7 +314,7 @@ async def central_manage_passpoint(
 # ----- radio -----
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_radio(
     ctx: Context,
     name: str | None = None,
@@ -337,7 +329,7 @@ async def central_get_radio(
     return await _get_resource(ctx, "radios", name)
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_radio(
     ctx: Context,
     name: Annotated[str, Field(description="``radio`` identifier (OpenAPI path param: ``name``).")],

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -9,23 +9,15 @@ from typing import Annotated
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from loguru import logger
-from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from hpe_networking_mcp.middleware.elicitation import elicitation_handler
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
-WRITE_DELETE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
-)
 
-
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wlan_profiles(
     ctx: Context,
     ssid: str | None = None,
@@ -58,7 +50,7 @@ async def central_get_wlan_profiles(
     return response.get("msg", {})
 
 
-@tool(annotations=WRITE_DELETE, tags={"central_write_delete"})
+@tool(capability=Capability.WRITE_DELETE)
 async def central_manage_wlan_profile(
     ctx: Context,
     ssid: Annotated[

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -3,13 +3,13 @@ from typing import Literal
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
-from hpe_networking_mcp.platforms.central.tools import READ_ONLY
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, resolve_time_window, retry_central_command
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wlans(
     ctx: Context,
     site_id: str | None = None,
@@ -65,7 +65,7 @@ async def central_get_wlans(
 TIME_RANGE = Literal["last_1h", "last_6h", "last_24h", "last_7d", "last_30d", "today", "yesterday"]
 
 
-@tool(annotations=READ_ONLY)
+@tool(capability=Capability.READ)
 async def central_get_wlan_stats(
     ctx: Context,
     wlan_name: str,


### PR DESCRIPTION
## What

The largest annotation migration: every Central tool (660) classified with `capability=` per the rubric; registry on the shared `make_tool_decorator` factory; all per-file `ToolAnnotations` constants deleted. References #466; advances the #415/#416 sequence (one platform — Mist, generator-side — remains before the universal gate PR).

### How it was done safely
- The legacy surface was uniform (`annotations=READ_ONLY` ×381, `annotations=WRITE_DELETE + central_write_delete tag` ×249, `OPERATIONAL` ×23, 7 scope-write variants) — migrated mechanically with special-casing only where judgment applies, then **runtime-verified**: imported the registries and asserted derived tags for gated writes (`central_write_delete` + `requires_confirmation`), benign ops (no gate tag), and the diagnostic reclassification.
- Visibility gating is byte-equivalent everywhere.

### The #416 payoff
- The ~20 formerly-ungated MRT/alert destructive tools now classify OPERATIONAL/WRITE_DELETE and **derive `requires_confirmation`** — the tag the universal gate reads. The #416 hole closes the moment the gate PR lands.
- `central_start_ap_ranging_scan` reclassified **WRITE_DELETE → DIAGNOSTIC** (issue #416's explicit mis-annotation call-out): triggers a calibration scan, no persistent change; no longer hidden behind the write flag. This is the one intentional gating change, called out per the issue.
- Benign ops (`clear/defer/reactivate_alerts`, `set_alert_priority`, `locate_device`) → `OPERATIONAL, gated=False` (no prompt, rubric's clear-alerts pattern).

### Footgun handled, not papered over
Scope-membership writes are `Capability.WRITE` **plus an explicit `central_write_delete` tag**, because Central's visibility transform only hides `_write_delete` (bare `central_write` gates nothing). Gating preserved exactly; whether to add `central_write` to the Visibility line is a separate deployment-behavior decision, deliberately not bundled here.

### Note for #429
The regenerated config tool files are source-of-truth since #423 (one-shot regen); any future auto-regen generator must emit `capability=` in this form.

## Tests
Runtime tag-derivation samples verified in-container; full suite **1802 passed, 1 skipped**; ruff + format + mypy + bandit clean. 8 of 9 platform registries now on the shared factory.