### PR TITLE
chore(vendor): sync Aruba OAS (New Central + AOS 8)

### DIFF
--- a/vendor/clearpass/_manifest.json
+++ b/vendor/clearpass/_manifest.json
@@ -2,116 +2,116 @@
   "definition_count": 16,
   "definitions": [
     {
-      "id": "69834f79b88f87eb659b7fb1",
+      "id": "6a2c121273cc0380fb39a52e",
       "path_count": 3,
       "slug": "api-operations",
       "title": "API Operations",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb2",
+      "id": "6a2c121273cc0380fb39a52f",
       "path_count": 14,
       "slug": "certificate-authority",
       "title": "Certificate Authority",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fbd",
+      "id": "6a2c121273cc0380fb39a53a",
       "path_count": 38,
       "slug": "endpoint-visibility",
       "title": "Endpoint Visibility",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fbf",
+      "id": "6a2c121273cc0380fb39a53c",
       "path_count": 45,
       "slug": "enforcement-profile",
       "title": "Enforcement Profile",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fba",
+      "id": "6a2c121273cc0380fb39a537",
       "path_count": 36,
       "slug": "global-server-configuration",
       "title": "Global Server Configuration",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb3",
+      "id": "6a2c121273cc0380fb39a530",
       "path_count": 5,
       "slug": "guest-actions",
       "title": "Guest Actions",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb4",
+      "id": "6a2c121273cc0380fb39a531",
       "path_count": 9,
       "slug": "guest-configuration",
       "title": "Guest Configuration",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb7",
+      "id": "6a2c121273cc0380fb39a534",
       "path_count": 23,
       "slug": "identities",
       "title": "Identities",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fc0",
+      "id": "6a2c121273cc0380fb39a53d",
       "path_count": 20,
       "slug": "insight",
       "title": "Insight",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fbb",
+      "id": "6a2c121273cc0380fb39a538",
       "path_count": 32,
       "slug": "integrations",
       "title": "Integrations",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb9",
+      "id": "6a2c121273cc0380fb39a536",
       "path_count": 18,
       "slug": "local-server-configuration",
       "title": "Local Server Configuration",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb8",
+      "id": "6a2c121273cc0380fb39a535",
       "path_count": 6,
       "slug": "logs",
       "title": "Logs",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb6",
+      "id": "6a2c121273cc0380fb39a533",
       "path_count": 17,
       "slug": "platform-certificates",
       "title": "Platform Certificates",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fbc",
+      "id": "6a2c121273cc0380fb39a539",
       "path_count": 51,
       "slug": "policy-elements",
       "title": "Policy Elements",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fbe",
+      "id": "6a2c121273cc0380fb39a53b",
       "path_count": 14,
       "slug": "session-control",
       "title": "Session Control",
-      "version": "6.12.7"
+      "version": "6.14.0"
     },
     {
-      "id": "69834f79b88f87eb659b7fb5",
+      "id": "6a2c121273cc0380fb39a532",
       "path_count": 4,
       "slug": "tools-and-utilities",
       "title": "Tools And Utilities",
-      "version": "6.12.7"
+      "version": "6.14.0"
     }
   ],
   "project": "cppm",

--- a/vendor/clearpass/api-operations.json
+++ b/vendor/clearpass/api-operations.json
@@ -124,7 +124,7 @@
   "info": {
     "contact": {},
     "title": "API Operations",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/certificate-authority.json
+++ b/vendor/clearpass/certificate-authority.json
@@ -1034,7 +1034,7 @@
   "info": {
     "contact": {},
     "title": "Certificate Authority",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/endpoint-visibility.json
+++ b/vendor/clearpass/endpoint-visibility.json
@@ -192,13 +192,6 @@
           "action": {
             "$ref": "#/components/schemas/Action"
           },
-          "checksums_32": {
-            "description": "SHA256 checksums of 32-bit Agentless OnGuard Wrapper EXEs",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "checksums_64": {
             "description": "SHA256 checksums of 64-bit Agentless OnGuard Wrapper EXEs",
             "items": {
@@ -262,13 +255,6 @@
         "properties": {
           "action": {
             "$ref": "#/components/schemas/Action"
-          },
-          "checksums_32": {
-            "description": "SHA256 checksums of 32-bit Agentless OnGuard Wrapper EXEs",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "checksums_64": {
             "description": "SHA256 checksums of 64-bit Agentless OnGuard Wrapper EXEs",
@@ -348,13 +334,6 @@
           "action": {
             "$ref": "#/components/schemas/Action"
           },
-          "checksums_32": {
-            "description": "SHA256 checksums of 32-bit Agentless OnGuard Wrapper EXEs",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "checksums_64": {
             "description": "SHA256 checksums of 64-bit Agentless OnGuard Wrapper EXEs",
             "items": {
@@ -421,13 +400,6 @@
         "properties": {
           "action": {
             "$ref": "#/components/schemas/Action"
-          },
-          "checksums_32": {
-            "description": "SHA256 checksums of 32-bit Agentless OnGuard Wrapper EXEs",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "checksums_64": {
             "description": "SHA256 checksums of 64-bit Agentless OnGuard Wrapper EXEs",
@@ -496,7 +468,6 @@
           "download_url",
           "validate_url_cert",
           "override_checksum",
-          "checksums_32",
           "checksums_64"
         ],
         "title": "AgentlessOnGuardSettingsResult",
@@ -506,13 +477,6 @@
         "properties": {
           "action": {
             "$ref": "#/components/schemas/Action"
-          },
-          "checksums_32": {
-            "description": "SHA256 checksums of 32-bit Agentless OnGuard Wrapper EXEs",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "checksums_64": {
             "description": "SHA256 checksums of 64-bit Agentless OnGuard Wrapper EXEs",
@@ -2519,14 +2483,6 @@
           "VPNDeviceNamesMacOS": {
             "description": "VPN Device Names (macOS)",
             "type": "string"
-          },
-          "WiredAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wired access",
-            "type": "string"
-          },
-          "WirelessAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wireless access",
-            "type": "string"
           }
         },
         "title": "OnGuardGlobalSettings",
@@ -2597,14 +2553,6 @@
           },
           "VPNDeviceNamesMacOS": {
             "description": "VPN Device Names (macOS)",
-            "type": "string"
-          },
-          "WiredAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wired access",
-            "type": "string"
-          },
-          "WirelessAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wireless access",
             "type": "string"
           }
         },
@@ -2688,14 +2636,6 @@
           "VPNDeviceNamesMacOS": {
             "description": "VPN Device Names (macOS)",
             "type": "string"
-          },
-          "WiredAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wired access",
-            "type": "string"
-          },
-          "WirelessAllowedSubnets": {
-            "description": "[Deprecated] Allowed Subnets for Wireless access",
-            "type": "string"
           }
         },
         "required": [
@@ -2714,9 +2654,7 @@
           "UseCurrentOSLanguage",
           "UseWindowsCredentials",
           "VPNDeviceNames",
-          "VPNDeviceNamesMacOS",
-          "WiredAllowedSubnets",
-          "WirelessAllowedSubnets"
+          "VPNDeviceNamesMacOS"
         ],
         "title": "OnGuardGlobalSettingsResult",
         "type": "object"
@@ -3095,13 +3033,10 @@
         "enum": [
           "Windows 10",
           "Windows 11",
-          "Windows 7",
-          "Windows 8",
-          "Windows Server 2008",
-          "Windows Server 2012",
           "Windows Server 2016",
           "Windows Server 2019",
-          "Windows Server 2022"
+          "Windows Server 2022",
+          "Windows Server 2025"
         ],
         "example": "Windows 10",
         "title": "OperatingSystem",
@@ -3789,7 +3724,7 @@
   "info": {
     "contact": {},
     "title": "Endpoint Visibility",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/enforcement-profile.json
+++ b/vendor/clearpass/enforcement-profile.json
@@ -4511,7 +4511,7 @@
   "info": {
     "contact": {},
     "title": "Enforcement Profile",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/global-server-configuration.json
+++ b/vendor/clearpass/global-server-configuration.json
@@ -1295,7 +1295,11 @@
         "description": "Authentication Protocol",
         "enum": [
           "MD5",
-          "SHA"
+          "SHA",
+          "SHA-224",
+          "SHA-256",
+          "SHA-384",
+          "SHA-512"
         ],
         "example": "MD5",
         "title": "AuthProtocol",
@@ -1464,6 +1468,10 @@
           "AutoBackupConfigOptions": {
             "$ref": "#/components/schemas/AutoBackupConfigOptions"
           },
+          "AutoBackupConfigPassword": {
+            "description": "Auto backup configuration password",
+            "type": "string"
+          },
           "CLISessionIdleTimeout": {
             "description": "CLI Session Idle Timeout in minutes",
             "type": "integer"
@@ -1506,12 +1514,6 @@
           "DesignatedStandbyPublisher": {
             "description": "Designated Standby Publisher",
             "type": "string"
-          },
-          "DisableTLS1.0": {
-            "$ref": "#/components/schemas/DisableTLS1.0"
-          },
-          "DisableTLS1.1": {
-            "$ref": "#/components/schemas/DisableTLS1.1"
           },
           "DisableTLS1.3": {
             "$ref": "#/components/schemas/DisableTLS1.3"
@@ -1564,6 +1566,10 @@
           "MACAddressFormat": {
             "$ref": "#/components/schemas/MACAddressFormat"
           },
+          "NetflowDecoderInactiveTimeout": {
+            "description": "Netflow Decoder Inactive Timeout",
+            "type": "integer"
+          },
           "NetflowReprofileInterval": {
             "description": "Netflow reprofile interval in days",
             "type": "integer"
@@ -1602,6 +1608,9 @@
           "PostAuthV2HttpEnforcement": {
             "$ref": "#/components/schemas/PostAuthV2HttpEnforcement"
           },
+          "PostureEngineAutoUpdatesFlag": {
+            "$ref": "#/components/schemas/PostureEngineAutoUpdatesFlag"
+          },
           "ProcessWiredFromIfMap": {
             "$ref": "#/components/schemas/ProcessWiredFromIfMap"
           },
@@ -1631,10 +1640,6 @@
           },
           "ProfilingAutoUpdatesFlag": {
             "$ref": "#/components/schemas/ProfilingAutoUpdatesFlag"
-          },
-          "SSHCipherMode": {
-            "description": "Allowed SSH Cipher Modes",
-            "type": "string"
           },
           "SessionLogsCleanupInterval": {
             "description": "Cleanup interval for Session log details in the database in days",
@@ -1757,6 +1762,10 @@
           "AutoBackupConfigOptions": {
             "$ref": "#/components/schemas/AutoBackupConfigOptions"
           },
+          "AutoBackupConfigPassword": {
+            "description": "Auto backup configuration password",
+            "type": "string"
+          },
           "CLISessionIdleTimeout": {
             "description": "CLI Session Idle Timeout in minutes",
             "type": "integer"
@@ -1799,12 +1808,6 @@
           "DesignatedStandbyPublisher": {
             "description": "Designated Standby Publisher",
             "type": "string"
-          },
-          "DisableTLS1.0": {
-            "$ref": "#/components/schemas/DisableTLS1.0"
-          },
-          "DisableTLS1.1": {
-            "$ref": "#/components/schemas/DisableTLS1.1"
           },
           "DisableTLS1.3": {
             "$ref": "#/components/schemas/DisableTLS1.3"
@@ -1857,6 +1860,10 @@
           "MACAddressFormat": {
             "$ref": "#/components/schemas/MACAddressFormat"
           },
+          "NetflowDecoderInactiveTimeout": {
+            "description": "Netflow Decoder Inactive Timeout",
+            "type": "integer"
+          },
           "NetflowReprofileInterval": {
             "description": "Netflow reprofile interval in days",
             "type": "integer"
@@ -1895,6 +1902,9 @@
           "PostAuthV2HttpEnforcement": {
             "$ref": "#/components/schemas/PostAuthV2HttpEnforcement"
           },
+          "PostureEngineAutoUpdatesFlag": {
+            "$ref": "#/components/schemas/PostureEngineAutoUpdatesFlag"
+          },
           "ProcessWiredFromIfMap": {
             "$ref": "#/components/schemas/ProcessWiredFromIfMap"
           },
@@ -1924,10 +1934,6 @@
           },
           "ProfilingAutoUpdatesFlag": {
             "$ref": "#/components/schemas/ProfilingAutoUpdatesFlag"
-          },
-          "SSHCipherMode": {
-            "description": "Allowed SSH Cipher Modes",
-            "type": "string"
           },
           "SessionLogsCleanupInterval": {
             "description": "Cleanup interval for Session log details in the database in days",
@@ -1997,6 +2003,7 @@
           "TacacsAllowUnencryptedCommunication",
           "AuditRecordsCleanupInterval",
           "AutoBackupConfigOptions",
+          "AutoBackupConfigPassword",
           "CLISessionIdleTimeout",
           "CSRCleanupInterval",
           "ClusterCommunicationMode",
@@ -2007,8 +2014,6 @@
           "ContextServerPollStartTime",
           "DbAppexternalUserPassword",
           "DesignatedStandbyPublisher",
-          "DisableTLS1.0",
-          "DisableTLS1.1",
           "EnableNTLMV1ForWmi",
           "EnablePublisherFailover",
           "EnableTelemetry",
@@ -2037,7 +2042,6 @@
           "ProfilerScanPorts",
           "ProfilerSubnetScanInterval",
           "ProfilingAutoUpdatesFlag",
-          "SSHCipherMode",
           "SessionLogsCleanupInterval",
           "SoftwareAutoUpdatesFlag",
           "ExtensionsAutoUpgradesFlag",
@@ -2411,30 +2415,6 @@
         "example": "1-365",
         "title": "DisableAfterUnchangedDays",
         "type": "integer"
-      },
-      "DisableTLS1.0": {
-        "description": "Disable TLSv1.0 support, this field cannot be modified in FIPS mode",
-        "enum": [
-          "None",
-          "Admin",
-          "Network",
-          "All"
-        ],
-        "example": "None",
-        "title": "DisableTLS1.0",
-        "type": "string"
-      },
-      "DisableTLS1.1": {
-        "description": "Disable TLSv1.1 support, this field cannot be modified in FIPS mode",
-        "enum": [
-          "None",
-          "Admin",
-          "Network",
-          "All"
-        ],
-        "example": "None",
-        "title": "DisableTLS1.1",
-        "type": "string"
       },
       "DisableTLS1.3": {
         "description": "",
@@ -3656,16 +3636,23 @@
         "title": "PostAuthV2HttpEnforcement",
         "type": "string"
       },
+      "PostureEngineAutoUpdatesFlag": {
+        "description": "Automatically check for available Posture Engine Updates",
+        "enum": [
+          "TRUE",
+          "FALSE"
+        ],
+        "example": "TRUE",
+        "title": "PostureEngineAutoUpdatesFlag",
+        "type": "string"
+      },
       "PrivProtocol": {
         "description": "Privacy Protocol",
         "enum": [
-          "DES_CBC",
-          "AES_128",
-          "AES_192",
-          "AES_256",
-          "AES_256_C"
+          "AES-128",
+          "AES-256"
         ],
-        "example": "DES_CBC",
+        "example": "AES-128",
         "title": "PrivProtocol",
         "type": "object"
       },
@@ -4388,7 +4375,7 @@
   "info": {
     "contact": {},
     "title": "Global Server Configuration",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/guest-actions.json
+++ b/vendor/clearpass/guest-actions.json
@@ -177,7 +177,7 @@
   "info": {
     "contact": {},
     "title": "Guest Actions",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/guest-configuration.json
+++ b/vendor/clearpass/guest-configuration.json
@@ -1232,7 +1232,7 @@
   "info": {
     "contact": {},
     "title": "Guest Configuration",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/identities.json
+++ b/vendor/clearpass/identities.json
@@ -527,6 +527,7 @@
           "Remote Control",
           "RFID Tracking",
           "Router",
+          "Screen Mirroring",
           "Security",
           "Sensors",
           "Server",
@@ -666,6 +667,7 @@
           "2Wire Residential Gateway",
           "3Com IP Phone",
           "3Com Switch",
+          "3D Printer",
           "3M Medical Device",
           "3PAR",
           "A10 Device",
@@ -689,6 +691,7 @@
           "Airista Flow Tag",
           "Air Quality Monitor",
           "AirRohr Sensor",
+          "Airtame",
           "Alaris Infusion Pump",
           "Alcatel IP Phone",
           "Alcon Medical Device",
@@ -851,6 +854,7 @@
           "Crestron Media Device",
           "Criticare Device",
           "Cutera Device",
+          "Cync Smart Thermostat",
           "Dahua Camera",
           "Dainippon Pharmaceutical Device",
           "DDoS Solution",
@@ -872,6 +876,7 @@
           "Dictum Health Device",
           "DigiBoard ES",
           "Digital Monitoring Device",
+          "Dimmer Switch",
           "Directv Audio",
           "DirecTV Set-Top Box",
           "Dixtal Biomedical Device",
@@ -898,6 +903,7 @@
           "Emerson UPS",
           "Eneo  Network Camera",
           "Energy Detective",
+          "Energy Flow Monitor",
           "Enlighted Sensors",
           "Enseo Media Player",
           "Enterasys HiPath AP",
@@ -910,6 +916,7 @@
           "Extron AV",
           "EyeFi Card",
           "Ezurio Device",
+          "Fanvil VOIP Phone",
           "Fedora",
           "Filtrete Thermostat",
           "Fios Wi-Fi Router",
@@ -925,6 +932,7 @@
           "Fujifilm Printer",
           "Fujitsu Thin Client",
           "Gambro Lundia",
+          "Gaming Console",
           "Geist iPDU",
           "Generic Printer",
           "Genetec Camera",
@@ -1038,6 +1046,7 @@
           "Levelone Router",
           "Leviton Light Switch",
           "Lexmark Printer",
+          "LG Air Conditioner",
           "LG Android",
           "LG BL40",
           "LG Device",
@@ -1144,6 +1153,7 @@
           "Oracle Enterprise Linux",
           "Otis Elevators",
           "Oukitel Android",
+          "PA3 SIP Paging Gateway",
           "Packet Forensics Security",
           "Palm OS",
           "Palo Alto Firewall",
@@ -1204,7 +1214,7 @@
           "S2 Security Camera",
           "SafeQ Terminal",
           "Sagemcom Router",
-          "Sagemcom STB",
+          "Sagemcom Set-Top Box",
           "Samsung Android",
           "Samsung Device",
           "Samsung Oven",
@@ -1221,6 +1231,7 @@
           "Schindler Elevators",
           "Schneider Electric",
           "Seagate Storage",
+          "Security Camera",
           "Sega Dreamcast",
           "Sennheiser Mic",
           "Sensi Wi-Fi Thermostat",
@@ -1238,6 +1249,7 @@
           "Sightlogix Camera",
           "Silex ECG",
           "SilverPeak SD-WAN",
+          "SIP Audio/Video Intercom",
           "Siqura Camera",
           "Slingbox",
           "Smart Appliance",
@@ -1251,10 +1263,12 @@
           "Smart Meter",
           "Smart Plug",
           "Smart Refrigerator",
+          "Smart Switch",
           "Smarttech Projector",
           "Smart Thermostat",
           "SmartThings Hub",
           "Smart Watch",
+          "Smoke Detector",
           "Snom IP Phone",
           "Solaris",
           "SonicWALL Device",
@@ -1287,7 +1301,7 @@
           "Tally Printer",
           "Tapo Dimmer Switch",
           "Tattile Camera",
-          "Tatung STB",
+          "Tatung Set-Top Box",
           "Technicolor WAP",
           "Technicolor xDSL Router",
           "Telemecanique PLC",
@@ -1299,6 +1313,7 @@
           "TesiraForte",
           "Tesla Gateway",
           "Tesla Model S",
+          "Thermostat",
           "Thin Client",
           "Thomson IP Phone",
           "ThyssenKrupp Elevators",
@@ -1323,7 +1338,7 @@
           "Tripplite UPS",
           "Truen Camera",
           "TSC Printer",
-          "TVIP STB",
+          "TVIP Set-Top Box",
           "TV One Video",
           "TVT Camera",
           "Tyre Pressure Monitor",
@@ -1336,12 +1351,14 @@
           "Unknown",
           "USB Adapter",
           "User Experience Insight Sensor",
+          "V64 Prime Business Phone",
           "Vacuum Robot",
           "Valve Steam",
           "VBrick Multimedia System",
           "Verint Camera",
           "Veriwave Testing",
           "Versalink Printer",
+          "Vibration Sensor",
           "Vicon Camera",
           "video Intercom",
           "Visonic Device",
@@ -1353,6 +1370,7 @@
           "Vocera Communication Badge",
           "Volvo Car",
           "Vtech VOIP Phone",
+          "W611W Portable Wi-Fi Phone",
           "Wall Connector",
           "WatchGuard Device",
           "Weather Station",
@@ -1396,6 +1414,9 @@
           "Wyse ThinClient",
           "WyzeCam",
           "Wyze Smart Plug",
+          "X3SG Entry Level IP Phone",
+          "X4U Enterprise IP Phone",
+          "X6U High-end IP Phone",
           "Xandros Workstation",
           "Xbox",
           "Xenon X-RADIO",
@@ -1404,7 +1425,9 @@
           "Xerox Phaser",
           "Xerox Printer",
           "Xerox WorkCenter",
+          "Xiaomi Camera",
           "Xiaomi Device",
+          "Xiaomi Router",
           "Xirrus AP",
           "Xyratex NAS",
           "Yamaha Audio",
@@ -1451,7 +1474,9 @@
           "Aiphone",
           "Airgradient",
           "Airista",
+          "Airius",
           "AirRohr",
+          "Airtame",
           "AKCP",
           "Alaris",
           "Alcatel",
@@ -1470,6 +1495,7 @@
           "Apple",
           "Apple Mac",
           "Applied Biosystems",
+          "Arcade",
           "Arecont",
           "Arista",
           "Arlo",
@@ -1578,6 +1604,7 @@
           "Dect",
           "Dedicated Micro",
           "Dell",
+          "Delta Dore",
           "Density",
           "Dentsply Gendex",
           "Devolo",
@@ -1620,6 +1647,7 @@
           "Extron",
           "EyeFi",
           "Ezurio",
+          "Fanvil",
           "Fisher & Paykel",
           "Fitbit",
           "Fluke",
@@ -1634,6 +1662,7 @@
           "Garmin",
           "GE",
           "Geist",
+          "GE Lighting",
           "Generic",
           "Genetec",
           "GeoVision",
@@ -1782,6 +1811,7 @@
           "Point of Sale device",
           "Polycom",
           "Precidia",
+          "Prusa",
           "PXE",
           "Qihoo360",
           "QNAP",
@@ -1822,8 +1852,8 @@
           "SGM Technology",
           "Shark",
           "Sharp",
+          "Shelly",
           "Shenzhen Bilian",
-          "Shenzhen Smarteye",
           "ShoreTel",
           "SHURE",
           "Siemens",
@@ -1835,6 +1865,7 @@
           "SkyQ",
           "Slingbox",
           "Smarttech",
+          "SMA Solar",
           "Snom",
           "Solaris",
           "SonicWALL",
@@ -1850,6 +1881,7 @@
           "Super Micro",
           "Suprema",
           "Sur-Gard Security",
+          "SU Tech",
           "Switch",
           "Symbian",
           "Symbol",
@@ -1868,6 +1900,7 @@
           "Tenda",
           "Teradek VidiU",
           "Tesla",
+          "Thermo Fisher Scientific",
           "Thermostat",
           "Thin Client",
           "Thomson",
@@ -1926,6 +1959,7 @@
           "WyzeCam",
           "Xenon",
           "Xerox",
+          "Xiaomi",
           "Xirrus",
           "Xyratex",
           "Yamaha",
@@ -2227,6 +2261,9 @@
             "description": "MAC Address of the endpoint",
             "type": "string"
           },
+          "nad_detail": {
+            "$ref": "#/components/schemas/NadDetail"
+          },
           "profile": {
             "$ref": "#/components/schemas/Profile"
           },
@@ -2395,6 +2432,9 @@
             "description": "MAC Address of the endpoint",
             "type": "string"
           },
+          "nad_detail": {
+            "$ref": "#/components/schemas/NadDetail"
+          },
           "profile": {
             "$ref": "#/components/schemas/Profile"
           },
@@ -2416,7 +2456,8 @@
           "status",
           "attributes",
           "randomized_mac",
-          "profile"
+          "profile",
+          "nad_detail"
         ],
         "title": "EndpointResult",
         "type": "object"
@@ -3657,16 +3698,29 @@
         "title": "LocalUserUpdate",
         "type": "object"
       },
+      "NadDetail": {
+        "properties": {
+          "nad_ip": {
+            "description": "NAD IP",
+            "type": "string"
+          },
+          "nad_port": {
+            "description": "NAD Port",
+            "type": "string"
+          }
+        },
+        "title": "NadDetail",
+        "type": "object"
+      },
       "PrivProtocol": {
         "description": "Privacy protocol for V3 SNMP external account",
         "enum": [
-          "DES_CBC",
           "AES_128",
           "AES_192",
           "AES_256",
           "AES_256_C"
         ],
-        "example": "DES_CBC",
+        "example": "AES_128",
         "title": "PrivProtocol",
         "type": "string"
       },
@@ -4000,7 +4054,7 @@
   "info": {
     "contact": {},
     "title": "Identities",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -5967,6 +6021,16 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "description": "<b>true:</b> Fetch the endpoint nad detail as well<br/><b>false:</b> Fetch only endpoint details(default)",
+            "in": "query",
+            "name": "nad_details",
+            "required": true,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -6192,6 +6256,16 @@
             "description": "<b>true:</b> Fetch the endpoint profile details as well<br/><b>false:</b> Fetch only endpoint details(default)",
             "in": "query",
             "name": "profile_details",
+            "required": true,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "<b>true:</b> Fetch the endpoint nad detail as well<br/><b>false:</b> Fetch only endpoint details(default)",
+            "in": "query",
+            "name": "nad_details",
             "required": true,
             "schema": {
               "default": false,
@@ -6551,6 +6625,16 @@
             "description": "<b>true:</b> Fetch the endpoint profile details as well<br/><b>false:</b> Fetch only endpoint details(default)",
             "in": "query",
             "name": "profile_details",
+            "required": true,
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "<b>true:</b> Fetch the endpoint nad detail as well<br/><b>false:</b> Fetch only endpoint details(default)",
+            "in": "query",
+            "name": "nad_details",
             "required": true,
             "schema": {
               "default": false,

--- a/vendor/clearpass/insight.json
+++ b/vendor/clearpass/insight.json
@@ -176,7 +176,7 @@
   "info": {
     "contact": {},
     "title": "Insight",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/integrations.json
+++ b/vendor/clearpass/integrations.json
@@ -152,6 +152,16 @@
         "title": "AuthMethod",
         "type": "string"
       },
+      "CentralMode": {
+        "description": "Central Mode",
+        "enum": [
+          "Classic Central",
+          "Central"
+        ],
+        "example": "Classic Central",
+        "title": "CentralMode",
+        "type": "string"
+      },
       "ContentType": {
         "description": "Content-Type of the Context Server Action. Note : For CUSTOM type use any string",
         "enum": [
@@ -192,7 +202,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "Headers(key/value pairs) of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
+            "description": "Headers of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
             "type": "object"
           },
           "http_method": {
@@ -246,7 +256,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "Headers(key/value pairs) of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
+            "description": "Headers of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
             "type": "object"
           },
           "http_method": {
@@ -338,7 +348,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "Headers(key/value pairs) of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
+            "description": "Headers of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
             "type": "object"
           },
           "http_method": {
@@ -393,7 +403,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "Headers(key/value pairs) of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
+            "description": "Headers of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
             "type": "object"
           },
           "http_method": {
@@ -456,7 +466,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "Headers(key/value pairs) of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
+            "description": "Headers of the Context Server Action (e.g., [{\"attr_name\":\"key1\", \"attr_value\":\"value1\"},{\"attr_name\":\"key2\", \"attr_value\":\"value2\"}])",
             "type": "object"
           },
           "http_method": {
@@ -506,6 +516,9 @@
           "bypass_proxy": {
             "description": "Bypass Proxy",
             "type": "boolean"
+          },
+          "central_mode": {
+            "$ref": "#/components/schemas/CentralMode"
           },
           "device_insight_collector_id": {
             "description": "Device Insight Collector Id",
@@ -589,6 +602,9 @@
           "bypass_proxy": {
             "description": "Bypass Proxy",
             "type": "boolean"
+          },
+          "central_mode": {
+            "$ref": "#/components/schemas/CentralMode"
           },
           "device_insight_collector_id": {
             "description": "Device Insight Collector Id",
@@ -683,6 +699,9 @@
           "bypass_proxy": {
             "description": "Bypass Proxy",
             "type": "boolean"
+          },
+          "central_mode": {
+            "$ref": "#/components/schemas/CentralMode"
           },
           "device_insight_collector_id": {
             "description": "Device Insight Collector Id",
@@ -2203,7 +2222,6 @@
         "enum": [
           "Aruba Activate",
           "VMware AirWatch",
-          "JAMF",
           "MobileIron Core",
           "IBM MaaS360",
           "SAP Afaria",
@@ -2833,7 +2851,7 @@
   "info": {
     "contact": {},
     "title": "Integrations",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/local-server-configuration.json
+++ b/vendor/clearpass/local-server-configuration.json
@@ -272,7 +272,11 @@
         "description": "Authentication Protocol of system monitoring settings",
         "enum": [
           "MD5",
-          "SHA"
+          "SHA",
+          "SHA-224",
+          "SHA-256",
+          "SHA-384",
+          "SHA-512"
         ],
         "example": "MD5",
         "title": "AuthProtocol",
@@ -439,11 +443,10 @@
       "PrivacyProtocol": {
         "description": "Privacy Protocol of system monitoring settings",
         "enum": [
-          "DES",
           "AES",
           "AES-256"
         ],
-        "example": "DES",
+        "example": "AES",
         "title": "PrivacyProtocol",
         "type": "string"
       },
@@ -1175,7 +1178,7 @@
   "info": {
     "contact": {},
     "title": "Local Server Configuration",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/logs.json
+++ b/vendor/clearpass/logs.json
@@ -27,6 +27,10 @@
             "description": "Domain of the endpoint",
             "type": "string"
           },
+          "hostname": {
+            "description": "Hostname of the endpoint",
+            "type": "string"
+          },
           "ip": {
             "description": "IP Address of the endpoint",
             "type": "string"
@@ -80,6 +84,7 @@
           "ip",
           "ipv6",
           "user",
+          "hostname",
           "domain",
           "roles",
           "spt",
@@ -341,7 +346,7 @@
   "info": {
     "contact": {},
     "title": "Logs",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/platform-certificates.json
+++ b/vendor/clearpass/platform-certificates.json
@@ -419,6 +419,7 @@
           "SAML",
           "SMTP",
           "EST",
+          "Syslog",
           "Others"
         ],
         "example": "AD/LDAP Servers",
@@ -1476,7 +1477,7 @@
   "info": {
     "contact": {},
     "title": "Platform Certificates",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/policy-elements.json
+++ b/vendor/clearpass/policy-elements.json
@@ -1134,10 +1134,6 @@
             "description": "Boolean to always use NetBIOS name instead of the domain part in username for authentication",
             "type": "boolean"
           },
-          "authorization_token": {
-            "description": "Authorization Token of Authentication Source",
-            "type": "string"
-          },
           "base_DN": {
             "description": "Base DN of Authentication Source",
             "type": "string"
@@ -1303,10 +1299,6 @@
             "description": "Boolean to always use NetBIOS name instead of the domain part in username for authentication",
             "type": "boolean"
           },
-          "authorization_token": {
-            "description": "Authorization Token of Authentication Source",
-            "type": "string"
-          },
           "base_DN": {
             "description": "Base DN of Authentication Source",
             "type": "string"
@@ -1471,10 +1463,6 @@
           "always_use_netBIOS_name": {
             "description": "Boolean to always use NetBIOS name instead of the domain part in username for authentication",
             "type": "boolean"
-          },
-          "authorization_token": {
-            "description": "Authorization Token of Authentication Source",
-            "type": "string"
           },
           "base_DN": {
             "description": "Base DN of Authentication Source",
@@ -1662,7 +1650,6 @@
           "realm",
           "server_principal",
           "server_principal_password",
-          "authorization_token",
           "protocol",
           "secret",
           "client_certificate",
@@ -1677,10 +1664,6 @@
           "always_use_netBIOS_name": {
             "description": "Boolean to always use NetBIOS name instead of the domain part in username for authentication",
             "type": "boolean"
-          },
-          "authorization_token": {
-            "description": "Authorization Token of Authentication Source",
-            "type": "string"
           },
           "base_DN": {
             "description": "Base DN of Authentication Source",
@@ -3772,10 +3755,9 @@
       "PrivacyProtocol": {
         "description": "Privacy protocol of the network device",
         "enum": [
-          "DES_CBC",
           "AES_128"
         ],
-        "example": "DES_CBC",
+        "example": "AES_128",
         "title": "PrivacyProtocol",
         "type": "string"
       },
@@ -6598,7 +6580,7 @@
   "info": {
     "contact": {},
     "title": "Policy Elements",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/session-control.json
+++ b/vendor/clearpass/session-control.json
@@ -447,7 +447,7 @@
   "info": {
     "contact": {},
     "title": "Session Control",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/vendor/clearpass/tools-and-utilities.json
+++ b/vendor/clearpass/tools-and-utilities.json
@@ -296,7 +296,7 @@
   "info": {
     "contact": {},
     "title": "Tools And Utilities",
-    "version": "6.12.7"
+    "version": "6.14.0"
   },
   "openapi": "3.0.0",
   "paths": {


### PR DESCRIPTION
Automated daily sync of the Aruba New Central + ArubaOS 8 OpenAPI definitions.

- **Source**: https://developer.arubanetworks.com (ReadMe `/openapi/<id>`)
- **Vendored to**: `vendor/central/mrt/`, `vendor/central/config/`, and `vendor/aos8/`
- Per-definition counts and provenance are in each project's
  `_manifest.json`.

Tool regeneration is **not** triggered by this PR — the maintainer
re-runs the Central importer at release time so tool-surface changes
are reviewed before shipping.

This PR has auto-merge enabled and will merge once required status
checks pass.