### PR TITLE
fix(code-mode): tolerate extra args on search/tags/get_schema (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0.1] - 2026-06-19
+
+**Patch — fix(code-mode): `search` / `tags` / `get_schema` tolerate extra args (#488).** Small local models routinely call the discovery entry point with a natural-but-undeclared argument, e.g. `search(query="sites list central", platform="central")`. fastmcp validates discovery-tool arguments against the function signature, so any unknown kwarg raised `Unexpected keyword argument` and the **entire** call was rejected — dead-ending discovery and (per external small-model testing) cascading into give-up or confabulation. This is a structural fix at the tool-behavior layer; it does not rely on guidance text.
+
+### Fixed
+- The three code-mode discovery tools (`search`, `tags`, `get_schema`) now normalize incoming arguments before validation via a new `_ArgTolerantFunctionTool` (`server.py`): a `platform` argument is **folded into the existing `tags` filter** (platforms are catalog tags, so intent is preserved and results stay relevance-scoped), and any other unknown key is dropped rather than failing the call. The published JSON schema is not fastmcp's validator, so relaxing `additionalProperties` would not have helped — the fix overrides the tool's `run()` to pre-filter arguments. (#488)
+
 ## [3.4.0.0] - 2026-06-16
 
 **Minor — feat(edgeconnect): new platform — Aruba EdgeConnect (Silver Peak) Orchestrator.** Adds a 9th platform with **1216 spec-driven tools** generated from the vendored Orchestrator OpenAPI spec, bringing the total to **3178 underlying tools**. SD-WAN orchestration: appliances, alarms, time-series + aggregate stats, configuration templates, HA/reachability, licensing, and more — all reachable in code mode via `await call_tool("edgeconnect_invoke_tool", ...)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.0.0"
+version = "3.4.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -587,7 +587,11 @@ class _ArgTolerantFunctionTool(FunctionTool):
         args = dict(arguments or {})
         platform = args.pop("platform", None)
         if platform is not None and "tags" in props:
-            plats = [platform] if isinstance(platform, str) else list(platform)
+            # Only list/tuple/set means "multiple platforms". Any other value
+            # (str, or a malformed scalar like int/bool) is treated as one —
+            # never list() a non-iterable scalar, which would raise TypeError
+            # and re-create the very dead-end this fix removes (#488).
+            plats = list(platform) if isinstance(platform, (list, tuple, set)) else [platform]
             existing = args.get("tags") or []
             if isinstance(existing, str):
                 existing = [existing]

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.tools.function_tool import FunctionTool
+from fastmcp.tools.tool import ToolResult
 from loguru import logger
 
 from hpe_networking_mcp.config import ServerConfig
@@ -561,6 +563,50 @@ _GET_SCHEMA_DESCRIPTION = _SKILLS_FIRST_GATE + (
 )
 
 
+class _ArgTolerantFunctionTool(FunctionTool):
+    """Discovery tool that tolerates extra / misnamed args (issue #488).
+
+    Small local models routinely call e.g.
+    ``search(query="sites", platform="central")``. fastmcp's generated
+    discovery tools validate incoming arguments against the function
+    signature (``type_adapter.validate_python``), so any unknown kwarg raises
+    ``Unexpected keyword argument`` and the **entire** call is rejected —
+    which dead-ends the discovery entry point and blocks everything
+    downstream. The published JSON schema is not the validator, so relaxing
+    ``additionalProperties`` would not help.
+
+    This subclass normalizes arguments before validation:
+      - a ``platform`` arg is folded into the existing ``tags`` filter
+        (platforms are catalog tags), preserving the model's intent; and
+      - any remaining key not in the published schema is dropped,
+    so the call succeeds instead of being rejected wholesale.
+    """
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        props = (self.parameters or {}).get("properties", {})
+        args = dict(arguments or {})
+        platform = args.pop("platform", None)
+        if platform is not None and "tags" in props:
+            plats = [platform] if isinstance(platform, str) else list(platform)
+            existing = args.get("tags") or []
+            if isinstance(existing, str):
+                existing = [existing]
+            args["tags"] = list(existing) + [str(p).lower() for p in plats]
+        # Drop any unknown keys so validate_python doesn't reject the call.
+        args = {k: v for k, v in args.items() if k in props}
+        return await super().run(args)
+
+
+def _make_arg_tolerant(tool: FunctionTool) -> _ArgTolerantFunctionTool:
+    """Reconstruct a produced discovery Tool as the arg-tolerant subclass.
+
+    fastmcp's discovery-tool factories always build a plain ``FunctionTool``;
+    we copy its validated field values into ``_ArgTolerantFunctionTool`` so the
+    argument-normalizing ``run`` override takes effect (issue #488).
+    """
+    return _ArgTolerantFunctionTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
+
+
 def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
@@ -589,25 +635,26 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     # client semantic tool_search surfaces our discovery tools on queries
     # like "list mist sites" / "search central tools" (issue #302). The
     # parent classes' __init__ doesn't accept a description argument, so we
-    # mutate the returned Tool object before it goes upstream.
+    # mutate the returned Tool object before it goes upstream, then
+    # reconstruct it as the arg-tolerant subclass (issue #488).
 
     class _HpeSearch(Search):
         def __call__(self, get_catalog):
             tool = super().__call__(get_catalog)
             tool.description = _SEARCH_DESCRIPTION
-            return tool
+            return _make_arg_tolerant(tool)
 
     class _HpeGetTags(GetTags):
         def __call__(self, get_catalog):
             tool = super().__call__(get_catalog)
             tool.description = _TAGS_DESCRIPTION
-            return tool
+            return _make_arg_tolerant(tool)
 
     class _HpeGetSchemas(GetSchemas):
         def __call__(self, get_catalog):
             tool = super().__call__(get_catalog)
             tool.description = _GET_SCHEMA_DESCRIPTION
-            return tool
+            return _make_arg_tolerant(tool)
 
     limits = ResourceLimits(
         max_duration_secs=max_duration_secs,

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -229,6 +229,15 @@ class TestDiscoveryArgTolerance:
         assert "central_get_sites" in text
         assert "mist_get_self" not in text  # filtered out by the platform->tags fold
 
+    async def test_tolerant_search_handles_scalar_nonstring_platform(self) -> None:
+        """#495 (Casey): a malformed non-string scalar `platform` (e.g. 123 / True)
+        must NOT raise — `list(123)` would TypeError and re-create the dead-end.
+        It is coerced to a single tag, so the call still runs."""
+        tool = self._search_tool(tolerant=True)
+        for bad in (123, True):
+            result = await tool.run({"query": "get", "platform": bad})
+            assert result.content  # ran without raising
+
     async def test_tolerant_search_plain_query_unaffected(self) -> None:
         """A normal call with no extra args still works unchanged."""
         tool = self._search_tool(tolerant=True)

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -167,6 +167,83 @@ PLATFORM_INIT_FILES = (
 
 
 @pytest.mark.unit
+class TestDiscoveryArgTolerance:
+    """#488: discovery tools must not be hard-rejected when a small model
+    passes an extra/misnamed arg (e.g. ``platform``). The whole call failing
+    dead-ends the discovery entry point and blocks everything downstream.
+
+    ``_ArgTolerantFunctionTool`` drops unknown keys before validation and
+    folds ``platform`` into the existing ``tags`` filter (platforms are
+    catalog tags), so the call succeeds and stays relevance-scoped.
+    """
+
+    @staticmethod
+    def _catalog():
+        from fastmcp.tools.tool import Tool
+
+        async def central_get_sites() -> dict:
+            return {}
+
+        async def mist_get_self() -> dict:
+            return {}
+
+        return [
+            Tool.from_function(fn=central_get_sites, name="central_get_sites", tags={"central"}),
+            Tool.from_function(fn=mist_get_self, name="mist_get_self", tags={"mist"}),
+        ]
+
+    def _search_tool(self, *, tolerant: bool):
+        from fastmcp.experimental.transforms.code_mode import Search
+
+        catalog = self._catalog()
+
+        async def get_catalog(ctx=None):
+            return catalog
+
+        base = Search(default_detail="brief")(get_catalog)
+        return srv._make_arg_tolerant(base) if tolerant else base
+
+    def _get_schema_tool(self):
+        from fastmcp.experimental.transforms.code_mode import GetSchemas
+
+        catalog = self._catalog()
+
+        async def get_catalog(ctx=None):
+            return catalog
+
+        return srv._make_arg_tolerant(GetSchemas(default_detail="detailed")(get_catalog))
+
+    async def test_base_search_rejects_platform_arg(self) -> None:
+        """Repro: the unwrapped fastmcp Search tool rejects `platform` outright."""
+        tool = self._search_tool(tolerant=False)
+        with pytest.raises(Exception):  # noqa: B017,PT011 — fastmcp raises ValidationError
+            await tool.run({"query": "sites", "platform": "central"})
+
+    async def test_tolerant_search_accepts_and_folds_platform(self) -> None:
+        """`platform` is accepted, folded into tags, and a junk key is dropped —
+        and the fold actually scopes results to the central-tagged tool."""
+        tool = self._search_tool(tolerant=True)
+        assert isinstance(tool, srv._ArgTolerantFunctionTool)
+        result = await tool.run({"query": "get", "platform": "central", "bogus": 1})
+        text = result.content[0].text
+        assert "central_get_sites" in text
+        assert "mist_get_self" not in text  # filtered out by the platform->tags fold
+
+    async def test_tolerant_search_plain_query_unaffected(self) -> None:
+        """A normal call with no extra args still works unchanged."""
+        tool = self._search_tool(tolerant=True)
+        result = await tool.run({"query": "get"})
+        assert result.content
+
+    async def test_tolerant_get_schema_drops_unknown_platform(self) -> None:
+        """A discovery tool with no `tags` param (get_schema) simply drops the
+        unknown `platform` key rather than rejecting the whole call."""
+        tool = self._get_schema_tool()
+        result = await tool.run({"tools": ["central_get_sites"], "platform": "central"})
+        assert result.content
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("init_path", PLATFORM_INIT_FILES)
 def test_platform_init_registers_meta_tools_unconditionally(init_path: str) -> None:
     """v3.0.1.15 (issue #302): each platform's register_tools must call


### PR DESCRIPTION
## Summary

Closes #488 — the first of the code-mode small-model hardening set (#488–#493).

In code mode, the `search` discovery tool hard-rejected any undeclared argument. A small model searching for Central sites naturally calls:

```
search(query="sites list central", platform="central")
```

and got `Unexpected keyword argument` — the **whole call** was rejected, so `search` never ran. Since `search` is the discovery entry point, this dead-ended everything downstream (give-up loops, and in the worst case confabulated data).

## Root cause

fastmcp validates discovery-tool arguments against the **function signature** (`type_adapter.validate_python`), not against the published JSON schema. So relaxing `additionalProperties` would not have helped — and `**kwargs` is rejected by fastmcp's `from_function`. The lever that works is to **normalize arguments before validation**.

## Fix (structural — tool behavior, not guidance text)

New `_ArgTolerantFunctionTool` (overrides `run()`), applied to all three discovery tools (`search`, `tags`, `get_schema`):

- a `platform` arg is **folded into the existing `tags` filter** — platforms are catalog tags, so the model's intent is preserved and results stay relevance-scoped (verified: a `platform="central"` search returns only central-tagged tools);
- any other unknown key is dropped rather than failing the call.

The subclass is hoisted to module level (it depends only on core fastmcp, not the code-mode extra) so it is directly unit-testable.

## Verification

- Live-repro'd in the dev container: unwrapped fastmcp `Search` raises `ValidationError: platform: Unexpected keyword argument`; the tolerant tool accepts it, folds to tags, drops junk, and plain queries are unaffected.
- New behavioral tests in `tests/unit/test_server_code_mode.py` (`TestDiscoveryArgTolerance`): repro + fold + plain-query + no-tags-tool drop.
- Full suite: **1861 passed, 1 skipped**; ruff + format + mypy clean.

## Docs / version
- CHANGELOG entry; version `3.4.0.0 → 3.4.0.1` (patch). No tool-count or new-tool changes, so README/TOOLS/INSTRUCTIONS are unaffected.
