### PR TITLE
fix(code-mode): enable sandbox clock + self-correcting errors for common small-model mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.1] - 2026-06-25
+
+**Patch — fix(code-mode): give the `execute()` sandbox a working clock + self-correcting errors for the common small-model mistakes.** Two failure modes reported from Claude Haiku 4.5 code-mode sessions: `datetime.utcnow()` (a 24h-window report) and `NameError: name 'org_id' is not defined` (a variable referenced across two `execute()` blocks). Both are structural — steering via INSTRUCTIONS.md is unreliable because MCP-server content is treated as advisory — so the fixes live in the sandbox/middleware layer, not the docs alone.
+
+### Added
+- **`ClockEnabledMontySandboxProvider`** (`code_sandbox.py`) — subclasses fastmcp's `MontySandboxProvider` to pass `os=OSAccess()` to monty, enabling the sandbox clock: `datetime.now()`, `datetime.now(datetime.timezone.utc)`, and `datetime.date.today()` now work inside `execute()`. The filesystem and environ stay fully sandboxed (verified live: host env vars and host files do not leak; `open` is unbound) — only the read-only clock is added.
+
+### Changed
+- **`SandboxErrorCatchMiddleware`** now appends a self-correcting hint to the error result (the channel models reliably act on) for the common dead-ends:
+  - clock/time: `datetime.utcnow()` (monty has no `utcnow`) and `time.time()` (no `time` module) → points at `datetime.now(datetime.timezone.utc)` / `datetime.now().timestamp()` and stamps the real current UTC time.
+  - cross-block state: `NameError: name 'X' is not defined` → explains that each `execute()` call is a fresh, stateless sandbox and that work must be self-contained in one block (or `X` recomputed).
+- `execute` tool description + INSTRUCTIONS.md sandbox reference: corrected the (previously inaccurate) clock guidance and added an explicit STATELESS note. Sandbox-compat lint no longer bans `datetime.now()`; it bans `datetime.utcnow()`.
+
 ## [3.4.5.0] - 2026-06-24
 
 **Minor — feat(translations): migrate all 12 AOS 8 → Central config kinds onto the canonical engine + retire the legacy JSON engine.** The non-WLAN config translations (`vlan_id`, `named_vlan`, `net_group`, `role`, `policy`, the AAA chain — `auth_server` / `server_group` / `dot1x_auth` / `mac_auth` / `captive_portal` / `aaa_profile` — and `gateway_cluster`) moved from the old JSON `emit_calls` engine to the canonical reader/writer architecture, exposed through new cross-platform bridge tools, with the legacy engine fully removed. References #279, #419/#420.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.0"
+version = "3.4.5.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -256,6 +256,8 @@ This applies even to "small" lists — anything > ~30 items is risky for small m
 
 The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports a subset of Python 3 — most data manipulation works, but several common modules and constructs are blocked. Authoring code that runs first try means staying inside the supported surface.
 
+**Each `execute()` call is STATELESS** — it runs in a fresh sandbox, so variables, imports, and results from a previous `execute()` block do NOT persist. Do all the work for one task inside a single block; never reference a variable (e.g. `org_id`) defined in an earlier call, or you'll hit `NameError: name '…' is not defined`.
+
 **Known-working** (verified in shipped skills + tests):
 - Built-in types: `str`, `int`, `float`, `bool`, `list`, `dict`, `set`, `tuple`, `None`
 - Comprehensions: list / dict / set / generator (the LATTER is fine when consumed eagerly via `list(...)`; bare generators that need `yield` syntax are NOT — see below)
@@ -263,6 +265,7 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 - Operators, slicing, f-strings, basic string methods
 - `json` (verified — Stage 9b uses it for body inspection)
 - `re` (verified — used by Stage 9b filtering helpers)
+- The clock: `datetime.now()`, `datetime.now(datetime.timezone.utc)`, `datetime.date.today()` (verified — the sandbox grants a read-only host clock; see the blocked table for the `utcnow()` / `time` gaps)
 - The injected `await call_tool(name, params)` for platform tool dispatch
 
 **Known-blocked** — using any of these returns a sandbox error:
@@ -273,7 +276,8 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 | `async def` (any function) | unawaited-coroutine footgun (sandbox already runs in async context) | Inline the code at the top level inside `execute()` |
 | `import hashlib` | `ModuleNotFoundError` | Accept a pre-computed digest as an input parameter |
 | `import hpe_networking_mcp.*` | `ModuleNotFoundError` | Use platform tools via `await call_tool(name, params)` |
-| `datetime.now()`, `time.time()` | `RuntimeError: OS access blocked` | Accept ISO-8601 timestamps as parameters; or hardcode literal ISO strings |
+| `datetime.utcnow()` | `AttributeError: 'datetime.datetime' object has no attribute 'utcnow'` | Use `datetime.now(datetime.timezone.utc)` — the sandbox clock works; `utcnow` simply isn't implemented |
+| `time.time()` / `import time` | `ModuleNotFoundError: No module named 'time'` | Use `datetime.now().timestamp()`; the `time` module doesn't exist in the sandbox |
 | `os.environ`, `subprocess`, file I/O | `RuntimeError: OS access blocked` | Accept config values as parameters |
 | `asyncio.gather()` | unavailable | Use sequential `await` calls — same wall-clock cost matters less here than in production async code |
 

--- a/src/hpe_networking_mcp/code_sandbox.py
+++ b/src/hpe_networking_mcp/code_sandbox.py
@@ -1,0 +1,59 @@
+"""Code-mode sandbox provider that grants ``execute()`` a read-only clock.
+
+fastmcp's stock ``MontySandboxProvider`` never passes an ``os=`` handler to
+``monty.run_async``, so every clock call inside an ``execute()`` block fails:
+
+    datetime.now()        -> NotImplementedError: OS function 'datetime.now' not implemented
+    datetime.utcnow()     -> AttributeError: 'datetime.datetime' object has no attribute 'utcnow'
+
+Network operators routinely need "now" to build time-window queries
+(last-24h reports, audit-log windows), and small models reach for
+``datetime.utcnow()`` by reflex (issue: Haiku 4.5 morning-report transcript).
+Steering them via INSTRUCTIONS.md is unreliable — MCP-server content is
+treated as advisory — so the fix is structural.
+
+Passing ``os=OSAccess()`` enables monty's clock callbacks, so
+``datetime.now()``, ``datetime.now(tz)`` and ``datetime.date.today()`` return
+the real host clock. A bare ``OSAccess`` is otherwise inert: it exposes an
+empty in-memory virtual filesystem and an empty environ, and ``open`` is not
+even bound in the sandbox — verified live, host env vars and host files do not
+leak (only the clock is added). A fresh instance per run keeps any in-memory
+state from bleeding between ``execute()`` calls.
+
+Monty implements only ``datetime.now`` — not ``datetime.utcnow`` — and has no
+``time`` module, so ``datetime.utcnow()`` and ``time.time()`` still fail.
+``SandboxErrorCatchMiddleware`` turns those residual dead-ends into a
+self-correcting error pointing at ``datetime.now(datetime.timezone.utc)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.experimental.transforms.code_mode import MontySandboxProvider
+from pydantic_monty import OSAccess
+
+
+class ClockEnabledMontySandboxProvider(MontySandboxProvider):
+    """``MontySandboxProvider`` that grants sandbox code a read-only clock.
+
+    Overrides the private ``_run_monty`` launch seam (the isolated point the
+    base class exposes so cancellation handling in ``run()`` stays testable)
+    to pass a fresh ``OSAccess`` as the monty ``os=`` handler. This is the
+    only mechanism monty offers to enable ``datetime.now`` — there is no
+    public knob on ``MontySandboxProvider`` for it.
+    """
+
+    def _run_monty(
+        self,
+        monty: Any,
+        *,
+        inputs: dict[str, Any] | None,
+        external_functions: dict[str, Any] | None,
+    ) -> Any:
+        return monty.run_async(
+            inputs=inputs,
+            external_functions=external_functions,
+            limits=self.limits,
+            os=OSAccess(),
+        )

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -32,6 +32,8 @@ Syntax errors from stray indentation in model-generated code are another.
 from __future__ import annotations
 
 import json
+import re
+from datetime import UTC, datetime
 from typing import Any
 
 import mcp.types
@@ -53,6 +55,70 @@ try:
 except ImportError:
     MontyError = Exception  # type: ignore[misc,assignment]
     _HAS_MONTY = False
+
+
+# Sandbox clock/time dead-ends monty can't satisfy even with the clock
+# enabled: `datetime.utcnow()` (monty implements only `datetime.now`) and the
+# absent `time` module. The clock-enabled provider makes `datetime.now()` /
+# `date.today()` work, but a model reaching for these specific names still
+# hard-fails — so we turn the raw error into a self-correcting one. Substring
+# match against the lower-cased cause text.
+_CLOCK_DEADEND_MARKERS: tuple[str, ...] = (
+    "utcnow",  # AttributeError: ... no attribute 'utcnow'
+    "no module named 'time'",  # ModuleNotFoundError on `import time`
+    "os function 'datetime",  # NotImplementedError (clock disabled / older deploy)
+    "os function 'date",
+)
+
+
+def _clock_error_hint(cause_text: str) -> str | None:
+    """Return self-correcting guidance for a sandbox clock/time dead-end.
+
+    The middleware runs in real (non-sandbox) Python, so it can stamp the
+    actual current time into the message — giving the model both the working
+    substitute API and a literal value it can hardcode. Returns ``None`` when
+    the error is unrelated to the clock.
+    """
+    low = cause_text.lower()
+    if not any(marker in low for marker in _CLOCK_DEADEND_MARKERS):
+        return None
+    now = datetime.now(UTC)
+    iso = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (
+        "Hint: the sandbox has no `datetime.utcnow()` and no `time` module, but "
+        "the clock IS available — use `datetime.now(datetime.timezone.utc)` "
+        "(or `datetime.now()` / `datetime.date.today()`), and "
+        "`datetime.now().timestamp()` instead of `time.time()`. "
+        f"Current UTC time is {iso}. Many search/report tools also accept a "
+        '`duration` argument (e.g. "1d"), so you often need not compute a '
+        "window at all."
+    )
+
+
+_NAMEERROR_RE = re.compile(r"name ['\"]([^'\"]+)['\"] is not defined")
+
+
+def _nameerror_hint(cause_text: str) -> str | None:
+    """Return guidance for a sandbox ``NameError``.
+
+    The single most common cause is a model splitting work across multiple
+    ``execute()`` calls and referencing a variable defined in an earlier
+    block — but each ``execute()`` runs in a FRESH, stateless sandbox, so
+    nothing persists between calls (observed: Haiku 4.5 referencing an
+    `org_id` set in a prior block). The hint also covers the plain-typo case.
+    Returns ``None`` for non-NameError causes.
+    """
+    m = _NAMEERROR_RE.search(cause_text)
+    if m is None:
+        return None
+    name = m.group(1)
+    return (
+        f"Hint: `{name}` is undefined. Each `execute()` call runs in a FRESH, "
+        "stateless sandbox — variables defined in a PREVIOUS `execute()` block "
+        "do NOT carry over. Do all the work for one task inside a SINGLE "
+        f"`execute()` block, or recompute/re-fetch `{name}` at the top of this "
+        "block before using it. (If it's simply a typo, fix the name.)"
+    )
 
 
 class SandboxErrorCatchMiddleware(Middleware):
@@ -100,7 +166,20 @@ class SandboxErrorCatchMiddleware(Middleware):
             # the model self-corrects instead of looping on the same call
             # (#489). The candidates are data, not an imperative.
             suggestion = unknown_tool_payload_from_text(str(cause))
-            error_text = json.dumps(suggestion) if suggestion is not None else f"Sandbox error: {cause}"
+            if suggestion is not None:
+                error_text = json.dumps(suggestion)
+            else:
+                error_text = f"Sandbox error: {cause}"
+                # Append a self-correcting hint for the common small-model
+                # sandbox-model mistakes (clock dead-ends, cross-block state).
+                # The error result is the one channel the model reliably acts
+                # on, unlike advisory INSTRUCTIONS.md content. The causes are
+                # mutually exclusive, so the first match wins.
+                for hint_fn in (_clock_error_hint, _nameerror_hint):
+                    hint = hint_fn(str(cause))
+                    if hint is not None:
+                        error_text = f"{error_text}\n\n{hint}"
+                        break
             logger.debug("SandboxErrorCatch: caught on {} → {}", tool_name, error_text)
             # Re-raise so the wire response sets isError=true. Middleware
             # sits outside the masking layer, so this propagates with the

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -727,10 +727,11 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
             CodeMode,
             GetSchemas,
             GetTags,
-            MontySandboxProvider,
             Search,
         )
         from pydantic_monty import ResourceLimits
+
+        from hpe_networking_mcp.code_sandbox import ClockEnabledMontySandboxProvider
     except ImportError as e:
         logger.error(
             "MCP_TOOL_MODE=code requires fastmcp[code-mode] + pydantic-monty ({}); "
@@ -784,6 +785,10 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     execute_description = (
         "Run Python in a sandbox to compose multiple platform tool calls. "
         "Use `return` to produce output.\n\n"
+        "STATELESS: each `execute()` call runs in a FRESH sandbox — variables, "
+        "imports, and results from a previous `execute()` block do NOT persist. "
+        "Do all the work for one task in a SINGLE block; never reference a "
+        "variable (e.g. `org_id`) defined in an earlier call.\n\n"
         "PREREQUISITE — call `skills_list` at the outer surface BEFORE "
         "using `execute`. If a bundled skill covers the request, "
         "`skills_load` it and follow that runbook; only write your own "
@@ -818,11 +823,14 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
         "Use them BEFORE writing your code block when the client surfaces "
         "them; otherwise use the `<platform>_list_tools` path above.\n\n"
         "Known sandbox limits: `asyncio.gather()` is unavailable — use "
-        "sequential `await` calls. OS-access functions are blocked, "
-        "including `datetime.now()`, `time.time()`, file I/O, `os.environ`, "
-        "and `subprocess`. For timestamps, accept ISO strings as parameters "
-        "or hardcode literal ISO-8601 strings rather than computing them "
-        "inside the sandbox. Not every stdlib module exists in the sandbox — "
+        "sequential `await` calls. The clock IS available: "
+        "`datetime.now()`, `datetime.now(datetime.timezone.utc)`, and "
+        "`datetime.date.today()` work. But `datetime.utcnow()` does NOT exist "
+        "in the sandbox (use `datetime.now(datetime.timezone.utc)`), there is "
+        "no `time` module (use `datetime.now().timestamp()`), and file I/O, "
+        "`os.environ`, and `subprocess` are blocked. Many search/report tools "
+        'also accept a `duration` argument (e.g. "1d") so you often don\'t '
+        "need to compute a window at all. Not every stdlib module exists in the sandbox — "
         "e.g. `import collections` (Counter/defaultdict) raises "
         "ModuleNotFoundError. Use builtins instead: a plain `dict` for "
         "counting/grouping, plus `set`, `sorted`, `sum`, and `min`/`max`."
@@ -889,7 +897,11 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
 
     mcp.add_transform(
         CodeMode(
-            sandbox_provider=MontySandboxProvider(limits=limits),
+            # ClockEnabledMontySandboxProvider passes os=OSAccess() so sandbox
+            # code can call datetime.now()/date.today() (the stock provider
+            # blocks the clock); the FS/env stay fully sandboxed. See
+            # code_sandbox.py.
+            sandbox_provider=ClockEnabledMontySandboxProvider(limits=limits),
             discovery_tools=discovery_tools,
             execute_description=execute_description,
         )

--- a/tests/unit/test_code_sandbox.py
+++ b/tests/unit/test_code_sandbox.py
@@ -1,0 +1,59 @@
+"""Tests for ClockEnabledMontySandboxProvider.
+
+The stock fastmcp ``MontySandboxProvider`` never passes an ``os=`` handler, so
+the sandbox clock is blocked. Our subclass passes ``os=OSAccess()`` to enable
+``datetime.now()`` / ``date.today()`` while keeping the filesystem and environ
+sandboxed. These run the real provider end-to-end (no mocking) so they pin the
+actual monty behavior, not our assumptions about it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pydantic_monty = pytest.importorskip("pydantic_monty")
+
+from hpe_networking_mcp.code_sandbox import ClockEnabledMontySandboxProvider  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _provider() -> ClockEnabledMontySandboxProvider:
+    # Default baseline limits (30s / 100MB) are fine for these trivial snippets.
+    return ClockEnabledMontySandboxProvider()
+
+
+async def test_datetime_now_works() -> None:
+    out = await _provider().run("import datetime\nreturn str(datetime.datetime.now())")
+    assert out  # an ISO-ish datetime string from the real clock
+    assert "-" in out and ":" in out
+
+
+async def test_datetime_now_utc_works() -> None:
+    out = await _provider().run("import datetime\nreturn str(datetime.datetime.now(datetime.timezone.utc))")
+    assert "+00:00" in out
+
+
+async def test_date_today_works() -> None:
+    out = await _provider().run("import datetime\nreturn str(datetime.date.today())")
+    assert out.count("-") == 2  # YYYY-MM-DD
+
+
+async def test_utcnow_still_fails() -> None:
+    """monty implements only `datetime.now`, never `utcnow` — enabling the
+    clock does not change that. (The middleware turns this into a hint.)"""
+    with pytest.raises(pydantic_monty.MontyError) as e:
+        await _provider().run("import datetime\nreturn datetime.datetime.utcnow()")
+    assert "utcnow" in str(e.value)
+
+
+async def test_environ_not_leaked() -> None:
+    """OSAccess exposes an empty environ — host env vars must not leak."""
+    out = await _provider().run("import os\nreturn os.environ.get('PATH')")
+    assert out is None
+
+
+async def test_filesystem_not_exposed() -> None:
+    """`open` is not even bound in the sandbox — no host file access."""
+    with pytest.raises(pydantic_monty.MontyError):
+        await _provider().run("return open('/etc/hostname').read()")

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -374,6 +374,103 @@ class TestSandboxErrorCatchMiddleware:
         assert text != "Error calling tool 'execute'"
 
     @pytest.mark.asyncio
+    async def test_utcnow_deadend_gets_self_correcting_hint(self):
+        """A model reaching for `datetime.utcnow()` (which monty doesn't
+        implement, even with the clock enabled) must get a self-correcting
+        error pointing at the working substitute + the real current time.
+        The error result is the channel the model reliably acts on, unlike
+        advisory INSTRUCTIONS.md content.
+        """
+        import pydantic_monty
+        from pydantic_monty import OSAccess
+
+        monty = pydantic_monty.Monty("import datetime\nreturn datetime.datetime.utcnow()")
+        cause = None
+        try:
+            await monty.run_async(os=OSAccess())
+        except pydantic_monty.MontyError as e:
+            cause = e
+        assert cause is not None, "expected utcnow() to raise in the sandbox"
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        text = str(exc_info.value)
+        assert "utcnow" in text.lower()  # original cause preserved
+        assert "datetime.now(datetime.timezone.utc)" in text  # working substitute
+        assert "current utc time is" in text.lower()  # stamped real time
+        assert "duration" in text.lower()  # the avoid-computing-a-window nudge
+
+    @pytest.mark.asyncio
+    async def test_time_module_deadend_gets_hint(self):
+        """`import time` → ModuleNotFoundError; the hint must fire for it too."""
+        cause = await _make_monty_error("No module named 'time'")
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        assert "datetime.now().timestamp()" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_non_clock_error_gets_no_clock_hint(self):
+        """A non-clock sandbox error must NOT acquire the clock hint."""
+        cause = await _make_monty_error("some unrelated runtime failure")
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        assert "datetime.now" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_nameerror_gets_statelessness_hint(self):
+        """A model referencing a variable from a previous execute() block
+        (each call is a FRESH sandbox) hits NameError. The hint must name the
+        missing variable and explain the cross-block statelessness — the exact
+        Haiku 4.5 `org_id` failure.
+        """
+        import pydantic_monty
+
+        monty = pydantic_monty.Monty("return org_id")
+        cause = None
+        try:
+            await monty.run_async()
+        except pydantic_monty.MontyError as e:
+            cause = e
+        assert cause is not None and "org_id" in str(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        text = str(exc_info.value)
+        assert "org_id" in text
+        assert "stateless" in text.lower()
+        assert "single" in text.lower() or "previous" in text.lower()
+
+    @pytest.mark.asyncio
     async def test_does_not_catch_on_non_execute_tools(self):
         """Sandbox errors only happen on `execute`. The middleware must NOT
         intercept anything on other tools — those have their own contract.

--- a/tests/unit/test_skill_snippet_sandbox_compat.py
+++ b/tests/unit/test_skill_snippet_sandbox_compat.py
@@ -73,11 +73,15 @@ _FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
     (
         # OS-access functions explicitly listed as blocked in
         # `server.py:execute_description`. These are the most-cited offenders.
-        re.compile(r"\b(?:datetime\.now|time\.time|os\.environ|subprocess\b|asyncio\.gather)\b"),
+        # NOTE: `datetime.now()` is NOT banned — the clock-enabled sandbox
+        # provider (code_sandbox.py) makes it work. `datetime.utcnow()` and
+        # `time.time()` stay banned (monty has no utcnow / no time module).
+        re.compile(r"\b(?:datetime\.utcnow|time\.time|os\.environ|subprocess\b|asyncio\.gather)\b"),
         "OS-access / asyncio.gather",
-        "The sandbox blocks `datetime.now()`, `time.time()`, `os.environ`, "
-        "`subprocess`, and `asyncio.gather()`. Use sequential `await` calls "
-        "for parallelism; accept ISO-8601 strings as parameters for timestamps.",
+        "The sandbox blocks `datetime.utcnow()`, `time.time()`, `os.environ`, "
+        "`subprocess`, and `asyncio.gather()`. Use `datetime.now(datetime.timezone.utc)` "
+        "for UTC and `datetime.now().timestamp()` for epoch; use sequential "
+        "`await` calls for parallelism.",
     ),
 ]
 


### PR DESCRIPTION
## Why

Two failures surfaced from **Claude Haiku 4.5** code-mode sessions (one on 3.4.0.0, one reproduced on 3.4.5.0):

1. `Sandbox error: AttributeError: 'datetime.datetime' object has no attribute 'utcnow'` — the model wrote `datetime.utcnow()` to build a 24h report window.
2. `Sandbox error: NameError: name 'org_id' is not defined` — the model referenced a variable it had defined in a *previous* `execute()` block.

Both are **structural** problems, not version-specific. The clock block comes from fastmcp's `MontySandboxProvider` never passing an `os=` handler to monty (unchanged across versions). And steering models via `INSTRUCTIONS.md` is unreliable — MCP-server content is treated as advisory — so the fix has to live in the sandbox/middleware layer, in the one channel the model reliably acts on: the **tool-call error result**.

Verified live in the dev container:

| Sandbox call | Before | After (`os=OSAccess()`) |
|---|---|---|
| `datetime.now()` | ❌ `NotImplementedError` | ✅ real clock |
| `datetime.now(timezone.utc)` | ❌ | ✅ |
| `date.today()` | ❌ | ✅ |
| `datetime.utcnow()` | ❌ AttributeError | ❌ still (monty has no `utcnow`) → middleware hint |
| `time.time()` | ❌ | ❌ (no `time` module) → middleware hint |

Safety of `os=OSAccess()` verified live: host env vars do **not** leak (`environ` is `{}`), host files are inaccessible (`open` is unbound, `os.listdir` absent). It adds **only** the read-only clock.

## What

- **`code_sandbox.py` — `ClockEnabledMontySandboxProvider`**: subclasses `MontySandboxProvider` and passes `os=OSAccess()` so `datetime.now()` / `now(tz)` / `date.today()` work in `execute()`. FS + environ stay sandboxed.
- **`SandboxErrorCatchMiddleware`** now appends a self-correcting hint to the error text for the common dead-ends:
  - clock/time → points at `datetime.now(datetime.timezone.utc)` / `datetime.now().timestamp()` and stamps the real current UTC time.
  - `NameError` → explains each `execute()` call is a fresh, stateless sandbox; work must be self-contained (or the variable recomputed). Names the missing variable.
- **Docs corrected** (were inaccurate): `execute` tool description + INSTRUCTIONS.md sandbox reference now state the clock works, that `utcnow`/`time` don't, and add an explicit STATELESS note. Sandbox-compat lint bans `datetime.utcnow()` instead of `datetime.now()`.

## Tests

- New `tests/unit/test_code_sandbox.py` — runs the real provider end-to-end: clock works, UTC/today work, `utcnow()` still fails, and **no env/file leak**.
- `test_middleware.py` — clock-deadend hint (with current time), `time` hint, NameError statelessness hint, and a negative (non-clock error gets no clock hint).
- Full suite green in Docker: ruff + ruff format + mypy + 1697 passed / 1 skipped.

Patch bump 3.4.5.0 → 3.4.5.1.