### PR TITLE
fix: regenerate stale uv.lock — prune removed SDKs, clear last pip-audit advisory (v3.3.13.3)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,11 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - name: Run pip-audit against the locked environment
-        run: uv run --frozen pip-audit --ignore-vuln CVE-2026-25645
-        # CVE-2026-25645 is in requests 2.32.5, which is pinned by pycentral==2.0a17.
-        # Standard requests usage is not affected; only direct calls to
-        # requests.utils.extract_zipped_paths() are impacted. Keep this explicit
-        # ignore until pycentral allows requests>=2.33.0, then remove it.
+        run: uv run --frozen pip-audit
 
   gitleaks:
     name: Secret Detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13.3] - 2026-06-12
+
+**Patch — fix: regenerate the stale lockfile; pip-audit now clean with zero ignores.** Closes #445. `uv.lock` had not been regenerated since v3.3.6.0, and because `uv sync --frozen` skips the pyproject↔lock consistency check, every container build since the SDK removals (#468/#470) **kept installing pycentral 2.0a17 and pyclearpass 1.0.8** — inert (nothing imports them; the import guards are clean) but shipped, along with the vulnerable requests 2.32.5 chain that pycentral's pin had frozen in place.
+
+### Fixed
+- `uv.lock` regenerated: **pycentral and pyclearpass pruned from the install graph** (with their orbit: requests-oauthlib, oauthlib, websocket-client, pytz, protobuf, h2/hpack/hyperframe); lockfile version metadata caught up from 3.3.6.0.
+- **requests 2.32.5 → 2.34.2**, closing CVE-2026-25645 — the last open advisory from the #445 audit, previously unfixable behind pycentral's `requests<2.33` pin.
+- `security.yml`: the `--ignore-vuln CVE-2026-25645` escape hatch and its stale pycentral comment removed — CI's `pip-audit` now passes with **zero ignores**.
+
+### Tests
+- Lockfile guards added to `TestNoPycentralAnywhere` / `TestNoPyclearpassAnywhere`: the SDK names must not appear in `uv.lock` — import guards alone cannot catch a stale lock reinstalling a removed dependency.
+
 ## [3.3.13.2] - 2026-06-12
 
 **Patch — fix: centralized URL path-segment escaping for interpolated selector values.** Closes #476. Operator-supplied selectors (usernames, MACs, attribute/template/server names, IDs) interpolated into URL paths were sent raw: httpx already percent-encodes spaces and unicode, but a value containing `/` restructured the route, `?` started the query string, and `#` silently truncated the path — a delete aimed at `Policy #2` would have quietly targeted `Policy ` instead of failing loudly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.3.13.2"
+version = "3.3.13.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/tests/unit/test_central_client.py
+++ b/tests/unit/test_central_client.py
@@ -43,6 +43,19 @@ class TestNoPycentralAnywhere:
                     offenders.append(f"{path}:{node.lineno}")
         assert not offenders, f"pycentral imports found (SDK was removed): {offenders}"
 
+    def test_no_pycentral_in_lockfile(self):
+        """A stale uv.lock kept INSTALLING pycentral for 7 releases after the
+        SDK was removed from pyproject (#445) — `uv sync --frozen` skips the
+        pyproject↔lock consistency check, so import guards alone can't see it.
+        """
+        import pathlib
+
+        lockfile = pathlib.Path(__file__).resolve().parents[2] / "uv.lock"
+        assert lockfile.is_file(), "uv.lock not found next to pyproject.toml"
+        assert 'name = "pycentral"' not in lockfile.read_text(), (
+            "pycentral is in uv.lock — regenerate the lock (uv lock); the SDK was removed in v3.3.11.0"
+        )
+
 
 def _make_secrets(**overrides) -> CentralSecrets:
     base = {

--- a/tests/unit/test_central_client.py
+++ b/tests/unit/test_central_client.py
@@ -52,7 +52,7 @@ class TestNoPycentralAnywhere:
 
         lockfile = pathlib.Path(__file__).resolve().parents[2] / "uv.lock"
         assert lockfile.is_file(), "uv.lock not found next to pyproject.toml"
-        assert 'name = "pycentral"' not in lockfile.read_text(), (
+        assert 'name = "pycentral"' not in lockfile.read_text(encoding="utf-8"), (
             "pycentral is in uv.lock — regenerate the lock (uv lock); the SDK was removed in v3.3.11.0"
         )
 

--- a/tests/unit/test_clearpass_client.py
+++ b/tests/unit/test_clearpass_client.py
@@ -65,6 +65,19 @@ class TestNoPyclearpassAnywhere:
                     offenders.append(f"{path}:{node.lineno}")
         assert not offenders, f"pyclearpass imports found (SDK was removed): {offenders}"
 
+    def test_no_pyclearpass_in_lockfile(self):
+        """A stale uv.lock kept INSTALLING pyclearpass for 7 releases after the
+        SDK was removed from pyproject (#445) — `uv sync --frozen` skips the
+        pyproject↔lock consistency check, so import guards alone can't see it.
+        """
+        import pathlib
+
+        lockfile = pathlib.Path(__file__).resolve().parents[2] / "uv.lock"
+        assert lockfile.is_file(), "uv.lock not found next to pyproject.toml"
+        assert 'name = "pyclearpass"' not in lockfile.read_text(), (
+            "pyclearpass is in uv.lock — regenerate the lock (uv lock); the SDK was removed in v3.3.12.0"
+        )
+
 
 @pytest.mark.unit
 class TestRequestContract:

--- a/tests/unit/test_clearpass_client.py
+++ b/tests/unit/test_clearpass_client.py
@@ -74,7 +74,7 @@ class TestNoPyclearpassAnywhere:
 
         lockfile = pathlib.Path(__file__).resolve().parents[2] / "uv.lock"
         assert lockfile.is_file(), "uv.lock not found next to pyproject.toml"
-        assert 'name = "pyclearpass"' not in lockfile.read_text(), (
+        assert 'name = "pyclearpass"' not in lockfile.read_text(encoding="utf-8"), (
             "pyclearpass is in uv.lock — regenerate the lock (uv lock); the SDK was removed in v3.3.12.0"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.3.13.2"
+version = "3.3.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["apps", "code-mode"] },

--- a/uv.lock
+++ b/uv.lock
@@ -664,38 +664,14 @@ wheels = [
 ]
 
 [[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
-]
-
-[[package]]
 name = "hpe-networking-mcp"
-version = "3.3.6.0"
+version = "3.3.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["apps", "code-mode"] },
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", extra = ["cli"] },
-    { name = "pycentral" },
-    { name = "pyclearpass" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -722,8 +698,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
-    { name = "pycentral", specifier = "==2.0a17" },
-    { name = "pyclearpass", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.0" },
@@ -772,11 +746,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
-]
-
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -784,15 +753,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1207,15 +1167,6 @@ wheels = [
 ]
 
 [[package]]
-name = "oauthlib"
-version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1380,21 +1331,6 @@ wheels = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "6.33.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
-    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
-    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
-]
-
-[[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1429,38 +1365,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
-]
-
-[[package]]
-name = "pycentral"
-version = "2.0a17"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "oauthlib" },
-    { name = "protobuf" },
-    { name = "pytz" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/0e/9068abaa0d34b25c6fd203bf8394b9c5698a542e272973b2850712c736de/pycentral-2.0a17.tar.gz", hash = "sha256:48c3bb88c6f46da4a1e99f1f792c979bee73a57711adad901fdd23b90c2ceb9d", size = 128494, upload-time = "2026-03-24T20:32:50.796Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/27/4f94c63fdf7effa6a70f031bb6641dc2bd898dabb17ab5ed234576362a84/pycentral-2.0a17-py3-none-any.whl", hash = "sha256:ec1f150c2870f9f529174530bc7ddfdd4762df1a22a46e778c547b09eeb7401b", size = 169300, upload-time = "2026-03-24T20:32:49.504Z" },
-]
-
-[[package]]
-name = "pyclearpass"
-version = "1.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/dc/eb095607b36250ba6946edddc9052fb50086a0e91b28d5043b7ef298f30d/pyclearpass-1.0.8.tar.gz", hash = "sha256:e12784915e31c8f5eaef14add9a7a69ba8c5a9ccc7a4e99675c4cc977b122114", size = 82727, upload-time = "2025-10-13T13:09:01.372Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/b9/8090537c378f7948e6af0c32a16fe9e173bfa11e13302e58f3b830b3961f/pyclearpass-1.0.8-py3-none-any.whl", hash = "sha256:57f9b2fb2400b64429482efe0f3d8869cd8eccb1bba12350b7c2019f1067edca", size = 89663, upload-time = "2025-10-13T13:08:59.989Z" },
 ]
 
 [[package]]
@@ -1744,15 +1648,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
-]
-
-[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -1839,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1847,22 +1742,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2314,15 +2196,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #445 — and fixes the root cause that kept it open.

`uv.lock` had not been regenerated since **v3.3.6.0**. Because `uv sync --frozen` (used by the Docker build and CI) skips the pyproject↔lock consistency check, every container built since the SDK removals (#468 / #470) **still installed pycentral 2.0a17 and pyclearpass 1.0.8** — inert (nothing imports them; the import guards are clean) but shipped — along with the vulnerable requests 2.32.5 chain that pycentral's `requests<2.33` pin had frozen in place.

## Changes

- **`uv.lock` regenerated** (`uv lock --upgrade-package requests`): pycentral and pyclearpass pruned from the install graph along with their orbit (requests-oauthlib, oauthlib, websocket-client, pytz, protobuf, h2/hpack/hyperframe).
- **requests 2.32.5 → 2.34.2** — closes CVE-2026-25645, the last open advisory from the #445 audit (10 of 11 were fixed by the earlier lock refresh; this one was unfixable until pycentral was deleted).
- **`security.yml`**: the `--ignore-vuln CVE-2026-25645` escape hatch and its stale pycentral comment removed — CI's pip-audit now runs with **zero ignores**, exactly as the original comment instructed ("remove once pycentral allows requests>=2.33.0").
- **Guard tests extended** (`TestNoPycentralAnywhere` / `TestNoPyclearpassAnywhere`): the SDK names must not appear in `uv.lock`. Import guards alone can't catch a stale lock silently reinstalling a removed dependency — that's precisely how this hid for 7 releases.

## Verification (rebuilt image, not the stale one)

- `uv pip list`: **zero** pycentral/pyclearpass packages installed; requests 2.34.2.
- `uv run --frozen pip-audit`: **no known vulnerabilities** (no ignores).
- Full battery: ruff + format + mypy + bandit clean; **1829 passed, 1 skipped** (includes the 2 new lockfile guards).

The 3 moderate Dependabot alerts on main should clear once this merges (same requests/urllib3 chain).

Net: 6 files, +44/−137.