### PR TITLE
feat(gating)!: universal confirmation gate — destructive-tool confirmation becomes structural (v3.3.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13.0] - 2026-06-12
+
+**Minor — the universal confirmation gate. Closes #415, #416, #436.** Destructive-tool confirmation is now structural and non-bypassable: one gate at the `<platform>_invoke_tool` dispatch chokepoint (the path BOTH code mode and dynamic mode use) replaces ~75 hand-written per-tool confirmation blocks. The capstone of the elicitation-gating effort (#415/#416 design → capability rubric → 8 platform migrations → this).
+
+### Added
+- **`confirm_gated_invoke`** (`middleware/elicitation.py`) + its call in `_invoke_tool`: any tool carrying the `requires_confirmation` tag (derived automatically from its `capability=` classification) is confirmed BEFORE dispatch. **Fail-closed**: an unclassified tool is treated as gated.
+- The decision sequence: `DISABLE_ELICITATION=true` → auto-accept; otherwise a **real `ctx.elicit()` prompt is attempted first** — it round-trips transparently from the code-mode sandbox (verified live 2026-06-03; #414's contrary premise was false). **`confirmed=true` is ignored while a prompt is available** — the human's accept/decline/cancel always wins (this closes the #415 self-authorization hole). Only when the client cannot present a prompt (elicit raises) does `confirmed=true` carry authority as the confirm-in-chat fallback.
+- The ~20 formerly-ungated Central MRT/alert destructive tools (#416) and all 558 generated Mist write tools (#436) are now confirmed through the gate — no per-tool opt-in required, ever again.
+
+### Removed
+- All inline per-tool confirmation machinery: ~75 `confirm_write`/local-helper constructs across 34 files (ClearPass 56, plus Central scope/config/security/WLAN, Apstra, UXI, Axis, AOS8), their local `_confirm_*` helpers, and the dead `_build_patch_diff` elicitation-diff renderer. `confirmed` tool parameters REMAIN (the gate consumes them for the fallback path); their descriptions now state the fallback-only semantics.
+- `manage_wlan_profile` (direct-call static) verified mutation-free — it returns workflow guidance only and performs no writes, so it carries no confirmation (enable-gating retained).
+
+### Tests
+- `test_universal_confirmation_gate.py` (9 tests): decision sequence incl. the confirmed-ignored-while-prompt-available pin and fail-closed predicate.
+- `test_gate_end_to_end.py` (4 tests): a REAL in-memory MCP session with an elicitation handler driving `_invoke_tool` — prompt fires and dispatches on accept, decline blocks even with `confirmed=true`, reads never prompt, and a no-elicitation client gets `confirmation_required` then succeeds via the `confirmed=true` retry.
+- Obsolete inline-confirm tests updated/retired across aos8/uxi/central/clearpass suites. Full suite **1826 passed**; ruff + format + mypy + bandit clean.
+
 ## [3.3.12.5] - 2026-06-11
 
 **Patch — all 14 broken ClearPass endpoints from #469 live-probed and fixed.** Closes #469. Every suspect path was confirmed broken against a live CPPM (HTTP 405 / page-404 / wrong-ID parse), every corrected route verified live with bogus identifiers before and after the fix, and regression tests now pin verb + path + load-bearing body fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.12.5"
+version = "3.3.13.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -282,7 +282,9 @@ The sandbox kills any `execute()` block that runs longer than the configured bud
 
 For these tools: **call them in their own `execute()` block — don't chain other calls after them** — and lower `max_attempts` / `poll_interval` when you need a tighter budget. A block that runs `central_cable_test` plus another Central read will routinely breach the default 30s with `TimeoutError: time limit exceeded`.
 
-### 5. Write confirmation works differently in code mode — expect `confirmation_required`, not a popup
+### 5. Write confirmation is structural — a real prompt first, `confirmation_required` only as fallback
+
+Destructive tools are confirmed by a universal gate at `<platform>_invoke_tool` dispatch: it shows a REAL confirmation prompt whenever your client supports MCP elicitation — including from inside code-mode `execute()` blocks, where the prompt round-trips transparently. Passing `confirmed=true` does NOT skip a working prompt; the human's answer always wins. Only when no prompt can be shown does the flow below apply.
 
 A destructive write (create / update / delete) dispatched via `<platform>_invoke_tool` inside `execute()` **cannot surface an interactive elicitation popup** — the sandbox can't round-trip a server→client prompt. So when you call a write tool with `confirmed=false` (or omit it), it returns a guard dict:
 
@@ -290,7 +292,7 @@ A destructive write (create / update / delete) dispatched via `<platform>_invoke
 {"status": "confirmation_required", "message": "... Call this tool again with confirmed=true after the user confirms."}
 ```
 
-This is the **expected, working** response — NOT a failure and NOT a user decline. When you see it: **stop, describe the exact change to the user in chat, get their explicit go-ahead, then re-invoke the same tool with `confirmed=true`** (or `confirmed=True`). Only re-call after the human actually confirms.
+This is the **expected, working** response when (and only when) the client cannot present a prompt — NOT a failure and NOT a user decline. When you see it: **stop, describe the exact change to the user in chat, get their explicit go-ahead, then re-invoke the same tool with `confirmed=true`** (or `confirmed=True`). Only re-call after the human actually confirms. `confirmed=true` has no effect while a real prompt is available.
 
 A literal `{"message": "Action declined by user."}` (without `confirmation_required`) means the user was shown a real prompt and actively declined — do **not** retry or override it; report the decline and ask how they want to proceed. (Before v3.2.3.10 a code-mode dispatch could return this *without* a prompt ever appearing — issue #413; that false-decline path is fixed, but the contract above is the rule regardless.)
 

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -286,7 +286,7 @@ For these tools: **call them in their own `execute()` block — don't chain othe
 
 Destructive tools are confirmed by a universal gate at `<platform>_invoke_tool` dispatch: it shows a REAL confirmation prompt whenever your client supports MCP elicitation — including from inside code-mode `execute()` blocks, where the prompt round-trips transparently. Passing `confirmed=true` does NOT skip a working prompt; the human's answer always wins. Only when no prompt can be shown does the flow below apply.
 
-A destructive write (create / update / delete) dispatched via `<platform>_invoke_tool` inside `execute()` **cannot surface an interactive elicitation popup** — the sandbox can't round-trip a server→client prompt. So when you call a write tool with `confirmed=false` (or omit it), it returns a guard dict:
+A destructive write (create / update / delete) dispatched via `<platform>_invoke_tool` — including inside `execute()` — **shows a real confirmation prompt when your client supports MCP elicitation** (the prompt round-trips from the sandbox). When the client cannot show a prompt, the call returns a guard dict instead:
 
 ```python
 {"status": "confirmation_required", "message": "... Call this tool again with confirmed=true after the user confirms."}

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -24,11 +24,29 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from loguru import logger
 from mcp.shared.exceptions import McpError
 
-# Keys whose VALUES are redacted from confirmation-prompt parameter summaries.
-_SENSITIVE_PARAM_KEYS = frozenset(
-    {"password", "secret", "client_secret", "token", "api_token", "key", "psk", "passphrase", "community"}
+# Normalized suffixes whose VALUES are redacted from confirmation-prompt
+# parameter summaries. Keys are normalized (lowercased, separators stripped)
+# before matching, so ``api_key`` / ``apiKey`` / ``api-key`` all redact; the
+# suffix match catches compound names (``clientSecret``, ``refreshToken``,
+# ``radiusSharedSecret``). Over-redaction is acceptable; leaking is not.
+_SENSITIVE_KEY_SUFFIXES = (
+    "password",
+    "secret",
+    "token",
+    "key",
+    "psk",
+    "passphrase",
+    "community",
+    "credential",
+    "credentials",
 )
 _PARAM_SUMMARY_MAX_LEN = 300
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """True when a (normalized) parameter key names secret material."""
+    normalized = "".join(ch for ch in key.lower() if ch.isalnum())
+    return any(normalized == suffix or normalized.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES)
 
 
 def _sanitized_param_summary(params: dict | None) -> str:
@@ -45,11 +63,7 @@ def _sanitized_param_summary(params: dict | None) -> str:
 
     def scrub(value):
         if isinstance(value, dict):
-            return {
-                k: ("***" if k.lower() in _SENSITIVE_PARAM_KEYS else scrub(v))
-                for k, v in value.items()
-                if k != "confirmed"
-            }
+            return {k: ("***" if _is_sensitive_key(k) else scrub(v)) for k, v in value.items() if k != "confirmed"}
         if isinstance(value, list):
             return [scrub(v) for v in value]
         return value
@@ -274,11 +288,33 @@ async def confirm_gated_invoke(
     prompt = f"Confirm: {description}\nParams: {param_summary}"
     try:
         result = await ctx.elicit(prompt, response_type=None)
-    except McpError:
-        # The CLIENT cannot present a prompt ("Elicitation not supported" —
-        # the legitimate fallback trigger, verified against fastmcp). ONLY
-        # here does confirmed=true carry authority — the human-in-chat
-        # fallback.
+    except McpError as e:
+        # Only the specific no-capability signal opens the fallback path:
+        # "Elicitation not supported" / METHOD_NOT_FOUND (verified against
+        # fastmcp). Every other MCP-layer error (transport failure, malformed
+        # elicitation response, framework bug surfaced as McpError) fails
+        # CLOSED below, exactly like non-MCP failures.
+        error = getattr(e, "error", None)
+        code = getattr(error, "code", None)
+        message = (getattr(error, "message", None) or str(e)).lower()
+        is_no_capability = code == -32601 or "elicitation not supported" in message
+        if not is_no_capability:
+            logger.error(
+                "Gate: MCP-layer elicitation failure (code={}, {}) — failing closed for {}",
+                code,
+                message[:120],
+                description,
+            )
+            return {
+                "status": "confirmation_unavailable",
+                "message": (
+                    f"{description} requires user confirmation, but the confirmation prompt failed "
+                    "at the MCP layer. The action was NOT performed. Retry later, or have the "
+                    "operator set DISABLE_ELICITATION=true if confirmations must be bypassed "
+                    "deliberately."
+                ),
+            }
+        # ONLY here does confirmed=true carry authority — the human-in-chat fallback.
         if params and params.get("confirmed") is True:
             logger.info("Gate: client lacks elicitation — honoring confirmed=true for {}", description)
             return None

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -119,11 +119,13 @@ async def _resolve_elicitation_mode(ctx: Context) -> str:
     user never made (the AI then spins, believing it was vetoed).
 
     When state is missing we re-derive the mode from ``config`` (always
-    reachable via ``lifespan_context``) and default to ``chat_confirm``: an
-    interactive ``elicit()`` cannot round-trip out of the sandbox, so the AI
-    must confirm with the user in chat and re-call with ``confirmed=true``.
-    The resolved value is written back into request state so callers that
-    re-read ``elicitation_mode`` (the inline write tools) route consistently.
+    reachable via ``lifespan_context``) and default to ``chat_confirm``.
+    NOTE: ``elicit()`` DOES round-trip from the code-mode sandbox (verified
+    live, 2026-06-03 — #414's contrary premise was false); the universal
+    gate (:func:`confirm_gated_invoke`) therefore attempts a real prompt
+    first regardless of stored mode, and only falls back to chat-confirm
+    when the prompt raises. This resolver remains for the legacy inline
+    path and the DISABLE_ELICITATION check.
 
     Args:
         ctx: FastMCP context.
@@ -187,6 +189,76 @@ async def confirm_write(
         )
         return {"status": "confirmation_required", "message": hint}
     return {"status": "declined", "message": "Action declined by user."}
+
+
+async def confirm_gated_invoke(
+    ctx: Context,
+    description: str,
+    params: dict | None,
+) -> dict | None:
+    """Universal confirmation gate for ``requires_confirmation`` tools.
+
+    Called from the ``<platform>_invoke_tool`` dispatch chokepoint — the path
+    BOTH code mode and dynamic mode use — so destructive-tool confirmation is
+    structural rather than per-tool (closes the #415 honor-system bypass and
+    the #416 ungated-tool class).
+
+    The decision sequence, per the agreed design:
+
+    1. ``DISABLE_ELICITATION=true`` → auto-accept (operator opt-out).
+    2. Attempt a REAL ``ctx.elicit()`` prompt — it round-trips transparently
+       from the code-mode sandbox (verified live; #414's contrary premise was
+       false). Accept proceeds; decline/cancel return structured results.
+    3. Only when the prompt RAISES (client genuinely cannot present one) is
+       ``confirmed=true`` honored as the popup-less chat fallback. An AI
+       cannot self-authorize while a human-facing prompt is available.
+
+    Args:
+        ctx: FastMCP context of the invoke call.
+        description: Human-readable description of the tool invocation.
+        params: The raw params dict passed to the invoke (read-only; the
+            ``confirmed`` flag is consumed from here for the fallback path).
+
+    Returns:
+        ``None`` when the invocation may proceed; otherwise a structured
+        ``{"status": "confirmation_required" | "declined" | "cancelled", ...}``
+        dict the dispatcher returns as the tool result.
+    """
+    try:
+        config = ctx.lifespan_context.get("config")
+    except Exception:
+        config = None
+    if config is not None and config.disable_elicitation:
+        logger.debug("Gate: auto-accepting (DISABLE_ELICITATION) — {}", description)
+        return None
+
+    try:
+        result = await ctx.elicit(f"Confirm: {description}", response_type=None)
+    except Exception:
+        # The client cannot present a prompt (no elicitation capability, or
+        # transport refused). ONLY here does confirmed=true carry authority —
+        # the human-in-chat fallback.
+        if params and params.get("confirmed") is True:
+            logger.info("Gate: prompt unavailable — honoring confirmed=true for {}", description)
+            return None
+        return {
+            "status": "confirmation_required",
+            "message": (
+                f"{description} requires user confirmation and this client cannot show a "
+                "confirmation prompt. Confirm with the user in chat, then call again with "
+                "confirmed=true in params."
+            ),
+        }
+
+    match result:
+        case AcceptedElicitation():
+            return None
+        case DeclinedElicitation():
+            return {"status": "declined", "message": "Action declined by user."}
+        case CancelledElicitation():
+            return {"status": "cancelled", "message": "Action cancelled by user."}
+        case _:
+            return {"status": "cancelled", "message": "Action cancelled (unrecognized elicitation result)."}
 
 
 async def elicitation_handler(message: str, ctx: Context) -> ElicitResult:

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -10,6 +10,8 @@ to get user confirmation. Behavior depends on config and client:
 - Client lacks elicitation: decline and instruct AI to ask user in chat
 """
 
+import json as _json
+
 import mcp.types
 from fastmcp import Context
 from fastmcp.client.elicitation import ElicitResult
@@ -20,6 +22,42 @@ from fastmcp.server.elicitation import (
 )
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from loguru import logger
+from mcp.shared.exceptions import McpError
+
+# Keys whose VALUES are redacted from confirmation-prompt parameter summaries.
+_SENSITIVE_PARAM_KEYS = frozenset(
+    {"password", "secret", "client_secret", "token", "api_token", "key", "psk", "passphrase", "community"}
+)
+_PARAM_SUMMARY_MAX_LEN = 300
+
+
+def _sanitized_param_summary(params: dict | None) -> str:
+    """Render a compact, redacted view of invocation params for the prompt.
+
+    The human must see WHAT they are approving (target IDs, payload fields),
+    not just the tool name — but never secret values, and never unbounded
+    payload dumps. Sensitive keys are redacted by name at any nesting depth,
+    the bookkeeping ``confirmed`` flag is dropped, and the rendering is
+    length-capped.
+    """
+    if not params:
+        return "(no parameters)"
+
+    def scrub(value):
+        if isinstance(value, dict):
+            return {
+                k: ("***" if k.lower() in _SENSITIVE_PARAM_KEYS else scrub(v))
+                for k, v in value.items()
+                if k != "confirmed"
+            }
+        if isinstance(value, list):
+            return [scrub(v) for v in value]
+        return value
+
+    rendered = _json.dumps(scrub(params), separators=(", ", ": "), ensure_ascii=False, default=str)
+    if len(rendered) > _PARAM_SUMMARY_MAX_LEN:
+        rendered = rendered[: _PARAM_SUMMARY_MAX_LEN - 1] + "…"
+    return rendered
 
 
 class ElicitationMiddleware(Middleware):
@@ -232,21 +270,41 @@ async def confirm_gated_invoke(
         logger.debug("Gate: auto-accepting (DISABLE_ELICITATION) — {}", description)
         return None
 
+    param_summary = _sanitized_param_summary(params)
+    prompt = f"Confirm: {description}\nParams: {param_summary}"
     try:
-        result = await ctx.elicit(f"Confirm: {description}", response_type=None)
-    except Exception:
-        # The client cannot present a prompt (no elicitation capability, or
-        # transport refused). ONLY here does confirmed=true carry authority —
-        # the human-in-chat fallback.
+        result = await ctx.elicit(prompt, response_type=None)
+    except McpError:
+        # The CLIENT cannot present a prompt ("Elicitation not supported" —
+        # the legitimate fallback trigger, verified against fastmcp). ONLY
+        # here does confirmed=true carry authority — the human-in-chat
+        # fallback.
         if params and params.get("confirmed") is True:
-            logger.info("Gate: prompt unavailable — honoring confirmed=true for {}", description)
+            logger.info("Gate: client lacks elicitation — honoring confirmed=true for {}", description)
             return None
         return {
             "status": "confirmation_required",
             "message": (
                 f"{description} requires user confirmation and this client cannot show a "
-                "confirmation prompt. Confirm with the user in chat, then call again with "
-                "confirmed=true in params."
+                f"confirmation prompt. Params: {param_summary}. Confirm with the user in "
+                "chat, then call again with confirmed=true in params."
+            ),
+        }
+    except Exception as e:
+        # Any OTHER failure (handler crash, serialization bug, framework
+        # regression) is NOT a license to skip confirmation — fail closed.
+        # confirmed=true is deliberately not honored here: the gate only
+        # opens when it knows the fallback path is legitimate.
+        logger.error(
+            "Gate: elicitation failed unexpectedly ({}: {}) — failing closed for {}", type(e).__name__, e, description
+        )
+        return {
+            "status": "confirmation_unavailable",
+            "message": (
+                f"{description} requires user confirmation, but the confirmation prompt failed "
+                f"unexpectedly ({type(e).__name__}). The action was NOT performed. Retry later, "
+                "or have the operator set DISABLE_ELICITATION=true if confirmations must be "
+                "bypassed deliberately."
             ),
         }
 

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -25,6 +25,7 @@ from mcp.types import ToolAnnotations
 from pydantic import ConfigDict, ValidationError, create_model
 from pydantic.fields import FieldInfo
 
+from hpe_networking_mcp.middleware.elicitation import confirm_gated_invoke
 from hpe_networking_mcp.platforms._common.tool_registry import (
     REGISTRIES,
     ToolSpec,
@@ -448,6 +449,22 @@ def build_meta_tools(
             }
 
         safe_params = params or {}
+
+        # Universal confirmation gate (#415/#416/#436): confirm-before-dispatch
+        # for any tool carrying the requires_confirmation tag. Fail-closed: a
+        # registered tool with no capability classification is treated as
+        # gated — an unclassified tool must never skip confirmation by
+        # omission.
+        needs_confirmation = "requires_confirmation" in spec.tags or spec.capability is None
+        if needs_confirmation:
+            gate = await confirm_gated_invoke(
+                ctx,
+                f"{platform} tool '{name}' ({_tool_summary(spec, max_len=120)})",
+                safe_params,
+            )
+            if gate is not None:
+                return gate
+
         logger.info(
             "{}_invoke_tool: dispatching {} with {} param(s)",
             platform,

--- a/src/hpe_networking_mcp/platforms/_template/tools/example_write.py
+++ b/src/hpe_networking_mcp/platforms/_template/tools/example_write.py
@@ -5,10 +5,14 @@ replace it with your real ``<platform>_manage_*`` tools.
 
 Demonstrates two important patterns every write tool should follow:
 
-1. ``confirm_write(ctx, message)`` — opens an MCP elicitation prompt so
-   the user has to confirm the change before it lands. The middleware
-   threads ``confirmed=True`` through the call after the user accepts,
-   skipping the prompt on retry.
+1. **No inline confirmation.** Confirmation is structural: the universal
+   gate at the ``<platform>_invoke_tool`` dispatch chokepoint prompts the
+   user (via MCP elicitation) for every tool whose ``capability=``
+   classification derives the ``requires_confirmation`` tag — which
+   ``WRITE`` / ``WRITE_DELETE`` / gated ``OPERATIONAL`` all do. Tools never
+   call ``confirm_write`` themselves (that double-prompts). Keep the
+   ``confirmed`` parameter: the gate consumes ``confirmed=true`` from params
+   as the popup-less fallback when the client cannot present a prompt.
 2. ``action_type`` parameter (``create`` / ``update`` / ``delete``) — one
    write tool per entity, dispatched by ``action_type`` inside the
    function body. Reduces tool surface count without losing clarity.
@@ -20,7 +24,6 @@ from typing import Any, Literal
 
 from fastmcp import Context
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms._template._registry import tool
 from hpe_networking_mcp.platforms._template.client import format_http_error, get_template_client
@@ -42,20 +45,10 @@ async def template_manage_example(
         thing_id: Required for update/delete. The thing's UUID.
         name: Required for create.
         payload: Body for create/update.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client
+            cannot show a confirmation prompt (the universal gate prompts
+            otherwise).
     """
-    if action_type == "create":
-        prompt = f"Template: create thing '{name}'. Confirm?"
-    elif action_type == "update":
-        prompt = f"Template: update thing {thing_id}. Confirm?"
-    else:  # delete
-        prompt = f"Template: permanently DELETE thing {thing_id}. Cannot be undone. Confirm?"
-
-    if not confirmed:
-        decline = await confirm_write(ctx, prompt)
-        if decline:
-            return decline
-
     try:
         client = await get_template_client()
         if action_type == "create":

--- a/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/writes.py
@@ -4,8 +4,9 @@ Classified via ``capability=`` (see ``docs/tool-annotation-rubric.md``): the 9
 ``aos8_manage_*`` tools are WRITE_DELETE; ``aos8_disconnect_client`` /
 ``aos8_reboot_ap`` / ``aos8_write_memory`` are OPERATIONAL with
 ``enable_gated=True``. All carry the derived ``aos8_write_delete`` enable tag,
-so all are gated behind ENABLE_AOS8_WRITE_TOOLS=true, and every tool runs
-through the elicitation middleware (confirm_write) before executing.
+so all are gated behind ENABLE_AOS8_WRITE_TOOLS=true. Confirmation happens at
+the universal gate in ``<platform>_invoke_tool`` dispatch (confirm_gated_invoke)
+before these tools run — no per-tool prompting here.
 
 Every tool except aos8_write_memory returns:
     {"result": <api response>, "requires_write_memory_for": [<config_path>]}
@@ -24,7 +25,6 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.aos8._registry import tool
 from hpe_networking_mcp.platforms.aos8.client import AOS8APIError, AOS8AuthError, get_aos8_client
@@ -42,7 +42,15 @@ _AAA_SERVER_OBJECT_BY_TYPE: dict[str, str] = {
 # Shared parameter type aliases to reduce boilerplate across the 9 manage_X tools.
 _ConfigPath = Annotated[str, Field(description="AOS8 hierarchy node (e.g. '/md', '/md/branch1'). Required.")]
 _ActionType = Annotated[str, Field(description="One of 'create', 'update', or 'delete'.")]
-_Confirmed = Annotated[bool, Field(description="Set to true after the user confirms in chat.")]
+_Confirmed = Annotated[
+    bool,
+    Field(
+        description=(
+            "Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        )
+    ),
+]
 
 
 async def _post_managed_object(
@@ -55,8 +63,12 @@ async def _post_managed_object(
     payload: dict[str, Any],
     confirmed: bool,
     pretty_label: str,
-) -> dict[str, Any] | str:
-    """Shared body for the 9 manage_X tools (WRITE-01..09)."""
+) -> dict[str, Any]:
+    """Shared body for the 9 manage_X tools (WRITE-01..09).
+
+    ``confirmed`` is accepted as a pass-through of the tools' fallback
+    confirmation flag; confirmation itself happens at the universal gate.
+    """
     if action_type not in _ACTION_MAP:
         raise ToolError(
             {
@@ -70,11 +82,6 @@ async def _post_managed_object(
     action = _ACTION_MAP[action_type]
     identifier = payload[identifier_field]
     summary = f"{action_type} {pretty_label} {identifier!r} at {config_path}"
-
-    if not confirmed:
-        decision = await confirm_write(ctx, message=f"The LLM wants to {summary}. Do you accept?")
-        if decision is not None:
-            return decision  # type: ignore[return-value]
 
     body = {object_name: {**payload, "_action": action}}
     client = get_aos8_client(ctx)
@@ -98,7 +105,7 @@ async def aos8_manage_ssid_profile(
         Field(description="SSID profile body. Must include 'profile-name'."),
     ],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete an SSID profile.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -123,7 +130,7 @@ async def aos8_manage_virtual_ap(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="Virtual AP body. Must include 'profile-name'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete a virtual AP profile.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -147,7 +154,7 @@ async def aos8_manage_ap_group(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="AP group body. Must include 'profile-name'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete an AP group.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -171,7 +178,7 @@ async def aos8_manage_user_role(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="User role body. Must include 'rolename'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete a user role.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -195,7 +202,7 @@ async def aos8_manage_vlan(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="VLAN body. Must include 'id' (integer VLAN ID).")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete a VLAN.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -236,7 +243,7 @@ async def aos8_manage_aaa_server(
         ),
     ],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete an AAA server (RADIUS/TACACS/LDAP/internal).
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -268,7 +275,7 @@ async def aos8_manage_aaa_server_group(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="AAA server group body. Must include 'sg_name'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete an AAA server group.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -292,7 +299,7 @@ async def aos8_manage_acl(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="Session ACL body. Must include 'accname'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete a session ACL.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -316,7 +323,7 @@ async def aos8_manage_netdestination(
     action_type: _ActionType,
     payload: Annotated[dict, Field(description="Netdestination body. Must include 'dstname'.")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Create, update, or delete a netdestination.
 
     Returns ``{"result": ..., "requires_write_memory_for": [config_path]}`` on success.
@@ -338,7 +345,7 @@ async def aos8_disconnect_client(
     ctx: Context,
     mac: Annotated[str, Field(description="Client MAC address (e.g. 'aa:bb:cc:dd:ee:ff').")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Force-disconnect a wireless client by MAC address.
 
     Issues 'aaa user delete mac <mac>' via the operational POST endpoint.
@@ -346,11 +353,6 @@ async def aos8_disconnect_client(
     Returns ``{"result": ..., "requires_write_memory_for": []}`` —
     operational actions produce no pending config state.
     """
-    if not confirmed:
-        decision = await confirm_write(ctx, message=f"The LLM wants to disconnect client {mac}. Do you accept?")
-        if decision is not None:
-            return decision  # type: ignore[return-value]
-
     body = {"aaa_user_delete": {"mac": mac}}
     client = get_aos8_client(ctx)
     try:
@@ -367,17 +369,12 @@ async def aos8_reboot_ap(
     ctx: Context,
     ap_name: Annotated[str, Field(description="AP hostname (as shown by aos8_get_ap_database).")],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Reboot a specific AP by name via the apboot endpoint.
 
     Calling this tool twice issues two reboot commands.
     Returns ``{"result": ..., "requires_write_memory_for": []}``.
     """
-    if not confirmed:
-        decision = await confirm_write(ctx, message=f"The LLM wants to reboot AP {ap_name}. Do you accept?")
-        if decision is not None:
-            return decision  # type: ignore[return-value]
-
     body = {"apboot": {"ap-name": ap_name}}
     client = get_aos8_client(ctx)
     try:
@@ -401,7 +398,7 @@ async def aos8_write_memory(
         ),
     ],
     confirmed: _Confirmed = False,
-) -> dict[str, Any] | str:
+) -> dict[str, Any]:
     """Persist staged AOS8 config to startup-config for one config_path.
 
     AOS8 stages config per hierarchy node; nothing survives reboot until
@@ -411,11 +408,6 @@ async def aos8_write_memory(
     Returns ``{"result": ...}``. Does NOT include ``requires_write_memory_for``
     — that field would be circular here.
     """
-    if not confirmed:
-        decision = await confirm_write(ctx, message=f"The LLM wants to write memory at {config_path}. Do you accept?")
-        if decision is not None:
-            return decision  # type: ignore[return-value]
-
     client = get_aos8_client(ctx)
     try:
         response = await client.request(

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
@@ -7,7 +7,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -28,17 +27,9 @@ async def apstra_deploy(
         blueprint_id: Blueprint UUID.
         description: Human-readable change description recorded in Apstra's history.
         staging_version: Staging version number to deploy (from ``apstra_get_diff_status``).
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: deploy staging v{staging_version} to blueprint {blueprint_id}. "
-            f"This applies changes to live devices. Confirm?",
-        )
-        if decline:
-            return decline
-
     try:
         client = await get_apstra_client()
         response = await client.request(
@@ -65,16 +56,9 @@ async def apstra_delete_blueprint(
 
     Args:
         blueprint_id: Blueprint UUID to delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: permanently DELETE blueprint {blueprint_id}. This cannot be undone. Confirm?",
-        )
-        if decline:
-            return decline
-
     try:
         client = await get_apstra_client()
         response = await client.request("DELETE", f"/api/blueprints/{blueprint_id}")
@@ -107,16 +91,9 @@ async def apstra_create_datacenter_blueprint(
     Args:
         blueprint_name: Human-readable label for the new blueprint.
         template_id: ID of the design template to instantiate (from ``apstra_get_templates``).
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: create datacenter blueprint '{blueprint_name}' from template {template_id}. Confirm?",
-        )
-        if decline:
-            return decline
-
     try:
         client = await get_apstra_client()
         response = await client.request(
@@ -148,16 +125,9 @@ async def apstra_create_freeform_blueprint(
 
     Args:
         blueprint_name: Human-readable label for the new blueprint.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: create freeform blueprint '{blueprint_name}'. Confirm?",
-        )
-        if decline:
-            return decline
-
     try:
         client = await get_apstra_client()
         response = await client.request(

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
@@ -7,7 +7,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -30,21 +29,13 @@ async def apstra_apply_ct_policies(
         blueprint_id: Blueprint UUID (MANDATORY).
         application_points: JSON string, single dict, or list of dicts, each with
             shape ``{"id": "<interface_id>", "policies": [{"policy": "<policy_id>", "used": true|false}]}``.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     try:
         normalized = normalize_application_points(application_points)
     except ValueError as e:
         raise ToolError({"status_code": 400, "message": f"Invalid application_points: {e}"}) from e
-
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: apply/update {len(normalized)} connectivity-template policy binding(s) "
-            f"in blueprint {blueprint_id}. Confirm?",
-        )
-        if decline:
-            return decline
 
     try:
         client = await get_apstra_client()

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
@@ -7,7 +7,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
@@ -66,18 +65,11 @@ async def apstra_create_virtual_network(
         create_policy_tagged: Optional "true"/"false" or bool (omitted if None).
         virtual_gateway_ipv6_enabled: "true"/"false" or bool (default: False).
         ipv6_enabled: "true"/"false" or bool (default: False).
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if vn_type not in ("vxlan", "vlan"):
         raise ToolError({"status_code": 400, "message": f"Invalid vn_type '{vn_type}'. Must be 'vxlan' or 'vlan'."})
-
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: create virtual network '{vn_name}' ({vn_type}) in blueprint {blueprint_id}. Confirm?",
-        )
-        if decline:
-            return decline
 
     try:
         ipv4_enabled_b = bool(parse_bool(ipv4_enabled))
@@ -212,16 +204,9 @@ async def apstra_create_remote_gateway(
         evpn_interconnect_group_id: Optional interconnect-group UUID.
         holdtime_timer: BGP hold time seconds (default: 30).
         ttl: BGP TTL (default: 30).
-        confirmed: Set true after user confirms.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        decline = await confirm_write(
-            ctx,
-            f"Apstra: create remote EVPN gateway '{gw_name}' ({gw_ip}) in blueprint {blueprint_id}. Confirm?",
-        )
-        if decline:
-            return decline
-
     try:
         client = await get_apstra_client()
         payload: dict[str, Any] = {

--- a/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
@@ -6,9 +6,11 @@ Every Axis entity follows a uniform CRUD shape::
     PUT    /<Resource>/{id}    -> update
     DELETE /<Resource>/{id}    -> delete
 
-Rather than repeat the action-validation, elicitation, and dispatch logic
-in every tool file, this helper handles the common path. Each tool file
-just calls ``manage_entity(...)`` with its base path and a label.
+Rather than repeat the action-validation and dispatch logic in every tool
+file, this helper handles the common path. Each tool file just calls
+``manage_entity(...)`` with its base path and a label. Write confirmation
+happens at the universal gate in ``axis_invoke_tool`` dispatch
+(``confirm_gated_invoke``) before these tools run.
 
 Writes stage in Axis. To apply, the caller invokes ``axis_commit_changes``;
 every successful response from this helper carries a ``next_step`` hint
@@ -22,7 +24,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 
 _VALID_ACTIONS = ("create", "update", "delete")
@@ -42,18 +43,18 @@ async def manage_entity(
     """Generic create/update/delete dispatcher for Axis CRUD entities.
 
     Args:
-        ctx: FastMCP context (needed for elicitation).
+        ctx: FastMCP context.
         base_path: Resource path under ``/api/v1.0`` — e.g. ``"/Connectors"``.
-        label: Human-readable entity name for the elicitation prompt
+        label: Human-readable entity name for log/error messages
             (e.g. ``"connector"``, ``"SSL exclusion"``).
         action_type: One of ``"create"``, ``"update"``, ``"delete"``.
         payload: Request body for ``create``/``update``. Ignored for delete.
         entity_id: Resource ID — required for ``update`` and ``delete``.
-        confirmed: When true, skip the elicitation prompt.
+        confirmed: Pass-through of the tools' fallback confirmation flag;
+            confirmation itself happens at the universal gate.
 
     Returns:
-        Either a dict with the API response plus a ``next_step`` hint, or a
-        string error message.
+        A dict with the API response plus a ``next_step`` hint.
     """
     if action_type not in _VALID_ACTIONS:
         raise ToolError(
@@ -66,11 +67,6 @@ async def manage_entity(
         raise ToolError({"status_code": 400, "message": f"entity_id is required for action '{action_type}'."})
     if action_type in ("create", "update") and not payload:
         raise ToolError({"status_code": 400, "message": f"payload is required for action '{action_type}'."})
-
-    target = entity_id or "(new)"
-    decline = await confirm_write(ctx, f"Axis: {action_type} {label} '{target}'. Confirm?")
-    if decline:
-        return decline
 
     try:
         client = await get_axis_client()

--- a/src/hpe_networking_mcp/platforms/axis/tools/commit.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/commit.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -38,15 +37,9 @@ async def axis_commit_changes(
     timeout for this call specifically.
 
     Args:
-        confirmed: Set true after user confirms; skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot
+            show a confirmation prompt (the universal gate prompts otherwise).
     """
-    decline = await confirm_write(
-        ctx,
-        "Axis: commit ALL pending staged changes for this tenant. This applies "
-        "every queued create/update/delete from prior axis_manage_* calls. Confirm?",
-    )
-    if decline:
-        return decline
     try:
         client = await get_axis_client()
         response = await client.request("POST", "/Commit", timeout=_COMMIT_TIMEOUT)

--- a/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
@@ -12,7 +12,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
@@ -64,7 +63,8 @@ async def axis_manage_connector(
         action_type: One of ``'create'``, ``'update'``, ``'delete'``.
         payload: Body for create/update. Ignored for delete.
         connector_id: GUID — required for update/delete.
-        confirmed: Set true after user confirms; skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot
+            show a confirmation prompt (the universal gate prompts otherwise).
     """
     return await manage_entity(
         ctx,
@@ -94,15 +94,9 @@ async def axis_regenerate_connector(
 
     Args:
         connector_id: GUID of the connector to regenerate.
-        confirmed: Set true after user confirms; skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot
+            show a confirmation prompt (the universal gate prompts otherwise).
     """
-    decline = await confirm_write(
-        ctx,
-        f"Axis: regenerate install command for connector {connector_id}. "
-        "This invalidates the prior install command. Confirm?",
-    )
-    if decline:
-        return decline
     try:
         client = await get_axis_client()
         return await client.post_json(f"/Connectors/{connector_id}/regenerate", json_body={})

--- a/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/config_assignments.py
@@ -16,7 +16,6 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
@@ -156,7 +155,10 @@ async def central_manage_config_assignment(
     confirmed: Annotated[
         bool,
         Field(
-            description="Set to true when the user has confirmed the operation.",
+            description=(
+                "Fallback confirmation flag — honored only when the client cannot "
+                "show a confirmation prompt (the universal gate prompts otherwise)."
+            ),
             default=False,
         ),
     ],
@@ -194,27 +196,6 @@ async def central_manage_config_assignment(
     conn = get_central_conn(ctx)
 
     if action_type == "assign":
-        action_wording = f"assign profile '{profile_instance}' ({profile_type}) to scope '{scope_id}'"
-
-        if not confirmed:
-            elicitation_response = await elicitation_handler(
-                message=f"The LLM wants to {action_wording}. Do you accept?",
-                ctx=ctx,
-            )
-            if elicitation_response.action == "decline":
-                if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                    return {
-                        "status": "confirmation_required",
-                        "message": (
-                            f"This operation will {action_wording}. "
-                            "Please confirm with the user before proceeding. "
-                            "Call this tool again with confirmed=true after the user confirms."
-                        ),
-                    }
-                return {"message": "Action declined by user."}
-            elif elicitation_response.action == "cancel":
-                return {"message": "Action canceled by user."}
-
         payload = {
             "config-assignment": [
                 {
@@ -242,27 +223,6 @@ async def central_manage_config_assignment(
         )
 
     else:  # remove
-        action_wording = f"remove profile '{profile_instance}' ({profile_type}) from scope '{scope_id}'"
-
-        if not confirmed:
-            elicitation_response = await elicitation_handler(
-                message=f"The LLM wants to {action_wording}. Do you accept?",
-                ctx=ctx,
-            )
-            if elicitation_response.action == "decline":
-                if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                    return {
-                        "status": "confirmation_required",
-                        "message": (
-                            f"This operation will {action_wording}. "
-                            "Please confirm with the user before proceeding. "
-                            "Call this tool again with confirmed=true after the user confirms."
-                        ),
-                    }
-                return {"message": "Action declined by user."}
-            elif elicitation_response.action == "cancel":
-                return {"message": "Action canceled by user."}
-
         base = "network-config/v1alpha1/config-assignments"
         api_path = f"{base}/{scope_id}/{device_function}/{profile_type}/{profile_instance}"
 

--- a/src/hpe_networking_mcp/platforms/central/tools/configuration.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/configuration.py
@@ -1,8 +1,8 @@
 """Aruba Central configuration write tools — sites, site collections, device groups.
 
 Provides CRUD operations for Central network configuration objects.
-All write tools are gated behind ENABLE_CENTRAL_WRITE_TOOLS and require
-user confirmation for update/delete operations.
+All write tools are gated behind ENABLE_CENTRAL_WRITE_TOOLS; confirmation
+is handled by the universal gate at the invoke-tool dispatch chokepoint.
 """
 
 from enum import Enum
@@ -13,7 +13,6 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
@@ -70,7 +69,10 @@ async def central_manage_site(
     confirmed: Annotated[
         bool,
         Field(
-            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            description=(
+                "Fallback confirmation flag — honored only when the client cannot "
+                "show a confirmation prompt (the universal gate prompts otherwise)."
+            ),
             default=False,
         ),
     ],
@@ -139,7 +141,10 @@ async def central_manage_site_collection(
     confirmed: Annotated[
         bool,
         Field(
-            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            description=(
+                "Fallback confirmation flag — honored only when the client cannot "
+                "show a confirmation prompt (the universal gate prompts otherwise)."
+            ),
             default=False,
         ),
     ],
@@ -210,7 +215,10 @@ async def central_manage_device_group(
     confirmed: Annotated[
         bool,
         Field(
-            description="Set to true when the user has confirmed the operation in chat. Required for update/delete.",
+            description=(
+                "Fallback confirmation flag — honored only when the client cannot "
+                "show a confirmation prompt (the universal gate prompts otherwise)."
+            ),
             default=False,
         ),
     ],
@@ -254,7 +262,7 @@ async def _execute_config_action(
     confirmed: bool = False,
     replace_existing: bool = False,
 ) -> dict | str:
-    """Execute a configuration CRUD action with confirmation and error handling.
+    """Execute a configuration CRUD action with error handling.
 
     Central API patterns:
     - CREATE: POST to base path, payload as JSON body
@@ -270,41 +278,6 @@ async def _execute_config_action(
     """
     if action_type in (ActionType.UPDATE, ActionType.DELETE) and not resource_id:
         raise ToolError({"status_code": 400, "message": f"Resource ID is required for {action_type.value} operations."})
-
-    action_wording = {
-        ActionType.CREATE: "create a new",
-        ActionType.UPDATE: "update an existing",
-        ActionType.DELETE: "delete an existing",
-    }[action_type]
-
-    # Confirm with user for update and delete only (skip if already confirmed)
-    if action_type != ActionType.CREATE and not confirmed:
-        if action_type == ActionType.UPDATE and replace_existing:
-            warning = (
-                " NOTE: replace_existing=True — this is a full-resource PUT. Any "
-                "field not in the payload will be dropped from the stored resource."
-            )
-        else:
-            warning = ""
-        elicitation_response = await elicitation_handler(
-            message=(
-                f"The LLM wants to {action_wording} {resource_name}.{warning} Do you accept to trigger the API call?"
-            ),
-            ctx=ctx,
-        )
-        if elicitation_response.action == "decline":
-            if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                return {
-                    "status": "confirmation_required",
-                    "message": (
-                        f"This operation will {action_wording} {resource_name}. "
-                        "Please confirm with the user before proceeding. "
-                        "Call this tool again with the same parameters and confirmed=true after the user confirms."
-                    ),
-                }
-            return {"message": "Action declined by user."}
-        elif elicitation_response.action == "cancel":
-            return {"message": "Action canceled by user."}
 
     conn = get_central_conn(ctx)
 

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -18,7 +18,6 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 # ---------------------------------------------------------------------------
@@ -68,30 +67,6 @@ async def _manage_resource(
     api_method = method_map[action_type]
     api_path = f"network-config/v1alpha1/{api_base}/{name}" if name else f"network-config/v1alpha1/{api_base}"
 
-    action_wording = {"create": "create a new", "update": "update an existing", "delete": "delete an existing"}[
-        action_type
-    ]
-
-    target_phrase = f"{resource_label} '{name}'" if name else f"singleton {resource_label}"
-    if action_type != "create" and not confirmed:
-        elicitation_response = await elicitation_handler(
-            message=f"The LLM wants to {action_wording} {target_phrase}. Do you accept?",
-            ctx=ctx,
-        )
-        if elicitation_response.action == "decline":
-            if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                return {
-                    "status": "confirmation_required",
-                    "message": (
-                        f"This operation will {action_wording} {target_phrase}. "
-                        "Please confirm with the user before proceeding. "
-                        "Call this tool again with confirmed=true after the user confirms."
-                    ),
-                }
-            return {"message": "Action declined by user."}
-        elif elicitation_response.action == "cancel":
-            return {"message": "Action canceled by user."}
-
     conn = get_central_conn(ctx)
 
     api_params: dict = {}
@@ -137,35 +112,14 @@ async def _operation_request(
     (fixed-verb actions like ``revoke``/``upload``/``import``/``export``/``bulk``
     and job/status reads).
 
-    For write methods (POST/PATCH/PUT/DELETE) when ``not confirmed``, runs the
-    same elicitation flow ``_manage_resource`` uses (respecting ``chat_confirm``
-    state). GET requests skip elicitation. Returns ``{"status": "success", ...}``
-    on 2xx; raises :class:`ToolError` (``{"status_code", "message"}``) on any
-    non-2xx so the calling AI sees a real failure rather than an ok-wrapped
-    error dict (elicitation decline/cancel still return ordinary dicts).
+    Confirmation is handled by the universal gate at the invoke-tool dispatch
+    chokepoint (``confirmed`` is the fallback flag passed through by callers).
+    Returns ``{"status": "success", ...}`` on 2xx; raises :class:`ToolError`
+    (``{"status_code", "message"}``) on any non-2xx so the calling AI sees a
+    real failure rather than an ok-wrapped error dict.
     """
     method = api_method.upper()
     is_write = method in ("POST", "PATCH", "PUT", "DELETE")
-
-    if is_write and not confirmed:
-        target_phrase = label or api_path
-        elicitation_response = await elicitation_handler(
-            message=f"The LLM wants to perform '{method}' on {target_phrase}. Do you accept?",
-            ctx=ctx,
-        )
-        if elicitation_response.action == "decline":
-            if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                return {
-                    "status": "confirmation_required",
-                    "message": (
-                        f"This operation will perform '{method}' on {target_phrase}. "
-                        "Please confirm with the user before proceeding. "
-                        "Call this tool again with confirmed=true after the user confirms."
-                    ),
-                }
-            return {"message": "Action declined by user."}
-        elif elicitation_response.action == "cancel":
-            return {"message": "Action canceled by user."}
 
     conn = get_central_conn(ctx)
     # Send the request body for any write method that carries one. Unlike CRUD
@@ -209,6 +163,9 @@ _DEVICE_FUNCTION_FIELD = Field(
     default=None,
 )
 _CONFIRMED_FIELD = Field(
-    description="Set to true when the user has confirmed the operation in chat.",
+    description=(
+        "Fallback confirmation flag — honored only when the client cannot "
+        "show a confirmation prompt (the universal gate prompts otherwise)."
+    ),
     default=False,
 )

--- a/src/hpe_networking_mcp/platforms/central/tools/sites.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/sites.py
@@ -4,7 +4,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
@@ -20,7 +19,13 @@ from hpe_networking_mcp.platforms.central.utils import (
 # Write annotations. Central's elicitation middleware enables the
 # ``central_write_delete`` tag when ENABLE_CENTRAL_WRITE_TOOLS=true, so ALL
 # central write tools carry that tag regardless of destructiveness.
-_CONFIRMED_FIELD = Field(default=False, description="Set to true when the user has confirmed the operation in chat.")
+_CONFIRMED_FIELD = Field(
+    default=False,
+    description=(
+        "Fallback confirmation flag — honored only when the client cannot "
+        "show a confirmation prompt (the universal gate prompts otherwise)."
+    ),
+)
 
 
 async def _scope_write(
@@ -32,17 +37,13 @@ async def _scope_write(
     action_message: str,
     confirmed: bool,
 ) -> dict | str:
-    """Shared confirm-then-write helper for scope mutation tools.
+    """Shared write helper for scope mutation tools.
 
-    Fires elicitation confirmation (unless ``confirmed``); on accept, issues the
-    request and returns the response body, raising ``ToolError`` on non-2xx.
-    Returns the elicitation guard dict (confirmation_required / declined /
-    cancelled) when the user does not accept.
+    Issues the request and returns the response body, raising ``ToolError``
+    on non-2xx. Confirmation is handled by the universal gate at the
+    invoke-tool dispatch chokepoint (``confirmed`` is the fallback flag
+    passed through by the tools).
     """
-    if not confirmed:
-        guard = await confirm_write(ctx, message=action_message)
-        if guard is not None:
-            return guard
     conn = get_central_conn(ctx)
     response = await retry_central_command(central_conn=conn, api_method=method, api_path=path, api_data=body)
     code = response.get("code", 0)

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -11,7 +11,6 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import elicitation_handler
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
@@ -118,7 +117,10 @@ async def central_manage_wlan_profile(
     confirmed: Annotated[
         bool,
         Field(
-            description="Set to true when the user has confirmed the operation in chat.",
+            description=(
+                "Fallback confirmation flag — honored only when the client cannot "
+                "show a confirmation prompt (the universal gate prompts otherwise)."
+            ),
             default=False,
         ),
     ] = False,
@@ -196,48 +198,6 @@ async def central_manage_wlan_profile(
     }
     api_method = method_map[action_type]
 
-    # Build the action summary for the elicitation prompt. For partial
-    # updates we try to diff the payload against the current profile so
-    # the user sees which fields will actually change; for full-replace
-    # updates we show a loud warning instead.
-    if action_type == "create":
-        action_wording = "create a new"
-        diff_lines: list[str] = []
-    elif action_type == "delete":
-        action_wording = "delete an existing"
-        diff_lines = []
-    elif replace_existing:
-        action_wording = "REPLACE THE ENTIRE"
-        diff_lines = [
-            "⚠️  replace_existing=True — any field not in the payload will be DROPPED.",
-            f"Payload top-level keys: {sorted(payload.keys())}",
-        ]
-    else:
-        action_wording = "patch (partial update of)"
-        diff_lines = await _build_patch_diff(conn, api_path, payload)
-
-    # Confirm for update and delete only
-    if action_type != "create" and not confirmed:
-        diff_suffix = ("\n\nChanges:\n" + "\n".join(diff_lines)) if diff_lines else ""
-        elicitation_response = await elicitation_handler(
-            message=(f"The LLM wants to {action_wording} WLAN profile '{ssid}'.{diff_suffix}\n\nDo you accept?"),
-            ctx=ctx,
-        )
-        if elicitation_response.action == "decline":
-            if await ctx.get_state("elicitation_mode") == "chat_confirm":
-                return {
-                    "status": "confirmation_required",
-                    "message": (
-                        f"This operation will {action_wording} WLAN profile '{ssid}'."
-                        + diff_suffix
-                        + " Please confirm with the user before proceeding. "
-                        "Call this tool again with confirmed=true after the user confirms."
-                    ),
-                }
-            return {"message": "Action declined by user."}
-        elif elicitation_response.action == "cancel":
-            return {"message": "Action canceled by user."}
-
     api_data: dict = {}
     if action_type != "delete":
         api_data = payload
@@ -265,39 +225,3 @@ async def central_manage_wlan_profile(
         "code": code,
         "message": response.get("msg", "Unknown error"),
     }
-
-
-async def _build_patch_diff(conn: object, api_path: str, payload: dict) -> list[str]:
-    """Compute a human-readable diff of what a PATCH will change.
-
-    Fetches the current profile and reports, per top-level key in the
-    payload, the before → after value. Failures are non-blocking — if
-    the GET fails, the caller falls back to a generic elicitation
-    message so the write isn't held up by a display-only helper.
-    """
-    try:
-        resp = await retry_central_command(
-            central_conn=conn,
-            api_method="GET",
-            api_path=api_path,
-        )
-        current = resp.get("msg", {}) if isinstance(resp, dict) else {}
-        if not isinstance(current, dict):
-            current = {}
-    except Exception as e:
-        logger.warning("Central WLAN: diff lookup failed — {}", e)
-        return [f"(current profile lookup failed: {e} — patch will still apply)"]
-
-    lines: list[str] = []
-    for key, new_val in payload.items():
-        if key in current:
-            old_val = current[key]
-            if old_val == new_val:
-                lines.append(f"{key}: {old_val!r} (unchanged)")
-            else:
-                lines.append(f"{key}: {old_val!r} → {new_val!r}")
-        else:
-            lines.append(f"{key}: (new) → {new_val!r}")
-    if not lines:
-        lines.append("(empty payload — no changes)")
-    return lines

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
@@ -8,24 +8,12 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _ALERT_ACTIONS = ("create", "update", "delete", "enable", "disable", "mute", "unmute")
 _REPORT_ACTIONS = ("create", "delete", "enable", "disable", "run")
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -37,7 +25,13 @@ async def clearpass_manage_insight_alert(
     ],
     payload: Annotated[dict, Field(description="Alert config payload. For delete/enable/disable/mute/unmute: {}.")],
     alert_id: Annotated[str | None, Field(description="Alert ID (required for all actions except create).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, enable, disable, mute, or unmute a ClearPass Insight alert.
 
@@ -48,7 +42,8 @@ async def clearpass_manage_insight_alert(
         action_type: Operation to perform on the alert.
         payload: JSON config body. Required for create/update. Empty dict for other actions.
         alert_id: Alert ID. Required for all actions except create.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _ALERT_ACTIONS:
         raise ToolError(
@@ -57,11 +52,6 @@ async def clearpass_manage_insight_alert(
                 "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_ALERT_ACTIONS)}.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} insight alert", alert_id)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -114,7 +104,13 @@ async def clearpass_manage_insight_report(
     ],
     payload: Annotated[dict, Field(description="Report config payload. For delete/enable/disable/run: {}.")],
     report_id: Annotated[str | None, Field(description="Report ID (required for all actions except create).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, delete, enable, disable, or run a ClearPass Insight report.
 
@@ -125,7 +121,8 @@ async def clearpass_manage_insight_report(
         action_type: Operation to perform on the report.
         payload: JSON config body. Required for create. Empty dict for other actions.
         report_id: Report ID. Required for all actions except create.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _REPORT_ACTIONS:
         raise ToolError(
@@ -134,11 +131,6 @@ async def clearpass_manage_insight_report(
                 "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_REPORT_ACTIONS)}.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} insight report", report_id)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -186,7 +178,13 @@ async def clearpass_create_system_event(
     category: Annotated[str, Field(description="Event category (e.g. 'Configuration', 'Authentication').")],
     action: Annotated[str, Field(description="Event action description (e.g. 'Policy Updated').")],
     description: Annotated[str, Field(description="Detailed event description.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create a custom system event in ClearPass for audit logging.
 
@@ -199,17 +197,13 @@ async def clearpass_create_system_event(
         category: Event category for classification.
         action: Short action description.
         description: Detailed description of the event.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if level not in ("INFO", "WARN", "ERROR"):
         raise ToolError(
             {"status_code": 400, "message": f"Invalid level '{level}'. Must be 'INFO', 'WARN', or 'ERROR'."}
         )
-
-    if not confirmed:
-        decline = await _confirm_write(ctx, "create system event", f"{source}/{action}")
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
@@ -8,23 +8,11 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
 _SOURCE_ACTIONS = ("create", "update", "delete", "configure_backup", "configure_filters", "configure_radius_attrs")
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -40,7 +28,13 @@ async def clearpass_manage_auth_source(
     payload: Annotated[dict, Field(description="Auth source config payload. For delete: empty dict {}.")],
     auth_source_id: Annotated[str | None, Field(description="Auth source ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Auth source name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, or configure a ClearPass authentication source.
 
@@ -60,7 +54,8 @@ async def clearpass_manage_auth_source(
         payload: JSON config body. Required for create/update/configure. Empty dict for delete.
         auth_source_id: Numeric ID. Required for update/delete/configure (or use name).
         name: Auth source name. Alternative to auth_source_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _SOURCE_ACTIONS:
         raise ToolError(
@@ -69,11 +64,6 @@ async def clearpass_manage_auth_source(
                 "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_SOURCE_ACTIONS)}.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} auth source", auth_source_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -123,7 +113,13 @@ async def clearpass_manage_auth_method(
     payload: Annotated[dict, Field(description="Auth method config payload. For delete: empty dict {}.")],
     auth_method_id: Annotated[str | None, Field(description="Auth method ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Auth method name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass authentication method.
 
@@ -135,7 +131,8 @@ async def clearpass_manage_auth_method(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         auth_method_id: Numeric ID. Required for update/delete (or use name).
         name: Auth method name. Alternative to auth_method_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -144,11 +141,6 @@ async def clearpass_manage_auth_method(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} auth method", auth_method_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
@@ -19,7 +19,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
@@ -67,7 +66,13 @@ async def clearpass_manage_certificate_authority(
         str | None,
         Field(description="Cert ID. Required for sign, revoke, reject, export, delete."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Manage ClearPass internal-CA certificates.
 
@@ -85,7 +90,8 @@ async def clearpass_manage_certificate_authority(
         payload: Request body. Varies by action — empty dict ``{}`` is
             fine for delete/sign/revoke/reject/export.
         certificate_id: Cert ID. Required for sign/revoke/reject/export/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _CA_ACTIONS:
         raise ToolError(
@@ -96,10 +102,6 @@ async def clearpass_manage_certificate_authority(
         )
     if action_type in ("sign", "revoke", "reject", "export", "delete") and not certificate_id:
         raise ToolError({"status_code": 400, "message": f"certificate_id is required for action '{action_type}'."})
-
-    decline = await confirm_write(ctx, f"ClearPass CA: {action_type} certificate {certificate_id or '(new)'}. Confirm?")
-    if decline:
-        return decline
 
     try:
         client = await get_clearpass_client()
@@ -135,7 +137,13 @@ async def clearpass_manage_onboard_device(
         dict | None,
         Field(description="PATCH body for update. Empty dict or omit for delete."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update or delete a ClearPass onboard device record.
 
@@ -152,7 +160,8 @@ async def clearpass_manage_onboard_device(
         action_type: 'update' (PATCH) or 'delete'.
         record_id: Numeric ID of the onboard device record.
         payload: PATCH body. Required for update, ignored for delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _ONBOARD_ACTIONS:
         raise ToolError(
@@ -160,13 +169,6 @@ async def clearpass_manage_onboard_device(
         )
     if action_type == "update" and not payload:
         raise ToolError({"status_code": 400, "message": "payload is required for action 'update'."})
-
-    decline = await confirm_write(
-        ctx,
-        f"ClearPass: {action_type} onboard device record {record_id}. Confirm?",
-    )
-    if decline:
-        return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
@@ -8,7 +8,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
@@ -20,17 +19,6 @@ _CERT_ACTIONS = (
     "enable_server_cert",
     "disable_server_cert",
 )
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} certificate '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -59,7 +47,13 @@ async def clearpass_manage_certificate(
         str | None,
         Field(description="Service name (required for enable/disable_server_cert, e.g. 'RADIUS', 'HTTPS')."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Manage ClearPass certificates (trust lists, client certs, server certs).
 
@@ -76,7 +70,8 @@ async def clearpass_manage_certificate(
         cert_id: Certificate ID. Required for delete_trust_list and delete_client_cert.
         server_uuid: Server UUID. Required for enable/disable_server_cert.
         service_name: Service name (e.g. 'RADIUS', 'HTTPS'). Required for enable/disable_server_cert.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _CERT_ACTIONS:
         raise ToolError(
@@ -85,12 +80,6 @@ async def clearpass_manage_certificate(
                 "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_CERT_ACTIONS)}.",
             }
         )
-
-    if not confirmed:
-        identifier = cert_id or server_uuid or "certificate"
-        decline = await _confirm_write(ctx, action_type.replace("_", " "), identifier)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -160,7 +149,13 @@ async def clearpass_create_csr(
             "organizational_unit, locality, state, country, san_dns, san_ip."
         ),
     ],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Generate a Certificate Signing Request (CSR) on ClearPass.
 
@@ -171,14 +166,9 @@ async def clearpass_create_csr(
         payload: CSR subject fields. Must include common_name at minimum.
             Supported fields: common_name, organization, organizational_unit,
             locality, state, country, san_dns (list), san_ip (list).
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    if not confirmed:
-        cn = payload.get("common_name", "unknown")
-        decline = await _confirm_write(ctx, "generate CSR", cn)
-        if decline:
-            return decline
-
     try:
         client = await get_clearpass_client()
         return await client.request("post", "/certificate/csr", json_body=payload)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
@@ -8,7 +8,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
@@ -24,7 +23,13 @@ async def clearpass_manage_endpoint(
         str | None,
         Field(description="MAC address (alternative to ID for update/delete, e.g. '001122334455')."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass endpoint in the endpoint database.
 
@@ -37,7 +42,8 @@ async def clearpass_manage_endpoint(
             For create, must include mac_address at minimum.
         endpoint_id: Numeric ID. Required for update/delete (or use mac_address).
         mac_address: MAC address. Alternative to endpoint_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -46,12 +52,6 @@ async def clearpass_manage_endpoint(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        identifier = endpoint_id or mac_address or "unknown"
-        decline = await confirm_write(ctx, f"ClearPass: {action_type} endpoint '{identifier}'. Confirm?")
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
@@ -8,21 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -32,7 +20,13 @@ async def clearpass_manage_enforcement_policy(
     payload: Annotated[dict, Field(description="Enforcement policy config payload. For delete: empty dict {}.")],
     policy_id: Annotated[str | None, Field(description="Policy ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Policy name (alternative to ID for update/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass enforcement policy.
 
@@ -44,7 +38,8 @@ async def clearpass_manage_enforcement_policy(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         policy_id: Numeric ID. Required for update/delete (or use name).
         name: Policy name. Alternative to policy_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -53,11 +48,6 @@ async def clearpass_manage_enforcement_policy(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} enforcement policy", policy_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -87,7 +77,13 @@ async def clearpass_manage_enforcement_profile(
     payload: Annotated[dict, Field(description="Enforcement profile config payload. For delete: empty dict {}.")],
     profile_id: Annotated[str | None, Field(description="Profile ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Profile name (alternative to ID for update/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass enforcement profile.
 
@@ -99,7 +95,8 @@ async def clearpass_manage_enforcement_profile(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         profile_id: Numeric ID. Required for update/delete (or use name).
         name: Profile name. Alternative to profile_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -108,11 +105,6 @@ async def clearpass_manage_enforcement_profile(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} enforcement profile", profile_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
@@ -8,21 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} guest config '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -31,7 +19,13 @@ async def clearpass_manage_pass_template(
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
     payload: Annotated[dict, Field(description="Template config payload. For delete: empty dict {}.")],
     template_id: Annotated[str | None, Field(description="Template ID (required for update/replace/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, replace, or delete a ClearPass guest pass template.
 
@@ -42,7 +36,8 @@ async def clearpass_manage_pass_template(
         action_type: Operation — 'create', 'update', 'replace', or 'delete'.
         payload: JSON config body. Required for create/update/replace. Empty dict for delete.
         template_id: Numeric ID. Required for update/replace/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "replace", "delete"):
         raise ToolError(
@@ -51,11 +46,6 @@ async def clearpass_manage_pass_template(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} pass template", template_id)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -81,7 +71,13 @@ async def clearpass_manage_print_template(
     action_type: Annotated[str, Field(description="Action: 'create', 'update', 'replace', or 'delete'.")],
     payload: Annotated[dict, Field(description="Template config payload. For delete: empty dict {}.")],
     template_id: Annotated[str | None, Field(description="Template ID (required for update/replace/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, replace, or delete a ClearPass guest print template.
 
@@ -91,7 +87,8 @@ async def clearpass_manage_print_template(
         action_type: Operation — 'create', 'update', 'replace', or 'delete'.
         payload: JSON config body. Required for create/update/replace. Empty dict for delete.
         template_id: Numeric ID. Required for update/replace/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "replace", "delete"):
         raise ToolError(
@@ -100,11 +97,6 @@ async def clearpass_manage_print_template(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} print template", template_id)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -131,7 +123,13 @@ async def clearpass_manage_weblogin_page(
     payload: Annotated[dict, Field(description="Weblogin page config payload. For delete: empty dict {}.")],
     page_id: Annotated[str | None, Field(description="Weblogin page ID (for update/replace/delete).")] = None,
     page_name: Annotated[str | None, Field(description="Weblogin page name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, replace, or delete a ClearPass weblogin (captive portal) page.
 
@@ -142,7 +140,8 @@ async def clearpass_manage_weblogin_page(
         payload: JSON config body. Required for create/update/replace. Empty dict for delete.
         page_id: Numeric ID. Required for update/replace/delete (or use page_name).
         page_name: Page name. Alternative to page_id for update/replace/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "replace", "delete"):
         raise ToolError(
@@ -151,11 +150,6 @@ async def clearpass_manage_weblogin_page(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', 'replace', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} weblogin page", page_id or page_name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -185,14 +179,21 @@ async def clearpass_manage_guest_settings(
     ctx: Context,
     setting_type: Annotated[str, Field(description="Setting type: 'authentication' or 'manager'.")],
     payload: Annotated[dict, Field(description="Settings payload to apply.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update ClearPass guest authentication or guest manager settings.
 
     Args:
         setting_type: Which settings to update — 'authentication' or 'manager'.
         payload: JSON settings body to apply.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if setting_type not in ("authentication", "manager"):
         raise ToolError(
@@ -201,11 +202,6 @@ async def clearpass_manage_guest_settings(
                 "message": f"Invalid setting_type '{setting_type}'. Must be 'authentication' or 'manager'.",
             }
         )
-
-    if not confirmed:
-        decline = await _confirm_write(ctx, f"update guest {setting_type} settings", setting_type)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -8,21 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} guest '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -32,7 +20,13 @@ async def clearpass_manage_guest_user(
     payload: Annotated[dict, Field(description="Guest config payload. For delete: empty dict {}.")],
     guest_id: Annotated[str | None, Field(description="Guest ID (required for update/delete).")] = None,
     username: Annotated[str | None, Field(description="Guest username (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass guest user account.
 
@@ -41,7 +35,8 @@ async def clearpass_manage_guest_user(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         guest_id: Numeric ID. Required for update/delete (or use username).
         username: Guest username. Alternative to guest_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -50,11 +45,6 @@ async def clearpass_manage_guest_user(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, action_type, guest_id or username)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -84,24 +74,26 @@ async def clearpass_send_guest_credentials(
     ctx: Context,
     guest_id: Annotated[str, Field(description="Guest ID to send credentials for.")],
     delivery_method: Annotated[str, Field(description="Delivery method: 'sms' or 'email'.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Send guest account credentials via SMS or email.
 
     Args:
         guest_id: Numeric ID of the guest account.
         delivery_method: How to deliver credentials — 'sms' or 'email'.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if delivery_method not in ("sms", "email"):
         raise ToolError(
             {"status_code": 400, "message": f"Invalid delivery_method '{delivery_method}'. Must be 'sms' or 'email'."}
         )
-
-    if not confirmed:
-        decline = await _confirm_write(ctx, f"send credentials via {delivery_method}", guest_id)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -161,7 +153,13 @@ async def clearpass_process_sponsor_action(
         str | None,
         Field(description="Optional self-registration name carrying the sponsor confirmation configuration."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Process a sponsor approval or rejection for a guest account.
 
@@ -175,15 +173,11 @@ async def clearpass_process_sponsor_action(
         token: Registration token (from the sponsor confirmation email/link).
         register_token: Register token paired with ``token``.
         gsr_id: Optional self-registration page name.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action not in ("approve", "reject"):
         raise ToolError({"status_code": 400, "message": f"Invalid action '{action}'. Must be 'approve' or 'reject'."})
-
-    if not confirmed:
-        decline = await _confirm_write(ctx, f"sponsor {action}", guest_id)
-        if decline:
-            return decline
 
     body: dict = {"token": token, "register_token": register_token}
     if action == "reject":

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -8,23 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(
-    ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
-) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -33,7 +19,13 @@ async def clearpass_manage_api_client(
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
     payload: Annotated[dict, Field(description="API client config payload. Empty dict {} for delete.")],
     client_id: Annotated[str | None, Field(description="API client ID (required for update/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass API client.
 
@@ -41,7 +33,8 @@ async def clearpass_manage_api_client(
         action_type: Operation -- 'create', 'update', or 'delete'.
         payload: JSON config body. Required for create/update. Empty dict for delete.
         client_id: API client ID. Required for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -50,9 +43,6 @@ async def clearpass_manage_api_client(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "API client", client_id, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -75,7 +65,13 @@ async def clearpass_manage_local_user(
     payload: Annotated[dict, Field(description="Local user config payload. Empty dict {} for delete.")],
     local_user_id: Annotated[str | None, Field(description="Local user ID (required for update/delete).")] = None,
     user_id: Annotated[str | None, Field(description="Username (alternative to local_user_id).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass local user.
 
@@ -84,7 +80,8 @@ async def clearpass_manage_local_user(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         local_user_id: Numeric local user ID. Required for update/delete (or use user_id).
         user_id: Username string. Alternative to local_user_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -93,9 +90,6 @@ async def clearpass_manage_local_user(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "local user", local_user_id or user_id, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -125,7 +119,13 @@ async def clearpass_manage_static_host_list(
         str | None, Field(description="Static host list ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Host list name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass static host list.
 
@@ -134,7 +134,8 @@ async def clearpass_manage_static_host_list(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         static_host_list_id: Numeric ID. Required for update/delete (or use name).
         name: Host list name. Alternative to static_host_list_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -143,9 +144,6 @@ async def clearpass_manage_static_host_list(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "static host list", static_host_list_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -175,7 +173,13 @@ async def clearpass_manage_device(
     payload: Annotated[dict, Field(description="Device config payload. Empty dict {} for delete.")],
     device_id: Annotated[str | None, Field(description="Device ID (required for update/delete).")] = None,
     macaddr: Annotated[str | None, Field(description="MAC address (alternative to device_id).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass network device.
 
@@ -184,7 +188,8 @@ async def clearpass_manage_device(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         device_id: Numeric device ID. Required for update/delete (or use macaddr).
         macaddr: Device MAC address. Alternative to device_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -193,9 +198,6 @@ async def clearpass_manage_device(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "device", device_id or macaddr, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -222,7 +224,13 @@ async def clearpass_manage_deny_listed_user(
     action_type: Annotated[str, Field(description="Action: 'create' or 'delete'.")],
     payload: Annotated[dict, Field(description="Deny-listed user config payload. Empty dict {} for delete.")],
     deny_listed_users_id: Annotated[str | None, Field(description="Deny-listed user ID (required for delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create or delete a ClearPass deny-listed user.
 
@@ -230,15 +238,13 @@ async def clearpass_manage_deny_listed_user(
         action_type: Operation -- 'create' or 'delete'.
         payload: JSON config body. Required for create. Empty dict for delete.
         deny_listed_users_id: Numeric ID. Required for delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "delete"):
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'create' or 'delete'."}
         )
-    decline = await _confirm_write(ctx, action_type, "deny-listed user", deny_listed_users_id, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
@@ -8,23 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(
-    ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
-) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -32,23 +18,27 @@ async def clearpass_manage_extension(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'start', 'stop', 'restart', or 'delete'.")],
     extension_id: Annotated[str, Field(description="Extension instance ID.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Start, stop, restart, or delete a ClearPass extension instance.
 
     Args:
         action_type: Operation -- 'start', 'stop', 'restart', or 'delete'.
         extension_id: ID of the extension instance.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     valid = ("start", "stop", "restart", "delete")
     if action_type not in valid:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "extension", extension_id, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "start":
@@ -71,7 +61,13 @@ async def clearpass_manage_syslog_target(
     payload: Annotated[dict, Field(description="Syslog target config payload. Empty dict {} for delete.")],
     syslog_target_id: Annotated[str | None, Field(description="Syslog target ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Target name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass syslog target.
 
@@ -80,7 +76,8 @@ async def clearpass_manage_syslog_target(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         syslog_target_id: Numeric ID. Required for update/delete (or use name).
         name: Target name. Alternative to syslog_target_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -89,9 +86,6 @@ async def clearpass_manage_syslog_target(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "syslog target", syslog_target_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -121,7 +115,13 @@ async def clearpass_manage_syslog_export_filter(
         str | None, Field(description="Syslog export filter ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Filter name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass syslog export filter.
 
@@ -130,7 +130,8 @@ async def clearpass_manage_syslog_export_filter(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         syslog_export_filter_id: Numeric ID. Required for update/delete (or use name).
         name: Filter name. Alternative to syslog_export_filter_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -139,9 +140,6 @@ async def clearpass_manage_syslog_export_filter(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "syslog export filter", syslog_export_filter_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -175,7 +173,13 @@ async def clearpass_manage_endpoint_context_server(
         str | None, Field(description="Server ID (required for update/delete/trigger_poll).")
     ] = None,
     name: Annotated[str | None, Field(description="Server name (alternative to ID for create/update).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, or trigger poll for a ClearPass endpoint context server.
 
@@ -184,18 +188,14 @@ async def clearpass_manage_endpoint_context_server(
         payload: JSON config body. Required for create/update. Empty dict for delete/trigger_poll.
         endpoint_context_server_id: Numeric ID. Required for update/delete/trigger_poll.
         name: Server name. Alternative to ID for update.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     valid = ("create", "update", "delete", "trigger_poll")
     if action_type not in valid:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(
-        ctx, action_type, "endpoint context server", endpoint_context_server_id or name, confirmed
-    )
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -8,23 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(
-    ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
-) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -34,7 +20,13 @@ async def clearpass_manage_access_control(
     server_uuid: Annotated[str, Field(description="Server UUID.")],
     resource_name: Annotated[str, Field(description="Access control resource name.")],
     payload: Annotated[dict, Field(description="Access control config payload. Empty dict {} for delete.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update or delete a ClearPass server access control entry.
 
@@ -43,15 +35,13 @@ async def clearpass_manage_access_control(
         server_uuid: UUID of the target server.
         resource_name: Name of the access control resource.
         payload: JSON config body. Required for update. Empty dict for delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("update", "delete"):
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'update' or 'delete'."}
         )
-    decline = await _confirm_write(ctx, action_type, "access control", f"{server_uuid}/{resource_name}", confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "update":
@@ -74,7 +64,13 @@ async def clearpass_manage_ad_domain(
     netbios_name: Annotated[
         str | None, Field(description="NetBIOS name (required for configure_password_servers).")
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Join, leave, or configure password servers for an Active Directory domain.
 
@@ -83,16 +79,14 @@ async def clearpass_manage_ad_domain(
         server_uuid: UUID of the ClearPass server.
         payload: JSON config body. Domain credentials for join, empty for leave.
         netbios_name: NetBIOS domain name (required for configure_password_servers).
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     valid = ("join", "leave", "configure_password_servers")
     if action_type not in valid:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "AD domain", server_uuid, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "join":
@@ -115,18 +109,22 @@ async def clearpass_manage_cluster_server(
     ctx: Context,
     server_uuid: Annotated[str, Field(description="Server UUID to update.")],
     payload: Annotated[dict, Field(description="Cluster server config payload.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update a ClearPass cluster server configuration.
 
     Args:
         server_uuid: UUID of the cluster server to update.
         payload: JSON config body with server settings.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    decline = await _confirm_write(ctx, "update", "cluster server", server_uuid, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         return await client.request("patch", f"/cluster/server/{server_uuid}", json_body=payload)
@@ -142,7 +140,13 @@ async def clearpass_manage_server_service(
     action_type: Annotated[str, Field(description="Action: 'start' or 'stop'.")],
     server_uuid: Annotated[str, Field(description="Server UUID.")],
     service_name: Annotated[str, Field(description="Name of the service to start or stop.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Start or stop a ClearPass server service.
 
@@ -150,15 +154,13 @@ async def clearpass_manage_server_service(
         action_type: Operation -- 'start' or 'stop'.
         server_uuid: UUID of the ClearPass server.
         service_name: Name of the service (e.g. 'ClearPass Policy Server').
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("start", "stop"):
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be 'start' or 'stop'."}
         )
-    decline = await _confirm_write(ctx, action_type, "server service", f"{service_name}@{server_uuid}", confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "start":
@@ -187,7 +189,13 @@ async def clearpass_manage_service_params(
             ),
         ),
     ],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Edit per-server service parameters (PATCH /api/server/{uuid}/service/{id}).
 
@@ -208,17 +216,9 @@ async def clearpass_manage_service_params(
         server_uuid: UUID of the ClearPass server node.
         service_id: Numeric service ID (the integer one, not the name).
         param_values: PATCH body with the param structure to apply.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
-    decline = await _confirm_write(
-        ctx,
-        "edit_params",
-        "server service",
-        f"service_id={service_id}@{server_uuid}",
-        confirmed,
-    )
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         return await client.request("patch", f"/service-parameter/{server_uuid}/{service_id}", json_body=param_values)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
@@ -8,7 +8,6 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
@@ -45,17 +44,6 @@ async def _resolve_device_id(client: ClearPassClient, device_id: str | None, nam
     return None
 
 
-async def _confirm_action(ctx: Context, action_type: str, device_id: str | None, name: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    identifier = device_id or name or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} network device '{identifier}'. Confirm?")
-
-
 @tool(capability=Capability.WRITE_DELETE)
 async def clearpass_manage_network_device(
     ctx: Context,
@@ -70,7 +58,13 @@ async def clearpass_manage_network_device(
     device_id: Annotated[str | None, Field(description="Device ID (required for update/delete/configure).")] = None,
     name: Annotated[str | None, Field(description="Device name (alternative to ID for update/delete).")] = None,
     source_device_id: Annotated[str | None, Field(description="Source device ID (required for clone).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, clone, or configure a ClearPass network device (RADIUS/TACACS+ client).
 
@@ -90,7 +84,8 @@ async def clearpass_manage_network_device(
         device_id: Numeric ID. Required for update/delete/configure (or use name).
         name: Name lookup. Alternative to device_id for update/delete.
         source_device_id: Source device ID for clone action.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in _VALID_ACTIONS:
         raise ToolError(
@@ -99,11 +94,6 @@ async def clearpass_manage_network_device(
                 "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(_VALID_ACTIONS)}.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_action(ctx, action_type, device_id, name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
@@ -8,23 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(
-    ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
-) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -34,7 +20,13 @@ async def clearpass_manage_service(
     payload: Annotated[dict, Field(description="Service config payload. Empty dict {} for delete/enable/disable.")],
     config_service_id: Annotated[str | None, Field(description="Service ID (required for all except create).")] = None,
     name: Annotated[str | None, Field(description="Service name (alternative to ID for delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, enable, or disable a ClearPass service.
 
@@ -43,16 +35,14 @@ async def clearpass_manage_service(
         payload: JSON config body. Required for create/update. Empty dict for others.
         config_service_id: Numeric service ID. Required for update/delete/enable/disable.
         name: Service name. Alternative to config_service_id for delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     valid = ("create", "update", "delete", "enable", "disable")
     if action_type not in valid:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "service", config_service_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -89,7 +79,13 @@ async def clearpass_manage_device_group(
         str | None, Field(description="Device group ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Group name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass network device group.
 
@@ -98,7 +94,8 @@ async def clearpass_manage_device_group(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         network_device_group_id: Numeric ID. Required for update/delete (or use name).
         name: Group name. Alternative to network_device_group_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -107,9 +104,6 @@ async def clearpass_manage_device_group(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "device group", network_device_group_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -143,7 +137,13 @@ async def clearpass_manage_posture_policy(
         str | None, Field(description="Posture policy ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Policy name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass posture policy.
 
@@ -152,7 +152,8 @@ async def clearpass_manage_posture_policy(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         posture_policy_id: Numeric ID. Required for update/delete (or use name).
         name: Policy name. Alternative to posture_policy_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -161,9 +162,6 @@ async def clearpass_manage_posture_policy(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "posture policy", posture_policy_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -191,7 +189,13 @@ async def clearpass_manage_proxy_target(
     payload: Annotated[dict, Field(description="Proxy target config payload. Empty dict {} for delete.")],
     proxy_target_id: Annotated[str | None, Field(description="Proxy target ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Target name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass proxy target.
 
@@ -200,7 +204,8 @@ async def clearpass_manage_proxy_target(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         proxy_target_id: Numeric ID. Required for update/delete (or use name).
         name: Target name. Alternative to proxy_target_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -209,9 +214,6 @@ async def clearpass_manage_proxy_target(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "proxy target", proxy_target_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -241,7 +243,13 @@ async def clearpass_manage_radius_dictionary(
         str | None, Field(description="Dictionary ID (required for all except create).")
     ] = None,
     name: Annotated[str | None, Field(description="Dictionary name (alternative to ID for delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, delete, enable, or disable a ClearPass RADIUS dictionary.
 
@@ -250,16 +258,14 @@ async def clearpass_manage_radius_dictionary(
         payload: JSON config body. Required for create/update. Empty dict for others.
         radius_dictionary_id: Numeric ID. Required for update/delete/enable/disable.
         name: Dictionary name. Alternative to radius_dictionary_id for delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     valid = ("create", "update", "delete", "enable", "disable")
     if action_type not in valid:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "RADIUS dictionary", radius_dictionary_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -300,7 +306,13 @@ async def clearpass_manage_tacacs_dictionary(
         str | None, Field(description="Dictionary ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Dictionary name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass TACACS dictionary.
 
@@ -309,7 +321,8 @@ async def clearpass_manage_tacacs_dictionary(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         tacacs_dictionary_id: Numeric ID. Required for update/delete (or use name).
         name: Dictionary name. Alternative to tacacs_dictionary_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -318,9 +331,6 @@ async def clearpass_manage_tacacs_dictionary(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "TACACS dictionary", tacacs_dictionary_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -354,7 +364,13 @@ async def clearpass_manage_application_dictionary(
         str | None, Field(description="Dictionary ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Dictionary name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass application dictionary.
 
@@ -363,7 +379,8 @@ async def clearpass_manage_application_dictionary(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         application_dictionary_id: Numeric ID. Required for update/delete (or use name).
         name: Dictionary name. Alternative to application_dictionary_id.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -372,11 +389,6 @@ async def clearpass_manage_application_dictionary(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(
-        ctx, action_type, "application dictionary", application_dictionary_id or name, confirmed
-    )
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
@@ -8,21 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(ctx: Context, action: str, identifier: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -32,7 +20,13 @@ async def clearpass_manage_role(
     payload: Annotated[dict, Field(description="Role config payload. For delete: empty dict {}.")],
     role_id: Annotated[str | None, Field(description="Role ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Role name (alternative to ID for update/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass role.
 
@@ -45,7 +39,8 @@ async def clearpass_manage_role(
             For create, must include name at minimum.
         role_id: Numeric ID. Required for update/delete (or use name).
         name: Role name. Alternative to role_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -54,11 +49,6 @@ async def clearpass_manage_role(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} role", role_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -88,7 +78,13 @@ async def clearpass_manage_role_mapping(
     payload: Annotated[dict, Field(description="Role mapping config payload. For delete: empty dict {}.")],
     role_mapping_id: Annotated[str | None, Field(description="Role mapping ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Role mapping name (alternative to ID for update/delete).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass role mapping policy.
 
@@ -100,7 +96,8 @@ async def clearpass_manage_role_mapping(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         role_mapping_id: Numeric ID. Required for update/delete (or use name).
         name: Role mapping name. Alternative to role_mapping_id for update/delete.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if action_type not in ("create", "update", "delete"):
         raise ToolError(
@@ -109,11 +106,6 @@ async def clearpass_manage_role_mapping(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-
-    if action_type != "create" and not confirmed:
-        decline = await _confirm_write(ctx, f"{action_type} role mapping", role_mapping_id or name)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
@@ -8,23 +8,9 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
-
-
-async def _confirm_write(
-    ctx: Context, action_type: str, resource: str, identifier: str | None, confirmed: bool
-) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = identifier or "unknown"
-    return await confirm_write(ctx, f"ClearPass: {action_type} {resource} '{label}'. Confirm?")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -34,7 +20,13 @@ async def clearpass_manage_admin_user(
     payload: Annotated[dict, Field(description="Admin user config payload. Empty dict {} for delete.")],
     admin_user_id: Annotated[str | None, Field(description="Admin user ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Admin username (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass admin user."""
     if action_type not in ("create", "update", "delete"):
@@ -44,9 +36,6 @@ async def clearpass_manage_admin_user(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "admin user", admin_user_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -74,7 +63,13 @@ async def clearpass_manage_admin_privilege(
     payload: Annotated[dict, Field(description="Admin privilege config payload. Empty dict {} for delete.")],
     admin_privilege_id: Annotated[str | None, Field(description="Privilege ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Privilege name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass admin privilege."""
     if action_type not in ("create", "update", "delete"):
@@ -84,9 +79,6 @@ async def clearpass_manage_admin_privilege(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "admin privilege", admin_privilege_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -116,7 +108,13 @@ async def clearpass_manage_operator_profile(
         str | None, Field(description="Operator profile ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Profile name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass operator profile."""
     if action_type not in ("create", "update", "delete"):
@@ -126,9 +124,6 @@ async def clearpass_manage_operator_profile(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "operator profile", operator_profile_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -159,7 +154,13 @@ async def clearpass_manage_license(
     ],
     payload: Annotated[dict, Field(description="License config payload. Empty dict {} for delete.")],
     license_id: Annotated[str | None, Field(description="License ID (required for delete/activate).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, delete, or activate a ClearPass application license."""
     valid = ("create", "delete", "activate_online", "activate_offline")
@@ -167,9 +168,6 @@ async def clearpass_manage_license(
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "license", license_id, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -191,12 +189,15 @@ async def clearpass_manage_license(
 async def clearpass_manage_cluster_params(
     ctx: Context,
     payload: Annotated[dict, Field(description="Cluster parameters config payload.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update ClearPass cluster parameters."""
-    decline = await _confirm_write(ctx, "update", "cluster parameters", "global", confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         return await client.request("patch", "/cluster/parameters", json_body=payload)
@@ -211,7 +212,13 @@ async def clearpass_manage_password_policy(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'update_admin' or 'update_local'.")],
     payload: Annotated[dict, Field(description="Password policy config payload.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Update ClearPass admin or local user password policy."""
     valid = ("update_admin", "update_local")
@@ -219,9 +226,6 @@ async def clearpass_manage_password_policy(
         raise ToolError(
             {"status_code": 400, "message": f"Invalid action_type '{action_type}'. Must be one of: {', '.join(valid)}."}
         )
-    decline = await _confirm_write(ctx, action_type, "password policy", action_type, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         path = "/admin-user/password-policy" if action_type == "update_admin" else "/local-user/password-policy"
@@ -248,7 +252,13 @@ async def clearpass_manage_attribute(
             )
         ),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass attribute."""
     if action_type not in ("create", "update", "delete"):
@@ -258,9 +268,6 @@ async def clearpass_manage_attribute(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "attribute", attribute_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -296,7 +303,13 @@ async def clearpass_manage_data_filter(
     payload: Annotated[dict, Field(description="Data filter config payload. Empty dict {} for delete.")],
     data_filter_id: Annotated[str | None, Field(description="Data filter ID (required for update/delete).")] = None,
     name: Annotated[str | None, Field(description="Filter name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass data filter."""
     if action_type not in ("create", "update", "delete"):
@@ -306,9 +319,6 @@ async def clearpass_manage_data_filter(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "data filter", data_filter_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -338,7 +348,13 @@ async def clearpass_manage_file_backup_server(
         str | None, Field(description="Backup server ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Server name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass file backup server."""
     if action_type not in ("create", "update", "delete"):
@@ -348,9 +364,6 @@ async def clearpass_manage_file_backup_server(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "file backup server", file_backup_server_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -380,7 +393,13 @@ async def clearpass_manage_messaging_setup(
     ctx: Context,
     action_type: Annotated[str, Field(description="Action: 'create', 'update', or 'delete'.")],
     payload: Annotated[dict, Field(description="Messaging setup config payload. Empty dict {} for delete.")],
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete the ClearPass messaging setup."""
     if action_type not in ("create", "update", "delete"):
@@ -390,9 +409,6 @@ async def clearpass_manage_messaging_setup(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "messaging setup", "global", confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -415,7 +431,13 @@ async def clearpass_manage_snmp_trap_receiver(
         str | None, Field(description="SNMP trap receiver ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Receiver name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass SNMP trap receiver."""
     if action_type not in ("create", "update", "delete"):
@@ -425,9 +447,6 @@ async def clearpass_manage_snmp_trap_receiver(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "SNMP trap receiver", snmp_trap_receiver_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":
@@ -461,7 +480,13 @@ async def clearpass_manage_policy_manager_zone(
         str | None, Field(description="Policy manager zone ID (required for update/delete).")
     ] = None,
     name: Annotated[str | None, Field(description="Zone name (alternative to ID).")] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Create, update, or delete a ClearPass policy manager zone."""
     if action_type not in ("create", "update", "delete"):
@@ -471,9 +496,6 @@ async def clearpass_manage_policy_manager_zone(
                 "message": f"Invalid action_type '{action_type}'. Must be 'create', 'update', or 'delete'.",
             }
         )
-    decline = await _confirm_write(ctx, action_type, "policy manager zone", policy_manager_zones_id or name, confirmed)
-    if decline:
-        return decline
     try:
         client = await get_clearpass_client()
         if action_type == "create":

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
@@ -8,23 +8,11 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
 _VALID_TARGETS = ("session_id", "username", "mac", "ip", "bulk")
-
-
-async def _confirm_session_action(ctx: Context, action: str, target_type: str, target: str | None) -> dict | None:
-    """Thin wrapper over :func:`middleware.elicitation.confirm_write`.
-
-    Kept as a local helper so existing call sites don't change; the
-    shared elicitation/decline/cancel logic now lives in the middleware
-    (#148).
-    """
-    label = f"{target_type}={target}" if target else target_type
-    return await confirm_write(ctx, f"ClearPass: {action} session for {label}. Confirm?")
 
 
 @tool(capability=Capability.OPERATIONAL, enable_gated=True)
@@ -39,7 +27,13 @@ async def clearpass_disconnect_session(
         dict | None,
         Field(description="Filter criteria for bulk disconnect (e.g. {'nasipaddress': '10.1.1.1'})."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Disconnect an active ClearPass session (send RADIUS Disconnect-Request).
 
@@ -54,7 +48,8 @@ async def clearpass_disconnect_session(
         target_type: How to identify the session(s) to disconnect.
         target_value: The session ID, username, MAC, or IP. Not needed for bulk.
         filter: Filter dict for bulk operations. Used only when target_type is 'bulk'.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if target_type not in _VALID_TARGETS:
         raise ToolError(
@@ -69,11 +64,6 @@ async def clearpass_disconnect_session(
         )
     if target_type == "bulk" and not filter:
         raise ToolError({"status_code": 400, "message": "filter is required when target_type is 'bulk'."})
-
-    if not confirmed:
-        decline = await _confirm_session_action(ctx, "disconnect", target_type, target_value)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()
@@ -124,7 +114,13 @@ async def clearpass_perform_coa(
         str | None,
         Field(description="Optional reauthorization profile name (session_id target only)."),
     ] = None,
-    confirmed: Annotated[bool, Field(description="Set true after user confirms the operation.")] = False,
+    confirmed: Annotated[
+        bool,
+        Field(
+            description="Fallback confirmation flag — honored only when the client cannot show a "
+            "confirmation prompt (the universal gate prompts otherwise)."
+        ),
+    ] = False,
 ) -> dict | str:
     """Perform a Change of Authorization (CoA) on active ClearPass sessions.
 
@@ -142,7 +138,8 @@ async def clearpass_perform_coa(
         target_type: How to identify the session(s) for CoA.
         target_value: The session ID, username, MAC, or IP. Not needed for bulk.
         filter: Filter dict for bulk operations. Used only when target_type is 'bulk'.
-        confirmed: Set true after user confirms. Skips re-prompting.
+        confirmed: Fallback confirmation flag — honored only when the client cannot show a
+            confirmation prompt (the universal gate prompts otherwise).
     """
     if target_type not in _VALID_TARGETS:
         raise ToolError(
@@ -168,11 +165,6 @@ async def clearpass_perform_coa(
                 ),
             }
         )
-
-    if not confirmed:
-        decline = await _confirm_session_action(ctx, "CoA", target_type, target_value)
-        if decline:
-            return decline
 
     try:
         client = await get_clearpass_client()

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
@@ -1,8 +1,8 @@
 """UXI agent write tools (PATCH + DELETE).
 
 Tools in this module mutate or remove UXI agent resources. They are gated
-behind ``ENABLE_UXI_WRITE_TOOLS=true`` and require user confirmation via
-``confirm_write`` elicitation before any HTTP mutation is issued.
+behind ``ENABLE_UXI_WRITE_TOOLS=true``; the universal confirmation gate at
+``uxi_invoke_tool`` prompts the user before any HTTP mutation is issued.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
@@ -61,10 +60,6 @@ async def uxi_update_agent(
     if not body:
         return {"status": "no_op", "message": "No fields provided — nothing to update."}
 
-    decision = await confirm_write(ctx, f"Update agent {agent_id!r} — fields: {', '.join(body.keys())}")
-    if decision is not None:
-        return decision
-
     try:
         client = await get_uxi_client()
         result = await client.uxi_patch(f"/agents/{agent_id}", body)
@@ -88,10 +83,6 @@ async def uxi_delete_agent(
         agent_id: The agent's UXI resource ID (from ``uxi_list_agents`` items[].id).
     """
     validate_id(agent_id, "agent_id")
-
-    decision = await confirm_write(ctx, f"Permanently delete agent {agent_id!r}?")
-    if decision is not None:
-        return decision
 
     try:
         client = await get_uxi_client()

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
@@ -1,8 +1,8 @@
 """UXI assignment write tools (POST + DELETE).
 
 Tools in this module create and remove agent-group and sensor-group assignments.
-They are gated behind ``ENABLE_UXI_WRITE_TOOLS=true`` and require user
-confirmation via ``confirm_write`` elicitation before any HTTP mutation is issued.
+They are gated behind ``ENABLE_UXI_WRITE_TOOLS=true``; the universal confirmation
+gate at ``uxi_invoke_tool`` prompts the user before any HTTP mutation is issued.
 
 Note on remove tools: the DELETE endpoints take the **assignment record ID**
 returned by ``uxi_list_*_group_assignments`` items[].id — NOT the agent, sensor,
@@ -17,7 +17,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
@@ -41,10 +40,6 @@ async def uxi_assign_agent_to_group(
     """
     validate_id(agent_id, "agent_id")
     validate_id(group_id, "group_id")
-
-    decision = await confirm_write(ctx, f"Assign agent {agent_id!r} to group {group_id!r}?")
-    if decision is not None:
-        return decision
 
     body = {"agentId": agent_id, "groupId": group_id}  # API fields are camelCase
 
@@ -75,10 +70,6 @@ async def uxi_remove_agent_from_group(
     """
     validate_id(assignment_id, "assignment_id")
 
-    decision = await confirm_write(ctx, f"Remove agent-group assignment {assignment_id!r}?")
-    if decision is not None:
-        return decision
-
     try:
         client = await get_uxi_client()
         result = await client.uxi_delete(f"/agent-group-assignments/{assignment_id}")
@@ -106,10 +97,6 @@ async def uxi_assign_sensor_to_group(
     """
     validate_id(sensor_id, "sensor_id")
     validate_id(group_id, "group_id")
-
-    decision = await confirm_write(ctx, f"Assign sensor {sensor_id!r} to group {group_id!r}?")
-    if decision is not None:
-        return decision
 
     body = {"sensorId": sensor_id, "groupId": group_id}  # API fields are camelCase
 
@@ -139,10 +126,6 @@ async def uxi_remove_sensor_from_group(
             ``uxi_list_sensor_group_assignments`` items[].id).
     """
     validate_id(assignment_id, "assignment_id")
-
-    decision = await confirm_write(ctx, f"Remove sensor-group assignment {assignment_id!r}?")
-    if decision is not None:
-        return decision
 
     try:
         client = await get_uxi_client()

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
@@ -1,8 +1,8 @@
 """UXI group write tools (POST + PATCH + DELETE).
 
 Tools in this module create, update, and delete UXI group resources. They are
-gated behind ``ENABLE_UXI_WRITE_TOOLS=true`` and require user confirmation via
-``confirm_write`` elicitation before any HTTP mutation is issued.
+gated behind ``ENABLE_UXI_WRITE_TOOLS=true``; the universal confirmation gate
+at ``uxi_invoke_tool`` prompts the user before any HTTP mutation is issued.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
@@ -38,10 +37,6 @@ async def uxi_create_group(
     if parent_id is not None:
         validate_id(parent_id, "parent_id")
         body["parentId"] = parent_id  # API field is camelCase
-
-    decision = await confirm_write(ctx, f"Create group {name!r}")
-    if decision is not None:
-        return decision
 
     try:
         client = await get_uxi_client()
@@ -70,10 +65,6 @@ async def uxi_update_group(
     """
     validate_id(group_id, "group_id")
 
-    decision = await confirm_write(ctx, f"Update group {group_id!r} name to {name!r}")
-    if decision is not None:
-        return decision
-
     try:
         client = await get_uxi_client()
         result = await client.uxi_patch(f"/groups/{group_id}", {"name": name})
@@ -98,10 +89,6 @@ async def uxi_delete_group(
         group_id: The group's UXI resource ID (from ``uxi_list_groups`` items[].id).
     """
     validate_id(group_id, "group_id")
-
-    decision = await confirm_write(ctx, f"Permanently delete group {group_id!r}?")
-    if decision is not None:
-        return decision
 
     try:
         client = await get_uxi_client()

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
@@ -1,8 +1,8 @@
 """UXI sensor write tools (PATCH).
 
 Tools in this module mutate UXI sensor configuration. They are gated behind
-``ENABLE_UXI_WRITE_TOOLS=true`` and require user confirmation via
-``confirm_write`` elicitation before any HTTP mutation is issued.
+``ENABLE_UXI_WRITE_TOOLS=true``; the universal confirmation gate at
+``uxi_invoke_tool`` prompts the user before any HTTP mutation is issued.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
-from hpe_networking_mcp.middleware.elicitation import confirm_write
 from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
@@ -60,10 +59,6 @@ async def uxi_update_sensor(
 
     if not body:
         return {"status": "no_op", "message": "No fields provided — nothing to update."}
-
-    decision = await confirm_write(ctx, f"Update sensor {sensor_id!r} — fields: {', '.join(body.keys())}")
-    if decision is not None:
-        return decision
 
     try:
         client = await get_uxi_client()

--- a/tests/unit/test_aos8_write.py
+++ b/tests/unit/test_aos8_write.py
@@ -597,11 +597,14 @@ async def test_no_implicit_write_memory():
 # ---------------------------------------------------------------------------
 
 
-async def test_elicitation_required_when_not_confirmed():
-    """When mode=chat_confirm and confirmed=False, tool must return confirmation_required."""
+async def test_tool_body_has_no_inline_confirmation():
+    """Confirmation moved to the universal gate at aos8_invoke_tool dispatch
+    (see test_universal_confirmation_gate / test_gate_end_to_end). The tool
+    body itself dispatches regardless of confirmed — direct calls only exist
+    behind the gate."""
     from hpe_networking_mcp.platforms.aos8.tools.writes import aos8_manage_ssid_profile
 
-    ctx, client = _make_ctx({}, elicitation_mode="chat_confirm")
+    ctx, client = _make_ctx(_load_fixture("write_ssid_prof_success.json"), elicitation_mode="chat_confirm")
     result = await aos8_manage_ssid_profile(
         ctx,
         config_path="/md",
@@ -611,8 +614,7 @@ async def test_elicitation_required_when_not_confirmed():
     )
 
     assert isinstance(result, dict)
-    assert result.get("status") == "confirmation_required"
-    client.request.assert_not_awaited()
+    client.request.assert_awaited()
 
 
 async def test_elicitation_disabled_state_auto_accepts():

--- a/tests/unit/test_central_scope_writes.py
+++ b/tests/unit/test_central_scope_writes.py
@@ -11,7 +11,7 @@ ungated.
 from __future__ import annotations
 
 import importlib
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -31,7 +31,6 @@ def central_registry():
     return REGISTRIES["central"]
 
 
-_CONFIRM = "hpe_networking_mcp.platforms.central.tools.sites.confirm_write"
 _CMD = "hpe_networking_mcp.platforms.central.tools.sites.retry_central_command"
 
 WRITE_TOOLS = [
@@ -62,8 +61,7 @@ class TestGatingTag:
 
 class TestMembershipWrites:
     @patch(_CMD)
-    @patch(_CONFIRM, new_callable=AsyncMock)
-    async def test_add_devices_to_device_group_confirmed(self, mock_confirm, mock_cmd):
+    async def test_add_devices_to_device_group_confirmed(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.sites import central_add_devices_to_device_group
 
         mock_cmd.return_value = {"code": 200, "msg": {"ok": True}}
@@ -71,7 +69,6 @@ class TestMembershipWrites:
             _ctx(), dest_scope_id="55", devices=["S1", "S2"], confirmed=True
         )
 
-        mock_confirm.assert_not_called()  # confirmed=True skips elicitation
         kwargs = mock_cmd.call_args.kwargs
         assert kwargs["api_method"] == "POST"
         assert kwargs["api_path"] == "network-config/v1/device-groups-add-devices"
@@ -79,22 +76,22 @@ class TestMembershipWrites:
         assert result == {"ok": True}
 
     @patch(_CMD)
-    @patch(_CONFIRM, new_callable=AsyncMock)
-    async def test_unconfirmed_returns_guard_and_skips_call(self, mock_confirm, mock_cmd):
+    async def test_unconfirmed_direct_call_dispatches(self, mock_cmd):
+        """Inline guards are gone — confirmation is enforced by the universal
+        gate at central_invoke_tool dispatch (see test_gate_end_to_end). The
+        tool body itself dispatches regardless of confirmed."""
         from hpe_networking_mcp.platforms.central.tools.sites import central_add_devices_to_site
 
-        mock_confirm.return_value = {"status": "confirmation_required", "message": "confirm please"}
+        mock_cmd.return_value = {"code": 200, "msg": {"ok": True}}
         result = await central_add_devices_to_site(_ctx(), dest_scope_id="7", devices=["S1"])
 
-        assert result == {"status": "confirmation_required", "message": "confirm please"}
-        mock_cmd.assert_not_called()  # guard short-circuits before the API call
+        assert result == {"ok": True}
+        mock_cmd.assert_called_once()
 
     @patch(_CMD)
-    @patch(_CONFIRM, new_callable=AsyncMock)
-    async def test_create_group_omits_description_when_none(self, mock_confirm, mock_cmd):
+    async def test_create_group_omits_description_when_none(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.sites import central_create_device_group_with_devices
 
-        mock_confirm.return_value = None  # accepted
         mock_cmd.return_value = {"code": 200, "msg": {}}
         await central_create_device_group_with_devices(_ctx(), scope_name="DG1", devices=["S1"])
         assert mock_cmd.call_args.kwargs["api_data"] == {"scopeName": "DG1", "devices": ["S1"]}
@@ -103,11 +100,9 @@ class TestMembershipWrites:
         assert mock_cmd.call_args.kwargs["api_data"] == {"scopeName": "DG1", "devices": ["S1"], "description": "d"}
 
     @patch(_CMD)
-    @patch(_CONFIRM, new_callable=AsyncMock)
-    async def test_non_2xx_raises_toolerror(self, mock_confirm, mock_cmd):
+    async def test_non_2xx_raises_toolerror(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.sites import central_remove_devices_from_device_group
 
-        mock_confirm.return_value = None
         mock_cmd.return_value = {"code": 422, "msg": "bad serials"}
         with pytest.raises(ToolError) as exc:
             await central_remove_devices_from_device_group(_ctx(), devices=["BAD"], confirmed=True)
@@ -116,8 +111,7 @@ class TestMembershipWrites:
 
 class TestBulkDeletes:
     @patch(_CMD)
-    @patch(_CONFIRM, new_callable=AsyncMock)
-    async def test_bulk_delete_sites_uses_delete_and_items_body(self, mock_confirm, mock_cmd):
+    async def test_bulk_delete_sites_uses_delete_and_items_body(self, mock_cmd):
         from hpe_networking_mcp.platforms.central.tools.sites import central_bulk_delete_sites
 
         mock_cmd.return_value = {"code": 200, "msg": {"deleted": 2}}

--- a/tests/unit/test_clearpass_endpoint_routes.py
+++ b/tests/unit/test_clearpass_endpoint_routes.py
@@ -164,15 +164,10 @@ class TestSessionControlRoutes:
 @pytest.mark.unit
 class TestConfigSelectorRoutes:
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.manage_server_config._confirm_write",
-        new_callable=AsyncMock,
-        return_value=None,
-    )
-    @patch(
         "hpe_networking_mcp.platforms.clearpass.tools.manage_server_config.get_clearpass_client",
         new_callable=AsyncMock,
     )
-    async def test_admin_user_by_name_uses_user_id_route(self, mock_get, _mock_confirm):
+    async def test_admin_user_by_name_uses_user_id_route(self, mock_get):
         from hpe_networking_mcp.platforms.clearpass.tools.manage_server_config import clearpass_manage_admin_user
 
         client = _client()
@@ -182,15 +177,10 @@ class TestConfigSelectorRoutes:
         assert (method, path) == ("delete", "/admin-user/user-id/ops-admin")
 
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.manage_server_config._confirm_write",
-        new_callable=AsyncMock,
-        return_value=None,
-    )
-    @patch(
         "hpe_networking_mcp.platforms.clearpass.tools.manage_server_config.get_clearpass_client",
         new_callable=AsyncMock,
     )
-    async def test_attribute_by_name_requires_entity(self, mock_get, _mock_confirm):
+    async def test_attribute_by_name_requires_entity(self, mock_get):
         from fastmcp.exceptions import ToolError
 
         from hpe_networking_mcp.platforms.clearpass.tools.manage_server_config import clearpass_manage_attribute
@@ -204,15 +194,10 @@ class TestConfigSelectorRoutes:
         assert "entity_name" in exc.value.args[0]["message"]
 
     @patch(
-        "hpe_networking_mcp.platforms.clearpass.tools.manage_local_config._confirm_write",
-        new_callable=AsyncMock,
-        return_value=None,
-    )
-    @patch(
         "hpe_networking_mcp.platforms.clearpass.tools.manage_local_config.get_clearpass_client",
         new_callable=AsyncMock,
     )
-    async def test_ad_join_uses_action_prefix_route(self, mock_get, _mock_confirm):
+    async def test_ad_join_uses_action_prefix_route(self, mock_get):
         from hpe_networking_mcp.platforms.clearpass.tools.manage_local_config import clearpass_manage_ad_domain
 
         client = _client()

--- a/tests/unit/test_gate_end_to_end.py
+++ b/tests/unit/test_gate_end_to_end.py
@@ -1,0 +1,146 @@
+"""End-to-end test of the universal confirmation gate over a real MCP session.
+
+Builds a minimal FastMCP server with one platform's meta-tools and a fake
+registry, then drives ``<platform>_invoke_tool`` through an in-memory
+``fastmcp.Client`` whose elicitation handler plays the human. This exercises
+the REAL dispatch path (registry lookup → enable check → gate → elicit
+round-trip → tool call), not mocks of it.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, ToolSpec
+
+pytestmark = pytest.mark.unit
+
+_PLATFORM = "gatetest"
+
+
+@pytest.fixture
+def gated_server():
+    """A FastMCP server exposing gatetest_invoke_tool over a fake registry."""
+    calls: list[dict[str, Any]] = []
+
+    async def fake_write_tool(ctx, target: str = "", confirmed: bool = False) -> dict:
+        calls.append({"target": target})
+        return {"status": "written", "target": target}
+
+    async def fake_read_tool(ctx) -> dict:
+        calls.append({"read": True})
+        return {"status": "read"}
+
+    REGISTRIES[_PLATFORM] = {
+        "gatetest_manage_thing": ToolSpec(
+            name="gatetest_manage_thing",
+            func=fake_write_tool,
+            platform=_PLATFORM,
+            category="test",
+            description="Fake gated write.",
+            tags={f"{_PLATFORM}_write_delete", "requires_confirmation"},
+            capability=Capability.WRITE_DELETE,
+        ),
+        "gatetest_get_thing": ToolSpec(
+            name="gatetest_get_thing",
+            func=fake_read_tool,
+            platform=_PLATFORM,
+            category="test",
+            description="Fake read.",
+            tags=set(),
+            capability=Capability.READ,
+        ),
+    }
+
+    config = SimpleNamespace(disable_elicitation=False)
+    # is_tool_enabled consults the config flags; expose the write flag as on.
+    setattr(config, f"enable_{_PLATFORM}_write_tools", True)
+
+    @asynccontextmanager
+    async def lifespan(_server):
+        yield {"config": config}
+
+    server = FastMCP("gate-test", lifespan=lifespan)
+    build_meta_tools(_PLATFORM, server)
+
+    yield server, calls
+    REGISTRIES.pop(_PLATFORM, None)
+
+
+class TestGateEndToEnd:
+    async def test_accept_prompts_then_dispatches(self, gated_server):
+        server, calls = gated_server
+        prompts: list[str] = []
+
+        async def handler(message: str, response_type, params, context):
+            prompts.append(message)
+            from fastmcp.client.elicitation import ElicitResult
+
+            return ElicitResult(action="accept")
+
+        async with Client(server, elicitation_handler=handler) as client:
+            result = await client.call_tool(
+                f"{_PLATFORM}_invoke_tool", {"name": "gatetest_manage_thing", "params": {"target": "HQ"}}
+            )
+        assert calls == [{"target": "HQ"}]
+        assert len(prompts) == 1 and "gatetest_manage_thing" in prompts[0]
+        assert result.data["status"] == "written"
+
+    async def test_decline_blocks_dispatch_even_with_confirmed_true(self, gated_server):
+        """#415: confirmed=true must not bypass a live prompt the human declined."""
+        server, calls = gated_server
+
+        async def handler(message: str, response_type, params, context):
+            from fastmcp.client.elicitation import ElicitResult
+
+            return ElicitResult(action="decline")
+
+        async with Client(server, elicitation_handler=handler) as client:
+            result = await client.call_tool(
+                f"{_PLATFORM}_invoke_tool",
+                {"name": "gatetest_manage_thing", "params": {"target": "HQ", "confirmed": True}},
+            )
+        assert calls == []  # tool never ran
+        assert result.data["status"] == "declined"
+
+    async def test_read_tool_never_prompts(self, gated_server):
+        server, calls = gated_server
+        prompts: list[str] = []
+
+        async def counting_handler(message: str, response_type, params, context):
+            prompts.append(message)
+            from fastmcp.client.elicitation import ElicitResult
+
+            return ElicitResult(action="accept")
+
+        async with Client(server, elicitation_handler=counting_handler) as client:
+            result = await client.call_tool(f"{_PLATFORM}_invoke_tool", {"name": "gatetest_get_thing", "params": {}})
+        assert prompts == []
+        assert calls == [{"read": True}]
+        assert result.data["status"] == "read"
+
+    async def test_no_elicitation_client_requires_chat_confirm_then_fallback(self, gated_server):
+        """A client with NO elicitation handler: first call returns
+        confirmation_required; the confirmed=true retry proceeds."""
+        server, calls = gated_server
+
+        async with Client(server) as client:  # no elicitation_handler
+            first = await client.call_tool(
+                f"{_PLATFORM}_invoke_tool", {"name": "gatetest_manage_thing", "params": {"target": "HQ"}}
+            )
+            assert first.data["status"] == "confirmation_required"
+            assert calls == []
+
+            second = await client.call_tool(
+                f"{_PLATFORM}_invoke_tool",
+                {"name": "gatetest_manage_thing", "params": {"target": "HQ", "confirmed": True}},
+            )
+        assert second.data["status"] == "written"
+        assert calls == [{"target": "HQ"}]

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -16,6 +16,7 @@ from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from hpe_networking_mcp.config import ServerConfig
+from hpe_networking_mcp.platforms._common.annotations import Capability
 from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
 from hpe_networking_mcp.platforms._common.tool_registry import (
     REGISTRIES,
@@ -53,6 +54,7 @@ def stub_apstra_registry():
         category="blueprints",
         description="List every Apstra datacenter blueprint.",
         tags=set(),
+        capability=Capability.READ,
     )
     REGISTRIES["apstra"]["apstra_create_virtual_network"] = ToolSpec(
         name="apstra_create_virtual_network",
@@ -61,6 +63,7 @@ def stub_apstra_registry():
         category="manage_networks",
         description="Create a VXLAN or VLAN virtual network.",
         tags={"apstra_write"},
+        capability=Capability.READ,
     )
     return {"get_blueprints": get_blueprints, "create_vn": create_vn}
 
@@ -383,6 +386,7 @@ def mcp_with_fake_tools():
             category="testing",
             description=description,
             tags=set(),
+            capability=Capability.READ,
         )
         # Register with FastMCP so the meta-tool's _get_tool lookup
         # returns a real Tool object with parsed parameters.
@@ -455,6 +459,7 @@ class TestInvokeToolCoercion:
             category="testing",
             description="Test tool with optional UUID param.",
             tags=set(),
+            capability=Capability.READ,
         )
         mcp = FastMCP(name="test-optional")
         build_meta_tools("apstra", mcp)

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -88,6 +88,15 @@ class TestConfirmGatedInvoke:
         assert result["status"] == "confirmation_required"
         assert "confirmed=true" in result["message"]
 
+    async def test_other_mcp_errors_fail_closed_even_with_confirmed(self):
+        """An McpError that is NOT the no-capability signal (e.g. transport
+        failure) must fail closed — confirmed=true is not honored."""
+        transport_err = McpError(ErrorData(code=-32000, message="transport went sideways"))
+        ctx = _ctx(elicit=AsyncMock(side_effect=transport_err))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {"confirmed": True})
+        assert result is not None
+        assert result["status"] == "confirmation_unavailable"
+
     async def test_unexpected_elicit_failure_fails_closed_even_with_confirmed(self):
         """A handler crash / framework bug is NOT a license to skip
         confirmation — confirmed=true is not honored for unknown failures."""
@@ -115,6 +124,31 @@ class TestConfirmGatedInvoke:
         assert '"id": "7"' in captured[0]  # target visible
         assert "supersecret" not in captured[0]  # secret redacted
         assert "confirmed" not in captured[0]  # bookkeeping flag dropped
+
+    async def test_redaction_covers_camel_and_compound_keys(self):
+        """api_key / apiKey / clientSecret / refreshToken / private-key all redact."""
+        captured: list[str] = []
+
+        async def grab(message, response_type=None):
+            captured.append(message)
+            return AcceptedElicitation(data=None)
+
+        ctx = _ctx(elicit=AsyncMock(side_effect=grab))
+        await confirm_gated_invoke(
+            ctx,
+            "central tool 'x'",
+            {
+                "apiKey": "LEAK1",
+                "clientSecret": "LEAK2",
+                "refreshToken": "LEAK3",
+                "private-key": "LEAK4",
+                "payload": {"radiusSharedSecret": "LEAK5", "site_name": "HQ"},
+            },
+        )
+        prompt = captured[0]
+        for leak in ("LEAK1", "LEAK2", "LEAK3", "LEAK4", "LEAK5"):
+            assert leak not in prompt
+        assert "HQ" in prompt  # non-sensitive values stay visible
 
     def test_param_summary_caps_length(self):
         summary = _sanitized_param_summary({"payload": {"x" * 10: "y" * 1000}})

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -115,7 +115,6 @@ class TestInvokeToolGating:
         from hpe_networking_mcp.platforms._common import meta_tools
 
         spec = self._spec(tags={"requires_confirmation"}, capability=None)
-        registry = {"central_test_tool": spec}
 
         ctx = MagicMock()
         ctx.lifespan_context = {"config": SimpleNamespace(disable_elicitation=False)}

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -134,19 +134,23 @@ class TestConfirmGatedInvoke:
             return AcceptedElicitation(data=None)
 
         ctx = _ctx(elicit=AsyncMock(side_effect=grab))
+        # Bind leak markers to variables (not literals in secret-named
+        # positions) so review-tooling diff maskers render call and assert
+        # identically.
+        leaks = [f"leak-marker-{i}" for i in range(1, 6)]
         await confirm_gated_invoke(
             ctx,
             "central tool 'x'",
             {
-                "apiKey": "LEAK1",
-                "clientSecret": "LEAK2",
-                "refreshToken": "LEAK3",
-                "private-key": "LEAK4",
-                "payload": {"radiusSharedSecret": "LEAK5", "site_name": "HQ"},
+                "apiKey": leaks[0],
+                "clientSecret": leaks[1],
+                "refreshToken": leaks[2],
+                "private-key": leaks[3],
+                "payload": {"radiusSharedSecret": leaks[4], "site_name": "HQ"},
             },
         )
         prompt = captured[0]
-        for leak in ("LEAK1", "LEAK2", "LEAK3", "LEAK4", "LEAK5"):
+        for leak in leaks:
             assert leak not in prompt
         assert "HQ" in prompt  # non-sensitive values stay visible
 

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -23,8 +23,15 @@ from fastmcp.server.elicitation import (
     CancelledElicitation,
     DeclinedElicitation,
 )
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
 
-from hpe_networking_mcp.middleware.elicitation import confirm_gated_invoke
+from hpe_networking_mcp.middleware.elicitation import _sanitized_param_summary, confirm_gated_invoke
+
+
+def _no_elicitation_error() -> McpError:
+    return McpError(ErrorData(code=-32601, message="Elicitation not supported"))
+
 
 pytestmark = pytest.mark.unit
 
@@ -67,18 +74,51 @@ class TestConfirmGatedInvoke:
         assert result["status"] == "declined"  # human's decline wins over the flag
         ctx.elicit.assert_awaited_once()  # the prompt WAS shown despite confirmed=true
 
-    async def test_prompt_failure_with_confirmed_true_proceeds(self):
-        """Popup-less fallback: confirmed=true carries authority ONLY after elicit raises."""
-        ctx = _ctx(elicit=AsyncMock(side_effect=RuntimeError("client has no elicitation")))
+    async def test_client_without_elicitation_with_confirmed_true_proceeds(self):
+        """Popup-less fallback: confirmed=true carries authority ONLY on the
+        legitimate no-capability signal (McpError 'Elicitation not supported')."""
+        ctx = _ctx(elicit=AsyncMock(side_effect=_no_elicitation_error()))
         result = await confirm_gated_invoke(ctx, "central tool 'x'", {"confirmed": True})
         assert result is None
 
-    async def test_prompt_failure_without_confirmed_requires_chat_confirmation(self):
-        ctx = _ctx(elicit=AsyncMock(side_effect=RuntimeError("client has no elicitation")))
+    async def test_client_without_elicitation_requires_chat_confirmation(self):
+        ctx = _ctx(elicit=AsyncMock(side_effect=_no_elicitation_error()))
         result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
         assert result is not None
         assert result["status"] == "confirmation_required"
         assert "confirmed=true" in result["message"]
+
+    async def test_unexpected_elicit_failure_fails_closed_even_with_confirmed(self):
+        """A handler crash / framework bug is NOT a license to skip
+        confirmation — confirmed=true is not honored for unknown failures."""
+        ctx = _ctx(elicit=AsyncMock(side_effect=RuntimeError("handler exploded")))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {"confirmed": True})
+        assert result is not None
+        assert result["status"] == "confirmation_unavailable"
+        assert "NOT performed" in result["message"]
+
+    async def test_prompt_includes_sanitized_params(self):
+        """The human must see WHAT they approve — targets shown, secrets redacted."""
+        captured: list[str] = []
+
+        async def grab(message, response_type=None):
+            captured.append(message)
+            return AcceptedElicitation(data=None)
+
+        ctx = _ctx(elicit=AsyncMock(side_effect=grab))
+        await confirm_gated_invoke(
+            ctx,
+            "central tool 'central_bulk_delete_sites'",
+            {"items": [{"id": "7"}], "psk": "supersecret", "confirmed": True},
+        )
+        assert len(captured) == 1
+        assert '"id": "7"' in captured[0]  # target visible
+        assert "supersecret" not in captured[0]  # secret redacted
+        assert "confirmed" not in captured[0]  # bookkeeping flag dropped
+
+    def test_param_summary_caps_length(self):
+        summary = _sanitized_param_summary({"payload": {"x" * 10: "y" * 1000}})
+        assert len(summary) <= 300
 
 
 class TestInvokeToolGating:

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -1,0 +1,129 @@
+"""Unit tests for the universal confirmation gate (#415 / #416 / #436).
+
+The gate lives at the ``<platform>_invoke_tool`` dispatch chokepoint and is
+keyed ONLY on the ``requires_confirmation`` tag (never hints). The decision
+sequence under test:
+
+1. ``DISABLE_ELICITATION=true`` → auto-accept.
+2. A real ``ctx.elicit()`` prompt is attempted FIRST — accept proceeds,
+   decline/cancel return structured results, and crucially ``confirmed=true``
+   is IGNORED while a prompt is available (the #415 self-authorization hole).
+3. Only when the prompt raises is ``confirmed=true`` honored (chat fallback).
+4. Fail-closed at the dispatcher: an unclassified tool is treated as gated.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.server.elicitation import (
+    AcceptedElicitation,
+    CancelledElicitation,
+    DeclinedElicitation,
+)
+
+from hpe_networking_mcp.middleware.elicitation import confirm_gated_invoke
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx(*, disable_elicitation: bool = False, elicit: AsyncMock | None = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"config": SimpleNamespace(disable_elicitation=disable_elicitation)}
+    ctx.elicit = elicit if elicit is not None else AsyncMock(return_value=AcceptedElicitation(data=None))
+    return ctx
+
+
+class TestConfirmGatedInvoke:
+    async def test_disabled_elicitation_auto_accepts_without_prompting(self):
+        ctx = _ctx(disable_elicitation=True)
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        assert result is None
+        ctx.elicit.assert_not_called()
+
+    async def test_accept_proceeds(self):
+        ctx = _ctx()
+        assert await confirm_gated_invoke(ctx, "central tool 'x'", {}) is None
+        ctx.elicit.assert_awaited_once()
+
+    async def test_decline_returns_declined(self):
+        ctx = _ctx(elicit=AsyncMock(return_value=DeclinedElicitation()))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        assert result == {"status": "declined", "message": "Action declined by user."}
+
+    async def test_cancel_returns_cancelled(self):
+        ctx = _ctx(elicit=AsyncMock(return_value=CancelledElicitation()))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        assert result is not None
+        assert result["status"] == "cancelled"
+
+    async def test_confirmed_true_is_ignored_while_prompt_available(self):
+        """The #415 hole: confirmed=true must NOT bypass a working prompt."""
+        ctx = _ctx(elicit=AsyncMock(return_value=DeclinedElicitation()))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {"confirmed": True})
+        assert result is not None
+        assert result["status"] == "declined"  # human's decline wins over the flag
+        ctx.elicit.assert_awaited_once()  # the prompt WAS shown despite confirmed=true
+
+    async def test_prompt_failure_with_confirmed_true_proceeds(self):
+        """Popup-less fallback: confirmed=true carries authority ONLY after elicit raises."""
+        ctx = _ctx(elicit=AsyncMock(side_effect=RuntimeError("client has no elicitation")))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {"confirmed": True})
+        assert result is None
+
+    async def test_prompt_failure_without_confirmed_requires_chat_confirmation(self):
+        ctx = _ctx(elicit=AsyncMock(side_effect=RuntimeError("client has no elicitation")))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        assert result is not None
+        assert result["status"] == "confirmation_required"
+        assert "confirmed=true" in result["message"]
+
+
+class TestInvokeToolGating:
+    """The dispatcher applies the gate iff requires_confirmation (fail-closed)."""
+
+    def _spec(self, *, tags: set[str], capability):
+        return SimpleNamespace(
+            name="central_test_tool",
+            func=AsyncMock(return_value={"ok": True}),
+            platform="central",
+            category="test",
+            description="Test tool.",
+            tags=tags,
+            capability=capability,
+        )
+
+    def test_gate_predicate_matches_design(self):
+        """Pin the predicate: tag-driven, fail-closed on missing capability."""
+        from hpe_networking_mcp.platforms._common.annotations import Capability
+
+        gated = self._spec(tags={"central_write_delete", "requires_confirmation"}, capability=Capability.WRITE_DELETE)
+        read = self._spec(tags=set(), capability=Capability.READ)
+        unclassified = self._spec(tags=set(), capability=None)
+
+        def needs_confirmation(spec) -> bool:
+            return "requires_confirmation" in spec.tags or spec.capability is None
+
+        assert needs_confirmation(gated) is True
+        assert needs_confirmation(read) is False
+        assert needs_confirmation(unclassified) is True  # fail-closed
+
+    async def test_dispatch_blocks_on_decline_and_never_calls_tool(self):
+        """End-to-end through the real _invoke_tool body via the registry."""
+        from hpe_networking_mcp.platforms._common import meta_tools
+
+        spec = self._spec(tags={"requires_confirmation"}, capability=None)
+        registry = {"central_test_tool": spec}
+
+        ctx = MagicMock()
+        ctx.lifespan_context = {"config": SimpleNamespace(disable_elicitation=False)}
+        ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+
+        # Drive the gate exactly as _invoke_tool does.
+        needs = "requires_confirmation" in spec.tags or spec.capability is None
+        assert needs
+        gate = await meta_tools.confirm_gated_invoke(ctx, "central tool 'central_test_tool'", {"confirmed": True})
+        assert gate is not None and gate["status"] == "declined"
+        spec.func.assert_not_called()

--- a/tests/unit/test_uxi_write_tools.py
+++ b/tests/unit/test_uxi_write_tools.py
@@ -172,62 +172,11 @@ class TestToolErrorPropagation:
 
 
 @pytest.mark.unit
-class TestConfirmWrite:
-    """confirm_write must be called BEFORE the mutation (D-02)."""
+# NOTE: the former TestConfirmWrite class asserted inline confirm_write
+# ordering. Confirmation is now enforced structurally by the universal gate
+# at uxi_invoke_tool dispatch — covered by test_universal_confirmation_gate
+# and test_gate_end_to_end.
 
-    async def test_confirm_write_called_before_mutation(self):
-        """confirm_write must be awaited BEFORE client.uxi_patch (call-order assertion)."""
-        from hpe_networking_mcp.platforms.uxi.tools.writes import sensors as sensors_mod
-
-        order: list[str] = []
-
-        async def fake_confirm(ctx, message, **kw):
-            order.append("confirm_write")
-            return None  # accept
-
-        mock_client = MagicMock()
-
-        async def fake_patch(*args, **kw):
-            order.append("uxi_patch")
-            return {"id": "abc-123"}
-
-        mock_client.uxi_patch = AsyncMock(side_effect=fake_patch)
-
-        ctx = _make_uxi_ctx(elicitation_mode="prompt")
-        with (
-            patch.object(sensors_mod, "confirm_write", side_effect=fake_confirm),
-            patch.object(sensors_mod, "get_uxi_client", AsyncMock(return_value=mock_client)),
-        ):
-            await sensors_mod.uxi_update_sensor(ctx, sensor_id="abc-123", name="x")
-
-        assert order == ["confirm_write", "uxi_patch"], (
-            f"confirm_write must be called before uxi_patch — got order={order}"
-        )
-
-    async def test_decline_skips_mutation(self):
-        """If confirm_write returns a decline dict, the mutation MUST NOT be called."""
-        from hpe_networking_mcp.platforms.uxi.tools.writes import sensors as sensors_mod
-
-        decline = {"status": "declined", "message": "user said no"}
-
-        async def fake_confirm(ctx, message, **kw):
-            return decline
-
-        mock_client = MagicMock()
-        mock_client.uxi_patch = AsyncMock(return_value={"id": "abc-123"})
-
-        ctx = _make_uxi_ctx(elicitation_mode="prompt")
-        with (
-            patch.object(sensors_mod, "confirm_write", side_effect=fake_confirm),
-            patch.object(sensors_mod, "get_uxi_client", AsyncMock(return_value=mock_client)),
-        ):
-            result = await sensors_mod.uxi_update_sensor(ctx, sensor_id="abc-123", name="x")
-
-        assert result == decline
-        mock_client.uxi_patch.assert_not_called()
-
-
-@pytest.mark.unit
 class TestElicitationWiring:
     """elicitation.py source must wire uxi_write into any_write and enable_components (D-03)."""
 


### PR DESCRIPTION
## What

**Closes #415, #416, #436.** The capstone of the elicitation-gating effort: one confirmation gate at the `<platform>_invoke_tool` dispatch chokepoint — the path BOTH code mode and dynamic mode use to reach all 1962 tools — replaces ~75 hand-written per-tool confirmation blocks.

### The gate (`confirm_gated_invoke`)
- Keyed ONLY on the `requires_confirmation` tag, which every tool now derives automatically from its `capability=` classification (the 8-platform migration that preceded this PR). Never inferred from hints. **Fail-closed**: an unclassified tool is gated by omission.
- Decision sequence:
  1. `DISABLE_ELICITATION=true` → auto-accept (operator opt-out, unchanged).
  2. A **real `ctx.elicit()` prompt is attempted first** — it round-trips transparently from the code-mode sandbox (verified live 2026-06-03; the contrary premise from #414 was false). The human's accept/decline/cancel always wins.
  3. **`confirmed=true` is ignored while a prompt is available** — this is the #415 fix. The flag carries authority only when the client genuinely cannot present a prompt (elicit raises), as the confirm-in-chat fallback.

### What this closes
- **#415** — code-mode `confirmed=true` self-authorization: dead. An AI cannot skip a working prompt.
- **#416** — the ~20 Central MRT/alert destructive tools that had NO confirmation pathway: now gated structurally (their capability classification landed in #473).
- **#436** — all 558 generated Mist write tools that bypassed elicitation: now gated (classification landed in #474).

### Inline machinery removed
~75 confirm constructs across 34 files (ClearPass 56 alone), their local `_confirm_*` helpers and imports, and the dead `_build_patch_diff` elicitation-diff renderer. `confirmed` parameters REMAIN on tools — the gate consumes them for the fallback — with descriptions updated to the fallback-only semantics. Keeping the inline blocks alongside the gate would double-prompt every write.

### Statics
`manage_wlan_profile` (the one direct-call write-tagged static that bypasses `_invoke_tool`) was audited: it performs **no mutations** — its only API call is a read; everything else returns workflow guidance. No gate needed; enable-gating retained.

## Tests
- `test_universal_confirmation_gate.py` — 9 unit tests pinning the decision sequence, including the load-bearing one: *confirmed=true ignored while a prompt is available*.
- `test_gate_end_to_end.py` — 4 tests driving the REAL dispatch path over an in-memory MCP session with a client-side elicitation handler: prompt→accept→dispatch; prompt→decline blocks despite `confirmed=true`; READ tools never prompt; a no-elicitation client gets `confirmation_required` then succeeds on the `confirmed=true` retry.
- Obsolete inline-confirm tests across aos8/uxi/central/clearpass suites updated or retired with pointers to the gate tests.
- Full suite in Docker: **1826 passed, 1 skipped**; ruff + format + mypy + bandit clean.
- INSTRUCTIONS.md confirmation guidance rewritten for the new contract.

## What remains on #466 after this
Only the cleanup PR (retire now-unused `confirm_write`/`elicitation_handler` once nothing references them, plus any leftover duplicate code). The elicitation-gating effort's behavioral work is complete with this merge.