### PR TITLE
fix: centralize URL path-segment escaping for interpolated selectors (v3.3.13.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13.2] - 2026-06-12
+
+**Patch — fix: centralized URL path-segment escaping for interpolated selector values.** Closes #476. Operator-supplied selectors (usernames, MACs, attribute/template/server names, IDs) interpolated into URL paths were sent raw: httpx already percent-encodes spaces and unicode, but a value containing `/` restructured the route, `?` started the query string, and `#` silently truncated the path — a delete aimed at `Policy #2` would have quietly targeted `Policy ` instead of failing loudly.
+
+### Added
+- `platforms/_common/url.py` — `path_seg(value)` (`urllib.parse.quote(str(value), safe="")`): one encoded path segment, no characters exempt.
+- `tests/unit/test_path_seg.py` — encoding-contract pins for the hostile characters, plus a **creep guard**: an AST scan of every f-string in the platform tree (call-shape-independent, so paths assigned to variables before the request call can't dodge it) asserting URL-path interpolations are `path_seg`-wrapped. Partial adoption is how this class of bug returns.
+
+### Fixed
+- **~450 interpolation sites wrapped across all 8 platforms** (ClearPass ~300 — the highest-value surface, free-text name selectors are common there; Central ~120 incl. the `monitoring_api` port and all MRT modules; Apstra, Axis, UXI, GreenLake, AOS8, and the cross-platform statics). The sweep ran to convergence against the guard: three rounds, each extending the guard's reach (wrapper-method call shapes, `retry_central_command`/`base_path` kwargs, variable-assigned path f-strings) until it found nothing.
+- Mist's 1037 generated tools fixed at the single `mist_request` path-substitution chokepoint (no regen needed).
+- MAC colons now percent-encode in paths (`aa%3Abb…`). **Live-verified harmless on all three changed gateways**: ClearPass, Central, and Mist each return the identical record for percent-encoded vs raw path segments (RFC 3986 decode confirmed against real tenants before shipping).
+
 ## [3.3.13.1] - 2026-06-12
 
 **Patch — refactor: retire the legacy inline-confirmation layer.** The final cleanup step of the elicitation-gating effort. With the universal gate (`confirm_gated_invoke`, v3.3.13.0) handling all confirmation at the `<platform>_invoke_tool` chokepoint, the pre-gate per-tool confirmation machinery had zero remaining callers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.13.1"
+version = "3.3.13.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/url.py
+++ b/src/hpe_networking_mcp/platforms/_common/url.py
@@ -1,0 +1,33 @@
+"""URL path-segment escaping for interpolated selector values (#476).
+
+Operator-supplied selectors (usernames, MACs, attribute names, template
+names) are interpolated into URL paths via f-strings throughout the
+platform tools. httpx percent-encodes spaces and unicode when normalizing
+the URL, but a value containing ``/`` restructures the route, ``?`` starts
+the query string, and ``#`` truncates everything after it — producing
+silently wrong requests (wrong resource targeted, no error) for
+legal-but-unusual names. Every interpolated path segment must go through
+:func:`path_seg`.
+"""
+
+from urllib.parse import quote
+
+
+def path_seg(value: object) -> str:
+    """Encode one URL path segment so it cannot restructure the route.
+
+    Args:
+        value: Selector value destined for a single path segment. Coerced
+            with ``str()`` first (numeric IDs are common).
+
+    Returns:
+        The percent-encoded segment with no characters exempt
+        (``safe=""``), so ``/``, ``?``, ``#``, and ``%`` are all escaped.
+        The value is treated as raw text — pre-encoded input is encoded
+        again rather than trusted.
+
+    Example:
+        >>> path_seg("Policy #2/v1")
+        'Policy%20%232%2Fv1'
+    """
+    return quote(str(value), safe="")

--- a/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
+++ b/src/hpe_networking_mcp/platforms/aos8/tools/_helpers.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.aos8.client import (
     AOS8APIError,
     AOS8AuthError,
@@ -196,7 +197,7 @@ async def get_object(
         params["type"] = entry_type
     response = await client.request(
         "GET",
-        f"/v1/configuration/object/{object_path}",
+        f"/v1/configuration/object/{path_seg(object_path)}",
         params=params,
     )
     return strip_meta(_decode_json_or_raise(response, f"object {object_path!r}"))

--- a/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/blueprint_topology.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -22,7 +23,7 @@ async def apstra_get_racks(ctx: Context, blueprint_id: str) -> dict[str, Any]:
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/racks")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/racks")
         items = payload.get("items", payload) if isinstance(payload, dict) else payload
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_device_guidelines(),
@@ -42,7 +43,7 @@ async def apstra_get_routing_zones(ctx: Context, blueprint_id: str) -> dict[str,
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/security-zones")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/security-zones")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_network_guidelines(),
             "data": payload,
@@ -61,7 +62,7 @@ async def apstra_get_system_info(ctx: Context, blueprint_id: str) -> dict[str, A
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/experience/web/system-info")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/experience/web/system-info")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_device_guidelines(),
             "data": payload,

--- a/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/connectivity.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -24,7 +25,7 @@ async def apstra_get_connectivity_templates(ctx: Context, blueprint_id: str) -> 
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/obj-policy-export")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/obj-policy-export")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_network_guidelines(),
             "data": payload,
@@ -46,7 +47,10 @@ async def apstra_get_application_endpoints(ctx: Context, blueprint_id: str) -> d
     """
     try:
         client = await get_apstra_client()
-        response = await client.request("POST", f"/api/blueprints/{blueprint_id}/obj-policy-application-points")
+        response = await client.request(
+            "POST",
+            f"/api/blueprints/{path_seg(blueprint_id)}/obj-policy-application-points",
+        )
         payload = response.json()
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_network_guidelines(),

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_blueprints.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -34,7 +35,7 @@ async def apstra_deploy(
         client = await get_apstra_client()
         response = await client.request(
             "PUT",
-            f"/api/blueprints/{blueprint_id}/deploy",
+            f"/api/blueprints/{path_seg(blueprint_id)}/deploy",
             json_body={"version": staging_version, "description": description},
         )
         return {
@@ -61,7 +62,7 @@ async def apstra_delete_blueprint(
     """
     try:
         client = await get_apstra_client()
-        response = await client.request("DELETE", f"/api/blueprints/{blueprint_id}")
+        response = await client.request("DELETE", f"/api/blueprints/{path_seg(blueprint_id)}")
         body: Any
         if response.content:
             try:

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_connectivity.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -41,7 +42,7 @@ async def apstra_apply_ct_policies(
         client = await get_apstra_client()
         response = await client.request(
             "PATCH",
-            f"/api/blueprints/{blueprint_id}/obj-policy-batch-apply",
+            f"/api/blueprints/{path_seg(blueprint_id)}/obj-policy-batch-apply",
             params={"async": "full"},
             json_body={"application_points": normalized},
         )

--- a/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/manage_networks.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -161,7 +162,7 @@ async def apstra_create_virtual_network(
 
         response = await client.request(
             "POST",
-            f"/api/blueprints/{blueprint_id}/virtual-networks-batch",
+            f"/api/blueprints/{path_seg(blueprint_id)}/virtual-networks-batch",
             params={"async": "full"},
             json_body={"virtual_networks": [vn_config]},
         )
@@ -226,7 +227,7 @@ async def apstra_create_remote_gateway(
 
         response = await client.request(
             "POST",
-            f"/api/blueprints/{blueprint_id}/remote_gateways",
+            f"/api/blueprints/{path_seg(blueprint_id)}/remote_gateways",
             json_body=payload,
         )
         return {

--- a/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/networks.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -22,7 +23,7 @@ async def apstra_get_virtual_networks(ctx: Context, blueprint_id: str) -> dict[s
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/virtual-networks")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/virtual-networks")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_network_guidelines(),
             "data": payload,
@@ -41,7 +42,7 @@ async def apstra_get_remote_gateways(ctx: Context, blueprint_id: str) -> dict[st
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/remote_gateways")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/remote_gateways")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_network_guidelines(),
             "data": payload,

--- a/src/hpe_networking_mcp/platforms/apstra/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/apstra/tools/status.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra import guidelines
 from hpe_networking_mcp.platforms.apstra._registry import tool
 from hpe_networking_mcp.platforms.apstra.client import format_http_error, get_apstra_client
@@ -22,7 +23,7 @@ async def apstra_get_anomalies(ctx: Context, blueprint_id: str) -> dict[str, Any
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/anomalies")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/anomalies")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_anomaly_guidelines(),
             "data": payload,
@@ -44,7 +45,7 @@ async def apstra_get_diff_status(ctx: Context, blueprint_id: str) -> dict[str, A
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/diff-status")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/diff-status")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_status_guidelines(),
             "data": payload,
@@ -63,7 +64,7 @@ async def apstra_get_protocol_sessions(ctx: Context, blueprint_id: str) -> dict[
     """
     try:
         client = await get_apstra_client()
-        payload = await client.get_json(f"/api/blueprints/{blueprint_id}/protocol-sessions")
+        payload = await client.get_json(f"/api/blueprints/{path_seg(blueprint_id)}/protocol-sessions")
         return {
             "guidelines": guidelines.get_base_guidelines() + guidelines.get_status_guidelines(),
             "data": payload,

--- a/src/hpe_networking_mcp/platforms/apstra/topology.py
+++ b/src/hpe_networking_mcp/platforms/apstra/topology.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from loguru import logger
 
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.apstra.client import ApstraClient
 
 
@@ -31,7 +32,7 @@ async def get_individual_leafs_from_system_ids(
         are returned unchanged so callers still receive a best-effort value.
     """
     try:
-        response = await client.request("GET", f"/api/blueprints/{blueprint_id}/experience/web/system-info")
+        response = await client.request("GET", f"/api/blueprints/{path_seg(blueprint_id)}/experience/web/system-info")
         payload: Any = response.json()
     except Exception as e:
         logger.error("Apstra: failed to resolve system-info for leaf expansion — {}", e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/_manage.py
@@ -24,6 +24,7 @@ from typing import Any
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 
 _VALID_ACTIONS = ("create", "update", "delete")
@@ -73,9 +74,9 @@ async def manage_entity(
         if action_type == "create":
             result = await client.post_json(base_path, payload)
         elif action_type == "update":
-            result = await client.put_json(f"{base_path}/{entity_id}", payload)
+            result = await client.put_json(f"{base_path}/{path_seg(entity_id)}", payload)
         else:
-            result = await client.delete_resource(f"{base_path}/{entity_id}")
+            result = await client.delete_resource(f"{base_path}/{path_seg(entity_id)}")
     except Exception as e:
         detail = format_http_error(e)
         raise ToolError({"status_code": 502, "message": f"Error during {action_type} {label}: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/application_groups.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -34,7 +35,7 @@ async def axis_get_application_groups(
     try:
         client = await get_axis_client()
         if application_group_id:
-            return await client.get_json(f"/Tags/{application_group_id}")
+            return await client.get_json(f"/Tags/{path_seg(application_group_id)}")
         return await client.get_paged("/Tags", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/applications.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/applications.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_applications(
     try:
         client = await get_axis_client()
         if application_id:
-            return await client.get_json(f"/Applications/{application_id}")
+            return await client.get_json(f"/Applications/{path_seg(application_id)}")
         return await client.get_paged("/Applications", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connector_zones.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_connector_zones(
     try:
         client = await get_axis_client()
         if connector_zone_id:
-            return await client.get_json(f"/ConnectorZones/{connector_zone_id}")
+            return await client.get_json(f"/ConnectorZones/{path_seg(connector_zone_id)}")
         return await client.get_paged("/ConnectorZones", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/connectors.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -40,7 +41,7 @@ async def axis_get_connectors(
     try:
         client = await get_axis_client()
         if connector_id:
-            return await client.get_json(f"/Connectors/{connector_id}")
+            return await client.get_json(f"/Connectors/{path_seg(connector_id)}")
         return await client.get_paged("/Connectors", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)
@@ -99,7 +100,7 @@ async def axis_regenerate_connector(
     """
     try:
         client = await get_axis_client()
-        return await client.post_json(f"/Connectors/{connector_id}/regenerate", json_body={})
+        return await client.post_json(f"/Connectors/{path_seg(connector_id)}/regenerate", json_body={})
     except Exception as e:
         detail = format_http_error(e)
         raise ToolError({"status_code": 502, "message": f"Error regenerating connector: {detail}"}) from e

--- a/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/custom_ip_categories.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -33,7 +34,7 @@ async def axis_get_custom_ip_categories(
     try:
         client = await get_axis_client()
         if custom_ip_category_id:
-            return await client.get_json(f"/IpCategories/{custom_ip_category_id}")
+            return await client.get_json(f"/IpCategories/{path_seg(custom_ip_category_id)}")
         return await client.get_paged("/IpCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/groups.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_groups(
     try:
         client = await get_axis_client()
         if group_id:
-            return await client.get_json(f"/Groups/{group_id}")
+            return await client.get_json(f"/Groups/{path_seg(group_id)}")
         return await client.get_paged("/Groups", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ip_feed_categories.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -33,7 +34,7 @@ async def axis_get_ip_feed_categories(
     try:
         client = await get_axis_client()
         if ip_feed_category_id:
-            return await client.get_json(f"/IpCategoriesFeed/{ip_feed_category_id}")
+            return await client.get_json(f"/IpCategoriesFeed/{path_seg(ip_feed_category_id)}")
         return await client.get_paged("/IpCategoriesFeed", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/locations.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/locations.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -34,7 +35,7 @@ async def axis_get_locations(
     try:
         client = await get_axis_client()
         if location_id:
-            return await client.get_json(f"/Locations/{location_id}")
+            return await client.get_json(f"/Locations/{path_seg(location_id)}")
         return await client.get_paged("/Locations", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)
@@ -60,9 +61,9 @@ async def axis_get_sub_locations(
     try:
         client = await get_axis_client()
         if sub_location_id:
-            return await client.get_json(f"/Locations/{location_id}/SubLocations/{sub_location_id}")
+            return await client.get_json(f"/Locations/{path_seg(location_id)}/SubLocations/{path_seg(sub_location_id)}")
         return await client.get_paged(
-            f"/Locations/{location_id}/SubLocations",
+            f"/Locations/{path_seg(location_id)}/SubLocations",
             page_number=page_number,
             page_size=page_size,
         )
@@ -122,7 +123,7 @@ async def axis_manage_sub_location(
     """
     return await manage_entity(
         ctx,
-        base_path=f"/Locations/{location_id}/SubLocations",
+        base_path=f"/Locations/{path_seg(location_id)}/SubLocations",
         label=f"sub-location under location {location_id}",
         action_type=action_type,
         payload=payload,

--- a/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/ssl_exclusions.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_ssl_exclusions(
     try:
         client = await get_axis_client()
         if ssl_exclusion_id:
-            return await client.get_json(f"/SslExclusions/{ssl_exclusion_id}")
+            return await client.get_json(f"/SslExclusions/{path_seg(ssl_exclusion_id)}")
         return await client.get_paged("/SslExclusions", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/status.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/status.py
@@ -14,6 +14,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 
@@ -35,9 +36,9 @@ async def axis_get_status(
         entity_id: GUID of the connector or tunnel.
     """
     if entity_type == "connector":
-        path = f"/Connectors/{entity_id}/status"
+        path = f"/Connectors/{path_seg(entity_id)}/status"
     elif entity_type == "tunnel":
-        path = f"/Tunnels/{entity_id}/status"
+        path = f"/Tunnels/{path_seg(entity_id)}/status"
     else:
         raise ToolError(
             {"status_code": 400, "message": f"Invalid entity_type '{entity_type}'. Must be 'connector' or 'tunnel'."}

--- a/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/tunnels.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -38,7 +39,7 @@ async def axis_get_tunnels(
     try:
         client = await get_axis_client()
         if tunnel_id:
-            return await client.get_json(f"/Tunnels/{tunnel_id}")
+            return await client.get_json(f"/Tunnels/{path_seg(tunnel_id)}")
         return await client.get_paged("/Tunnels", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/users.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_users(
     try:
         client = await get_axis_client()
         if user_id:
-            return await client.get_json(f"/Users/{user_id}")
+            return await client.get_json(f"/Users/{path_seg(user_id)}")
         return await client.get_paged("/Users", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
+++ b/src/hpe_networking_mcp/platforms/axis/tools/web_categories.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.axis._registry import tool
 from hpe_networking_mcp.platforms.axis.client import format_http_error, get_axis_client
 from hpe_networking_mcp.platforms.axis.tools._manage import manage_entity
@@ -30,7 +31,7 @@ async def axis_get_web_categories(
     try:
         client = await get_axis_client()
         if web_category_id:
-            return await client.get_json(f"/WebCategories/{web_category_id}")
+            return await client.get_json(f"/WebCategories/{path_seg(web_category_id)}")
         return await client.get_paged("/WebCategories", page_number=page_number, page_size=page_size)
     except Exception as e:
         detail = format_http_error(e)

--- a/src/hpe_networking_mcp/platforms/central/monitoring_api.py
+++ b/src/hpe_networking_mcp/platforms/central/monitoring_api.py
@@ -22,6 +22,8 @@ from typing import Any
 
 from loguru import logger
 
+from hpe_networking_mcp.platforms._common.url import path_seg
+
 
 class ParameterError(ValueError):
     """Invalid or missing parameter (local stand-in for pycentral's ParameterError)."""
@@ -1332,7 +1334,10 @@ async def disconnect_all_clients(central_conn: Any, device_type: str, serial_num
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectClientAll", "troubleshooting"),
+        api_path=_generate_url(
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/disconnectClientAll",
+            "troubleshooting",
+        ),
     )
     if resp["code"] != 202:
         raise Exception(f"Failed to initiate disconnect for all clients: {resp['code']} - {resp['msg']}")
@@ -1363,7 +1368,10 @@ async def disconnect_all_users(central_conn: Any, device_type: str, serial_numbe
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserAll", "troubleshooting"),
+        api_path=_generate_url(
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/disconnectUserAll",
+            "troubleshooting",
+        ),
     )
     if resp["code"] != 202:
         raise Exception(f"Failed to initiate disconnect for all users: {resp['code']} - {resp['msg']}")
@@ -1406,7 +1414,10 @@ async def disconnect_all_users_ssid(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserByNetwork", "troubleshooting"),
+        api_path=_generate_url(
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/disconnectUserByNetwork",
+            "troubleshooting",
+        ),
         api_data=api_data,
     )
     if resp["code"] != 202:
@@ -1453,7 +1464,10 @@ async def disconnect_client_mac_addr(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectClientByMacAddress", "troubleshooting"),
+        api_path=_generate_url(
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/disconnectClientByMacAddress",
+            "troubleshooting",
+        ),
         api_data=api_data,
     )
     if resp["code"] != 202:
@@ -1498,7 +1512,10 @@ async def disconnect_user_mac_addr(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/disconnectUserByMacAddress", "troubleshooting"),
+        api_path=_generate_url(
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/disconnectUserByMacAddress",
+            "troubleshooting",
+        ),
         api_data=api_data,
     )
     if resp["code"] != 202:
@@ -1597,7 +1614,7 @@ async def initiate_port_bounce_test(
 
     api_data = {"ports": ports}
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/portBounce", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/portBounce", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -1641,7 +1658,7 @@ async def get_port_bounce_test_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/portBounce/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/portBounce/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )
@@ -1748,7 +1765,7 @@ async def initiate_poe_bounce_test(
 
     api_data = {"ports": ports}
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/poeBounce", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/poeBounce", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -1792,7 +1809,7 @@ async def get_poe_bounce_test_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/poeBounce/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/poeBounce/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )
@@ -2093,7 +2110,7 @@ async def initiate_ping_aps_test(
     elif include_raw_output:
         raise ParameterError("include_raw_output must be a boolean value.")
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/ping", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -2179,7 +2196,7 @@ async def initiate_ping_cx_test(
     elif include_raw_output:
         raise ParameterError("include_raw_output must be a boolean value.")
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/ping", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -2286,7 +2303,7 @@ async def initiate_ping_gateways_test(
     elif include_raw_output:
         raise ParameterError("include_raw_output must be a boolean value.")
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/ping", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/ping", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -2326,7 +2343,7 @@ async def get_ping_test_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/ping/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/ping/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )
@@ -2560,7 +2577,7 @@ async def initiate_traceroute_aps_test(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_path=_generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/traceroute", "troubleshooting"),
         api_data=api_data,
     )
 
@@ -2634,7 +2651,7 @@ async def initiate_traceroute_cx_test(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_path=_generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/traceroute", "troubleshooting"),
         api_data=api_data,
     )
 
@@ -2695,7 +2712,7 @@ async def initiate_traceroute_gateways_test(
 
     resp = await central_conn.command(
         api_method="POST",
-        api_path=_generate_url(f"{device_type}/{serial_number}/traceroute", "troubleshooting"),
+        api_path=_generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/traceroute", "troubleshooting"),
         api_data=api_data,
     )
 
@@ -2736,7 +2753,7 @@ async def get_traceroute_test_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/traceroute/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/traceroute/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )
@@ -2850,7 +2867,7 @@ async def initiate_cable_test(
 
     api_data = {"ports": ports}
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/cableTest", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/cableTest", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -2893,7 +2910,7 @@ async def get_cable_test_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/cableTest/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/cableTest/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )
@@ -3043,7 +3060,7 @@ async def initiate_show_commands(
 
     api_data = {"commands": commands_list}
 
-    api_path = _generate_url(f"{device_type}/{serial_number}/showCommands", "troubleshooting")
+    api_path = _generate_url(f"{path_seg(device_type)}/{path_seg(serial_number)}/showCommands", "troubleshooting")
     resp = await central_conn.command(api_method="POST", api_path=api_path, api_data=api_data)
 
     if resp["code"] != 202:
@@ -3088,7 +3105,7 @@ async def get_show_commands_result(
     resp = await central_conn.command(
         api_method="GET",
         api_path=_generate_url(
-            f"{device_type}/{serial_number}/showCommands/async-operations/{task_id}",
+            f"{path_seg(device_type)}/{path_seg(serial_number)}/showCommands/async-operations/{path_seg(task_id)}",
             "troubleshooting",
         ),
     )

--- a/src/hpe_networking_mcp/platforms/central/tools/actions.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/actions.py
@@ -4,6 +4,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn
@@ -25,7 +26,7 @@ async def _resolve_switch_id(conn, serial_number: str) -> str:
         resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}"),
         )
         msg = resp.get("msg", {})
         stack_id = msg.get("stackId")
@@ -223,7 +224,7 @@ async def _get_switch_total_poe(conn, serial_number: str) -> float:
         resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}/hardware-trends"),
         )
         msg = resp.get("msg", {})
         data = msg.get("response", msg)
@@ -248,7 +249,7 @@ async def _get_switch_ports(conn, serial_number: str) -> dict:
     resp = await retry_central_command(
         central_conn=conn,
         api_method="GET",
-        api_path=(f"network-monitoring/v1/switches/{serial_number}/interfaces"),
+        api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}/interfaces"),
         api_params={"limit": 200},
     )
     items = resp.get("msg", {}).get("items", [])

--- a/src/hpe_networking_mcp/platforms/central/tools/alerts.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alerts.py
@@ -4,6 +4,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.models import PaginatedAlerts
 from hpe_networking_mcp.platforms.central.utils import (
@@ -212,7 +213,7 @@ async def central_get_alert_action_status(
     response = await retry_central_command(
         get_central_conn(ctx),
         api_method="GET",
-        api_path=f"network-notifications/v1/alerts/async-operations/{task_id}",
+        api_path=f"network-notifications/v1/alerts/async-operations/{path_seg(task_id)}",
     )
     msg = response.get("msg", response)
     if not msg:

--- a/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/audit_logs.py
@@ -2,6 +2,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import deprecation_notice, get_central_conn, retry_central_command
 
@@ -93,7 +94,7 @@ async def central_get_audit_log_detail(
         resp = await retry_central_command(
             conn,
             api_method="GET",
-            api_path=f"network-services/v1/audit/{id}",
+            api_path=f"network-services/v1/audit/{path_seg(id)}",
             api_params={},
         )
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/central/tools/central_nac_service.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/central_nac_service.py
@@ -22,6 +22,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.tools.security_policy import (
     _CONFIRMED_FIELD,
@@ -459,7 +460,7 @@ async def central_get_cnac_image_download(
     Parameters:
         image_id: Path parameter (OpenAPI path param: ``image-id``).
     """
-    api_path = f"network-config/v1alpha1/cnac-image/download/{image_id}"
+    api_path = f"network-config/v1alpha1/cnac-image/download/{path_seg(image_id)}"
     return await _operation_request(ctx, "GET", api_path)
 
 
@@ -478,7 +479,7 @@ async def central_get_cnac_job_error(
     Parameters:
         job_id: Path parameter (OpenAPI path param: ``job-id``).
     """
-    api_path = f"network-config/v1alpha1/cnac-job/{job_id}/error"
+    api_path = f"network-config/v1alpha1/cnac-job/{path_seg(job_id)}/error"
     return await _operation_request(ctx, "GET", api_path)
 
 
@@ -497,7 +498,7 @@ async def central_get_cnac_job_input(
     Parameters:
         job_id: Path parameter (OpenAPI path param: ``job-id``).
     """
-    api_path = f"network-config/v1alpha1/cnac-job/{job_id}/input"
+    api_path = f"network-config/v1alpha1/cnac-job/{path_seg(job_id)}/input"
     return await _operation_request(ctx, "GET", api_path)
 
 
@@ -516,7 +517,7 @@ async def central_get_cnac_job_status(
     Parameters:
         job_id: Path parameter (OpenAPI path param: ``job-id``).
     """
-    api_path = f"network-config/v1alpha1/cnac-job/{job_id}/status"
+    api_path = f"network-config/v1alpha1/cnac-job/{path_seg(job_id)}/status"
     return await _operation_request(ctx, "GET", api_path)
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/monitoring.py
@@ -4,6 +4,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import (
@@ -179,7 +180,7 @@ async def central_get_switch_details(
         resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}"),
         )
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching switch details: {e}"}) from e
@@ -198,7 +199,7 @@ async def central_get_switch_details(
         hw_resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}/hardware-trends"),
         )
         hw_data = hw_resp.get("msg", {})
         hw_response = hw_data.get("response", hw_data)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import coerce_enum, get_central_conn, retry_central_command
 
@@ -97,7 +98,7 @@ async def central_get_ap_trend(
         params["interface-type"] = interface_type or "WIRELESS"
     return await _get(
         conn,
-        f"network-monitoring/v1/aps/{serial_number}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/aps/{path_seg(serial_number)}/{path_seg(suffix_map[dimension])}",
         params,
     )
 
@@ -114,7 +115,7 @@ async def central_get_ap_radios(
 ) -> dict | str:
     """List the radios on an AP (2.4, 5, 6 GHz typically)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/radios")
+    return await _get(conn, f"network-monitoring/v1/aps/{path_seg(serial_number)}/radios")
 
 
 _RadioTrendDimension = Literal["throughput", "channel-utilization", "channel-quality", "noise-floor", "frames"]
@@ -148,7 +149,8 @@ async def central_get_ap_radio_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/aps/{serial_number}/radios/{radio_number}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/aps/{path_seg(serial_number)}/radios/"
+        f"{path_seg(radio_number)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -165,7 +167,7 @@ async def central_get_ap_ports(
 ) -> dict | str:
     """List the Ethernet ports on an AP."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/ports")
+    return await _get(conn, f"network-monitoring/v1/aps/{path_seg(serial_number)}/ports")
 
 
 _PortTrendDimension = Literal["throughput", "frames", "crc", "collisions"]
@@ -193,7 +195,8 @@ async def central_get_ap_port_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/aps/{serial_number}/ports/{port_index}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/aps/{path_seg(serial_number)}/ports/"
+        f"{path_seg(port_index)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -210,7 +213,7 @@ async def central_get_ap_tunnels(
 ) -> dict | str:
     """List active tunnels on an AP."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels")
+    return await _get(conn, f"network-monitoring/v1/aps/{path_seg(serial_number)}/tunnels")
 
 
 @tool(capability=Capability.READ)
@@ -221,7 +224,7 @@ async def central_get_ap_tunnel(
 ) -> dict | str:
     """Get one tunnel's detail on an AP."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}")
+    return await _get(conn, f"network-monitoring/v1/aps/{path_seg(serial_number)}/tunnels/{path_seg(tunnel_id)}")
 
 
 _TunnelTrendDimension = Literal["throughput", "packet-loss", "mos", "jitter", "latency"]
@@ -255,7 +258,8 @@ async def central_get_ap_tunnel_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/aps/{serial_number}/tunnels/{tunnel_id}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/aps/{path_seg(serial_number)}/tunnels/"
+        f"{path_seg(tunnel_id)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -277,7 +281,7 @@ async def central_get_ap_wlans_monitoring(
     ``/aps/:serial/wlans`` endpoint directly.
     """
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/aps/{serial_number}/wlans")
+    return await _get(conn, f"network-monitoring/v1/aps/{path_seg(serial_number)}/wlans")
 
 
 @tool(capability=Capability.READ)
@@ -292,7 +296,7 @@ async def central_get_ap_wlan_throughput(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/aps/{serial_number}/wlans/{wlan_name}/throughput-trends",
+        f"network-monitoring/v1/aps/{path_seg(serial_number)}/wlans/{path_seg(wlan_name)}/throughput-trends",
         _time_params(start, end),
     )
 
@@ -338,7 +342,7 @@ async def central_get_top_aps_by_usage(
     params: dict = {"topN": top_n}
     if filter:
         params["filter"] = filter
-    return await _get(conn, f"network-monitoring/v1/{suffix_map[metric]}", params)
+    return await _get(conn, f"network-monitoring/v1/{path_seg(suffix_map[metric])}", params)
 
 
 # ---------------------------------------------------------------------------
@@ -403,7 +407,7 @@ async def central_get_wlan_monitoring_detail(
 ) -> dict | str:
     """Get one WLAN's monitoring-side detail by name."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/wlans/{wlan_name}")
+    return await _get(conn, f"network-monitoring/v1/wlans/{path_seg(wlan_name)}")
 
 
 @tool(capability=Capability.READ)
@@ -428,7 +432,7 @@ async def central_get_swarm(
 ) -> dict | str:
     """Get one swarm / IAP cluster's detail."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/swarms/{cluster_id}")
+    return await _get(conn, f"network-monitoring/v1/swarms/{path_seg(cluster_id)}")
 
 
 @tool(capability=Capability.READ)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -80,7 +81,7 @@ async def central_get_client_mobility_trail(
         params["start"] = start
     if end:
         params["end"] = end
-    return await _get(conn, f"network-monitoring/v1/clients/{mac_address}/mobility-trail", params)
+    return await _get(conn, f"network-monitoring/v1/clients/{path_seg(mac_address)}/mobility-trail", params)
 
 
 @tool(capability=Capability.READ)
@@ -90,7 +91,7 @@ async def central_get_client_detail(
 ) -> dict | str:
     """Get one client's full record (deeper than ``central_get_clients`` list view)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/clients/{mac_address}")
+    return await _get(conn, f"network-monitoring/v1/clients/{path_seg(mac_address)}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -90,7 +91,7 @@ async def central_get_gateway_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -107,7 +108,7 @@ async def central_get_gateway_ports(
 ) -> dict | str:
     """List ports on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/ports")
 
 
 @tool(capability=Capability.READ)
@@ -118,7 +119,7 @@ async def central_get_gateway_port(
 ) -> dict | str:
     """Get one gateway-port's detail."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/ports/{port_number}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/ports/{path_seg(port_number)}")
 
 
 _GwPortTrendDimension = Literal["throughput", "frames", "frames-errors", "frames-packets"]
@@ -148,7 +149,8 @@ async def central_get_gateway_port_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/ports/{port_number}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/ports/"
+        f"{path_seg(port_number)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -165,7 +167,7 @@ async def central_get_gateway_tunnels(
 ) -> dict | str:
     """List active tunnels terminating on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/tunnels")
 
 
 @tool(capability=Capability.READ)
@@ -176,7 +178,7 @@ async def central_get_gateway_tunnel(
 ) -> dict | str:
     """Get one tunnel's detail on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/tunnels/{path_seg(tunnel_name)}")
 
 
 _GwTunnelTrendDimension = Literal["throughput", "status", "dropped-packet"]
@@ -203,7 +205,8 @@ async def central_get_gateway_tunnel_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/tunnels/{tunnel_name}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/tunnels/"
+        f"{path_seg(tunnel_name)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -222,7 +225,10 @@ async def central_get_gateway_tunnels_health_summary(
 ) -> dict | str:
     """Get tunnel health summary for a gateway (LAN-side or WAN-side rollup)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/{scope}-tunnels-health-summary")
+    return await _get(
+        conn,
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/{path_seg(scope)}-tunnels-health-summary",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +243,7 @@ async def central_get_gateway_vlans_runtime(
 ) -> dict | str:
     """List runtime VLANs on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/vlans")
 
 
 @tool(capability=Capability.READ)
@@ -248,7 +254,7 @@ async def central_get_gateway_vlan_runtime(
 ) -> dict | str:
     """Get one runtime VLAN's detail on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/vlans/{vlan_id}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/vlans/{path_seg(vlan_id)}")
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +269,7 @@ async def central_get_gateway_uplinks(
 ) -> dict | str:
     """List uplinks (WAN links) on a gateway."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks")
 
 
 @tool(capability=Capability.READ)
@@ -274,7 +280,7 @@ async def central_get_gateway_uplink(
 ) -> dict | str:
     """Get one gateway-uplink's detail."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/{path_seg(link_tag)}")
 
 
 _UplinkTrendDimension = Literal["throughput", "wan-compression", "wan-availability"]
@@ -301,7 +307,8 @@ async def central_get_gateway_uplink_trend(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/{suffix_map[dimension]}",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/"
+        f"{path_seg(link_tag)}/{path_seg(suffix_map[dimension])}",
         _time_params(start, end),
     )
 
@@ -314,7 +321,10 @@ async def central_get_gateway_uplink_probes(
 ) -> dict | str:
     """List configured uplink probes on a gateway uplink."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes")
+    return await _get(
+        conn,
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/{path_seg(link_tag)}/probes",
+    )
 
 
 @tool(capability=Capability.READ)
@@ -330,7 +340,8 @@ async def central_get_gateway_uplink_probe_performance(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/uplinks/{link_tag}/probes/{probe}/performance-trends",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/"
+        f"{path_seg(link_tag)}/probes/{path_seg(probe)}/performance-trends",
         _time_params(start, end),
     )
 
@@ -354,7 +365,7 @@ async def central_get_gateway_uplink_vpn_availability(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-monitoring/v1/gateways/{serial_number}/uplinks/{vlan_id}/vpn-availability-trends",
+        f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/{path_seg(vlan_id)}/vpn-availability-trends",
         _time_params(start, end),
     )
 
@@ -378,7 +389,7 @@ async def central_get_gateway_dhcp(
 ) -> dict | str:
     """Get DHCP state on a gateway (pools or active client leases)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/gateways/{serial_number}/dhcp-{view}")
+    return await _get(conn, f"network-monitoring/v1/gateways/{path_seg(serial_number)}/dhcp-{path_seg(view)}")
 
 
 # ---------------------------------------------------------------------------
@@ -393,7 +404,7 @@ async def central_get_cluster_members(
 ) -> dict | str:
     """List member gateways of a cluster."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/members")
+    return await _get(conn, f"network-monitoring/v1/clusters/{path_seg(cluster_name)}/members")
 
 
 _ClusterSummaryKind = Literal[
@@ -423,7 +434,7 @@ async def central_get_cluster_summary(
 ) -> dict | str:
     """Get one of the cluster-level summary endpoints."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/clusters/{cluster_name}/{kind}")
+    return await _get(conn, f"network-monitoring/v1/clusters/{path_seg(cluster_name)}/{path_seg(kind)}")
 
 
 @tool(capability=Capability.READ)
@@ -444,6 +455,6 @@ async def central_get_cluster_capacity_trends(
 ) -> dict | str:
     """Get cluster capacity trends (cluster-wide or per-member)."""
     conn = get_central_conn(ctx)
-    base = f"network-monitoring/v1/clusters/{cluster_name}/capacity-trends"
-    path = f"{base}/{serial_number}" if serial_number else base
+    base = f"network-monitoring/v1/clusters/{path_seg(cluster_name)}/capacity-trends"
+    path = f"{base}/{path_seg(serial_number)}" if serial_number else base
     return await _get(conn, path, _time_params(start, end))

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -42,7 +43,7 @@ async def central_get_site_health_detail(
     endpoint directly for one site's full health detail.
     """
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/site-health/{site_id}")
+    return await _get(conn, f"network-monitoring/v1/site-health/{path_seg(site_id)}")
 
 
 @tool(capability=Capability.READ)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_reporting.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -73,7 +74,7 @@ async def central_get_report_runs(
     response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
-        api_path=f"network-reporting/v1/reports/{report_id}/report-runs",
+        api_path=f"network-reporting/v1/reports/{path_seg(report_id)}/report-runs",
         api_params=api_params,
     )
     code = response.get("code", 0)
@@ -109,7 +110,7 @@ async def central_update_report(
     response = await retry_central_command(
         central_conn=conn,
         api_method="PUT",
-        api_path=f"network-reporting/v1/reports/{report_id}",
+        api_path=f"network-reporting/v1/reports/{path_seg(report_id)}",
         api_data=payload,
     )
     code = response.get("code", 0)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -15,6 +15,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -49,7 +50,7 @@ async def central_get_fco_resp_info(
     pre-shared-key / claim-code workflows.
     """
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-services/v1/fco-resp-info/{serial_number}")
+    return await _get(conn, f"network-services/v1/fco-resp-info/{path_seg(serial_number)}")
 
 
 @tool(capability=Capability.READ)
@@ -115,7 +116,7 @@ async def central_get_asset_tag(
     and the last-known location for the tracked tag.
     """
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-services/v1/asset-tags/{asset_tag_id}")
+    return await _get(conn, f"network-services/v1/asset-tags/{path_seg(asset_tag_id)}")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -161,7 +162,7 @@ async def central_manage_asset_tag_metadata(
     response = await retry_central_command(
         central_conn=conn,
         api_method=method,
-        api_path=f"network-services/v1/asset-tags/{asset_tag_id}/metadata",
+        api_path=f"network-services/v1/asset-tags/{path_seg(asset_tag_id)}/metadata",
         api_data=payload or {},
     )
     code = response.get("code", 0)
@@ -224,7 +225,7 @@ async def central_get_ap_ranging_scans(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans",
+        f"network-services/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/ap-ranging-scans",
     )
 
 
@@ -239,7 +240,8 @@ async def central_get_ap_ranging_scan(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans/{scan_id}",
+        f"network-services/v1/sitemaps/{path_seg(site_id)}/floors/"
+        f"{path_seg(floor_id)}/ap-ranging-scans/{path_seg(scan_id)}",
     )
 
 
@@ -255,7 +257,10 @@ async def central_delete_ap_ranging_scan(
     response = await retry_central_command(
         central_conn=conn,
         api_method="DELETE",
-        api_path=f"network-services/v1/sitemaps/{site_id}/floors/{floor_id}/ap-ranging-scans/{scan_id}",
+        api_path=(
+            f"network-services/v1/sitemaps/{path_seg(site_id)}"
+            f"/floors/{path_seg(floor_id)}/ap-ranging-scans/{path_seg(scan_id)}"
+        ),
     )
     code = response.get("code", 0)
     if 200 <= code < 300:
@@ -279,7 +284,7 @@ async def central_get_site_device_locations(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-services/v1/sites/{site_id}/device-locations",
+        f"network-services/v1/sites/{path_seg(site_id)}/device-locations",
         {"limit": limit, "offset": offset},
     )
 
@@ -292,7 +297,7 @@ async def central_get_site_device_location(
 ) -> dict:
     """Get one device-location record."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-services/v1/sites/{site_id}/device-locations/{location_id}")
+    return await _get(conn, f"network-services/v1/sites/{path_seg(site_id)}/device-locations/{path_seg(location_id)}")
 
 
 @tool(capability=Capability.READ)
@@ -305,7 +310,7 @@ async def central_get_device_location(
     conn = get_central_conn(ctx)
     return await _get(
         conn,
-        f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
+        f"network-services/v1/sites/{path_seg(site_id)}/devices/{path_seg(serial_number)}/location",
     )
 
 
@@ -336,14 +341,14 @@ async def central_manage_device_location(
         response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
-            api_path=f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
+            api_path=f"network-services/v1/sites/{path_seg(site_id)}/devices/{path_seg(serial_number)}/location",
             api_data=payload,
         )
     elif action_type == "delete":
         response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
-            api_path=f"network-services/v1/sites/{site_id}/devices/{serial_number}/location",
+            api_path=f"network-services/v1/sites/{path_seg(site_id)}/devices/{path_seg(serial_number)}/location",
         )
     else:
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_sitemaps.py
@@ -13,6 +13,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -43,7 +44,7 @@ async def central_get_sitemap_summary(
 ) -> dict:
     """Get high-level sitemap summary for a site (counts, floors, devices placed)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps-summary/{path_seg(site_id)}")
 
 
 @tool(capability=Capability.READ)
@@ -87,7 +88,11 @@ async def central_get_sitemap_devices(
     seen online at the placement.
     """
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/network-devices-{status}")
+    return await _call(
+        conn,
+        "GET",
+        f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/network-devices-{path_seg(status)}",
+    )
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -131,7 +136,7 @@ async def central_manage_sitemap_devices(
     response = await retry_central_command(
         central_conn=conn,
         api_method=method,
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/{segment}",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/{path_seg(segment)}",
         api_data=payload,
     )
     code = response.get("code", 0)
@@ -153,7 +158,7 @@ async def central_get_floor(
 ) -> dict:
     """Get one floor's configuration (dimensions, scale, building, image ref)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -181,7 +186,7 @@ async def central_manage_floor(
         response = await retry_central_command(
             central_conn=conn,
             api_method="POST",
-            api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors",
+            api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors",
             api_data=payload,
         )
     elif action_type == "update":
@@ -190,7 +195,7 @@ async def central_manage_floor(
         response = await retry_central_command(
             central_conn=conn,
             api_method="PUT",
-            api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}",
+            api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}",
             api_data=payload,
         )
     elif action_type == "delete":
@@ -199,7 +204,7 @@ async def central_manage_floor(
         response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
-            api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}",
+            api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}",
         )
     else:
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
@@ -224,7 +229,7 @@ async def central_set_floor_scale(
     response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/scale",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/scale",
         api_data=payload,
     )
     code = response.get("code", 0)
@@ -241,7 +246,11 @@ async def central_get_floor_image(
 ) -> dict:
     """Get the floor-plan image reference / metadata."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image")
+    return await _call(
+        conn,
+        "GET",
+        f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/image",
+    )
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -259,7 +268,7 @@ async def central_set_floor_image(
     response = await retry_central_command(
         central_conn=conn,
         api_method="PUT",
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/image",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/image",
         api_data=payload,
     )
     code = response.get("code", 0)
@@ -280,7 +289,7 @@ async def central_get_buildings(
 ) -> dict:
     """List buildings at a site."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/buildings")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/buildings")
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -305,14 +314,14 @@ async def central_manage_building(
         response = await retry_central_command(
             central_conn=conn,
             api_method="PUT",
-            api_path=f"network-monitoring/v1/sitemaps/{site_id}/buildings/{building_id}",
+            api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/buildings/{path_seg(building_id)}",
             api_data=payload,
         )
     elif action_type == "delete":
         response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
-            api_path=f"network-monitoring/v1/sitemaps/{site_id}/buildings/{building_id}",
+            api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/buildings/{path_seg(building_id)}",
         )
     else:
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
@@ -343,7 +352,7 @@ async def central_import_sitemap(
     response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/import",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/import",
         api_data=payload,
     )
     code = response.get("code", 0)
@@ -360,7 +369,7 @@ async def central_get_sitemap_import_status(
 ) -> dict:
     """Get the status / result of a sitemap import job."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/import/{import_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/import/{path_seg(import_id)}")
 
 
 # ---------------------------------------------------------------------------
@@ -419,7 +428,11 @@ async def central_get_floor_walls(
 ) -> dict:
     """List walls placed on a floor (used by location services for signal attenuation modeling)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls")
+    return await _call(
+        conn,
+        "GET",
+        f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/walls",
+    )
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -446,7 +459,7 @@ async def central_manage_floor_walls(
     response = await retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/walls",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/walls",
         api_data=payload or {},
     )
     code = response.get("code", 0)
@@ -463,7 +476,11 @@ async def central_get_floor_zones(
 ) -> dict:
     """List zones placed on a floor (named polygons used for location analytics)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones")
+    return await _call(
+        conn,
+        "GET",
+        f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/zones",
+    )
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -490,7 +507,7 @@ async def central_manage_floor_zones(
     response = await retry_central_command(
         central_conn=conn,
         api_method=method_map[action_type],
-        api_path=f"network-monitoring/v1/sitemaps/{site_id}/floors/{floor_id}/zones",
+        api_path=f"network-monitoring/v1/sitemaps/{path_seg(site_id)}/floors/{path_seg(floor_id)}/zones",
         api_data=payload or {},
     )
     code = response.get("code", 0)

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -55,7 +56,7 @@ async def central_get_switch_lag(
 ) -> dict | str:
     """Get LAG (link-aggregation) state for a switch."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/lag")
+    return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/lag")
 
 
 @tool(capability=Capability.READ)
@@ -65,7 +66,7 @@ async def central_get_switch_vlans(
 ) -> dict | str:
     """Get configured VLANs on a switch (runtime view)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vlans")
+    return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/vlans")
 
 
 @tool(capability=Capability.READ)
@@ -75,7 +76,7 @@ async def central_get_switch_hardware_categories(
 ) -> dict | str:
     """Get available hardware-trend categories for a switch (drives the trend dimensions valid for this model)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/hardware-categories")
+    return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/hardware-categories")
 
 
 @tool(capability=Capability.READ)
@@ -97,7 +98,7 @@ async def central_get_switch_interface_trends(
         params["start"] = start
     if end:
         params["end"] = end
-    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/interface-trends", params)
+    return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/interface-trends", params)
 
 
 @tool(capability=Capability.READ)
@@ -121,7 +122,7 @@ async def central_get_switch_vsx(
 ) -> dict | str:
     """Get the VSX pairing state for a switch (peer / status / sync info)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/switches/{serial_number}/vsx")
+    return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/vsx")
 
 
 @tool(capability=Capability.READ)
@@ -131,4 +132,4 @@ async def central_get_switch_stack_members(
 ) -> dict | str:
     """Get stack members for a stacked switch (returns members of the stack the conductor belongs to)."""
     conn = get_central_conn(ctx)
-    return await _get(conn, f"network-monitoring/v1/stack/{serial_number}/members")
+    return await _get(conn, f"network-monitoring/v1/stack/{path_seg(serial_number)}/members")

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_topology.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -37,7 +38,7 @@ async def central_get_topology(
 ) -> dict | str:
     """Get the network topology graph for a site (nodes + edges)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/topology/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/topology/{path_seg(site_id)}")
 
 
 @tool(capability=Capability.READ)
@@ -47,7 +48,7 @@ async def central_get_neighbours(
 ) -> dict | str:
     """Get LLDP / CDP neighbour records as seen by a specific device."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/neighbours/{serial_number}")
+    return await _call(conn, "GET", f"network-monitoring/v1/neighbours/{path_seg(serial_number)}")
 
 
 @tool(capability=Capability.READ)
@@ -57,7 +58,7 @@ async def central_get_unmanaged_device(
 ) -> dict | str:
     """Get details on an unmanaged device (seen on the network but not under Central management)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/unmanaged-device/{mac_address}")
+    return await _call(conn, "GET", f"network-monitoring/v1/unmanaged-device/{path_seg(mac_address)}")
 
 
 @tool(capability=Capability.READ)
@@ -67,7 +68,7 @@ async def central_get_isolated_devices(
 ) -> dict | str:
     """List isolated devices at a site (managed devices that lost connectivity to peers)."""
     conn = get_central_conn(ctx)
-    return await _call(conn, "GET", f"network-monitoring/v1/isolated-devices/{site_id}")
+    return await _call(conn, "GET", f"network-monitoring/v1/isolated-devices/{path_seg(site_id)}")
 
 
 @tool(capability=Capability.READ)
@@ -108,7 +109,7 @@ async def central_update_device(
     response = await retry_central_command(
         central_conn=conn,
         api_method="PATCH",
-        api_path=f"network-monitoring/v1/devices/{serial_number}",
+        api_path=f"network-monitoring/v1/devices/{path_seg(serial_number)}",
         api_data=payload,
     )
     code = response.get("code", 0)
@@ -133,7 +134,7 @@ async def central_delete_device(
     response = await retry_central_command(
         central_conn=conn,
         api_method="DELETE",
-        api_path=f"network-monitoring/v1/devices/{serial_number}",
+        api_path=f"network-monitoring/v1/devices/{path_seg(serial_number)}",
     )
     code = response.get("code", 0)
     if 200 <= code < 300:

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -31,6 +31,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -67,7 +68,7 @@ async def _post_action(conn, family: str, serial: str, action: str, payload: dic
     return await _call(
         conn,
         "POST",
-        f"network-troubleshooting/v1/{family}/{serial}/{action}",
+        f"network-troubleshooting/v1/{path_seg(family)}/{path_seg(serial)}/{path_seg(action)}",
         data=payload or {},
     )
 
@@ -109,7 +110,8 @@ async def central_get_troubleshooting_task_status(
     return await _call(
         conn,
         "GET",
-        f"network-troubleshooting/v1/{device_family}/{serial_number}/{action}/async-operations/{task_id}",
+        f"network-troubleshooting/v1/{path_seg(device_family)}/{path_seg(serial_number)}"
+        f"/{path_seg(action)}/async-operations/{path_seg(task_id)}",
     )
 
 
@@ -127,7 +129,7 @@ async def central_list_troubleshooting_tasks(
     return await _call(
         conn,
         "GET",
-        f"network-troubleshooting/v1/{device_family}/{serial_number}/list-tasks",
+        f"network-troubleshooting/v1/{path_seg(device_family)}/{path_seg(serial_number)}/list-tasks",
     )
 
 
@@ -150,7 +152,7 @@ async def central_list_supported_show_commands(
     return await _call(
         conn,
         "GET",
-        f"network-troubleshooting/v1/{device_family}/{serial_number}/show-commands",
+        f"network-troubleshooting/v1/{path_seg(device_family)}/{path_seg(serial_number)}/show-commands",
     )
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_webhooks.py
@@ -17,6 +17,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -56,7 +57,7 @@ async def central_get_webhook(
     response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
-        api_path=f"network-services/v1/webhooks/{webhook_id}",
+        api_path=f"network-services/v1/webhooks/{path_seg(webhook_id)}",
     )
     code = response.get("code", 0)
     if 200 <= code < 300:
@@ -124,7 +125,7 @@ async def central_manage_webhook(
         response = await retry_central_command(
             central_conn=conn,
             api_method=method,
-            api_path=f"network-services/v1/webhooks/{webhook_id}",
+            api_path=f"network-services/v1/webhooks/{path_seg(webhook_id)}",
             api_data=payload,
         )
     elif action_type == "delete":
@@ -133,7 +134,7 @@ async def central_manage_webhook(
         response = await retry_central_command(
             central_conn=conn,
             api_method="DELETE",
-            api_path=f"network-services/v1/webhooks/{webhook_id}",
+            api_path=f"network-services/v1/webhooks/{path_seg(webhook_id)}",
         )
     else:
         raise ToolError({"status_code": 400, "message": f"unknown action_type '{action_type}'."})
@@ -159,7 +160,7 @@ async def central_rotate_webhook_hmac_key(
     response = await retry_central_command(
         central_conn=conn,
         api_method="POST",
-        api_path=f"network-services/v1/webhooks/{webhook_id}/rotate-hmac-key",
+        api_path=f"network-services/v1/webhooks/{path_seg(webhook_id)}/rotate-hmac-key",
     )
     code = response.get("code", 0)
     if 200 <= code < 300:

--- a/src/hpe_networking_mcp/platforms/central/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/roles.py
@@ -14,6 +14,7 @@ API: GET /network-config/v1alpha1/roles/{name},
 from fastmcp import Context
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -113,7 +114,7 @@ async def central_get_role_with_policy(
     }
 
     # --- 1. Fetch the role ---
-    role_path = f"network-config/v1alpha1/roles/{name}"
+    role_path = f"network-config/v1alpha1/roles/{path_seg(name)}"
     role_body: dict = {}
     try:
         response = await retry_central_command(
@@ -133,7 +134,7 @@ async def central_get_role_with_policy(
 
     # --- 2. Resolve each policy the role is bound to ---
     for policy_name in _extract_policy_names(role_body):
-        policy_path = f"network-config/v1alpha1/policies/{policy_name}"
+        policy_path = f"network-config/v1alpha1/policies/{path_seg(policy_name)}"
         try:
             response = await retry_central_command(
                 central_conn=conn,

--- a/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/security_policy.py
@@ -18,6 +18,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
 # ---------------------------------------------------------------------------
@@ -28,7 +29,7 @@ from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_c
 async def _get_resource(ctx: Context, api_base: str, name: str | None) -> dict | list | str:
     """Generic GET for /network-config/v1alpha1/{api_base}[/{name}]."""
     conn = get_central_conn(ctx)
-    api_path = f"network-config/v1alpha1/{api_base}/{name}" if name else f"network-config/v1alpha1/{api_base}"
+    api_path = f"network-config/v1alpha1/{api_base}/{path_seg(name)}" if name else f"network-config/v1alpha1/{api_base}"
     response = await retry_central_command(central_conn=conn, api_method="GET", api_path=api_path)
     code = response.get("code", 0)
     if code and not 200 <= code < 300:
@@ -65,7 +66,7 @@ async def _manage_resource(
 
     method_map = {"create": "POST", "update": "PATCH", "delete": "DELETE"}
     api_method = method_map[action_type]
-    api_path = f"network-config/v1alpha1/{api_base}/{name}" if name else f"network-config/v1alpha1/{api_base}"
+    api_path = f"network-config/v1alpha1/{api_base}/{path_seg(name)}" if name else f"network-config/v1alpha1/{api_base}"
 
     conn = get_central_conn(ctx)
 

--- a/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/switch_poe.py
@@ -4,6 +4,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -34,7 +35,7 @@ async def central_get_switch_hardware_trends(
         resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}/hardware-trends"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}/hardware-trends"),
         )
     except Exception as e:
         raise ToolError({"status_code": 502, "message": f"Error fetching hardware trends: {e}"}) from e
@@ -123,7 +124,7 @@ async def central_get_switch_poe(
         resp = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=(f"network-monitoring/v1/switches/{serial_number}/interface-poe"),
+            api_path=(f"network-monitoring/v1/switches/{path_seg(serial_number)}/interface-poe"),
             api_params={"limit": limit},
         )
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlan_profiles.py
@@ -12,6 +12,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_central_command
 
@@ -39,7 +40,7 @@ async def central_get_wlan_profiles(
     """
     conn = get_central_conn(ctx)
 
-    api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}" if ssid else "network-config/v1alpha1/wlan-ssids"
+    api_path = f"network-config/v1alpha1/wlan-ssids/{path_seg(ssid)}" if ssid else "network-config/v1alpha1/wlan-ssids"
 
     response = await retry_central_command(
         central_conn=conn,
@@ -186,7 +187,7 @@ async def central_manage_wlan_profile(
                 }
             )
 
-    api_path = f"network-config/v1alpha1/wlan-ssids/{ssid}"
+    api_path = f"network-config/v1alpha1/wlan-ssids/{path_seg(ssid)}"
     conn = get_central_conn(ctx)
 
     # Method selection: update defaults to PATCH (partial merge on the

--- a/src/hpe_networking_mcp/platforms/central/tools/wlans.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wlans.py
@@ -4,6 +4,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central import monitoring_api
 from hpe_networking_mcp.platforms.central._registry import tool
 from hpe_networking_mcp.platforms.central.utils import get_central_conn, resolve_time_window, retry_central_command
@@ -98,7 +99,7 @@ async def central_get_wlan_stats(
         response = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=f"network-monitoring/v1/wlans/{wlan_name}/throughput-trends",
+            api_path=f"network-monitoring/v1/wlans/{path_seg(wlan_name)}/throughput-trends",
             api_params={"filter": f"timestamp gt {start_at} and timestamp lt {end_at}"},
         )
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/audit.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -25,7 +26,7 @@ async def clearpass_get_audit_logs(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/login-audit/{username}")
+        return await client.request("get", f"/login-audit/{path_seg(username)}")
     except ToolError:
         raise
     except Exception as e:
@@ -92,9 +93,9 @@ async def clearpass_get_insight_alerts(
     try:
         client = await get_clearpass_client()
         if alert_id:
-            return await client.request("get", f"/alert/{alert_id}")
+            return await client.request("get", f"/alert/{path_seg(alert_id)}")
         if name:
-            return await client.request("get", f"/alert/{name}")
+            return await client.request("get", f"/alert/{path_seg(name)}")
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return await clearpass_get(client, "/alert" + query)
     except ToolError:
@@ -131,9 +132,9 @@ async def clearpass_get_insight_reports(
     try:
         client = await get_clearpass_client()
         if report_id:
-            return await client.request("get", f"/report/{report_id}")
+            return await client.request("get", f"/report/{path_seg(report_id)}")
         if name:
-            return await client.request("get", f"/report/{name}")
+            return await client.request("get", f"/report/{path_seg(name)}")
         query = f"?offset={offset}&limit={limit}&calculate_count={'true' if calculate_count else 'false'}"
         return await clearpass_get(client, "/report" + query)
     except ToolError:
@@ -166,13 +167,15 @@ async def clearpass_get_endpoint_insights(
     try:
         client = await get_clearpass_client()
         if mac:
-            return await client.request("get", f"/insight/endpoint/mac/{mac}")
+            return await client.request("get", f"/insight/endpoint/mac/{path_seg(mac)}")
         if ip:
-            return await client.request("get", f"/insight/endpoint/ip/{ip}")
+            return await client.request("get", f"/insight/endpoint/ip/{path_seg(ip)}")
         if ip_range:
-            return await client.request("get", f"/insight/endpoint/ip-range/{ip_range}")
+            return await client.request("get", f"/insight/endpoint/ip-range/{path_seg(ip_range)}")
         if from_time and to_time:
-            return await client.request("get", f"/insight/endpoint/time-range/{from_time}/{to_time}")
+            return await client.request(
+                "get", f"/insight/endpoint/time-range/{path_seg(from_time)}/{path_seg(to_time)}"
+            )
         raise ToolError(
             {
                 "status_code": 400,

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/auth.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -38,9 +39,9 @@ async def clearpass_get_auth_sources(
     try:
         client = await get_clearpass_client()
         if auth_source_id:
-            return await client.request("get", f"/auth-source/{auth_source_id}")
+            return await client.request("get", f"/auth-source/{path_seg(auth_source_id)}")
         if name:
-            return await client.request("get", f"/auth-source/name/{name}")
+            return await client.request("get", f"/auth-source/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -71,7 +72,7 @@ async def clearpass_get_auth_source_status(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/auth-source/{auth_source_id}")
+        return await client.request("get", f"/auth-source/{path_seg(auth_source_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -94,7 +95,7 @@ async def clearpass_test_auth_source(
     """
     try:
         client = await get_clearpass_client()
-        result = await client.request("get", f"/auth-source/{auth_source_id}")
+        result = await client.request("get", f"/auth-source/{path_seg(auth_source_id)}")
         return {
             "auth_source": result,
             "note": "Actual connectivity testing (LDAP bind, AD join check) "
@@ -133,9 +134,9 @@ async def clearpass_get_auth_methods(
     try:
         client = await get_clearpass_client()
         if auth_method_id:
-            return await client.request("get", f"/auth-method/{auth_method_id}")
+            return await client.request("get", f"/auth-method/{path_seg(auth_method_id)}")
         if name:
-            return await client.request("get", f"/auth-method/name/{name}")
+            return await client.request("get", f"/auth-method/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificate_authority.py
@@ -18,6 +18,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -56,9 +57,9 @@ async def clearpass_get_certificates(
     try:
         client = await get_clearpass_client()
         if certificate_id and chain:
-            return await clearpass_get(client, f"/certificate/{certificate_id}/chain")
+            return await clearpass_get(client, f"/certificate/{path_seg(certificate_id)}/chain")
         if certificate_id:
-            return await clearpass_get(client, f"/certificate/{certificate_id}")
+            return await clearpass_get(client, f"/certificate/{path_seg(certificate_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/certificate" + query)
     except ToolError:
@@ -103,7 +104,7 @@ async def clearpass_get_onboard_devices(
     try:
         client = await get_clearpass_client()
         if onboard_device_id:
-            return await clearpass_get(client, f"/onboard/device/{onboard_device_id}")
+            return await clearpass_get(client, f"/onboard/device/{path_seg(onboard_device_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/onboard/device" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/certificates.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -39,9 +40,9 @@ async def clearpass_get_trust_list(
     try:
         client = await get_clearpass_client()
         if details_id:
-            return await client.request("get", f"/cert-trust-list-details/{details_id}")
+            return await client.request("get", f"/cert-trust-list-details/{path_seg(details_id)}")
         if cert_trust_list_id:
-            return await client.request("get", f"/cert-trust-list/{cert_trust_list_id}")
+            return await client.request("get", f"/cert-trust-list/{path_seg(cert_trust_list_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/cert-trust-list" + query)
     except ToolError:
@@ -75,7 +76,7 @@ async def clearpass_get_client_certificates(
     try:
         client = await get_clearpass_client()
         if client_cert_id:
-            return await client.request("get", f"/client-cert/{client_cert_id}")
+            return await client.request("get", f"/client-cert/{path_seg(client_cert_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/client-cert" + query)
     except ToolError:
@@ -105,9 +106,9 @@ async def clearpass_get_server_certificates(
     try:
         client = await get_clearpass_client()
         if service_id:
-            return await client.request("get", f"/server-cert/{service_id}")
+            return await client.request("get", f"/server-cert/{path_seg(service_id)}")
         if server_uuid and service_name:
-            return await client.request("get", f"/server-cert/name/{server_uuid}/{service_name}")
+            return await client.request("get", f"/server-cert/name/{path_seg(server_uuid)}/{path_seg(service_name)}")
         return await clearpass_get(client, "/server-cert")
     except ToolError:
         raise
@@ -140,7 +141,7 @@ async def clearpass_get_service_certificates(
     try:
         client = await get_clearpass_client()
         if service_cert_id:
-            return await client.request("get", f"/service-cert/{service_cert_id}")
+            return await client.request("get", f"/service-cert/{path_seg(service_cert_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/service-cert" + query)
     except ToolError:
@@ -180,7 +181,7 @@ async def clearpass_get_revocation_list(
     try:
         client = await get_clearpass_client()
         if revocation_list_id:
-            return await clearpass_get(client, f"/revocation-list/{revocation_list_id}")
+            return await clearpass_get(client, f"/revocation-list/{path_seg(revocation_list_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/revocation-list" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoint_visibility.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -48,9 +49,9 @@ async def clearpass_get_onguard_activity(
     try:
         client = await get_clearpass_client()
         if activity_id:
-            return await clearpass_get(client, f"/onguard-activity/{activity_id}")
+            return await clearpass_get(client, f"/onguard-activity/{path_seg(activity_id)}")
         if mac:
-            return await clearpass_get(client, f"/onguard-activity/mac/{mac}")
+            return await clearpass_get(client, f"/onguard-activity/mac/{path_seg(mac)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/onguard-activity" + query)
     except ToolError:
@@ -91,7 +92,7 @@ async def clearpass_get_fingerprint_dictionary(
     try:
         client = await get_clearpass_client()
         if fingerprint_id:
-            return await clearpass_get(client, f"/fingerprint/{fingerprint_id}")
+            return await clearpass_get(client, f"/fingerprint/{path_seg(fingerprint_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/fingerprint" + query)
     except ToolError:
@@ -132,7 +133,7 @@ async def clearpass_get_network_scan(
     try:
         client = await get_clearpass_client()
         if scan_id:
-            return await clearpass_get(client, f"/config/network-scan/{scan_id}")
+            return await clearpass_get(client, f"/config/network-scan/{path_seg(scan_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/config/network-scan" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/endpoints.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -43,9 +44,9 @@ async def clearpass_get_endpoints(
     try:
         client = await get_clearpass_client()
         if endpoint_id:
-            return await client.request("get", f"/endpoint/{endpoint_id}")
+            return await client.request("get", f"/endpoint/{path_seg(endpoint_id)}")
         if mac_address:
-            return await client.request("get", f"/endpoint/mac-address/{mac_address}")
+            return await client.request("get", f"/endpoint/mac-address/{path_seg(mac_address)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -79,7 +80,7 @@ async def clearpass_get_endpoint_profiler(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/device-profiler/device-fingerprint/{mac_or_ip}")
+        return await client.request("get", f"/device-profiler/device-fingerprint/{path_seg(mac_or_ip)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/enforcement.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -41,9 +42,9 @@ async def clearpass_get_enforcement_policies(
     try:
         client = await get_clearpass_client()
         if policy_id:
-            return await client.request("get", f"/enforcement-policy/{policy_id}")
+            return await client.request("get", f"/enforcement-policy/{path_seg(policy_id)}")
         if name:
-            return await client.request("get", f"/enforcement-policy/name/{name}")
+            return await client.request("get", f"/enforcement-policy/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -89,9 +90,9 @@ async def clearpass_get_enforcement_profiles(
     try:
         client = await get_clearpass_client()
         if profile_id:
-            return await client.request("get", f"/enforcement-profile/{profile_id}")
+            return await client.request("get", f"/enforcement-profile/{path_seg(profile_id)}")
         if name:
-            return await client.request("get", f"/enforcement-profile/name/{name}")
+            return await client.request("get", f"/enforcement-profile/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guest_config.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -36,7 +37,7 @@ async def clearpass_get_pass_templates(
     try:
         client = await get_clearpass_client()
         if template_id:
-            return await client.request("get", f"/template/pass/{template_id}")
+            return await client.request("get", f"/template/pass/{path_seg(template_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/template/pass" + query)
     except ToolError:
@@ -70,7 +71,7 @@ async def clearpass_get_print_templates(
     try:
         client = await get_clearpass_client()
         if template_id:
-            return await client.request("get", f"/template/print/{template_id}")
+            return await client.request("get", f"/template/print/{path_seg(template_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/template/print" + query)
     except ToolError:
@@ -106,9 +107,9 @@ async def clearpass_get_weblogin_pages(
     try:
         client = await get_clearpass_client()
         if page_id:
-            return await client.request("get", f"/weblogin/{page_id}")
+            return await client.request("get", f"/weblogin/{path_seg(page_id)}")
         if page_name:
-            return await client.request("get", f"/weblogin/page-name/{page_name}")
+            return await client.request("get", f"/weblogin/page-name/{path_seg(page_name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/weblogin" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/guests.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -38,9 +39,9 @@ async def clearpass_get_guest_users(
     try:
         client = await get_clearpass_client()
         if guest_id:
-            return await client.request("get", f"/guest/{guest_id}")
+            return await client.request("get", f"/guest/{path_seg(guest_id)}")
         if username:
-            return await client.request("get", f"/guest/username/{username}")
+            return await client.request("get", f"/guest/username/{path_seg(username)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/identities.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -36,7 +37,7 @@ async def clearpass_get_api_clients(
     try:
         client = await get_clearpass_client()
         if client_id:
-            return await client.request("get", f"/api-client/{client_id}")
+            return await client.request("get", f"/api-client/{path_seg(client_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/api-client" + query)
     except ToolError:
@@ -73,9 +74,9 @@ async def clearpass_get_local_users(
     try:
         client = await get_clearpass_client()
         if local_user_id:
-            return await client.request("get", f"/local-user/{local_user_id}")
+            return await client.request("get", f"/local-user/{path_seg(local_user_id)}")
         if user_id:
-            return await client.request("get", f"/local-user/user-id/{user_id}")
+            return await client.request("get", f"/local-user/user-id/{path_seg(user_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/local-user" + query)
     except ToolError:
@@ -111,9 +112,9 @@ async def clearpass_get_static_host_lists(
     try:
         client = await get_clearpass_client()
         if static_host_list_id:
-            return await client.request("get", f"/static-host-list/{static_host_list_id}")
+            return await client.request("get", f"/static-host-list/{path_seg(static_host_list_id)}")
         if name:
-            return await client.request("get", f"/static-host-list/name/{name}")
+            return await client.request("get", f"/static-host-list/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/static-host-list" + query)
     except ToolError:
@@ -149,9 +150,9 @@ async def clearpass_get_devices(
     try:
         client = await get_clearpass_client()
         if device_id:
-            return await client.request("get", f"/device/{device_id}")
+            return await client.request("get", f"/device/{path_seg(device_id)}")
         if macaddr:
-            return await client.request("get", f"/device/mac/{macaddr}")
+            return await client.request("get", f"/device/mac/{path_seg(macaddr)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/device" + query)
     except ToolError:
@@ -185,7 +186,7 @@ async def clearpass_get_deny_listed_users(
     try:
         client = await get_clearpass_client()
         if deny_listed_users_id:
-            return await client.request("get", f"/deny-listed-users/{deny_listed_users_id}")
+            return await client.request("get", f"/deny-listed-users/{path_seg(deny_listed_users_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/deny-listed-users" + query)
     except ToolError:
@@ -229,9 +230,9 @@ async def clearpass_get_external_accounts(
     try:
         client = await get_clearpass_client()
         if external_account_id:
-            return await clearpass_get(client, f"/external-account/{external_account_id}")
+            return await clearpass_get(client, f"/external-account/{path_seg(external_account_id)}")
         if name:
-            return await clearpass_get(client, f"/external-account/name/{name}")
+            return await clearpass_get(client, f"/external-account/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/external-account" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/integrations.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -39,9 +40,9 @@ async def clearpass_get_extensions(
     try:
         client = await get_clearpass_client()
         if extension_id and show_config:
-            return await client.request("get", f"/extension/instance/{extension_id}/config")
+            return await client.request("get", f"/extension/instance/{path_seg(extension_id)}/config")
         if extension_id:
-            return await client.request("get", f"/extension/instance/{extension_id}")
+            return await client.request("get", f"/extension/instance/{path_seg(extension_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/extension/instance" + query)
     except ToolError:
@@ -75,7 +76,7 @@ async def clearpass_get_syslog_targets(
     try:
         client = await get_clearpass_client()
         if syslog_target_id:
-            return await client.request("get", f"/syslog-target/{syslog_target_id}")
+            return await client.request("get", f"/syslog-target/{path_seg(syslog_target_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/syslog-target" + query)
     except ToolError:
@@ -109,7 +110,7 @@ async def clearpass_get_syslog_export_filters(
     try:
         client = await get_clearpass_client()
         if syslog_export_filter_id:
-            return await client.request("get", f"/syslog-export-filter/{syslog_export_filter_id}")
+            return await client.request("get", f"/syslog-export-filter/{path_seg(syslog_export_filter_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/syslog-export-filter" + query)
     except ToolError:
@@ -143,7 +144,7 @@ async def clearpass_get_event_sources(
     try:
         client = await get_clearpass_client()
         if event_sources_id:
-            return await client.request("get", f"/event-sources/{event_sources_id}")
+            return await client.request("get", f"/event-sources/{path_seg(event_sources_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/event-sources" + query)
     except ToolError:
@@ -177,7 +178,7 @@ async def clearpass_get_context_servers(
     try:
         client = await get_clearpass_client()
         if context_server_action_id:
-            return await client.request("get", f"/context-server-action/{context_server_action_id}")
+            return await client.request("get", f"/context-server-action/{path_seg(context_server_action_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/context-server-action" + query)
     except ToolError:
@@ -211,7 +212,7 @@ async def clearpass_get_endpoint_context_servers(
     try:
         client = await get_clearpass_client()
         if endpoint_context_server_id:
-            return await client.request("get", f"/endpoint-context-server/{endpoint_context_server_id}")
+            return await client.request("get", f"/endpoint-context-server/{path_seg(endpoint_context_server_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/endpoint-context-server" + query)
     except ToolError:
@@ -239,7 +240,7 @@ async def clearpass_get_extension_log(
     """
     try:
         client = await get_clearpass_client()
-        path = f"/extension/instance/{extension_id}/log"
+        path = f"/extension/instance/{path_seg(extension_id)}/log"
         if tail is not None:
             path += f"?tail={tail}"
         return await clearpass_get(client, path)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/local_config.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -28,8 +29,10 @@ async def clearpass_get_access_controls(
     try:
         client = await get_clearpass_client()
         if resource_name:
-            return await client.request("get", f"/server/access-control/{server_uuid}/{resource_name}")
-        return await client.request("get", f"/server/access-control/{server_uuid}")
+            return await client.request(
+                "get", f"/server/access-control/{path_seg(server_uuid)}/{path_seg(resource_name)}"
+            )
+        return await client.request("get", f"/server/access-control/{path_seg(server_uuid)}")
     except ToolError:
         raise
     except Exception as e:
@@ -54,8 +57,10 @@ async def clearpass_get_ad_domains(
     try:
         client = await get_clearpass_client()
         if netbios_name:
-            return await client.request("get", f"/ad-domain/{server_uuid}/netbios-name/{netbios_name}")
-        return await client.request("get", f"/ad-domain/{server_uuid}")
+            return await client.request(
+                "get", f"/ad-domain/{path_seg(server_uuid)}/netbios-name/{path_seg(netbios_name)}"
+            )
+        return await client.request("get", f"/ad-domain/{path_seg(server_uuid)}")
     except ToolError:
         raise
     except Exception as e:
@@ -78,7 +83,7 @@ async def clearpass_get_server_version(
     try:
         client = await get_clearpass_client()
         if uuid:
-            return await client.request("get", f"/cluster/server/{uuid}")
+            return await client.request("get", f"/cluster/server/{path_seg(uuid)}")
         return {
             "cppm_version": await client.request("get", "/cppm-version"),
             "server_version": await client.request("get", "/server/version"),
@@ -124,8 +129,8 @@ async def clearpass_get_server_services(
     try:
         client = await get_clearpass_client()
         if service_name:
-            return await client.request("get", f"/server/service/{server_uuid}/{service_name}")
-        return await client.request("get", f"/server/service/{server_uuid}")
+            return await client.request("get", f"/server/service/{path_seg(server_uuid)}/{path_seg(service_name)}")
+        return await client.request("get", f"/server/service/{path_seg(server_uuid)}")
     except ToolError:
         raise
     except Exception as e:
@@ -147,7 +152,7 @@ async def clearpass_get_server_snmp(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/server/snmp/{server_uuid}")
+        return await client.request("get", f"/server/snmp/{path_seg(server_uuid)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_audit.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
@@ -81,17 +82,17 @@ async def _execute_alert_action(
     if not alert_id:
         raise ToolError({"status_code": 400, "message": "alert_id is required for this action."})
     if action_type == "update":
-        return await client.request("patch", f"/alert/{alert_id}", json_body=payload)
+        return await client.request("patch", f"/alert/{path_seg(alert_id)}", json_body=payload)
     if action_type == "delete":
-        return await client.request("delete", f"/alert/{alert_id}")
+        return await client.request("delete", f"/alert/{path_seg(alert_id)}")
     if action_type == "enable":
-        return await client.request("patch", f"/alert/{alert_id}/enable")
+        return await client.request("patch", f"/alert/{path_seg(alert_id)}/enable")
     if action_type == "disable":
-        return await client.request("patch", f"/alert/{alert_id}/disable")
+        return await client.request("patch", f"/alert/{path_seg(alert_id)}/disable")
     if action_type == "mute":
-        return await client.request("patch", f"/alert/{alert_id}/mute", json_body={})
+        return await client.request("patch", f"/alert/{path_seg(alert_id)}/mute", json_body={})
     if action_type == "unmute":
-        return await client.request("patch", f"/alert/{alert_id}/unmute", json_body={})
+        return await client.request("patch", f"/alert/{path_seg(alert_id)}/unmute", json_body={})
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 
@@ -160,13 +161,13 @@ async def _execute_report_action(
     if not report_id:
         raise ToolError({"status_code": 400, "message": "report_id is required for this action."})
     if action_type == "delete":
-        return await client.request("delete", f"/report/{report_id}")
+        return await client.request("delete", f"/report/{path_seg(report_id)}")
     if action_type == "enable":
-        return await client.request("patch", f"/report/{report_id}/enable")
+        return await client.request("patch", f"/report/{path_seg(report_id)}/enable")
     if action_type == "disable":
-        return await client.request("patch", f"/report/{report_id}/disable")
+        return await client.request("patch", f"/report/{path_seg(report_id)}/disable")
     if action_type == "run":
-        return await client.request("post", f"/report/{report_id}/run")
+        return await client.request("post", f"/report/{path_seg(report_id)}/run")
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})
 
 

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_auth.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
@@ -97,13 +98,13 @@ async def _execute_auth_source_action(
 
     if action_type == "delete":
         if auth_source_id:
-            return await client.request("delete", f"/auth-source/{auth_source_id}")
-        return await client.request("delete", f"/auth-source/name/{name}")
+            return await client.request("delete", f"/auth-source/{path_seg(auth_source_id)}")
+        return await client.request("delete", f"/auth-source/name/{path_seg(name)}")
 
     # update, configure_backup, configure_filters, configure_radius_attrs — all PATCH
     if auth_source_id:
-        return await client.request("patch", f"/auth-source/{auth_source_id}", json_body=payload)
-    return await client.request("patch", f"/auth-source/name/{name}", json_body=payload)
+        return await client.request("patch", f"/auth-source/{path_seg(auth_source_id)}", json_body=payload)
+    return await client.request("patch", f"/auth-source/name/{path_seg(name)}", json_body=payload)
 
 
 @tool(capability=Capability.WRITE_DELETE)
@@ -153,12 +154,12 @@ async def clearpass_manage_auth_method(
             )
         if action_type == "update":
             if auth_method_id:
-                return await client.request("patch", f"/auth-method/{auth_method_id}", json_body=payload)
-            return await client.request("patch", f"/auth-method/name/{name}", json_body=payload)
+                return await client.request("patch", f"/auth-method/{path_seg(auth_method_id)}", json_body=payload)
+            return await client.request("patch", f"/auth-method/name/{path_seg(name)}", json_body=payload)
         # delete
         if auth_method_id:
-            return await client.request("delete", f"/auth-method/{auth_method_id}")
-        return await client.request("delete", f"/auth-method/name/{name}")
+            return await client.request("delete", f"/auth-method/{path_seg(auth_method_id)}")
+        return await client.request("delete", f"/auth-method/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificate_authority.py
@@ -20,6 +20,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -113,9 +114,11 @@ async def clearpass_manage_certificate_authority(
         if action_type == "request":
             return await client.request("post", "/certificate/request", json_body=payload)
         if action_type == "delete":
-            return await client.request("delete", f"/certificate/{certificate_id}")
+            return await client.request("delete", f"/certificate/{path_seg(certificate_id)}")
         # sign / revoke / reject / export
-        return await client.request("post", f"/certificate/{certificate_id}/{action_type}", json_body=payload)
+        return await client.request(
+            "post", f"/certificate/{path_seg(certificate_id)}/{path_seg(action_type)}", json_body=payload
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -172,7 +175,7 @@ async def clearpass_manage_onboard_device(
 
     try:
         client = await get_clearpass_client()
-        path = f"/onboard/device/{record_id}"
+        path = f"/onboard/device/{path_seg(record_id)}"
         if action_type == "delete":
             return await client.request("delete", path)
         body: Any = payload if payload is not None else {}

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_certificates.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
@@ -117,12 +118,12 @@ async def _execute_cert_action(
     if action_type == "delete_trust_list":
         if not cert_id:
             raise ToolError({"status_code": 400, "message": "cert_id is required for delete_trust_list."})
-        return await client.request("delete", f"/cert-trust-list/{cert_id}")
+        return await client.request("delete", f"/cert-trust-list/{path_seg(cert_id)}")
 
     if action_type == "delete_client_cert":
         if not cert_id:
             raise ToolError({"status_code": 400, "message": "cert_id is required for delete_client_cert."})
-        return await client.request("delete", f"/client-cert/{cert_id}")
+        return await client.request("delete", f"/client-cert/{path_seg(cert_id)}")
 
     if action_type in ("enable_server_cert", "disable_server_cert"):
         if not server_uuid or not service_name:
@@ -133,7 +134,7 @@ async def _execute_cert_action(
                 }
             )
         action = "enable" if action_type == "enable_server_cert" else "disable"
-        path = f"/server-cert/name/{server_uuid}/{service_name}/{action}"
+        path = f"/server-cert/name/{path_seg(server_uuid)}/{path_seg(service_name)}/{path_seg(action)}"
         return await client.request("patch", path, json_body={})
 
     raise ToolError({"status_code": 500, "message": f"Unhandled action_type: {action_type}"})

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_endpoints.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -66,13 +67,13 @@ async def clearpass_manage_endpoint(
 
         if action_type == "update":
             if endpoint_id:
-                return await client.request("patch", f"/endpoint/{endpoint_id}", json_body=payload)
-            return await client.request("patch", f"/endpoint/mac-address/{mac_address}", json_body=payload)
+                return await client.request("patch", f"/endpoint/{path_seg(endpoint_id)}", json_body=payload)
+            return await client.request("patch", f"/endpoint/mac-address/{path_seg(mac_address)}", json_body=payload)
 
         # delete
         if endpoint_id:
-            return await client.request("delete", f"/endpoint/{endpoint_id}")
-        return await client.request("delete", f"/endpoint/mac-address/{mac_address}")
+            return await client.request("delete", f"/endpoint/{path_seg(endpoint_id)}")
+        return await client.request("delete", f"/endpoint/mac-address/{path_seg(mac_address)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_enforcement.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -58,12 +59,12 @@ async def clearpass_manage_enforcement_policy(
             raise ToolError({"status_code": 400, "message": "Either policy_id or name is required for update/delete."})
         if action_type == "update":
             if policy_id:
-                return await client.request("patch", f"/enforcement-policy/{policy_id}", json_body=payload)
-            return await client.request("patch", f"/enforcement-policy/name/{name}", json_body=payload)
+                return await client.request("patch", f"/enforcement-policy/{path_seg(policy_id)}", json_body=payload)
+            return await client.request("patch", f"/enforcement-policy/name/{path_seg(name)}", json_body=payload)
         # delete
         if policy_id:
-            return await client.request("delete", f"/enforcement-policy/{policy_id}")
-        return await client.request("delete", f"/enforcement-policy/name/{name}")
+            return await client.request("delete", f"/enforcement-policy/{path_seg(policy_id)}")
+        return await client.request("delete", f"/enforcement-policy/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -115,12 +116,12 @@ async def clearpass_manage_enforcement_profile(
             raise ToolError({"status_code": 400, "message": "Either profile_id or name is required for update/delete."})
         if action_type == "update":
             if profile_id:
-                return await client.request("patch", f"/enforcement-profile/{profile_id}", json_body=payload)
-            return await client.request("patch", f"/enforcement-profile/name/{name}", json_body=payload)
+                return await client.request("patch", f"/enforcement-profile/{path_seg(profile_id)}", json_body=payload)
+            return await client.request("patch", f"/enforcement-profile/name/{path_seg(name)}", json_body=payload)
         # delete
         if profile_id:
-            return await client.request("delete", f"/enforcement-profile/{profile_id}")
-        return await client.request("delete", f"/enforcement-profile/name/{name}")
+            return await client.request("delete", f"/enforcement-profile/{path_seg(profile_id)}")
+        return await client.request("delete", f"/enforcement-profile/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guest_config.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -55,10 +56,10 @@ async def clearpass_manage_pass_template(
         if not template_id:
             raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
-            return await client.request("patch", f"/template/pass/{template_id}", json_body=payload)
+            return await client.request("patch", f"/template/pass/{path_seg(template_id)}", json_body=payload)
         if action_type == "replace":
-            return await client.request("put", f"/template/pass/{template_id}", json_body=payload)
-        return await client.request("delete", f"/template/pass/{template_id}")
+            return await client.request("put", f"/template/pass/{path_seg(template_id)}", json_body=payload)
+        return await client.request("delete", f"/template/pass/{path_seg(template_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -106,10 +107,10 @@ async def clearpass_manage_print_template(
         if not template_id:
             raise ToolError({"status_code": 400, "message": "template_id is required for update/replace/delete."})
         if action_type == "update":
-            return await client.request("patch", f"/template/print/{template_id}", json_body=payload)
+            return await client.request("patch", f"/template/print/{path_seg(template_id)}", json_body=payload)
         if action_type == "replace":
-            return await client.request("put", f"/template/print/{template_id}", json_body=payload)
-        return await client.request("delete", f"/template/print/{template_id}")
+            return await client.request("put", f"/template/print/{path_seg(template_id)}", json_body=payload)
+        return await client.request("delete", f"/template/print/{path_seg(template_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -162,10 +163,10 @@ async def clearpass_manage_weblogin_page(
             )
         if action_type == "delete":
             if page_id:
-                return await client.request("delete", f"/weblogin/{page_id}")
-            return await client.request("delete", f"/weblogin/page-name/{page_name}")
+                return await client.request("delete", f"/weblogin/{path_seg(page_id)}")
+            return await client.request("delete", f"/weblogin/page-name/{path_seg(page_name)}")
         # update or replace
-        path_suffix = f"/{page_id}" if page_id else f"/page-name/{page_name}"
+        path_suffix = f"/{path_seg(page_id)}" if page_id else f"/page-name/{path_seg(page_name)}"
         method = "patch" if action_type == "update" else "put"
         return await client.request(method, f"/weblogin{path_suffix}", json_body=payload)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -57,12 +58,12 @@ async def clearpass_manage_guest_user(
             )
         if action_type == "update":
             if guest_id:
-                return await client.request("patch", f"/guest/{guest_id}", json_body=payload)
-            return await client.request("patch", f"/guest/username/{username}", json_body=payload)
+                return await client.request("patch", f"/guest/{path_seg(guest_id)}", json_body=payload)
+            return await client.request("patch", f"/guest/username/{path_seg(username)}", json_body=payload)
         # delete
         if guest_id:
-            return await client.request("delete", f"/guest/{guest_id}")
-        return await client.request("delete", f"/guest/username/{username}")
+            return await client.request("delete", f"/guest/{path_seg(guest_id)}")
+        return await client.request("delete", f"/guest/username/{path_seg(username)}")
     except ToolError:
         raise
     except Exception as e:
@@ -100,7 +101,9 @@ async def clearpass_send_guest_credentials(
         # Live-verified route (#469): /sendreceipt/sms|smtp with a required
         # confirm flag — the old /send-sms|send-email paths return HTTP 405.
         channel = "sms" if delivery_method == "sms" else "smtp"
-        return await client.request("post", f"/guest/{guest_id}/sendreceipt/{channel}", json_body={"confirm": 1})
+        return await client.request(
+            "post", f"/guest/{path_seg(guest_id)}/sendreceipt/{path_seg(channel)}", json_body={"confirm": 1}
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -135,7 +138,7 @@ async def clearpass_generate_guest_pass(
     try:
         client = await get_clearpass_client()
         endpoint = "pass" if pass_type == "digital" else "receipt"  # nosec B105 — API path, not a password
-        return await client.request("get", f"/guest/{guest_id}/{endpoint}/{template_id}")
+        return await client.request("get", f"/guest/{path_seg(guest_id)}/{path_seg(endpoint)}/{path_seg(template_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -187,7 +190,7 @@ async def clearpass_process_sponsor_action(
         client = await get_clearpass_client()
         return await client.request(
             "post",
-            f"/guest/{guest_id}/sponsor",
+            f"/guest/{path_seg(guest_id)}/sponsor",
             params={"gsr_id": gsr_id} if gsr_id else None,
             json_body=body,
         )

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -50,8 +51,8 @@ async def clearpass_manage_api_client(
         if not client_id:
             raise ToolError({"status_code": 400, "message": "client_id is required for update/delete."})
         if action_type == "update":
-            return await client.request("patch", f"/api-client/{client_id}", json_body=payload)
-        return await client.request("delete", f"/api-client/{client_id}")
+            return await client.request("patch", f"/api-client/{path_seg(client_id)}", json_body=payload)
+        return await client.request("delete", f"/api-client/{path_seg(client_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -99,11 +100,15 @@ async def clearpass_manage_local_user(
                 {"status_code": 400, "message": "Either local_user_id or user_id is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/local-user/{local_user_id}" if local_user_id else f"/local-user/user-id/{user_id}"
+            path = (
+                f"/local-user/{path_seg(local_user_id)}"
+                if local_user_id
+                else f"/local-user/user-id/{path_seg(user_id)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if local_user_id:
-            return await client.request("delete", f"/local-user/{local_user_id}")
-        return await client.request("delete", f"/local-user/user-id/{user_id}")
+            return await client.request("delete", f"/local-user/{path_seg(local_user_id)}")
+        return await client.request("delete", f"/local-user/user-id/{path_seg(user_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -154,12 +159,14 @@ async def clearpass_manage_static_host_list(
             )
         if action_type == "update":
             path = (
-                f"/static-host-list/{static_host_list_id}" if static_host_list_id else f"/static-host-list/name/{name}"
+                f"/static-host-list/{path_seg(static_host_list_id)}"
+                if static_host_list_id
+                else f"/static-host-list/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if static_host_list_id:
-            return await client.request("delete", f"/static-host-list/{static_host_list_id}")
-        return await client.request("delete", f"/static-host-list/name/{name}")
+            return await client.request("delete", f"/static-host-list/{path_seg(static_host_list_id)}")
+        return await client.request("delete", f"/static-host-list/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -207,11 +214,11 @@ async def clearpass_manage_device(
                 {"status_code": 400, "message": "Either device_id or macaddr is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/device/{device_id}" if device_id else f"/device/mac/{macaddr}"
+            path = f"/device/{path_seg(device_id)}" if device_id else f"/device/mac/{path_seg(macaddr)}"
             return await client.request("patch", path, json_body=payload)
         if device_id:
-            return await client.request("delete", f"/device/{device_id}")
-        return await client.request("delete", f"/device/mac/{macaddr}")
+            return await client.request("delete", f"/device/{path_seg(device_id)}")
+        return await client.request("delete", f"/device/mac/{path_seg(macaddr)}")
     except ToolError:
         raise
     except Exception as e:
@@ -251,7 +258,7 @@ async def clearpass_manage_deny_listed_user(
             return await client.request("post", "/deny-listed-users", json_body=payload)
         if not deny_listed_users_id:
             raise ToolError({"status_code": 400, "message": "deny_listed_users_id is required for delete."})
-        return await client.request("delete", f"/deny-listed-users/{deny_listed_users_id}")
+        return await client.request("delete", f"/deny-listed-users/{path_seg(deny_listed_users_id)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_integrations.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -42,12 +43,12 @@ async def clearpass_manage_extension(
     try:
         client = await get_clearpass_client()
         if action_type == "start":
-            return await client.request("post", f"/extension/instance/{extension_id}/start")
+            return await client.request("post", f"/extension/instance/{path_seg(extension_id)}/start")
         if action_type == "stop":
-            return await client.request("post", f"/extension/instance/{extension_id}/stop")
+            return await client.request("post", f"/extension/instance/{path_seg(extension_id)}/stop")
         if action_type == "restart":
-            return await client.request("post", f"/extension/instance/{extension_id}/restart")
-        return await client.request("delete", f"/extension/instance/{extension_id}")
+            return await client.request("post", f"/extension/instance/{path_seg(extension_id)}/restart")
+        return await client.request("delete", f"/extension/instance/{path_seg(extension_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -95,11 +96,15 @@ async def clearpass_manage_syslog_target(
                 {"status_code": 400, "message": "Either syslog_target_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/syslog-target/{syslog_target_id}" if syslog_target_id else f"/syslog-target/host-address/{name}"
+            path = (
+                f"/syslog-target/{path_seg(syslog_target_id)}"
+                if syslog_target_id
+                else f"/syslog-target/host-address/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if syslog_target_id:
-            return await client.request("delete", f"/syslog-target/{syslog_target_id}")
-        return await client.request("delete", f"/syslog-target/host-address/{name}")
+            return await client.request("delete", f"/syslog-target/{path_seg(syslog_target_id)}")
+        return await client.request("delete", f"/syslog-target/host-address/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -150,14 +155,14 @@ async def clearpass_manage_syslog_export_filter(
             )
         if action_type == "update":
             path = (
-                f"/syslog-export-filter/{syslog_export_filter_id}"
+                f"/syslog-export-filter/{path_seg(syslog_export_filter_id)}"
                 if syslog_export_filter_id
-                else f"/syslog-export-filter/name/{name}"
+                else f"/syslog-export-filter/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if syslog_export_filter_id:
-            return await client.request("delete", f"/syslog-export-filter/{syslog_export_filter_id}")
-        return await client.request("delete", f"/syslog-export-filter/name/{name}")
+            return await client.request("delete", f"/syslog-export-filter/{path_seg(syslog_export_filter_id)}")
+        return await client.request("delete", f"/syslog-export-filter/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -204,9 +209,9 @@ async def clearpass_manage_endpoint_context_server(
             raise ToolError({"status_code": 400, "message": "Either endpoint_context_server_id or name is required."})
         if action_type == "update":
             path = (
-                f"/endpoint-context-server/{endpoint_context_server_id}"
+                f"/endpoint-context-server/{path_seg(endpoint_context_server_id)}"
                 if endpoint_context_server_id
-                else f"/endpoint-context-server/server-name/{name}"
+                else f"/endpoint-context-server/server-name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if not endpoint_context_server_id:
@@ -214,8 +219,10 @@ async def clearpass_manage_endpoint_context_server(
                 {"status_code": 400, "message": "endpoint_context_server_id is required for delete/trigger_poll."}
             )
         if action_type == "trigger_poll":
-            return await client.request("patch", f"/endpoint-context-server/{endpoint_context_server_id}/trigger-poll")
-        return await client.request("delete", f"/endpoint-context-server/{endpoint_context_server_id}")
+            return await client.request(
+                "patch", f"/endpoint-context-server/{path_seg(endpoint_context_server_id)}/trigger-poll"
+            )
+        return await client.request("delete", f"/endpoint-context-server/{path_seg(endpoint_context_server_id)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_local_config.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -46,9 +47,11 @@ async def clearpass_manage_access_control(
         client = await get_clearpass_client()
         if action_type == "update":
             return await client.request(
-                "put", f"/server/access-control/{server_uuid}/{resource_name}", json_body=payload
+                "put", f"/server/access-control/{path_seg(server_uuid)}/{path_seg(resource_name)}", json_body=payload
             )
-        return await client.request("delete", f"/server/access-control/{server_uuid}/{resource_name}")
+        return await client.request(
+            "delete", f"/server/access-control/{path_seg(server_uuid)}/{path_seg(resource_name)}"
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -90,13 +93,15 @@ async def clearpass_manage_ad_domain(
     try:
         client = await get_clearpass_client()
         if action_type == "join":
-            return await client.request("put", f"/ad-domain/join/{server_uuid}", json_body=payload)
+            return await client.request("put", f"/ad-domain/join/{path_seg(server_uuid)}", json_body=payload)
         if action_type == "leave":
-            return await client.request("put", f"/ad-domain/leave/{server_uuid}", json_body=payload)
+            return await client.request("put", f"/ad-domain/leave/{path_seg(server_uuid)}", json_body=payload)
         if not netbios_name:
             raise ToolError({"status_code": 400, "message": "netbios_name is required for configure_password_servers."})
         return await client.request(
-            "patch", f"/ad-domain/password-servers/{server_uuid}", json_body={"netbios_name": netbios_name, **payload}
+            "patch",
+            f"/ad-domain/password-servers/{path_seg(server_uuid)}",
+            json_body={"netbios_name": netbios_name, **payload},
         )
     except ToolError:
         raise
@@ -127,7 +132,7 @@ async def clearpass_manage_cluster_server(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("patch", f"/cluster/server/{server_uuid}", json_body=payload)
+        return await client.request("patch", f"/cluster/server/{path_seg(server_uuid)}", json_body=payload)
     except ToolError:
         raise
     except Exception as e:
@@ -164,8 +169,10 @@ async def clearpass_manage_server_service(
     try:
         client = await get_clearpass_client()
         if action_type == "start":
-            return await client.request("patch", f"/server/service/{server_uuid}/{service_name}/start")
-        return await client.request("patch", f"/server/service/{server_uuid}/{service_name}/stop")
+            return await client.request(
+                "patch", f"/server/service/{path_seg(server_uuid)}/{path_seg(service_name)}/start"
+            )
+        return await client.request("patch", f"/server/service/{path_seg(server_uuid)}/{path_seg(service_name)}/stop")
     except ToolError:
         raise
     except Exception as e:
@@ -221,7 +228,9 @@ async def clearpass_manage_service_params(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("patch", f"/service-parameter/{server_uuid}/{service_id}", json_body=param_values)
+        return await client.request(
+            "patch", f"/service-parameter/{path_seg(server_uuid)}/{path_seg(service_id)}", json_body=param_values
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_network_devices.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import ClearPassClient, get_clearpass_client
 
@@ -38,7 +39,7 @@ async def _resolve_device_id(client: ClearPassClient, device_id: str | None, nam
     if device_id:
         return device_id
     if name:
-        result = await client.request("get", f"/network-device/name/{name}")
+        result = await client.request("get", f"/network-device/name/{path_seg(name)}")
         if isinstance(result, dict) and "id" in result:
             return str(result["id"])
     return None
@@ -131,7 +132,7 @@ async def _execute_device_action(
     if action_type == "clone":
         if not source_device_id:
             raise ToolError({"status_code": 400, "message": "source_device_id is required for clone action."})
-        source = await client.request("get", f"/network-device/{source_device_id}")
+        source = await client.request("get", f"/network-device/{path_seg(source_device_id)}")
         if not isinstance(source, dict):
             raise ToolError({"status_code": 404, "message": f"Failed to retrieve source device {source_device_id}."})
         source.pop("id", None)
@@ -140,14 +141,14 @@ async def _execute_device_action(
 
     resolved_id = await _resolve_device_id(client, device_id, name)
     if not resolved_id and action_type == "delete" and name:
-        return await client.request("delete", f"/network-device/name/{name}")
+        return await client.request("delete", f"/network-device/name/{path_seg(name)}")
     if not resolved_id:
         raise ToolError({"status_code": 400, "message": "Either device_id or name is required for this action."})
 
     if action_type == "update":
-        return await client.request("patch", f"/network-device/{resolved_id}", json_body=payload)
+        return await client.request("patch", f"/network-device/{path_seg(resolved_id)}", json_body=payload)
     if action_type == "delete":
-        return await client.request("delete", f"/network-device/{resolved_id}")
+        return await client.request("delete", f"/network-device/{path_seg(resolved_id)}")
 
     # configure_snmp, configure_radsec, configure_cli, configure_onconnect
-    return await client.request("patch", f"/network-device/{resolved_id}", json_body=payload)
+    return await client.request("patch", f"/network-device/{path_seg(resolved_id)}", json_body=payload)

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_policy_elements.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -50,20 +51,24 @@ async def clearpass_manage_service(
         if not config_service_id and not name:
             raise ToolError({"status_code": 400, "message": "Either config_service_id or name is required."})
         if action_type == "update":
-            path = f"/config/service/{config_service_id}" if config_service_id else f"/config/service/name/{name}"
+            path = (
+                f"/config/service/{path_seg(config_service_id)}"
+                if config_service_id
+                else f"/config/service/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if action_type == "enable":
             if not config_service_id:
                 raise ToolError({"status_code": 400, "message": "config_service_id is required for enable."})
-            return await client.request("patch", f"/config/service/{config_service_id}/enable")
+            return await client.request("patch", f"/config/service/{path_seg(config_service_id)}/enable")
         if action_type == "disable":
             if not config_service_id:
                 raise ToolError({"status_code": 400, "message": "config_service_id is required for disable."})
-            return await client.request("patch", f"/config/service/{config_service_id}/disable")
+            return await client.request("patch", f"/config/service/{path_seg(config_service_id)}/disable")
         # delete
         if config_service_id:
-            return await client.request("delete", f"/config/service/{config_service_id}")
-        return await client.request("delete", f"/config/service/name/{name}")
+            return await client.request("delete", f"/config/service/{path_seg(config_service_id)}")
+        return await client.request("delete", f"/config/service/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -114,14 +119,14 @@ async def clearpass_manage_device_group(
             )
         if action_type == "update":
             path = (
-                f"/network-device-group/{network_device_group_id}"
+                f"/network-device-group/{path_seg(network_device_group_id)}"
                 if network_device_group_id
-                else f"/network-device-group/name/{name}"
+                else f"/network-device-group/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if network_device_group_id:
-            return await client.request("delete", f"/network-device-group/{network_device_group_id}")
-        return await client.request("delete", f"/network-device-group/name/{name}")
+            return await client.request("delete", f"/network-device-group/{path_seg(network_device_group_id)}")
+        return await client.request("delete", f"/network-device-group/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -171,11 +176,15 @@ async def clearpass_manage_posture_policy(
                 {"status_code": 400, "message": "Either posture_policy_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/posture-policy/{posture_policy_id}" if posture_policy_id else f"/posture-policy/name/{name}"
+            path = (
+                f"/posture-policy/{path_seg(posture_policy_id)}"
+                if posture_policy_id
+                else f"/posture-policy/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if posture_policy_id:
-            return await client.request("delete", f"/posture-policy/{posture_policy_id}")
-        return await client.request("delete", f"/posture-policy/name/{name}")
+            return await client.request("delete", f"/posture-policy/{path_seg(posture_policy_id)}")
+        return await client.request("delete", f"/posture-policy/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -223,11 +232,15 @@ async def clearpass_manage_proxy_target(
                 {"status_code": 400, "message": "Either proxy_target_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/proxy-target/{proxy_target_id}" if proxy_target_id else f"/proxy-target/name/{name}"
+            path = (
+                f"/proxy-target/{path_seg(proxy_target_id)}"
+                if proxy_target_id
+                else f"/proxy-target/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if proxy_target_id:
-            return await client.request("delete", f"/proxy-target/{proxy_target_id}")
-        return await client.request("delete", f"/proxy-target/name/{name}")
+            return await client.request("delete", f"/proxy-target/{path_seg(proxy_target_id)}")
+        return await client.request("delete", f"/proxy-target/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -274,23 +287,23 @@ async def clearpass_manage_radius_dictionary(
             raise ToolError({"status_code": 400, "message": "Either radius_dictionary_id or name is required."})
         if action_type == "update":
             path = (
-                f"/radius-dictionary/{radius_dictionary_id}"
+                f"/radius-dictionary/{path_seg(radius_dictionary_id)}"
                 if radius_dictionary_id
-                else f"/radius-dictionary/name/{name}"
+                else f"/radius-dictionary/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if action_type == "enable":
             if not radius_dictionary_id:
                 raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for enable."})
-            return await client.request("patch", f"/radius-dictionary/{radius_dictionary_id}/enable")
+            return await client.request("patch", f"/radius-dictionary/{path_seg(radius_dictionary_id)}/enable")
         if action_type == "disable":
             if not radius_dictionary_id:
                 raise ToolError({"status_code": 400, "message": "radius_dictionary_id is required for disable."})
-            return await client.request("patch", f"/radius-dictionary/{radius_dictionary_id}/disable")
+            return await client.request("patch", f"/radius-dictionary/{path_seg(radius_dictionary_id)}/disable")
         # delete
         if radius_dictionary_id:
-            return await client.request("delete", f"/radius-dictionary/{radius_dictionary_id}")
-        return await client.request("delete", f"/radius-dictionary/name/{name}")
+            return await client.request("delete", f"/radius-dictionary/{path_seg(radius_dictionary_id)}")
+        return await client.request("delete", f"/radius-dictionary/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -341,14 +354,14 @@ async def clearpass_manage_tacacs_dictionary(
             )
         if action_type == "update":
             path = (
-                f"/tacacs-dictionary/{tacacs_dictionary_id}"
+                f"/tacacs-dictionary/{path_seg(tacacs_dictionary_id)}"
                 if tacacs_dictionary_id
-                else f"/tacacs-dictionary/name/{name}"
+                else f"/tacacs-dictionary/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if tacacs_dictionary_id:
-            return await client.request("delete", f"/tacacs-dictionary/{tacacs_dictionary_id}")
-        return await client.request("delete", f"/tacacs-dictionary/name/{name}")
+            return await client.request("delete", f"/tacacs-dictionary/{path_seg(tacacs_dictionary_id)}")
+        return await client.request("delete", f"/tacacs-dictionary/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -402,14 +415,14 @@ async def clearpass_manage_application_dictionary(
             )
         if action_type == "update":
             path = (
-                f"/application-dictionary/{application_dictionary_id}"
+                f"/application-dictionary/{path_seg(application_dictionary_id)}"
                 if application_dictionary_id
-                else f"/application-dictionary/name/{name}"
+                else f"/application-dictionary/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if application_dictionary_id:
-            return await client.request("delete", f"/application-dictionary/{application_dictionary_id}")
-        return await client.request("delete", f"/application-dictionary/name/{name}")
+            return await client.request("delete", f"/application-dictionary/{path_seg(application_dictionary_id)}")
+        return await client.request("delete", f"/application-dictionary/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_roles.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -59,12 +60,12 @@ async def clearpass_manage_role(
             raise ToolError({"status_code": 400, "message": "Either role_id or name is required for update/delete."})
         if action_type == "update":
             if role_id:
-                return await client.request("patch", f"/role/{role_id}", json_body=payload)
-            return await client.request("patch", f"/role/name/{name}", json_body=payload)
+                return await client.request("patch", f"/role/{path_seg(role_id)}", json_body=payload)
+            return await client.request("patch", f"/role/name/{path_seg(name)}", json_body=payload)
         # delete
         if role_id:
-            return await client.request("delete", f"/role/{role_id}")
-        return await client.request("delete", f"/role/name/{name}")
+            return await client.request("delete", f"/role/{path_seg(role_id)}")
+        return await client.request("delete", f"/role/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -118,12 +119,12 @@ async def clearpass_manage_role_mapping(
             )
         if action_type == "update":
             if role_mapping_id:
-                return await client.request("patch", f"/role-mapping/{role_mapping_id}", json_body=payload)
-            return await client.request("patch", f"/role-mapping/name/{name}", json_body=payload)
+                return await client.request("patch", f"/role-mapping/{path_seg(role_mapping_id)}", json_body=payload)
+            return await client.request("patch", f"/role-mapping/name/{path_seg(name)}", json_body=payload)
         # delete
         if role_mapping_id:
-            return await client.request("delete", f"/role-mapping/{role_mapping_id}")
-        return await client.request("delete", f"/role-mapping/name/{name}")
+            return await client.request("delete", f"/role-mapping/{path_seg(role_mapping_id)}")
+        return await client.request("delete", f"/role-mapping/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_server_config.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -45,11 +46,13 @@ async def clearpass_manage_admin_user(
                 {"status_code": 400, "message": "Either admin_user_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/admin-user/{admin_user_id}" if admin_user_id else f"/admin-user/user-id/{name}"
+            path = (
+                f"/admin-user/{path_seg(admin_user_id)}" if admin_user_id else f"/admin-user/user-id/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if admin_user_id:
-            return await client.request("delete", f"/admin-user/{admin_user_id}")
-        return await client.request("delete", f"/admin-user/user-id/{name}")
+            return await client.request("delete", f"/admin-user/{path_seg(admin_user_id)}")
+        return await client.request("delete", f"/admin-user/user-id/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -88,11 +91,15 @@ async def clearpass_manage_admin_privilege(
                 {"status_code": 400, "message": "Either admin_privilege_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/admin-privilege/{admin_privilege_id}" if admin_privilege_id else f"/admin-privilege/name/{name}"
+            path = (
+                f"/admin-privilege/{path_seg(admin_privilege_id)}"
+                if admin_privilege_id
+                else f"/admin-privilege/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if admin_privilege_id:
-            return await client.request("delete", f"/admin-privilege/{admin_privilege_id}")
-        return await client.request("delete", f"/admin-privilege/name/{name}")
+            return await client.request("delete", f"/admin-privilege/{path_seg(admin_privilege_id)}")
+        return await client.request("delete", f"/admin-privilege/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -134,12 +141,14 @@ async def clearpass_manage_operator_profile(
             )
         if action_type == "update":
             path = (
-                f"/operator-profile/{operator_profile_id}" if operator_profile_id else f"/operator-profile/name/{name}"
+                f"/operator-profile/{path_seg(operator_profile_id)}"
+                if operator_profile_id
+                else f"/operator-profile/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if operator_profile_id:
-            return await client.request("delete", f"/operator-profile/{operator_profile_id}")
-        return await client.request("delete", f"/operator-profile/name/{name}")
+            return await client.request("delete", f"/operator-profile/{path_seg(operator_profile_id)}")
+        return await client.request("delete", f"/operator-profile/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -175,10 +184,10 @@ async def clearpass_manage_license(
         if not license_id:
             raise ToolError({"status_code": 400, "message": "license_id is required for delete/activate operations."})
         if action_type == "delete":
-            return await client.request("delete", f"/application-license/{license_id}")
+            return await client.request("delete", f"/application-license/{path_seg(license_id)}")
         if action_type == "activate_online":
-            return await client.request("patch", f"/application-license/activate-online/{license_id}")
-        return await client.request("patch", f"/application-license/activate-offline/{license_id}")
+            return await client.request("patch", f"/application-license/activate-online/{path_seg(license_id)}")
+        return await client.request("patch", f"/application-license/activate-offline/{path_seg(license_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -285,11 +294,15 @@ async def clearpass_manage_attribute(
                 }
             )
         if action_type == "update":
-            path = f"/attribute/{attribute_id}" if attribute_id else f"/attribute/{entity_name}/name/{name}"
+            path = (
+                f"/attribute/{path_seg(attribute_id)}"
+                if attribute_id
+                else f"/attribute/{path_seg(entity_name)}/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if attribute_id:
-            return await client.request("delete", f"/attribute/{attribute_id}")
-        return await client.request("delete", f"/attribute/{entity_name}/name/{name}")
+            return await client.request("delete", f"/attribute/{path_seg(attribute_id)}")
+        return await client.request("delete", f"/attribute/{path_seg(entity_name)}/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -328,11 +341,13 @@ async def clearpass_manage_data_filter(
                 {"status_code": 400, "message": "Either data_filter_id or name is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/data-filter/{data_filter_id}" if data_filter_id else f"/data-filter/name/{name}"
+            path = (
+                f"/data-filter/{path_seg(data_filter_id)}" if data_filter_id else f"/data-filter/name/{path_seg(name)}"
+            )
             return await client.request("patch", path, json_body=payload)
         if data_filter_id:
-            return await client.request("delete", f"/data-filter/{data_filter_id}")
-        return await client.request("delete", f"/data-filter/name/{name}")
+            return await client.request("delete", f"/data-filter/{path_seg(data_filter_id)}")
+        return await client.request("delete", f"/data-filter/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -374,14 +389,14 @@ async def clearpass_manage_file_backup_server(
             )
         if action_type == "update":
             path = (
-                f"/file-backup-server/{file_backup_server_id}"
+                f"/file-backup-server/{path_seg(file_backup_server_id)}"
                 if file_backup_server_id
-                else f"/file-backup-server/host-address/{name}"
+                else f"/file-backup-server/host-address/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if file_backup_server_id:
-            return await client.request("delete", f"/file-backup-server/{file_backup_server_id}")
-        return await client.request("delete", f"/file-backup-server/host-address/{name}")
+            return await client.request("delete", f"/file-backup-server/{path_seg(file_backup_server_id)}")
+        return await client.request("delete", f"/file-backup-server/host-address/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -457,14 +472,14 @@ async def clearpass_manage_snmp_trap_receiver(
             )
         if action_type == "update":
             path = (
-                f"/snmp-trap-receiver/{snmp_trap_receiver_id}"
+                f"/snmp-trap-receiver/{path_seg(snmp_trap_receiver_id)}"
                 if snmp_trap_receiver_id
-                else f"/snmp-trap-receiver/name/{name}"
+                else f"/snmp-trap-receiver/name/{path_seg(name)}"
             )
             return await client.request("patch", path, json_body=payload)
         if snmp_trap_receiver_id:
-            return await client.request("delete", f"/snmp-trap-receiver/{snmp_trap_receiver_id}")
-        return await client.request("delete", f"/snmp-trap-receiver/name/{name}")
+            return await client.request("delete", f"/snmp-trap-receiver/{path_seg(snmp_trap_receiver_id)}")
+        return await client.request("delete", f"/snmp-trap-receiver/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:
@@ -506,14 +521,14 @@ async def clearpass_manage_policy_manager_zone(
             )
         if action_type == "update":
             path = (
-                f"/server/policy-manager-zones/{policy_manager_zones_id}"
+                f"/server/policy-manager-zones/{path_seg(policy_manager_zones_id)}"
                 if policy_manager_zones_id
-                else f"/server/policy-manager-zones/name/{name}"
+                else f"/server/policy-manager-zones/name/{path_seg(name)}"
             )
             return await client.request("put", path, json_body=payload)
         if policy_manager_zones_id:
-            return await client.request("delete", f"/server/policy-manager-zones/{policy_manager_zones_id}")
-        return await client.request("delete", f"/server/policy-manager-zones/name/{name}")
+            return await client.request("delete", f"/server/policy-manager-zones/{path_seg(policy_manager_zones_id)}")
+        return await client.request("delete", f"/server/policy-manager-zones/name/{path_seg(name)}")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_sessions.py
@@ -9,6 +9,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 
@@ -74,14 +75,16 @@ async def clearpass_disconnect_session(
         if target_type == "session_id":
             return await client.request(
                 "post",
-                f"/session/{target_value}/disconnect",
+                f"/session/{path_seg(target_value)}/disconnect",
                 json_body={"id": target_value, "confirm_disconnect": True},
             )
         if target_type == "bulk":
             return await client.request("post", "/session-action/disconnect", json_body={"filter": filter})
         selector_map = {"username": "username", "mac": "mac", "ip": "ip"}
         return await client.request(
-            "post", f"/session-action/disconnect/{selector_map[target_type]}/{target_value}", json_body={}
+            "post",
+            f"/session-action/disconnect/{path_seg(selector_map[target_type])}/{path_seg(target_value)}",
+            json_body={},
         )
     except ToolError:
         raise
@@ -179,7 +182,7 @@ async def clearpass_perform_coa(
             body: dict = {"confirm_reauthorize": True}
             if reauthorize_profile:
                 body["reauthorize_profile"] = reauthorize_profile
-            return await client.request("post", f"/session/{target_value}/reauthorize", json_body=body)
+            return await client.request("post", f"/session/{path_seg(target_value)}/reauthorize", json_body=body)
         if target_type == "bulk":
             return await client.request(
                 "post",
@@ -189,7 +192,7 @@ async def clearpass_perform_coa(
         selector_map = {"username": "username", "mac": "mac", "ip": "ip"}
         return await client.request(
             "post",
-            f"/session-action/coa/{selector_map[target_type]}/{target_value}",
+            f"/session-action/coa/{path_seg(selector_map[target_type])}/{path_seg(target_value)}",
             json_body={"enforcement_profile": enforcement_profile},
         )
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/network_devices.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -38,9 +39,9 @@ async def clearpass_get_network_devices(
     try:
         client = await get_clearpass_client()
         if device_id:
-            return await client.request("get", f"/network-device/{device_id}")
+            return await client.request("get", f"/network-device/{path_seg(device_id)}")
         if name:
-            return await client.request("get", f"/network-device/name/{name}")
+            return await client.request("get", f"/network-device/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/network-device" + query)
     except ToolError:
@@ -64,7 +65,7 @@ async def clearpass_get_network_device_stats(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/network-device/{device_id}")
+        return await client.request("get", f"/network-device/{path_seg(device_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -87,7 +88,7 @@ async def clearpass_test_device_connectivity(
     """
     try:
         client = await get_clearpass_client()
-        result = await client.request("get", f"/network-device/{device_id}")
+        result = await client.request("get", f"/network-device/{path_seg(device_id)}")
         return {
             "device": result,
             "note": "Actual connectivity testing requires ClearPass server-side capabilities.",
@@ -113,7 +114,7 @@ async def clearpass_validate_device_config(
     """
     try:
         client = await get_clearpass_client()
-        device = await client.request("get", f"/network-device/{device_id}")
+        device = await client.request("get", f"/network-device/{path_seg(device_id)}")
 
         issues: list[str] = []
         if isinstance(device, dict):

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/policy_elements.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -38,9 +39,9 @@ async def clearpass_get_services(
     try:
         client = await get_clearpass_client()
         if config_service_id:
-            return await client.request("get", f"/config/service/{config_service_id}")
+            return await client.request("get", f"/config/service/{path_seg(config_service_id)}")
         if name:
-            return await client.request("get", f"/config/service/name/{name}")
+            return await client.request("get", f"/config/service/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/config/service" + query)
     except ToolError:
@@ -76,9 +77,9 @@ async def clearpass_get_posture_policies(
     try:
         client = await get_clearpass_client()
         if posture_policy_id:
-            return await client.request("get", f"/posture-policy/{posture_policy_id}")
+            return await client.request("get", f"/posture-policy/{path_seg(posture_policy_id)}")
         if name:
-            return await client.request("get", f"/posture-policy/name/{name}")
+            return await client.request("get", f"/posture-policy/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/posture-policy" + query)
     except ToolError:
@@ -114,9 +115,9 @@ async def clearpass_get_device_groups(
     try:
         client = await get_clearpass_client()
         if network_device_group_id:
-            return await client.request("get", f"/network-device-group/{network_device_group_id}")
+            return await client.request("get", f"/network-device-group/{path_seg(network_device_group_id)}")
         if name:
-            return await client.request("get", f"/network-device-group/name/{name}")
+            return await client.request("get", f"/network-device-group/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/network-device-group" + query)
     except ToolError:
@@ -152,9 +153,9 @@ async def clearpass_get_proxy_targets(
     try:
         client = await get_clearpass_client()
         if proxy_target_id:
-            return await client.request("get", f"/proxy-target/{proxy_target_id}")
+            return await client.request("get", f"/proxy-target/{path_seg(proxy_target_id)}")
         if name:
-            return await client.request("get", f"/proxy-target/name/{name}")
+            return await client.request("get", f"/proxy-target/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/proxy-target" + query)
     except ToolError:
@@ -190,9 +191,9 @@ async def clearpass_get_radius_dictionaries(
     try:
         client = await get_clearpass_client()
         if radius_dictionary_id:
-            return await client.request("get", f"/radius-dictionary/{radius_dictionary_id}")
+            return await client.request("get", f"/radius-dictionary/{path_seg(radius_dictionary_id)}")
         if name:
-            return await client.request("get", f"/radius-dictionary/name/{name}")
+            return await client.request("get", f"/radius-dictionary/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/radius-dictionary" + query)
     except ToolError:
@@ -228,9 +229,9 @@ async def clearpass_get_tacacs_dictionaries(
     try:
         client = await get_clearpass_client()
         if tacacs_service_dictionary_id:
-            return await client.request("get", f"/tacacs-service-dictionary/{tacacs_service_dictionary_id}")
+            return await client.request("get", f"/tacacs-service-dictionary/{path_seg(tacacs_service_dictionary_id)}")
         if name:
-            return await client.request("get", f"/tacacs-service-dictionary/name/{name}")
+            return await client.request("get", f"/tacacs-service-dictionary/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/tacacs-service-dictionary" + query)
     except ToolError:
@@ -266,9 +267,9 @@ async def clearpass_get_application_dictionaries(
     try:
         client = await get_clearpass_client()
         if application_dictionary_id:
-            return await client.request("get", f"/application-dictionary/{application_dictionary_id}")
+            return await client.request("get", f"/application-dictionary/{path_seg(application_dictionary_id)}")
         if name:
-            return await client.request("get", f"/application-dictionary/name/{name}")
+            return await client.request("get", f"/application-dictionary/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/application-dictionary" + query)
     except ToolError:
@@ -311,9 +312,9 @@ async def clearpass_get_radius_dynamic_authorization_template(
     try:
         client = await get_clearpass_client()
         if template_id:
-            return await clearpass_get(client, f"/radius-dynamic-authorization-template/{template_id}")
+            return await clearpass_get(client, f"/radius-dynamic-authorization-template/{path_seg(template_id)}")
         if name:
-            return await clearpass_get(client, f"/radius-dynamic-authorization-template/name/{name}")
+            return await clearpass_get(client, f"/radius-dynamic-authorization-template/name/{path_seg(name)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/radius-dynamic-authorization-template" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/roles.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -38,9 +39,9 @@ async def clearpass_get_roles(
     try:
         client = await get_clearpass_client()
         if role_id:
-            return await client.request("get", f"/role/{role_id}")
+            return await client.request("get", f"/role/{path_seg(role_id)}")
         if name:
-            return await client.request("get", f"/role/name/{name}")
+            return await client.request("get", f"/role/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -86,9 +87,9 @@ async def clearpass_get_role_mappings(
     try:
         client = await get_clearpass_client()
         if role_mapping_id:
-            return await client.request("get", f"/role-mapping/{role_mapping_id}")
+            return await client.request("get", f"/role-mapping/{path_seg(role_mapping_id)}")
         if name:
-            return await client.request("get", f"/role-mapping/name/{name}")
+            return await client.request("get", f"/role-mapping/name/{path_seg(name)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/server_config.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import build_query_string, clearpass_get
@@ -36,7 +37,7 @@ async def clearpass_get_admin_users(
     try:
         client = await get_clearpass_client()
         if admin_user_id:
-            return await client.request("get", f"/admin-user/{admin_user_id}")
+            return await client.request("get", f"/admin-user/{path_seg(admin_user_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/admin-user" + query)
     except ToolError:
@@ -70,7 +71,7 @@ async def clearpass_get_admin_privileges(
     try:
         client = await get_clearpass_client()
         if admin_privilege_id:
-            return await client.request("get", f"/admin-privilege/{admin_privilege_id}")
+            return await client.request("get", f"/admin-privilege/{path_seg(admin_privilege_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/admin-privilege" + query)
     except ToolError:
@@ -124,7 +125,7 @@ async def clearpass_get_licenses(
     try:
         client = await get_clearpass_client()
         if license_id:
-            return await client.request("get", f"/application-license/{license_id}")
+            return await client.request("get", f"/application-license/{path_seg(license_id)}")
         return await client.request("get", "/application-license/summary")
     except ToolError:
         raise
@@ -197,7 +198,7 @@ async def clearpass_get_attributes(
     try:
         client = await get_clearpass_client()
         if attribute_id:
-            return await client.request("get", f"/attribute/{attribute_id}")
+            return await client.request("get", f"/attribute/{path_seg(attribute_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/attribute" + query)
     except ToolError:
@@ -231,7 +232,7 @@ async def clearpass_get_data_filters(
     try:
         client = await get_clearpass_client()
         if data_filter_id:
-            return await client.request("get", f"/data-filter/{data_filter_id}")
+            return await client.request("get", f"/data-filter/{path_seg(data_filter_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/data-filter" + query)
     except ToolError:
@@ -265,7 +266,7 @@ async def clearpass_get_file_backup_servers(
     try:
         client = await get_clearpass_client()
         if file_backup_server_id:
-            return await client.request("get", f"/file-backup-server/{file_backup_server_id}")
+            return await client.request("get", f"/file-backup-server/{path_seg(file_backup_server_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/file-backup-server" + query)
     except ToolError:
@@ -317,7 +318,7 @@ async def clearpass_get_snmp_trap_receivers(
     try:
         client = await get_clearpass_client()
         if snmp_trap_receiver_id:
-            return await client.request("get", f"/snmp-trap-receiver/{snmp_trap_receiver_id}")
+            return await client.request("get", f"/snmp-trap-receiver/{path_seg(snmp_trap_receiver_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/snmp-trap-receiver" + query)
     except ToolError:
@@ -351,7 +352,7 @@ async def clearpass_get_policy_manager_zones(
     try:
         client = await get_clearpass_client()
         if policy_manager_zones_id:
-            return await client.request("get", f"/server/policy-manager-zones/{policy_manager_zones_id}")
+            return await client.request("get", f"/server/policy-manager-zones/{path_seg(policy_manager_zones_id)}")
         query = build_query_string(filter, sort, offset, limit, calculate_count)
         return await clearpass_get(client, "/server/policy-manager-zones" + query)
     except ToolError:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.clearpass._registry import tool
 from hpe_networking_mcp.platforms.clearpass.client import get_clearpass_client
 from hpe_networking_mcp.platforms.clearpass.utils import clearpass_get
@@ -36,7 +37,7 @@ async def clearpass_get_sessions(
     try:
         client = await get_clearpass_client()
         if session_id:
-            return await client.request("get", f"/session/{session_id}")
+            return await client.request("get", f"/session/{path_seg(session_id)}")
         params = [
             f"filter={filter}" if filter else "",
             f"sort={sort}" if sort else "",
@@ -67,7 +68,7 @@ async def clearpass_get_session_action_status(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/session-action/{action_id}")
+        return await client.request("get", f"/session-action/{path_seg(action_id)}")
     except ToolError:
         raise
     except Exception as e:
@@ -89,7 +90,7 @@ async def clearpass_get_reauth_profiles(
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/session/{session_id}/reauthorize")
+        return await client.request("get", f"/session/{path_seg(session_id)}/reauthorize")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/greenlake/client.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/client.py
@@ -15,6 +15,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 
 from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager, oauth2_client_credentials
+from hpe_networking_mcp.platforms._common.url import path_seg
 
 if TYPE_CHECKING:
     from fastmcp import Context
@@ -34,7 +35,7 @@ def make_token_manager(secrets: GreenLakeSecrets) -> AsyncTokenManager:
     (``client_secret_post`` — what the old ``OAuth2Provider`` sent).
     Construction is non-blocking; the first request fetches the token.
     """
-    token_url = f"{secrets.api_base_url.rstrip('/')}/authorization/v2/oauth2/{secrets.workspace_id}/token"
+    token_url = f"{secrets.api_base_url.rstrip('/')}/authorization/v2/oauth2/{path_seg(secrets.workspace_id)}/token"
     return AsyncTokenManager(
         oauth2_client_credentials(
             token_url,

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/audit_logs.py
@@ -17,6 +17,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -150,4 +151,4 @@ async def greenlake_get_audit_log_details(
         raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/audit-log/v1/logs/{id}/detail")
+        return await client.get(f"/audit-log/v1/logs/{path_seg(id)}/detail")

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/devices.py
@@ -17,6 +17,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -162,4 +163,4 @@ async def greenlake_get_device_by_id(
         raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/devices/v1/devices/{id}")
+        return await client.get(f"/devices/v1/devices/{path_seg(id)}")

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/subscriptions.py
@@ -17,6 +17,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -163,4 +164,4 @@ async def greenlake_get_subscription_details(
         raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/subscriptions/v1/subscriptions/{id}")
+        return await client.get(f"/subscriptions/v1/subscriptions/{path_seg(id)}")

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/users.py
@@ -18,6 +18,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -131,4 +132,4 @@ async def greenlake_get_user_details(
         raise ToolError({"status_code": 400, "message": "id is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/identity/v1/users/{id}")
+        return await client.get(f"/identity/v1/users/{path_seg(id)}")

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/workspaces.py
@@ -18,6 +18,7 @@ from loguru import logger
 from pydantic import Field
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.greenlake._registry import tool
 from hpe_networking_mcp.platforms.greenlake.client import get_greenlake_client
 
@@ -51,7 +52,7 @@ async def greenlake_get_workspace(
         raise ToolError({"status_code": 400, "message": "workspaceId is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/workspaces/v1/workspaces/{workspaceId}")
+        return await client.get(f"/workspaces/v1/workspaces/{path_seg(workspaceId)}")
 
 
 # ---------------------------------------------------------------------------
@@ -84,4 +85,4 @@ async def greenlake_get_workspace_details(
         raise ToolError({"status_code": 400, "message": "workspaceId is required and cannot be empty"})
 
     async with get_greenlake_client(ctx) as client:
-        return await client.get(f"/workspaces/v1/workspaces/{workspaceId}/contact")
+        return await client.get(f"/workspaces/v1/workspaces/{path_seg(workspaceId)}/contact")

--- a/src/hpe_networking_mcp/platforms/manage_wlan.py
+++ b/src/hpe_networking_mcp/platforms/manage_wlan.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from loguru import logger
 from pydantic import Field
 
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.central.utils import retry_central_command
 
 # Mist → Central sync workflow returned when SSID exists in Mist
@@ -376,7 +377,7 @@ async def _find_mist_wlan(ctx: Context, ssid: str) -> dict | None:
         return None
 
     try:
-        response = await client.get(f"/api/v1/orgs/{org_id}/wlans")
+        response = await client.get(f"/api/v1/orgs/{path_seg(org_id)}/wlans")
         if response.status_code == 200:
             payload = response.json()
             if isinstance(payload, list):
@@ -398,7 +399,7 @@ async def _find_central_profile(ctx: Context, ssid: str) -> dict | None:
         response = await retry_central_command(
             central_conn=conn,
             api_method="GET",
-            api_path=f"network-config/v1alpha1/wlan-ssids/{ssid}",
+            api_path=f"network-config/v1alpha1/wlan-ssids/{path_seg(ssid)}",
         )
         code = response.get("code", 0)
         if 200 <= code < 300:

--- a/src/hpe_networking_mcp/platforms/mist/_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/_client.py
@@ -26,6 +26,7 @@ from fastmcp.exceptions import ToolError
 from loguru import logger
 
 from hpe_networking_mcp.platforms._common.auth import AsyncTokenManager
+from hpe_networking_mcp.platforms._common.url import path_seg
 
 # Status code → human-friendly message used in ToolError responses when the
 # server doesn't return a useful detail body.
@@ -224,7 +225,7 @@ async def mist_request(
         for name, value in path_params.items():
             if name == "org_id":
                 value = _validate_org_id(ctx, value)
-            substituted = substituted.replace("{" + name + "}", str(value))
+            substituted = substituted.replace("{" + name + "}", path_seg(value))
 
     clean_query = _strip_none(query_params or {})
     request_kwargs: dict[str, Any] = {"params": clean_query} if clean_query else {}

--- a/src/hpe_networking_mcp/platforms/site_health_check.py
+++ b/src/hpe_networking_mcp/platforms/site_health_check.py
@@ -14,6 +14,8 @@ from fastmcp import Context
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from hpe_networking_mcp.platforms._common.url import path_seg
+
 # Response models — kept compact to minimize token cost in Claude's context.
 
 
@@ -121,7 +123,7 @@ async def _collect_mist(ctx: Context, site_name: str, window_hours: int) -> Mist
     summary = MistSummary()
 
     try:
-        sites_resp = await client.get(f"/api/v1/orgs/{org_id}/sites")
+        sites_resp = await client.get(f"/api/v1/orgs/{path_seg(org_id)}/sites")
         if sites_resp.status_code != 200:
             summary.error = f"Mist listOrgSites HTTP {sites_resp.status_code}"
             return summary
@@ -149,9 +151,9 @@ async def _collect_mist(ctx: Context, site_name: str, window_hours: int) -> Mist
     alarms_resp: Any = None
     try:
         stats_resp, alarms_resp = await asyncio.gather(
-            client.get(f"/api/v1/sites/{site_id}/stats"),
+            client.get(f"/api/v1/sites/{path_seg(site_id)}/stats"),
             client.get(
-                f"/api/v1/sites/{site_id}/alarms/search",
+                f"/api/v1/sites/{path_seg(site_id)}/alarms/search",
                 params={"start": start, "end": end, "limit": 100},
             ),
             return_exceptions=True,
@@ -286,7 +288,7 @@ async def _extract_mist_device_ips(ctx: Context, site_id: str) -> list[str]:
     if not client:
         return []
     try:
-        resp = await client.get(f"/api/v1/sites/{site_id}/devices")
+        resp = await client.get(f"/api/v1/sites/{path_seg(site_id)}/devices")
         if resp.status_code != 200:
             return []
         devices = resp.json()

--- a/src/hpe_networking_mcp/platforms/site_rf_check.py
+++ b/src/hpe_networking_mcp/platforms/site_rf_check.py
@@ -21,6 +21,8 @@ from fastmcp import Context
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from hpe_networking_mcp.platforms._common.url import path_seg
+
 # Response models — compact shapes to keep Claude's context cheap.
 
 
@@ -208,7 +210,7 @@ async def _collect_mist(
     summary = MistRF()
 
     try:
-        sites_resp = await client.get(f"/api/v1/orgs/{org_id}/sites")
+        sites_resp = await client.get(f"/api/v1/orgs/{path_seg(org_id)}/sites")
         if sites_resp.status_code != 200:
             summary.error = f"Mist listOrgSites HTTP {sites_resp.status_code}"
             return summary, []
@@ -237,10 +239,10 @@ async def _collect_mist(
     try:
         stats_resp, template_resp = await asyncio.gather(
             client.get(
-                f"/api/v1/sites/{site_id}/stats/devices",
+                f"/api/v1/sites/{path_seg(site_id)}/stats/devices",
                 params={"type": "ap", "limit": 100},
             ),
-            client.get(f"/api/v1/sites/{site_id}/rrm/current"),
+            client.get(f"/api/v1/sites/{path_seg(site_id)}/rrm/current"),
             return_exceptions=True,
         )
     except Exception as e:
@@ -528,9 +530,9 @@ async def _list_mist_site_options(ctx: Context) -> list[SiteOption]:
     devices_resp: Any = None
     try:
         sites_resp, devices_resp = await asyncio.gather(
-            client.get(f"/api/v1/orgs/{org_id}/sites"),
+            client.get(f"/api/v1/orgs/{path_seg(org_id)}/sites"),
             client.get(
-                f"/api/v1/orgs/{org_id}/inventory",
+                f"/api/v1/orgs/{path_seg(org_id)}/inventory",
                 params={"type": "ap", "limit": 1000},
             ),
             return_exceptions=True,

--- a/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
@@ -52,7 +53,7 @@ async def uxi_get_sensor_status(
     validate_id(sensor_id, "sensor_id")
     try:
         client = await get_uxi_client()
-        return await client.uxi_get_single(f"/sensors/{sensor_id}/status")
+        return await client.uxi_get_single(f"/sensors/{path_seg(sensor_id)}/status")
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/agents.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
@@ -62,7 +63,7 @@ async def uxi_update_agent(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_patch(f"/agents/{agent_id}", body)
+        result = await client.uxi_patch(f"/agents/{path_seg(agent_id)}", body)
         return {"result": result}
     except ToolError:
         raise
@@ -86,7 +87,7 @@ async def uxi_delete_agent(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_delete(f"/agents/{agent_id}")
+        result = await client.uxi_delete(f"/agents/{path_seg(agent_id)}")
         return {"result": result}
     except ToolError:
         raise

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/assignments.py
@@ -18,6 +18,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
@@ -72,7 +73,7 @@ async def uxi_remove_agent_from_group(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_delete(f"/agent-group-assignments/{assignment_id}")
+        result = await client.uxi_delete(f"/agent-group-assignments/{path_seg(assignment_id)}")
         return {"result": result}
     except ToolError:
         raise
@@ -129,7 +130,7 @@ async def uxi_remove_sensor_from_group(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_delete(f"/sensor-group-assignments/{assignment_id}")
+        result = await client.uxi_delete(f"/sensor-group-assignments/{path_seg(assignment_id)}")
         return {"result": result}
     except ToolError:
         raise

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/groups.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
@@ -67,7 +68,7 @@ async def uxi_update_group(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_patch(f"/groups/{group_id}", {"name": name})
+        result = await client.uxi_patch(f"/groups/{path_seg(group_id)}", {"name": name})
         return {"result": result}
     except ToolError:
         raise
@@ -92,7 +93,7 @@ async def uxi_delete_group(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_delete(f"/groups/{group_id}")
+        result = await client.uxi_delete(f"/groups/{path_seg(group_id)}")
         return {"result": result}
     except ToolError:
         raise

--- a/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/writes/sensors.py
@@ -13,6 +13,7 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.url import path_seg
 from hpe_networking_mcp.platforms.uxi._registry import tool
 from hpe_networking_mcp.platforms.uxi.client import format_http_error, get_uxi_client
 from hpe_networking_mcp.platforms.uxi.tools._validators import validate_id
@@ -62,7 +63,7 @@ async def uxi_update_sensor(
 
     try:
         client = await get_uxi_client()
-        result = await client.uxi_patch(f"/sensors/{sensor_id}", body)
+        result = await client.uxi_patch(f"/sensors/{path_seg(sensor_id)}", body)
         return {"result": result}
     except ToolError:
         raise

--- a/tests/unit/test_clearpass_endpoint_routes.py
+++ b/tests/unit/test_clearpass_endpoint_routes.py
@@ -117,7 +117,8 @@ class TestSessionControlRoutes:
         mock_get.return_value = client
         await clearpass_disconnect_session(_ctx(), target_type="mac", target_value="aa:bb:cc:dd:ee:ff", confirmed=True)
         method, path, _, _ = _call(client)
-        assert (method, path) == ("post", "/session-action/disconnect/mac/aa:bb:cc:dd:ee:ff")
+        # Colons percent-encode via path_seg (#476); CPPM decodes path segments per RFC 3986.
+        assert (method, path) == ("post", "/session-action/disconnect/mac/aa%3Abb%3Acc%3Add%3Aee%3Aff")
 
     @patch("hpe_networking_mcp.platforms.clearpass.tools.manage_sessions.get_clearpass_client", new_callable=AsyncMock)
     async def test_coa_by_session_id_posts_reauthorize_with_confirm(self, mock_get):

--- a/tests/unit/test_path_seg.py
+++ b/tests/unit/test_path_seg.py
@@ -1,0 +1,139 @@
+"""Pin tests for the shared URL path-segment escaper (#476).
+
+Two layers:
+
+- ``TestPathSeg`` pins the encoding contract for the hostile characters
+  that motivated the helper (``/`` restructures the route, ``?`` starts
+  the query, ``#`` truncates to the fragment).
+- ``TestNoRawPathInterpolation`` is the creep guard: an AST scan of every
+  platform tool module asserting that f-string path arguments to HTTP
+  request calls only interpolate values wrapped in ``path_seg(...)``.
+  Partial adoption is how the inconsistency returns (#476 scope note).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+
+from hpe_networking_mcp.platforms._common.url import path_seg
+
+pytestmark = pytest.mark.unit
+
+PLATFORMS_DIR = Path(__file__).resolve().parents[2] / "src" / "hpe_networking_mcp" / "platforms"
+
+
+class TestPathSeg:
+    def test_slash_cannot_restructure_route(self):
+        assert path_seg("jon/adams") == "jon%2Fadams"
+
+    def test_question_mark_cannot_start_query(self):
+        assert path_seg("page?x=1") == "page%3Fx%3D1"
+
+    def test_hash_cannot_truncate_path(self):
+        assert path_seg("Policy #2") == "Policy%20%232"
+
+    def test_space_encodes(self):
+        assert path_seg("Guest Admin") == "Guest%20Admin"
+
+    def test_percent_is_escaped_not_trusted(self):
+        """Pre-encoded input is raw text, not a passthrough."""
+        assert path_seg("a%2Fb") == "a%252Fb"
+
+    def test_non_string_values_coerced(self):
+        assert path_seg(42) == "42"
+
+    def test_plain_identifiers_unchanged(self):
+        for value in ("5f1c-uuid-4711", "CORP-WIFI", "ssid_prof"):
+            assert path_seg(value) == value
+
+    def test_mac_colons_percent_encode(self):
+        """``safe=""`` encodes colons too — RFC 3986 servers decode path
+        segments, so ``%3A`` reaches the API as ``:`` exactly as before."""
+        assert path_seg("aa:bb:cc:dd:ee:ff") == "aa%3Abb%3Acc%3Add%3Aee%3Aff"
+
+    def test_encoded_segment_survives_httpx_normalization(self):
+        """The wire path targets ONE segment even for hostile input."""
+        url = httpx.URL("https://cppm.example.com/api/admin-user/user-id/" + path_seg("frag#2/x"))
+        assert url.raw_path.decode() == "/api/admin-user/user-id/frag%232%2Fx"
+
+
+# --- creep guard -----------------------------------------------------------
+#
+# Scans EVERY f-string in the platform tree (not just request-call arguments —
+# paths assigned to variables before the call would dodge any call-shape
+# anchor). An f-string is treated as a URL path when its literal text starts
+# with "/" or matches a `name/vN` API prefix AND contains no spaces (prose —
+# error messages, log lines, prompts — virtually always has spaces).
+
+_PATH_LITERAL = re.compile(r"^(/|[a-z][a-z0-9-]*/v\d)")
+
+# Interpolated names that legitimately hold multi-segment path fragments
+# (joined from constants or earlier-built paths), not operator selectors.
+_MULTI_SEGMENT_NAMES = {
+    "api_path",
+    "full_path",
+    "path",
+    "path_suffix",
+    "base_path",
+    "url",
+    "base_url",
+    "uri",
+    "base",
+    "prefix",
+    "suffix",
+}
+
+
+def _is_path_seg_call(node: ast.expr) -> bool:
+    return isinstance(node, ast.Call) and (
+        (isinstance(node.func, ast.Name) and node.func.id == "path_seg")
+        or (isinstance(node.func, ast.Attribute) and node.func.attr == "path_seg")
+    )
+
+
+def _interpolates_path_fragment(value: ast.expr) -> bool:
+    """True when the interpolated expression names a multi-segment fragment.
+
+    Token-based so it matches ``api_base``, ``secrets.api_base_url.rstrip('/')``
+    etc. without false-skipping selectors like ``database_id``.
+    """
+    tokens = set(re.split(r"[^a-z]+", ast.unparse(value).lower()))
+    return bool(tokens & (_MULTI_SEGMENT_NAMES | {"url"}))
+
+
+def _fstring_path_violations(fstring: ast.JoinedStr, filename: str) -> list[str]:
+    literal = "".join(str(part.value) for part in fstring.values if isinstance(part, ast.Constant))
+    # A URL path literal has no spaces (prose does) and at least one letter
+    # (CIDR suffixes like "/32" and pure-separator compositions don't).
+    if not _PATH_LITERAL.match(literal) or " " in literal or not re.search(r"[a-z]", literal):
+        return []
+    violations: list[str] = []
+    in_query = False
+    for part in fstring.values:
+        if isinstance(part, ast.Constant) and "?" in str(part.value):
+            in_query = True  # query-string portion — httpx params territory, out of scope
+        if not isinstance(part, ast.FormattedValue) or in_query:
+            continue
+        value = part.value
+        if _is_path_seg_call(value) or _interpolates_path_fragment(value):
+            continue
+        violations.append(f"{filename}:{part.lineno}: {ast.unparse(value)!r} interpolated without path_seg()")
+    return violations
+
+
+class TestNoRawPathInterpolation:
+    def test_all_platform_path_interpolations_use_path_seg(self):
+        violations: list[str] = []
+        for py_file in sorted(PLATFORMS_DIR.rglob("*.py")):
+            if "_template" in py_file.parts:
+                continue
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.JoinedStr):
+                    violations.extend(_fstring_path_violations(node, str(py_file.relative_to(PLATFORMS_DIR))))
+        assert not violations, "Raw f-string path interpolation (wrap with path_seg):\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

Closes #476. Operator-supplied selector values (usernames, MACs, attribute/template/server names, IDs) interpolated into URL path f-strings were sent raw. httpx already percent-encodes spaces and unicode — but a value containing `/` restructures the route, `?` starts the query string, and `#` silently truncates the path. The failure mode is **silently targeting the wrong resource** (a delete aimed at `Policy #2` would have operated on `Policy `), worst on the write surface.

## What changed

- **`path_seg()`** in `platforms/_common/url.py`: `urllib.parse.quote(str(value), safe="")` — one encoded path segment, no characters exempt, pre-encoded input treated as raw text.
- **~450 interpolation sites wrapped across all 8 platforms**: ClearPass ~300 (highest-value — free-text name selectors are common there), Central ~120 (including the `monitoring_api` SDK port and all MRT modules; URL lines only, the byte-matched error strings are untouched), Apstra, Axis, UXI, GreenLake, AOS8, and the cross-platform statics.
- **Mist's 1037 generated tools fixed at one chokepoint** — the `mist_request` path-param substitution in `mist/_client.py`; no regen needed.
- **Creep guard** (`tests/unit/test_path_seg.py`): an AST scan of **every f-string in the platform tree** — deliberately call-shape-independent, so a path assigned to a variable before the request call can't dodge it. An f-string counts as a URL path when its literal text starts with `/` (or matches `name/vN`), has no spaces, and contains a letter; multi-segment fragment names (`api_path`, `base`, `*url*`…) are token-matched and exempt. The sweep ran to convergence against this guard: three rounds, each round extending the guard's reach (platform wrapper-method shapes → `retry_central_command`/`base_path` kwargs and local `_get` helpers → variable-assigned f-strings), until it found nothing.

## Behavior note: MAC colons

`safe=""` means MAC colons percent-encode in paths (`aa%3Abb…`). Per RFC 3986 servers decode path segments, but per project practice this was **live-verified before shipping** on all three changed gateways: ClearPass (`/endpoint/mac-address/…`), Central (`/aps/{serial}` with an encoded leading character), and Mist (`/sites/{site_id}` with an encoded leading character) each return the **identical record** for percent-encoded vs raw segments. One route-pin test updated to the encoded wire form.

## Validation

Full Docker battery: ruff + format + mypy + bandit clean; **1827 passed, 1 skipped** (includes the new encoding pins + the tree-wide guard).

Net: 98 files, +857/−465.