### PR TITLE
feat(code-mode): advertise optional `platform` arg in search schema (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0.2] - 2026-06-19
+
+**Patch — feat(code-mode): advertise the optional `platform` arg in the `search` schema (#496).** Follow-up to #488/#495: the discovery tools already *tolerate* a `platform` argument (folding it into the tag filter), but the published input schema didn't surface it, so only models passing it blind benefited. `search` now advertises `platform` as an optional parameter, letting schema-introspecting clients scope a search deliberately. Idea contributed by @gaoflow (#494).
+
+### Added
+- `search`'s published input schema now includes an optional `platform` parameter (string or list of strings) documenting the accepted platform names. It is advertised only on discovery tools that have a `tags` filter to act on it (in practice, `search`) — `tags`/`get_schema` are unchanged. Runtime behavior is identical: `run()` validates against the function signature, not the published schema, so the existing fold-into-tags tolerance (incl. list/scalar handling) is unaffected. (#496)
+
 ## [3.4.0.1] - 2026-06-19
 
 **Patch — fix(code-mode): `search` / `tags` / `get_schema` tolerate extra args (#488).** Small local models routinely call the discovery entry point with a natural-but-undeclared argument, e.g. `search(query="sites list central", platform="central")`. fastmcp validates discovery-tool arguments against the function signature, so any unknown kwarg raised `Unexpected keyword argument` and the **entire** call was rejected — dead-ending discovery and (per external small-model testing) cascading into give-up or confabulation. This is a structural fix at the tool-behavior layer; it does not rely on guidance text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.0.1"
+version = "3.4.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -601,14 +601,47 @@ class _ArgTolerantFunctionTool(FunctionTool):
         return await super().run(args)
 
 
+# Published-schema description for the optional `platform` argument (#496).
+_PLATFORM_ARG_SCHEMA: dict[str, Any] = {
+    "anyOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}],
+    "default": None,
+    "description": (
+        "Optional platform to scope results to — one name (e.g. 'central') or a "
+        "list. One of: mist, central, greenlake, clearpass, apstra, axis, aos8, "
+        "uxi, edgeconnect. Folded into the tag filter."
+    ),
+}
+
+
+def _advertise_platform_arg(tool: _ArgTolerantFunctionTool) -> None:
+    """Surface the tolerated ``platform`` arg in the published input schema (#496).
+
+    ``_ArgTolerantFunctionTool`` already *accepts* a ``platform`` argument and
+    folds it into ``tags`` (#488), but a model that introspects the schema has
+    no signal that ``platform`` is a first-class way to scope a call — it only
+    works for models that pass it blind. Advertising it lets schema-aware
+    clients use it deliberately. Only tools that actually have a ``tags`` filter
+    can act on ``platform``, so we add it solely where ``tags`` exists (in
+    practice: ``search``). Runtime behavior is unchanged — ``run`` validates
+    against the function signature, not this schema. Idea from @gaoflow (#494).
+    """
+    params = tool.parameters
+    props = params.get("properties") if isinstance(params, dict) else None
+    if props is not None and "tags" in props and "platform" not in props:
+        props["platform"] = dict(_PLATFORM_ARG_SCHEMA)
+
+
 def _make_arg_tolerant(tool: FunctionTool) -> _ArgTolerantFunctionTool:
     """Reconstruct a produced discovery Tool as the arg-tolerant subclass.
 
     fastmcp's discovery-tool factories always build a plain ``FunctionTool``;
     we copy its validated field values into ``_ArgTolerantFunctionTool`` so the
-    argument-normalizing ``run`` override takes effect (issue #488).
+    argument-normalizing ``run`` override takes effect (issue #488), then
+    advertise the optional ``platform`` arg in the published schema (#496).
     """
-    return _ArgTolerantFunctionTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
+    tolerant = _ArgTolerantFunctionTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
+    _advertise_platform_arg(tolerant)
+    return tolerant
 
 
 def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -251,6 +251,34 @@ class TestDiscoveryArgTolerance:
         result = await tool.run({"tools": ["central_get_sites"], "platform": "central"})
         assert result.content
 
+    def test_search_advertises_platform_in_published_schema(self) -> None:
+        """#496 (idea from @gaoflow #494): `search` advertises the optional
+        `platform` arg in its published input schema so schema-introspecting
+        clients use it deliberately — alongside the runtime tolerance."""
+        tool = self._search_tool(tolerant=True)
+        props = tool.parameters["properties"]
+        assert "platform" in props
+        # It's optional (not required) and documents the platform names.
+        assert "platform" not in tool.parameters.get("required", [])
+        assert "central" in props["platform"]["description"]
+
+    def test_get_schema_does_not_advertise_platform(self) -> None:
+        """`platform` is only advertised where a `tags` filter can act on it.
+        get_schema has no `tags` param, so it must NOT advertise `platform`
+        (advertising an arg it silently drops would be misleading)."""
+        tool = self._get_schema_tool()
+        assert "platform" not in tool.parameters.get("properties", {})
+
+    async def test_advertised_platform_still_folds_at_runtime(self) -> None:
+        """Advertising `platform` must not change runtime behavior — it still
+        folds into tags and scopes results (run() validates against the
+        signature, not the published schema)."""
+        tool = self._search_tool(tolerant=True)
+        result = await tool.run({"query": "get", "platform": "central"})
+        text = result.content[0].text
+        assert "central_get_sites" in text
+        assert "mist_get_self" not in text
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize("init_path", PLATFORM_INIT_FILES)


### PR DESCRIPTION
## Summary

Closes #496 — a follow-up to #488/#495, implementing the schema-advertisement idea contributed by @gaoflow in #494.

#495 made the code-mode discovery tools **tolerate** a `platform` argument (folding it into the existing `tags` filter), but the published input schema never surfaced it — so only models that pass `platform` blind benefited. This PR advertises `platform` as an optional parameter on `search`, so schema-introspecting clients can scope a search deliberately.

## Change

- `_advertise_platform_arg()` injects an optional `platform` property (string **or** list of strings, with the platform names documented) into the published schema — **only** for discovery tools that have a `tags` filter to act on it. In practice that's `search`; `tags` and `get_schema` (no `tags` param) are intentionally left unchanged, since advertising an arg they silently drop would be misleading.
- **Runtime behavior is unchanged.** `run()` validates against the function signature, not the published schema, so #495's fold-into-tags tolerance (including list/scalar handling) is untouched — this is purely additive advertisement.

## Tests (`tests/unit/test_server_code_mode.py`)
- `search` advertises `platform` (optional, documents platform names);
- `get_schema` does **not** advertise it;
- advertised `platform` still folds into tags and scopes results at runtime.
- Full suite: **1865 passed, 1 skipped**; ruff + format + mypy clean.

## Credit
Idea from @gaoflow's #494. Thanks again! 🙏

## Docs / version
- CHANGELOG entry; version `3.4.0.1 → 3.4.0.2` (patch).
