### PR TITLE
fix(code-mode): compact skills_list payload (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0.4] - 2026-06-19
+
+**Patch — fix(code-mode): compact `skills_list` payload (#490).** `skills_list` returned every matching skill's full multi-paragraph description **and** complete tool array — ~30k+ characters for ~15 skills — as a small model's *first* tool result (it's the prerequisite call before `execute`), flooding the context before any work began. The default listing is now compact, with full detail one `skills_load` away.
+
+### Changed
+- `skills_list` returns a compact entry per skill — `name`, `title`, `tags`, `platforms`, `load_with` — by default (new `Skill.to_summary()`). The full `description` and `tools[]` remain available via `skills_load` (unchanged) or by passing the new `detail=true` parameter to `skills_list`. ~90% payload reduction with no loss of discoverability. (#490)
+
 ## [3.4.0.3] - 2026-06-19
 
 **Patch — fix(code-mode): `Unknown tool` errors return a structured "did you mean" candidate list (#489).** A model that guessed a plausible-but-wrong tool name (e.g. `central_list_sites` when the real tool is `central_get_sites`) got a bare `Unknown tool` string with no recovery affordance — and (per external small-model testing) either looped on the identical call ~12× or concluded the platform was "unavailable" and gave up. The error now carries real, registered candidate names as **data**, so the model self-corrects. Structural fix — no reliance on guidance text.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.0.3"
+version = "3.4.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/_engine.py
+++ b/src/hpe_networking_mcp/skills/_engine.py
@@ -66,6 +66,23 @@ class Skill:
             "tools": list(self.tools),
         }
 
+    def to_summary(self) -> dict[str, Any]:
+        """Return a compact listing entry for ``skills_list`` (#490).
+
+        Omits the (often multi-paragraph) ``description`` and the full
+        ``tools`` array — both live behind ``skills_load``. Keeps just enough
+        to judge relevance and load the right skill. Across ~15 matching
+        skills this is roughly a 90% payload reduction versus
+        ``to_metadata``, which otherwise floods a small model's context on
+        its very first tool result.
+        """
+        return {
+            "name": self.name,
+            "title": self.title,
+            "platforms": list(self.platforms),
+            "tags": list(self.tags),
+        }
+
 
 def _as_str_tuple(value: Any) -> tuple[str, ...]:
     """Coerce a frontmatter list-or-None field to a tuple of strings."""
@@ -223,10 +240,12 @@ _SKILLS_LIST_DESC = (
     "procedures for AOS 8 → Central migration, infrastructure health "
     "checks, RF / channel-planning checks, change pre-check / post-check, "
     "WLAN sync validation, scope audits (mist / central), and morning "
-    "network reports. Returns skill metadata only — if a skill matches, "
-    "call `skills_load(name)` for the full runbook and follow it. Optional "
-    "`platform` / `tag` filters each accept a string or list of strings. "
-    "Only proceed to `search` / `execute` / platform tools when "
+    "network reports. Returns a compact listing (name / title / tags / "
+    "platforms) — if a skill matches, call `skills_load(name)` for its full "
+    "description, tool list, and runbook body, then follow it. Optional "
+    "`platform` / `tag` filters each accept a string or list of strings; pass "
+    "`detail=true` to include each skill's full description and tool list "
+    "inline. Only proceed to `search` / `execute` / platform tools when "
     "`skills_list` returns no applicable skill."
 )
 
@@ -262,11 +281,15 @@ def _make_skills_list_fn(registry: SkillRegistry):
         ctx: Context = None,  # type: ignore[assignment]
         platform: str | list[str] | None = None,
         tag: str | list[str] | None = None,
+        detail: bool = False,
     ) -> dict[str, Any]:
         results = registry.filter(platform=platform, tag=tag)
         skills: list[dict[str, Any]] = []
         for s in results:
-            entry = s.to_metadata()
+            # Compact by default (#490): full description + tools[] live behind
+            # skills_load, so the first discovery result doesn't flood a small
+            # model's context. detail=True restores the full metadata.
+            entry = s.to_metadata() if detail else s.to_summary()
             # The literal next call to make for this skill — issue #336.
             entry["load_with"] = f"skills_load(name={s.name!r})"
             skills.append(entry)

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -372,6 +372,34 @@ class TestDiscoveryToolFactories:
             assert entry["load_with"] == f"skills_load(name={entry['name']!r})"
 
     @pytest.mark.asyncio
+    async def test_skills_list_compact_by_default(self):
+        """#490: the default listing is compact — name / title / tags /
+        platforms / load_with only. The full description and tools[] live
+        behind skills_load so the first result doesn't flood a small model."""
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry([_skill("alpha", platforms=("mist",), tags=("health",))])
+        tool = SkillsListDiscoveryTool(reg)(get_catalog=None)
+        entry = (await tool.fn())["skills"][0]
+
+        assert set(entry) == {"name", "title", "platforms", "tags", "load_with"}
+        assert "description" not in entry
+        assert "tools" not in entry
+
+    @pytest.mark.asyncio
+    async def test_skills_list_detail_true_includes_full_metadata(self):
+        """#490: detail=true restores the full description + tools[] inline."""
+        from hpe_networking_mcp.skills._engine import SkillsListDiscoveryTool
+
+        reg = SkillRegistry([_skill("alpha", platforms=("mist",), tags=("health",))])
+        tool = SkillsListDiscoveryTool(reg)(get_catalog=None)
+        entry = (await tool.fn(detail=True))["skills"][0]
+
+        assert "description" in entry
+        assert "tools" in entry
+        assert entry["load_with"] == "skills_load(name='alpha')"
+
+    @pytest.mark.asyncio
     async def test_skills_list_factory_empty_result_has_fallback_next_step(self):
         """Issue #336: with no matches, next_step tells the AI to fall back
         to per-platform tools rather than (wrongly) pushing skills_load."""


### PR DESCRIPTION
## Summary

Closes #490 — third of the code-mode small-model hardening set (#488–#493). Now rebased directly onto `main` (the #489 dependency merged in #498).

`skills_list` returned every matching skill's full multi-paragraph description **and** complete tool array — ~30k+ characters for ~15 skills — as a small model's *first* tool result (it's the prerequisite call before `execute`). On a 4B-class model that floods/poisons the context before any work begins, contributing to the give-up and repetition-collapse seen in testing.

## Change

- New `Skill.to_summary()` → compact entry: `name`, `title`, `tags`, `platforms` (+ the existing `load_with`).
- `skills_list` returns the compact form **by default**; the full `description` + `tools[]` stay behind `skills_load` (unchanged) or inline via a new `detail=true` parameter.
- Tool description updated to reflect the compact listing + `detail` toggle.
- ~90% payload reduction with no loss of discoverability — `name` + `load_with` are all a model needs to drill in.

## Tests
- New `test_skills.py` cases: compact-by-default (asserts `description`/`tools` absent), and `detail=true` restores them. Existing factory tests still pass.
- Full suite: 1867 passed, 1 skipped; ruff + format + mypy clean.

## Docs / version
- CHANGELOG entry; version `3.4.0.3 → 3.4.0.4` (patch).
