### PR TITLE
feat(code-mode): surface matching skills as search result data (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1.2] - 2026-06-19
+
+**Patch — feat(code-mode): surface matching skills as `search` result data (#493).** Skills-first was enforced only through untrusted channels — the server `instructions` blob and prepended tool-description prose — which frontier models do not reliably honor. This makes it structural: when a code-mode `search` query matches a bundled skill, the match list is **prepended to the search result** as an observation the model acts on, not an instruction it must trust. Completes the code-mode small-model hardening set (#488–#493).
+
+### Added
+- `SkillRegistry.match(query, limit=3)`: lightweight token-overlap matcher (skill name / title / tags / platforms), ties broken by name. Short domain terms like `rf` survive; generic fillers/verbs are stopworded.
+- `_SkillAwareSearchTool` (`server.py`): the code-mode `search` tool now prepends a `MATCHING SKILLS` block (each with its `skills_load(name=…)` call) when the query matches a bundled skill. Inert when no skill matches. Inherits the #488 arg-tolerance and #496 `platform` advertisement.
+
+### Notes
+- The existing prose skills-first gate (`_SKILLS_FIRST_GATE` on the discovery descriptions, `execute` PREREQUISITE) is retained as a complementary hint for models that do honor it — this PR adds the durable, model-agnostic mechanism alongside it.
+
 ## [3.4.1.1] - 2026-06-19
 
 **Patch — fix(docs): scrub parrot-able example values from shipped artifacts (#492).** Part 2 of #492 (the confabulation root cause was already addressed structurally by #488–#491). A small model that exhausted discovery had fabricated a site with a realistic-looking ID; this pass removes example values realistic enough to be regurgitated as live data, replacing them with self-evidently synthetic placeholders. An audit of shipped runtime artifacts (`INSTRUCTIONS.md`, `skills/*.md`, tool docstrings) found **no** parrot-able hex/numeric IDs — only a few realistic names/addresses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.1.1"
+version = "3.4.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -650,6 +650,55 @@ def _make_arg_tolerant(tool: FunctionTool) -> _ArgTolerantFunctionTool:
     return tolerant
 
 
+# Set during _register_code_mode so the skill-aware `search` tool — which is
+# reconstructed via model_fields and therefore can't carry instance state —
+# can reach the skill registry at request time (issue #493).
+_SEARCH_SKILL_REGISTRY: Any = None
+
+
+def _render_skill_matches(matches: list) -> str:
+    """Render matched skills as an observation block prepended to search results (#493)."""
+    lines = ["MATCHING SKILLS (vetted runbooks — load with skills_load before improvising):"]
+    for s in matches:
+        lines.append(f"- {s.name} — {s.title}  ->  skills_load(name={s.name!r})")
+    return "\n".join(lines)
+
+
+class _SkillAwareSearchTool(_ArgTolerantFunctionTool):
+    """`search` that surfaces matching bundled skills as result data (issue #493).
+
+    Skills-first was previously enforced only through untrusted channels — the
+    server ``instructions`` blob and prepended description prose, which frontier
+    models do not reliably honor. This makes it structural: when the query
+    matches a bundled skill, the match list is prepended to the search result
+    as an observation the model acts on, not an instruction it must trust.
+    Builds on the arg-tolerant ``run`` (#488); inert if no registry is set or
+    no skill matches.
+    """
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        result = await super().run(arguments)
+        registry = _SEARCH_SKILL_REGISTRY
+        query = (arguments or {}).get("query", "")
+        if registry is None or not isinstance(query, str):
+            return result
+        matches = registry.match(query)
+        if not matches:
+            return result
+        from mcp.types import TextContent
+
+        result.content = [TextContent(type="text", text=_render_skill_matches(matches)), *result.content]
+        return result
+
+
+def _make_skill_aware_search(tool: FunctionTool) -> _SkillAwareSearchTool:
+    """Reconstruct the produced `search` tool as the skill-aware subclass (#493),
+    preserving the #488 arg-tolerance and #496 platform advertisement."""
+    aware = _SkillAwareSearchTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
+    _advertise_platform_arg(aware)
+    return aware
+
+
 def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
@@ -685,7 +734,7 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
         def __call__(self, get_catalog):
             tool = super().__call__(get_catalog)
             tool.description = _SEARCH_DESCRIPTION
-            return _make_arg_tolerant(tool)
+            return _make_skill_aware_search(tool)
 
     class _HpeGetTags(GetTags):
         def __call__(self, get_catalog):
@@ -772,6 +821,10 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     )
 
     skill_registry = SkillRegistry.from_directory()
+    # Expose the registry to the skill-aware `search` tool so it can surface
+    # matching skills as result data at request time (issue #493).
+    global _SEARCH_SKILL_REGISTRY
+    _SEARCH_SKILL_REGISTRY = skill_registry
     logger.info("Skills: registered {} skill(s) (code mode discovery layer)", len(skill_registry.all()))
 
     # Heterogeneous discovery-tool factories (the _Hpe* subclasses, the Skills

--- a/src/hpe_networking_mcp/skills/_engine.py
+++ b/src/hpe_networking_mcp/skills/_engine.py
@@ -175,6 +175,66 @@ def _coerce_filter(value: str | list[str] | None) -> set[str] | None:
     return {str(v) for v in value}
 
 
+# Generic filler/verb tokens that don't discriminate between skills. Kept
+# deliberately small: discriminating domain terms that happen to be short
+# (e.g. "rf") or appear in skill names (e.g. "check", "scope") are NOT
+# stopworded — over-pruning misses real matches.
+_MATCH_STOPWORDS = frozenset(
+    {
+        "the",
+        "for",
+        "all",
+        "and",
+        "with",
+        "from",
+        "this",
+        "that",
+        "any",
+        "are",
+        "what",
+        "which",
+        "how",
+        "please",
+        "need",
+        "give",
+        "get",
+        "show",
+        "list",
+        "find",
+        "to",
+        "of",
+        "is",
+        "in",
+        "on",
+        "or",
+        "no",
+        "my",
+        "we",
+        "it",
+        "be",
+        "as",
+        "at",
+        "by",
+        "do",
+        "an",
+    }
+)
+
+
+def _match_tokens(text: str) -> set[str]:
+    """Tokenize free text into significant lowercase tokens for skill matching.
+
+    Min length 2 so short domain terms like ``rf`` survive; stopwords drop
+    generic fillers/verbs that would otherwise cause spurious overlap.
+    """
+    out: set[str] = set()
+    for raw in text.replace("-", " ").replace("_", " ").replace("/", " ").split():
+        tok = "".join(c for c in raw.lower() if c.isalnum())
+        if len(tok) >= 2 and tok not in _MATCH_STOPWORDS:
+            out.add(tok)
+    return out
+
+
 class SkillRegistry:
     """In-memory skill index built once at server startup."""
 
@@ -208,6 +268,28 @@ class SkillRegistry:
         if wanted_tags is not None:
             results = [s for s in results if any(t in wanted_tags for t in s.tags)]
         return results
+
+    def match(self, query: str, *, limit: int = 3) -> list[Skill]:
+        """Free-text match a query to bundled skills, best first (#493).
+
+        Lightweight token-overlap scoring against each skill's name / title /
+        tags / platforms. Returns skills sharing at least one significant
+        token with the query, most-overlapping first (ties broken by name),
+        capped at ``limit``. Drives the structural skills-first surfacing in
+        code-mode ``search`` results — a skill match arrives as observation
+        data, not prose the model must trust.
+        """
+        q_tokens = _match_tokens(query or "")
+        if not q_tokens:
+            return []
+        scored: list[tuple[int, Skill]] = []
+        for skill in self.all():
+            searchable = " ".join([skill.name, skill.title, " ".join(skill.tags), " ".join(skill.platforms)])
+            overlap = len(q_tokens & _match_tokens(searchable))
+            if overlap:
+                scored.append((overlap, skill))
+        scored.sort(key=lambda pair: (-pair[0], pair[1].name))
+        return [skill for _score, skill in scored[:limit]]
 
     def lookup(self, name: str) -> Skill | list[Skill] | None:
         """Return one ``Skill`` on exact match, a list on multiple substring

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -281,6 +281,79 @@ class TestDiscoveryArgTolerance:
 
 
 @pytest.mark.unit
+class TestSkillAwareSearch:
+    """#493: `search` surfaces matching bundled skills as result data, so
+    skills-first is structural (an observation in the result) rather than
+    prose in the tool description that frontier models ignore.
+    """
+
+    @staticmethod
+    def _catalog():
+        from fastmcp.tools.tool import Tool
+
+        async def central_get_sites() -> dict:
+            return {}
+
+        return [Tool.from_function(fn=central_get_sites, name="central_get_sites", tags={"central"})]
+
+    def _search_tool(self):
+        from fastmcp.experimental.transforms.code_mode import Search
+
+        catalog = self._catalog()
+
+        async def get_catalog(ctx=None):
+            return catalog
+
+        base = Search(default_detail="brief")(get_catalog)
+        return srv._make_skill_aware_search(base)
+
+    @staticmethod
+    def _registry():
+        from hpe_networking_mcp.skills._engine import Skill, SkillRegistry
+
+        return SkillRegistry(
+            [
+                Skill(
+                    name="central-site-dashboard",
+                    title="Single-site Central dashboard",
+                    description="d",
+                    platforms=("central",),
+                    tags=("dashboard", "site"),
+                )
+            ]
+        )
+
+    async def test_matching_query_prepends_skill_block(self, monkeypatch) -> None:
+        monkeypatch.setattr(srv, "_SEARCH_SKILL_REGISTRY", self._registry())
+        tool = self._search_tool()
+        assert isinstance(tool, srv._SkillAwareSearchTool)
+        result = await tool.run({"query": "central site dashboard"})
+        text = result.content[0].text
+        assert "MATCHING SKILLS" in text
+        assert "central-site-dashboard" in text
+        assert "skills_load(name='central-site-dashboard')" in text
+
+    async def test_non_matching_query_has_no_skill_block(self, monkeypatch) -> None:
+        monkeypatch.setattr(srv, "_SEARCH_SKILL_REGISTRY", self._registry())
+        tool = self._search_tool()
+        result = await tool.run({"query": "switches"})
+        assert "MATCHING SKILLS" not in result.content[0].text
+
+    async def test_no_registry_is_inert(self, monkeypatch) -> None:
+        monkeypatch.setattr(srv, "_SEARCH_SKILL_REGISTRY", None)
+        tool = self._search_tool()
+        result = await tool.run({"query": "central site dashboard"})
+        assert "MATCHING SKILLS" not in result.content[0].text
+
+    async def test_arg_tolerance_still_applies(self, monkeypatch) -> None:
+        # #488 behavior is inherited: an extra `platform` arg must not reject.
+        monkeypatch.setattr(srv, "_SEARCH_SKILL_REGISTRY", self._registry())
+        tool = self._search_tool()
+        result = await tool.run({"query": "sites", "platform": "central", "junk": 1})
+        assert result.content
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("init_path", PLATFORM_INIT_FILES)
 def test_platform_init_registers_meta_tools_unconditionally(init_path: str) -> None:
     """v3.0.1.15 (issue #302): each platform's register_tools must call

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -170,6 +170,39 @@ def registry() -> SkillRegistry:
 
 
 @pytest.mark.unit
+class TestRegistryMatch:
+    """Free-text skill matching that drives structural skills-first (#493)."""
+
+    def test_matches_on_tag_tokens(self, registry):
+        matches = registry.match("sync wlan")
+        assert [s.name for s in matches] == ["alpha-sync"]
+
+    def test_matches_on_name_token(self, registry):
+        matches = registry.match("health")
+        assert [s.name for s in matches] == ["alpha-health"]
+
+    def test_ranks_by_overlap(self, registry):
+        # "alpha" hits both alpha-* skills; "sync" additionally hits alpha-sync,
+        # so alpha-sync (overlap 2) must rank above alpha-health (overlap 1).
+        matches = registry.match("alpha sync")
+        assert matches[0].name == "alpha-sync"
+        assert {s.name for s in matches} == {"alpha-sync", "alpha-health"}
+
+    def test_respects_limit(self, registry):
+        assert len(registry.match("alpha", limit=1)) == 1
+
+    def test_no_match_returns_empty(self, registry):
+        assert registry.match("nonexistent zzzz") == []
+
+    def test_empty_query_returns_empty(self, registry):
+        assert registry.match("") == []
+
+    def test_generic_filler_tokens_do_not_match(self, registry):
+        # "the", "for", "all" are stopwords; "list"/"get" are generic verbs.
+        assert registry.match("list all the get") == []
+
+
+@pytest.mark.unit
 class TestRegistryFilter:
     def test_no_filter_returns_all(self, registry):
         assert {s.name for s in registry.filter()} == {


### PR DESCRIPTION
## Summary

Closes #493 — the **final** issue of the code-mode small-model hardening set (#488–#493).

Skills-first was enforced only through **untrusted channels**: the server `instructions` blob and prepended tool-description prose (`_SKILLS_FIRST_GATE`, the `execute` PREREQUISITE line). Frontier models do not reliably honor server-provided instructions, and small models honor them only inconsistently. This makes skills-first **structural**: when a code-mode `search` query matches a bundled skill, the match list is prepended to the search result as an **observation** the model acts on — not an instruction it must trust.

## Change

- `SkillRegistry.match(query, limit=3)` — lightweight token-overlap matcher over each skill's name / title / tags / platforms, ties broken by name. Min token length 2 so short domain terms like `rf` survive; generic fillers/verbs are stopworded (so `"list all the"` matches nothing).
- `_SkillAwareSearchTool` (`server.py`) — the code-mode `search` tool prepends a `MATCHING SKILLS` block (each line carrying its `skills_load(name=…)` call) when the query matches a bundled skill. Inert when nothing matches or no registry is set. Inherits the #488 arg-tolerance and #496 `platform` advertisement (it subclasses `_ArgTolerantFunctionTool`).
- The registry is held in a module-level ref set at registration, because the tool is reconstructed via `model_fields` (which drops instance state) — same pattern as the rest of the discovery wrapper.

## Relation to #489

#489 (the "did you mean" unknown-tool fix) deliberately carried **no** skills-first prose. This PR is the structural mechanism that was deferred to — skills-first now lives in trusted result data, not in error strings or descriptions.

## Tests
- `SkillRegistry.match`: tag/name matching, overlap ranking, limit, empty query, and that generic filler tokens match nothing.
- `_SkillAwareSearchTool`: matching query prepends the block, non-matching doesn't, no-registry is inert, and #488 arg-tolerance still applies.
- Full suite: **1892 passed, 1 skipped**; ruff + `ruff format --check .` + mypy clean.

## Docs / version
- CHANGELOG entry; version `3.4.1.1 → 3.4.1.2` (patch — additive). The existing prose gate is retained as a complementary hint.
