### PR TITLE
fix(code-mode): structured "did you mean" for Unknown tool errors (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0.3] - 2026-06-19
+
+**Patch — fix(code-mode): `Unknown tool` errors return a structured "did you mean" candidate list (#489).** A model that guessed a plausible-but-wrong tool name (e.g. `central_list_sites` when the real tool is `central_get_sites`) got a bare `Unknown tool` string with no recovery affordance — and (per external small-model testing) either looped on the identical call ~12× or concluded the platform was "unavailable" and gave up. The error now carries real, registered candidate names as **data**, so the model self-corrects. Structural fix — no reliance on guidance text.
+
+### Added
+- `platforms/_common/tool_suggest.py`: fuzzy tool-name suggester (`difflib` over the live `REGISTRIES`), scoped to the requested name's platform prefix where determinable. Returns `{error, requested, candidates, dispatch}`.
+- `UnknownToolSuggestMiddleware`: catches an `Unknown tool` error for any **top-level** call (a model treating a per-platform tool as first-class) and re-raises it as the structured payload.
+
+### Changed
+- `SandboxErrorCatchMiddleware` now converts an in-sandbox `Unknown tool: X` into the structured payload (the ~12×-retry case). Non-actionable cases — e.g. a model calling the top-level `search` tool from inside `execute` (#208), where there is no platform-tool to suggest — fall through to the existing readable error text unchanged.
+- The `<platform>_invoke_tool` / `<platform>_get_tool_schema` `not_found` responses now include a `candidates` list for a wrong inner tool name.
+
 ## [3.4.0.2] - 2026-06-19
 
 **Patch — feat(code-mode): advertise the optional `platform` arg in the `search` schema (#496).** Follow-up to #488/#495: the discovery tools already *tolerate* a `platform` argument (folding it into the tag filter), but the published input schema didn't surface it, so only models passing it blind benefited. `search` now advertises `platform` as an optional parameter, letting schema-introspecting clients scope a search deliberately. Idea contributed by @gaoflow (#494).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.0.2"
+version = "3.4.0.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -31,12 +31,17 @@ Syntax errors from stray indentation in model-generated code are another.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import mcp.types
 from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from loguru import logger
+
+from hpe_networking_mcp.platforms._common.tool_suggest import (
+    unknown_tool_payload_from_text,
+)
 
 # pydantic_monty ships in the fastmcp[code-mode] extra. If it's missing,
 # code mode itself can't run, so we don't need this middleware to act —
@@ -89,7 +94,13 @@ class SandboxErrorCatchMiddleware(Middleware):
             if not isinstance(cause, MontyError):
                 # Not a sandbox failure — let the masked ToolError propagate.
                 raise
-            error_text = f"Sandbox error: {cause}"
+            # An "Unknown tool: X" inside execute() is the single most common
+            # sandbox error (a model guessing a tool name). Turn it into a
+            # structured "did you mean" payload with real candidate names so
+            # the model self-corrects instead of looping on the same call
+            # (#489). The candidates are data, not an imperative.
+            suggestion = unknown_tool_payload_from_text(str(cause))
+            error_text = json.dumps(suggestion) if suggestion is not None else f"Sandbox error: {cause}"
             logger.debug("SandboxErrorCatch: caught on {} → {}", tool_name, error_text)
             # Re-raise so the wire response sets isError=true. Middleware
             # sits outside the masking layer, so this propagates with the

--- a/src/hpe_networking_mcp/middleware/unknown_tool_suggest.py
+++ b/src/hpe_networking_mcp/middleware/unknown_tool_suggest.py
@@ -1,0 +1,58 @@
+"""UnknownToolSuggestMiddleware — teach the model when it calls a missing tool.
+
+In code mode the only top-level tools are ``execute`` plus the discovery
+tools. A model that assumes per-platform tools are first-class calls
+``central_list_sites`` directly at the MCP surface and gets a bare
+``Unknown tool`` error, from which it typically concludes the platform is
+"unavailable" and gives up (#489).
+
+This middleware catches an ``Unknown tool`` failure for **any** top-level tool
+call and re-raises it as a structured "did you mean" payload carrying real,
+registered candidate names — so the model self-corrects instead of giving up.
+
+It is the top-surface companion to ``SandboxErrorCatchMiddleware``, which
+handles the same class of error for guesses made *inside* ``execute``. The two
+do not collide: the sandbox middleware emits a JSON payload whose text does
+not contain the ``Unknown tool:`` phrase, so this middleware leaves it
+untouched regardless of ordering.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import mcp.types
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from loguru import logger
+
+from hpe_networking_mcp.platforms._common.tool_suggest import (
+    unknown_tool_payload_from_text,
+)
+
+
+class UnknownToolSuggestMiddleware(Middleware):
+    """Convert a top-level ``Unknown tool`` error into a structured suggestion.
+
+    Re-raises (rather than returning a result) so the wire response keeps
+    ``isError: true`` while carrying the readable candidate list in the
+    content — matching the contract ``SandboxErrorCatchMiddleware`` uses.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: Any,
+    ) -> Any:
+        try:
+            return await call_next(context)
+        except Exception as e:
+            # Only act on an "Unknown tool: X" error; everything else (real
+            # tool failures, validation, sandbox payloads already formatted by
+            # SandboxErrorCatch) passes through unchanged.
+            payload = unknown_tool_payload_from_text(str(e))
+            if payload is None:
+                raise
+            logger.debug("UnknownToolSuggest: {} → {}", getattr(context.message, "name", ""), payload)
+            raise ToolError(json.dumps(payload)) from e

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -31,6 +31,7 @@ from hpe_networking_mcp.platforms._common.tool_registry import (
     ToolSpec,
     is_tool_enabled,
 )
+from hpe_networking_mcp.platforms._common.tool_suggest import suggest_tools
 
 # Parameter names we strip from the Pydantic validation model because
 # ``_invoke_tool`` injects them itself.
@@ -357,6 +358,7 @@ def build_meta_tools(
                 "status": "not_found",
                 "message": f"{platform} has no tool named {name!r}.",
                 "hint": f"Call {platform}_list_tools to see available tools.",
+                "candidates": suggest_tools(name, platform=platform)["candidates"],
             }
         config = ctx.lifespan_context.get("config")
         if not is_tool_enabled(spec, config):
@@ -437,6 +439,7 @@ def build_meta_tools(
                 "status": "not_found",
                 "message": f"{platform} has no tool named {name!r}.",
                 "hint": f"Call {platform}_list_tools to see available tools.",
+                "candidates": suggest_tools(name, platform=platform)["candidates"],
             }
         config = ctx.lifespan_context.get("config")
         if not is_tool_enabled(spec, config):

--- a/src/hpe_networking_mcp/platforms/_common/tool_suggest.py
+++ b/src/hpe_networking_mcp/platforms/_common/tool_suggest.py
@@ -1,0 +1,115 @@
+"""Fuzzy "did you mean" tool-name suggestions for unknown-tool errors (#489).
+
+When a model guesses a plausible-but-wrong tool name — e.g.
+``central_list_sites`` when the real tool is ``central_get_sites`` — a bare
+``Unknown tool`` string gives it nothing to self-correct from, so it either
+loops on the identical call or gives up. This module turns that dead-end into
+structured **result data**: a ranked list of real, registered tool names plus
+the universal dispatch hint.
+
+The suggestion is data, not an imperative. It carries no "call X first" prose
+(skills-first is handled structurally elsewhere, #493) — the model consumes
+the candidate list as an observation and self-corrects, which is the normal
+agent loop.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+# fastmcp raises ``NotFoundError("Unknown tool: <name>")`` for an unresolved
+# name; inside the code-mode sandbox that surfaces as a MontyError whose text
+# still contains the phrase. The top-surface NotFoundError quotes the name
+# (``Unknown tool: 'central_x'``) while the in-sandbox text does not, so the
+# optional quote is tolerated. Tool names are ``[a-z0-9_]+``.
+_UNKNOWN_TOOL_RE = re.compile(r"""Unknown tool:\s*['"]?([A-Za-z0-9_]+)""")
+
+_FUZZY_CUTOFF = 0.6
+
+
+def _name_to_platform() -> dict[str, str]:
+    """Map every registered underlying tool name to its platform.
+
+    Built fresh on each call so it reflects the live registry (tests mutate
+    ``REGISTRIES``; the corpus is small enough that rebuilding is cheap).
+    """
+    out: dict[str, str] = {}
+    for platform, reg in REGISTRIES.items():
+        if platform == "_template":
+            continue
+        for name in reg:
+            out[name] = platform
+    return out
+
+
+def _platform_from_name(name: str) -> str | None:
+    """Best-effort platform from a tool name's prefix (``central_get_x`` -> ``central``)."""
+    head = name.split("_", 1)[0].lower()
+    return head if head in REGISTRIES and head != "_template" else None
+
+
+def suggest_tools(requested: str, *, platform: str | None = None, limit: int = 5) -> dict:
+    """Build a structured ``did you mean`` payload for an unknown tool name.
+
+    Args:
+        requested: The (wrong) tool name the model asked for.
+        platform: Scope candidates to this platform when known (the meta-tool
+            call sites know it). When ``None`` it is inferred from the name's
+            prefix, falling back to the full corpus.
+        limit: Maximum number of candidate names to return.
+
+    Returns:
+        ``{"error": "unknown_tool", "requested": ..., "candidates": [...],
+        "dispatch": "<platform>_invoke_tool(name, params)"}``. ``dispatch`` is
+        omitted only when no platform can be determined. ``candidates`` is a
+        list of real registered tool names ranked by similarity (possibly
+        empty).
+    """
+    requested = (requested or "").strip()
+    name_to_platform = _name_to_platform()
+    plat = platform or _platform_from_name(requested)
+
+    # Prefer same-platform candidates; widen to the full corpus if the scoped
+    # search finds nothing.
+    scoped = [n for n, p in name_to_platform.items() if plat is None or p == plat]
+    candidates = difflib.get_close_matches(requested, scoped, n=limit, cutoff=_FUZZY_CUTOFF)
+    if not candidates and plat is not None:
+        candidates = difflib.get_close_matches(requested, list(name_to_platform), n=limit, cutoff=_FUZZY_CUTOFF)
+    # Last resort: substring overlap (handles list_sites <-> get_sites where the
+    # shared token is short enough to fall under the fuzzy cutoff).
+    if not candidates and requested:
+        low = requested.lower()
+        candidates = sorted(n for n in scoped if low in n.lower() or n.lower() in low)[:limit]
+
+    payload: dict = {
+        "error": "unknown_tool",
+        "requested": requested,
+        "candidates": candidates,
+    }
+    if plat is not None:
+        payload["dispatch"] = f"{plat}_invoke_tool(name, params)"
+    return payload
+
+
+def unknown_tool_payload_from_text(text: str) -> dict | None:
+    """Return a ``did you mean`` payload if ``text`` is an ``Unknown tool`` error.
+
+    Parses the ``Unknown tool: <name>`` phrase out of a sandbox error string
+    and resolves candidates. Returns ``None`` when the text is some other
+    error, so the caller can fall through to its generic handling.
+    """
+    match = _UNKNOWN_TOOL_RE.search(text or "")
+    if not match:
+        return None
+    payload = suggest_tools(match.group(1))
+    # Only surface the structured payload when it is actionable — a resolved
+    # platform dispatch hint or at least one real candidate name. A bare name
+    # with neither (e.g. a model calling the top-level `search` tool from
+    # inside execute, #208 — not a platform-tool typo) falls through to the
+    # caller's plain error text so that behavior is preserved.
+    if payload.get("dispatch") or payload.get("candidates"):
+        return payload
+    return None

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -325,6 +325,9 @@ def create_server(config: ServerConfig) -> FastMCP:
     from hpe_networking_mcp.middleware.sandbox_error_catch import (
         SandboxErrorCatchMiddleware,
     )
+    from hpe_networking_mcp.middleware.unknown_tool_suggest import (
+        UnknownToolSuggestMiddleware,
+    )
     from hpe_networking_mcp.middleware.validation_catch import ValidationCatchMiddleware
     from hpe_networking_mcp.redaction.token_store import TokenStore
 
@@ -337,6 +340,8 @@ def create_server(config: ServerConfig) -> FastMCP:
     #   NullStrip           — drop nulls before validation
     #   ValidationCatch     — Pydantic ValidationError → readable string return
     #   SandboxErrorCatch   — code-mode MontyRuntimeError on execute → string return
+    #   UnknownToolSuggest  — top-level "Unknown tool" → structured "did you
+    #                         mean" candidate list (#489)
     #   PIITokenization     — detokenize inbound args / tokenize outbound results
     #                         (always normalizes MACs even when toggle is off)
     #   Elicitation         — write-tool confirmation gate; user sees real values
@@ -357,6 +362,7 @@ def create_server(config: ServerConfig) -> FastMCP:
             NullStripMiddleware(),
             ValidationCatchMiddleware(),
             SandboxErrorCatchMiddleware(),
+            UnknownToolSuggestMiddleware(),
             PIITokenizationMiddleware(token_store, enabled=config.enable_pii_tokenization),
             ElicitationMiddleware(),
             RetryMiddleware(),

--- a/tests/unit/test_tool_suggest.py
+++ b/tests/unit/test_tool_suggest.py
@@ -1,0 +1,138 @@
+"""Unit tests for the unknown-tool "did you mean" suggestion layer (#489).
+
+Covers the pure suggestion helper, the error-text parser, and the top-surface
+``UnknownToolSuggestMiddleware``. The in-sandbox glue in
+``SandboxErrorCatchMiddleware`` reuses the same helper (``MontyError`` is not
+directly instantiable, so the helper is the testable seam).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp.exceptions import NotFoundError, ToolError
+
+from hpe_networking_mcp.platforms._common import tool_registry
+from hpe_networking_mcp.platforms._common.tool_registry import ToolSpec
+from hpe_networking_mcp.platforms._common.tool_suggest import (
+    suggest_tools,
+    unknown_tool_payload_from_text,
+)
+
+
+@pytest.fixture
+def fake_registry():
+    """Inject a few fake central/mist tools into REGISTRIES; clean up after."""
+    reg = tool_registry.REGISTRIES
+    added = {
+        "central": [
+            "central_get_sites",
+            "central_get_site_name_id_mapping",
+            "central_get_aps",
+        ],
+        "mist": ["mist_get_self", "mist_list_sites"],
+    }
+
+    def _spec(name: str, platform: str) -> ToolSpec:
+        return ToolSpec(name=name, func=lambda: None, platform=platform, category="test")
+
+    for plat, names in added.items():
+        for n in names:
+            reg[plat][n] = _spec(n, plat)
+    yield
+    for plat, names in added.items():
+        for n in names:
+            reg[plat].pop(n, None)
+
+
+@pytest.mark.unit
+class TestSuggestTools:
+    def test_close_match_scoped_to_platform_prefix(self, fake_registry) -> None:
+        out = suggest_tools("central_list_sites")
+        assert out["error"] == "unknown_tool"
+        assert out["requested"] == "central_list_sites"
+        assert "central_get_sites" in out["candidates"]
+        # scoped by the `central_` prefix — no cross-platform noise
+        assert all(not c.startswith("mist_") for c in out["candidates"])
+        assert out["dispatch"] == "central_invoke_tool(name, params)"
+
+    def test_explicit_platform_scopes_unprefixed_name(self, fake_registry) -> None:
+        out = suggest_tools("get_site", platform="central")
+        assert out["candidates"]
+        assert all(c.startswith("central_") for c in out["candidates"])
+        assert out["dispatch"] == "central_invoke_tool(name, params)"
+
+    def test_unknown_platform_has_no_dispatch(self, fake_registry) -> None:
+        out = suggest_tools("zzz_made_up_thing")
+        assert "dispatch" not in out  # no resolvable platform
+        assert out["candidates"] == [] or all(isinstance(c, str) for c in out["candidates"])
+
+    def test_substring_fallback_when_below_fuzzy_cutoff(self, fake_registry) -> None:
+        # "sites" is a short shared token; ensure it still surfaces matches
+        out = suggest_tools("central_sites")
+        assert any("sites" in c for c in out["candidates"])
+
+
+@pytest.mark.unit
+class TestUnknownToolPayloadFromText:
+    def test_parses_unquoted_in_sandbox_form(self, fake_registry) -> None:
+        out = unknown_tool_payload_from_text("Unknown tool: central_list_sites")
+        assert out is not None
+        assert out["requested"] == "central_list_sites"
+        assert "central_get_sites" in out["candidates"]
+
+    def test_parses_quoted_top_surface_form(self, fake_registry) -> None:
+        out = unknown_tool_payload_from_text("Unknown tool: 'central_list_sites'")
+        assert out is not None
+        assert out["requested"] == "central_list_sites"
+
+    def test_returns_none_for_unrelated_error(self) -> None:
+        assert unknown_tool_payload_from_text("Some other sandbox error") is None
+        assert unknown_tool_payload_from_text("") is None
+
+    def test_returns_none_for_nonactionable_discovery_tool(self, fake_registry) -> None:
+        """#208 preserved: a model calling the top-level `search` tool from
+        inside execute is not a platform-tool typo — no platform prefix and no
+        candidates — so the helper declines (caller keeps its plain text)."""
+        assert unknown_tool_payload_from_text("Unknown tool: search") is None
+
+
+@pytest.mark.unit
+class TestUnknownToolSuggestMiddleware:
+    async def test_reraises_structured_payload(self, fake_registry) -> None:
+        from hpe_networking_mcp.middleware.unknown_tool_suggest import (
+            UnknownToolSuggestMiddleware,
+        )
+
+        mw = UnknownToolSuggestMiddleware()
+
+        class _Ctx:
+            message = type("M", (), {"name": "central_list_sites"})()
+
+        async def call_next(ctx):
+            raise NotFoundError("Unknown tool: 'central_list_sites'")
+
+        with pytest.raises(ToolError) as ei:
+            await mw.on_call_tool(_Ctx(), call_next)
+        payload = json.loads(str(ei.value))
+        assert payload["error"] == "unknown_tool"
+        assert payload["requested"] == "central_list_sites"
+        assert "central_get_sites" in payload["candidates"]
+        assert payload["dispatch"] == "central_invoke_tool(name, params)"
+
+    async def test_passthrough_unrelated_error(self) -> None:
+        from hpe_networking_mcp.middleware.unknown_tool_suggest import (
+            UnknownToolSuggestMiddleware,
+        )
+
+        mw = UnknownToolSuggestMiddleware()
+
+        class _Ctx:
+            message = type("M", (), {"name": "x"})()
+
+        async def call_next(ctx):
+            raise ValueError("totally unrelated")
+
+        with pytest.raises(ValueError):
+            await mw.on_call_tool(_Ctx(), call_next)


### PR DESCRIPTION
## Summary

Closes #489 — second of the code-mode small-model hardening set (#488–#493).

A model that guessed a plausible-but-wrong tool name (e.g. `central_list_sites` when the real tool is `central_get_sites`) got a bare `Unknown tool` string with no recovery affordance. Per external small-model testing it then either **looped on the identical call ~12×** or concluded the platform was "unavailable" and gave up. The error now carries real, registered candidate names as **data**, so the model self-corrects.

## Two surfaces (both verified in the dev container)

- **In-sandbox** — a bare `await call_tool("central_list_sites", ...)` raises `NotFoundError("Unknown tool: ...")`, surfacing through `SandboxErrorCatchMiddleware`. It now emits the structured payload.
- **Top-surface** — a model calling `central_list_sites` directly at the MCP surface. Probed that `on_call_tool` middleware *does* fire for an unknown top-level tool (even with `mask_error_details=True`, the resolution error reaches middleware unmasked), so a new `UnknownToolSuggestMiddleware` handles it.

## Payload (data, not imperatives)

```json
{ "error": "unknown_tool", "requested": "central_list_sites",
  "candidates": ["central_get_sites", "central_get_site_name_id_mapping"],
  "dispatch": "central_invoke_tool(name, params)" }
```

- `platforms/_common/tool_suggest.py` — `difflib` over the live `REGISTRIES`, scoped to the requested name's platform prefix where determinable, with a substring fallback.
- Carries **no** skills-first prose (#493 owns that structurally); the in-sandbox path does not bounce the model back to `skills_list`.
- **Conservative:** only fires when actionable (a resolved platform or real candidates). The #208 case — a model calling the top-level `search` tool from inside `execute` — has no platform-tool to suggest, so it falls through to the existing readable text unchanged (existing middleware test still green).
- `<platform>_invoke_tool` / `<platform>_get_tool_schema` `not_found` responses now include `candidates` for a wrong inner name.

## Tests
- New `tests/unit/test_tool_suggest.py`: suggester scoping/fallback, quoted vs unquoted parsing, the #208 non-actionable passthrough, and the top-surface middleware (re-raise + passthrough).
- Full suite: **1875 passed, 1 skipped**; ruff + format + mypy clean.

## Docs / version
- CHANGELOG entry; version `3.4.0.2 → 3.4.0.3` (patch).
