### PR TITLE
Accept platform in code-mode search discovery

### DIFF
--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -2,7 +2,7 @@
 
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from loguru import logger
@@ -575,7 +575,10 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
             GetTags,
             MontySandboxProvider,
             Search,
+            ToolDetailLevel,
         )
+        from fastmcp.server.context import Context
+        from fastmcp.tools import Tool
         from pydantic_monty import ResourceLimits
     except ImportError as e:
         logger.error(
@@ -593,7 +596,47 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
 
     class _HpeSearch(Search):
         def __call__(self, get_catalog):
-            tool = super().__call__(get_catalog)
+            base_tool = super().__call__(get_catalog)
+            base_search = base_tool.fn
+            default_detail = self._default_detail
+            default_limit = self._default_limit
+
+            async def search(
+                query: Annotated[str, "Search query to find available tools"],
+                platform: Annotated[
+                    str | None,
+                    "Optional platform tag such as mist, central, greenlake, clearpass, "
+                    "apstra, axis, aos8, uxi, or edgeconnect",
+                ] = None,
+                tags: Annotated[
+                    list[str] | None,
+                    "Filter to tools with any of these tags before searching",
+                ] = None,
+                detail: Annotated[
+                    ToolDetailLevel,
+                    "'brief' for names and descriptions, 'detailed' for parameter schemas "
+                    "as markdown, 'full' for complete JSON schemas",
+                ] = default_detail,
+                limit: Annotated[
+                    int | None,
+                    "Maximum number of results to return",
+                ] = default_limit,
+                ctx: Context = None,  # type: ignore[assignment]  # ty:ignore[invalid-parameter-default]
+            ) -> str:
+                """Search for available tools by query.
+
+                Returns matching tools ranked by relevance.
+                """
+                effective_tags = tags
+                if platform:
+                    platform_tag = platform.strip().lower()
+                    if platform_tag:
+                        effective_tags = list(tags or [])
+                        if platform_tag not in effective_tags:
+                            effective_tags.append(platform_tag)
+                return await base_search(query=query, tags=effective_tags, detail=detail, limit=limit, ctx=ctx)
+
+            tool = Tool.from_function(fn=search, name=self._name)
             tool.description = _SEARCH_DESCRIPTION
             return tool
 

--- a/tests/unit/test_code_mode.py
+++ b/tests/unit/test_code_mode.py
@@ -11,6 +11,7 @@ suite stays offline-friendly.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -249,6 +250,36 @@ class TestCodeModeRegistrationHook:
             # Should not raise — just log and return.
             _register_code_mode(m)
             assert m.transforms == [], "no transform should be added when imports fail"
+
+
+@pytest.mark.unit
+class TestCodeModeSearchTool:
+    """Regression coverage for HPE's wrapped top-level ``search`` discovery tool."""
+
+    def test_search_accepts_platform_argument_and_filters_by_tag(self):
+        from fastmcp import FastMCP
+
+        from hpe_networking_mcp.server import _register_code_mode
+
+        mcp = FastMCP("test-code-mode-search-platform")
+
+        @mcp.tool(name="central_list_sites", description="List Aruba Central sites", tags={"central"})
+        async def central_list_sites():  # pragma: no cover - catalog-only fixture
+            return []
+
+        @mcp.tool(name="mist_list_sites", description="List Juniper Mist sites", tags={"mist"})
+        async def mist_list_sites():  # pragma: no cover - catalog-only fixture
+            return []
+
+        _register_code_mode(mcp)
+
+        search_tool = asyncio.run(mcp.get_tool("search"))
+        assert "platform" in search_tool.parameters["properties"]
+
+        result = asyncio.run(mcp.call_tool("search", {"query": "sites", "platform": "central"}))
+        rendered = result.structured_content["result"]
+        assert "central_list_sites" in rendered
+        assert "mist_list_sites" not in rendered
 
 
 # NOTE: per-platform register_tools behavior (skipping build_meta_tools in code


### PR DESCRIPTION
Closes #488

## Summary
- Add an optional `platform` argument to the top-level code-mode `search` discovery tool.
- Fold `platform` into the existing tag filter before delegating to FastMCP search, so calls like `search(query="sites list", platform="central")` validate and stay scoped to Central tools.
- Add a regression test covering both the generated schema and platform-scoped search behavior.

## Tests
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen mypy src/ --ignore-missing-imports`
- `uv run --frozen pytest tests/ -q` (1847 passed, 12 skipped)
- `git diff --check`

Docker compose CI was not run locally because the Docker daemon is unavailable at `/Users/vinzzy/.orbstack/run/docker.sock`.

AI assistance was used under my direction.