### PR TITLE
fix(health): await async Central command in _probe_central

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1.3] - 2026-06-19
+
+**Patch — fix(health): await the async Central command in the health probe.** `_probe_central` called `conn.command(...)` without awaiting it (the `CentralClient.command` coroutine), so `resp.get("code")` raised `'coroutine' object has no attribute 'get'` and the `health` tool **always reported Central as `degraded`** even when the tenant was fully reachable. Missed during the Central async migration (v3.3.11.0); every other probe awaits correctly.
+
+### Fixed
+- `platforms/health.py`: `resp = await conn.command(...)` in `_probe_central`. Live-verified against the tenant (`status: ok, http_status: 200`). Added `_probe_central` unit tests (ok / non-2xx degraded / exception degraded / unavailable) — the ok-path test pins the regression by requiring the async `command` to be awaited.
+
 ## [3.4.1.2] - 2026-06-19
 
 **Patch — feat(code-mode): surface matching skills as `search` result data (#493).** Skills-first was enforced only through untrusted channels — the server `instructions` blob and prepended tool-description prose — which frontier models do not reliably honor. This makes it structural: when a code-mode `search` query matches a bundled skill, the match list is **prepended to the search result** as an observation the model acts on, not an instruction it must trust. Completes the code-mode small-model hardening set (#488–#493).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.1.2"
+version = "3.4.1.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/health.py
+++ b/src/hpe_networking_mcp/platforms/health.py
@@ -102,7 +102,7 @@ async def _probe_central(ctx: Context) -> dict[str, Any]:
     if conn is None:
         return {"status": "unavailable", "message": "Central is not configured or failed to initialize"}
     try:
-        resp = conn.command(
+        resp = await conn.command(
             "GET",
             "network-monitoring/v1/sites-health",
             api_params={"limit": 1},

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -182,3 +182,52 @@ class TestProbeAOS8:
         result = await _probe_aos8(ctx)
         assert result["status"] == "degraded"
         assert "conductor unreachable" in result["message"]
+
+
+@pytest.mark.unit
+class TestProbeCentral:
+    async def test_probe_central_unavailable_when_conn_none(self):
+        from hpe_networking_mcp.platforms.health import _probe_central
+
+        ctx = _make_ctx({"central_conn": None})
+        result = await _probe_central(ctx)
+        assert result["status"] == "unavailable"
+
+    async def test_probe_central_ok_awaits_async_command(self):
+        """Regression: CentralClient.command is async; the probe must AWAIT it.
+        With the un-awaited bug, resp is a coroutine and resp.get(...) raised
+        "'coroutine' object has no attribute 'get'" → always-degraded Central."""
+        from hpe_networking_mcp.platforms.health import _probe_central
+
+        class _FakeConn:
+            async def command(self, method, path, api_params=None):
+                return {"code": 200, "msg": {"items": []}}
+
+        ctx = _make_ctx({"central_conn": _FakeConn()})
+        result = await _probe_central(ctx)
+        assert result["status"] == "ok"
+        assert result["http_status"] == 200
+
+    async def test_probe_central_degraded_on_non_2xx(self):
+        from hpe_networking_mcp.platforms.health import _probe_central
+
+        class _FakeConn:
+            async def command(self, method, path, api_params=None):
+                return {"code": 503, "msg": {"error": "upstream"}}
+
+        ctx = _make_ctx({"central_conn": _FakeConn()})
+        result = await _probe_central(ctx)
+        assert result["status"] == "degraded"
+        assert "503" in result["message"]
+
+    async def test_probe_central_degraded_on_exception(self):
+        from hpe_networking_mcp.platforms.health import _probe_central
+
+        class _BoomConn:
+            async def command(self, method, path, api_params=None):
+                raise RuntimeError("central unreachable")
+
+        ctx = _make_ctx({"central_conn": _BoomConn()})
+        result = await _probe_central(ctx)
+        assert result["status"] == "degraded"
+        assert "central unreachable" in result["message"]


### PR DESCRIPTION
## Summary

`_probe_central` (the `health` tool's Central probe) called `conn.command(...)` **without awaiting it** — but `CentralClient.command` has been `async def` since the Central async migration (v3.3.11.0). So `resp` was a coroutine, `resp.get("code")` raised `'coroutine' object has no attribute 'get'`, and the `health` tool **always reported Central as `degraded`** even when the tenant was fully reachable. Every other probe awaits correctly; this one was missed.

Central is in production, so the always-degraded health signal is a real (if cosmetic) defect.

## Fix

- `platforms/health.py`: `resp = await conn.command(...)` in `_probe_central`. One line.

## Verification

- **Live-verified** against the tenant in the dev container: `_probe_central` now returns `{status: ok, message: "Central REST API reachable", http_status: 200}` (before the fix it returned the `'coroutine' object has no attribute 'get'` degraded message).
- Added `_probe_central` unit tests: ok-path (async `command` awaited), non-2xx → degraded, exception → degraded, conn-None → unavailable. The ok-path test pins the regression — it requires the async `command` to be awaited, so the un-awaited bug fails it.
- `health` suite green; ruff + format + mypy clean.

## Docs / version
- CHANGELOG entry; version `3.4.1.2 → 3.4.1.3` (patch).
