### PR TITLE
fix(safety): envelope ok:false for blocked/error states (#520) + safe retry for invoke-tool writes (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.2] - 2026-06-25
+
+**Patch — fix(safety): two small-model safety bugs in the middleware chain (#520, #521).** Both are most dangerous for small/local models that branch literally on the envelope contract and lean on the universal `<platform>_invoke_tool` dispatch.
+
+### Fixed
+- **#520 — response envelope no longer marks blocked/error states as `ok: true`.** Known control payloads from `<platform>_invoke_tool` and the confirmation gate (`forbidden`, `not_found`, `invalid_params`, `tool_error`, `confirmation_required`, `confirmation_unavailable`, `declined`, `cancelled`) now produce a failed envelope (`ok: false`) with the appropriate HTTP `status` and a promoted top-level `message`. Previously a refused or confirmation-pending write was wrapped `ok: true`, so a model could report a change that never happened. Detection requires both a known string `status` AND a string `message` so genuine data records aren't mis-flagged; user-choice/pending states map to 4xx so they can't trip the 5xx retry path.
+- **#521 — RetryMiddleware no longer risks retrying writes dispatched through `<platform>_invoke_tool`.** The meta-tool is tagged only `<platform>_meta`, so a destructive write invoked through it previously looked retry-safe and a 5xx could be retried. Retry now resolves the underlying target from the `name` argument (`REGISTRIES[platform][name]`) and classifies by its capability/tags; if the target can't be resolved it **fails closed** (treated as a write → no 5xx retry). 429 remains retried for all tools (server-requested backoff is always safe).
+
 ## [3.4.5.1] - 2026-06-25
 
 **Patch — fix(code-mode): give the `execute()` sandbox a working clock + self-correcting errors for the common small-model mistakes.** Two failure modes reported from Claude Haiku 4.5 code-mode sessions: `datetime.utcnow()` (a 24h-window report) and `NameError: name 'org_id' is not defined` (a variable referenced across two `execute()` blocks). Both are structural — steering via INSTRUCTIONS.md is unreliable because MCP-server content is treated as advisory — so the fixes live in the sandbox/middleware layer, not the docs alone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.1"
+version = "3.4.5.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -87,6 +87,45 @@ _ENVELOPE_REQUIRED_KEYS: frozenset[str] = frozenset({"ok", "data", "tool"})
 # is populated consistently with what RetryMiddleware would see.
 _STATUS_CODE_KEYS: tuple[str, ...] = ("status_code", "code", "http_status")
 
+# Known blocked/error string-statuses our own layers return as plain dicts
+# (``<platform>_invoke_tool`` and the ``confirm_gated_invoke`` gate), mapped to
+# the HTTP status the envelope should carry. Wrapping these with ``ok: true``
+# (the old behavior) lets a small/local model treat a refused write or a
+# confirmation-pending action as success — dangerous on write paths (#520).
+# All these payloads carry a string ``message``; we require it as a corroborator
+# so a genuine data record whose ``status`` field happens to read "cancelled"
+# isn't mis-flagged. User-choice / pending states map to 4xx (never 5xx) so they
+# can't accidentally trip RetryMiddleware's 5xx-retry path.
+_BLOCKED_STATUS_HTTP: dict[str, int] = {
+    "not_found": 404,
+    "forbidden": 403,
+    "invalid_params": 400,
+    "tool_error": 502,
+    "confirmation_required": 409,
+    "confirmation_unavailable": 409,
+    "declined": 409,
+    "cancelled": 409,
+}
+
+
+def _blocked_state(raw: Any) -> tuple[int, str] | None:
+    """Detect a known blocked/error control payload.
+
+    Returns ``(http_status, message)`` when ``raw`` is one of our structured
+    blocked/error dicts, else ``None``. Requires both a known string ``status``
+    AND a string ``message`` to avoid false-positives on real data records.
+    A numeric ``status_code`` in the payload (e.g. a ``tool_error`` wrapping a
+    Mist 503) takes precedence over the mapped default.
+    """
+    if not isinstance(raw, dict):
+        return None
+    status = raw.get("status")
+    message = raw.get("message")
+    if not (isinstance(status, str) and status in _BLOCKED_STATUS_HTTP and isinstance(message, str)):
+        return None
+    http_status = _extract_status(raw) or _BLOCKED_STATUS_HTTP[status]
+    return http_status, message
+
 
 def _infer_platform(tool_name: str) -> str | None:
     """Derive ``platform`` from a tool name's prefix.
@@ -240,16 +279,32 @@ class ResponseEnvelopeMiddleware(Middleware):
             logger.debug("response_envelope: {} already enveloped, pass-through", tool_name)
             return result  # type: ignore[return-value]
 
-        envelope = _build_envelope(
-            ok=True,
-            data=raw,
-            status=_extract_status(raw),
-            message=None,
-            tool=tool_name,
-            platform=platform,
-        )
-
-        logger.debug("response_envelope: wrapped {} (platform={})", tool_name, platform)
+        # Known blocked/error control payloads (forbidden / not_found /
+        # confirmation_required / declined / ...) must surface as a FAILED
+        # envelope so models don't read ``ok: true`` and report a refused or
+        # pending write as success (#520).
+        blocked = _blocked_state(raw)
+        if blocked is not None:
+            status, message = blocked
+            envelope = _build_envelope(
+                ok=False,
+                data=raw,
+                status=status,
+                message=message,
+                tool=tool_name,
+                platform=platform,
+            )
+            logger.debug("response_envelope: {} blocked/error state ({}), ok=false", tool_name, status)
+        else:
+            envelope = _build_envelope(
+                ok=True,
+                data=raw,
+                status=_extract_status(raw),
+                message=None,
+                tool=tool_name,
+                platform=platform,
+            )
+            logger.debug("response_envelope: wrapped {} (platform={})", tool_name, platform)
 
         return ToolResult(
             content=result.content,

--- a/src/hpe_networking_mcp/middleware/retry.py
+++ b/src/hpe_networking_mcp/middleware/retry.py
@@ -131,13 +131,65 @@ def _exception_status_code(exc: BaseException) -> int | None:
         return None
 
 
+def _spec_is_write(spec: Any) -> bool:
+    """Classify a registry ``ToolSpec`` as a write (True) or a safe read.
+
+    Mirrors the direct-call tag convention (``*_write`` / ``*_write_delete``)
+    and additionally honors the ``capability`` facet: only ``READ`` /
+    ``DIAGNOSTIC`` are 5xx-retry-safe; ``WRITE`` / ``WRITE_DELETE`` /
+    ``OPERATIONAL`` are not (OPERATIONAL actions like reboot are not
+    idempotent). An unclassified, untagged spec is treated as a read — the
+    same as the direct-call path, so this never regresses real reads.
+    """
+    from hpe_networking_mcp.platforms._common.annotations import Capability
+
+    tags: set[str] = set(getattr(spec, "tags", None) or set())
+    if any(tag.endswith("_write") or tag.endswith("_write_delete") for tag in tags):
+        return True
+    capability = getattr(spec, "capability", None)
+    if capability is not None:
+        return capability not in (Capability.READ, Capability.DIAGNOSTIC)
+    return False
+
+
+def _meta_invoke_is_write(meta_name: str, arguments: Any) -> bool:
+    """Resolve write-safety for a ``<platform>_invoke_tool`` meta-dispatch.
+
+    The visible meta-tool is tagged only ``<platform>_meta``, so its FastMCP
+    tags say nothing about the UNDERLYING tool named in the ``name`` argument
+    — a destructive write dispatched this way would otherwise look retry-safe
+    (issue #521). Resolve the target from ``REGISTRIES[platform][name]`` and
+    classify that. **Fail closed**: if the target can't be resolved (no
+    ``name`` arg, unknown platform, or missing spec), treat it as a write so
+    a 5xx is NOT retried.
+    """
+    from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+    platform = meta_name[: -len("_invoke_tool")]
+    target = (arguments or {}).get("name") if isinstance(arguments, dict) else None
+    if not isinstance(target, str) or not target:
+        return True  # no resolvable target → fail closed (no 5xx retry)
+    registry = REGISTRIES.get(platform)
+    spec = registry.get(target) if registry else None
+    if spec is None:
+        return True  # unresolvable target → fail closed
+    return _spec_is_write(spec)
+
+
 async def _is_write_tool(context: MiddlewareContext[mcp.types.CallToolRequestParams], name: str) -> bool:
     """Look up the tool's tags via FastMCP and return True if any tag ends
     in ``_write`` or ``_write_delete`` (the cross-platform convention).
     Falls back to False if the lookup fails — better to retry once
     erroneously than to mis-classify a real read as a write and skip
     the retry entirely.
+
+    Special case: ``<platform>_invoke_tool`` meta-dispatch. The meta-tool's
+    own tags don't reflect the underlying target, so resolve write-safety
+    from the ``name`` argument instead (issue #521).
     """
+    if name.endswith("_invoke_tool"):
+        return _meta_invoke_is_write(name, getattr(context.message, "arguments", None))
+
     ctx = context.fastmcp_context
     if ctx is None:
         return False

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -885,3 +885,104 @@ class TestRetryMiddleware:
         with pytest.raises(RuntimeError, match="boom"):
             await middleware.on_call_tool(ctx, call_next)
         assert call_next.call_count == 1  # no retry on unknown exception
+
+
+def _make_meta_retry_context(meta_name: str, target: str | None):
+    """Retry context for a ``<platform>_invoke_tool`` call whose underlying
+    target is named in ``message.arguments['name']`` (None → omitted)."""
+    message = MagicMock()
+    message.name = meta_name
+    message.arguments = {"params": {}} if target is None else {"name": target, "params": {}}
+    context = MagicMock()
+    context.message = message
+    context.fastmcp_context = None  # meta path never consults FastMCP tags
+    return context
+
+
+@pytest.mark.unit
+class TestRetryMetaInvokeWriteSafety:
+    """#521 — ``<platform>_invoke_tool`` is tagged only ``<platform>_meta``, so
+    retry write-safety must be resolved from the UNDERLYING target named in the
+    ``name`` argument, NOT the meta-tool's own tags. Fail closed (treat as a
+    write → no 5xx retry) when the target can't be resolved.
+    """
+
+    def setup_method(self):
+        from types import SimpleNamespace
+
+        from hpe_networking_mcp.platforms._common.annotations import Capability
+        from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES
+
+        self._registry = REGISTRIES.setdefault("central", {})
+        self._added = ("central_get_widget_521", "central_manage_widget_521")
+        self._registry["central_get_widget_521"] = SimpleNamespace(tags=set(), capability=Capability.READ)
+        self._registry["central_manage_widget_521"] = SimpleNamespace(
+            tags={"central_write_delete"}, capability=Capability.WRITE_DELETE
+        )
+
+    def teardown_method(self):
+        for name in self._added:
+            self._registry.pop(name, None)
+
+    @pytest.mark.asyncio
+    async def test_meta_invoke_write_target_503_not_retried(self):
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_meta_retry_context("central_invoke_tool", "central_manage_widget_521")
+        call_next = AsyncMock(return_value=_toolresult_with_status(503))
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 1  # write resolved from name arg → no 5xx retry
+
+    @pytest.mark.asyncio
+    async def test_meta_invoke_read_target_503_is_retried(self):
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_meta_retry_context("central_invoke_tool", "central_get_widget_521")
+        call_next = AsyncMock(side_effect=[_toolresult_with_status(503), _toolresult_ok()])
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 2  # read target → 5xx retried
+        assert result.structured_content["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_meta_invoke_unknown_target_503_not_retried(self):
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_meta_retry_context("central_invoke_tool", "central_nonexistent_tool")
+        call_next = AsyncMock(return_value=_toolresult_with_status(503))
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 1  # unresolvable → fail closed (no retry)
+
+    @pytest.mark.asyncio
+    async def test_meta_invoke_missing_name_arg_503_not_retried(self):
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_meta_retry_context("central_invoke_tool", None)
+        call_next = AsyncMock(return_value=_toolresult_with_status(503))
+
+        await middleware.on_call_tool(ctx, call_next)
+
+        assert call_next.call_count == 1  # no name arg → fail closed
+
+    @pytest.mark.asyncio
+    async def test_meta_invoke_read_target_429_retried(self):
+        from hpe_networking_mcp.middleware.retry import RetryMiddleware
+
+        middleware = RetryMiddleware(max_attempts=3, initial_delay=0.0, max_delay=0.0)
+        ctx = _make_meta_retry_context("central_invoke_tool", "central_manage_widget_521")
+        call_next = AsyncMock(side_effect=[_toolresult_with_status(429), _toolresult_ok()])
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        # 429 is always safe to retry, even for writes (server asked us to slow down)
+        assert call_next.call_count == 2
+        assert result.structured_content["ok"] is True

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -289,6 +289,83 @@ class TestResponseEnvelopeMiddleware:
         assert envelope["ok"] is True
 
 
+@pytest.mark.unit
+class TestBlockedStateEnvelope:
+    """#520 — known blocked/error control payloads must surface as a FAILED
+    envelope (``ok: false``) so small/local models don't read ``ok: true`` and
+    report a refused or confirmation-pending write as success.
+    """
+
+    @pytest.mark.asyncio
+    async def test_forbidden_marks_ok_false(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        raw = {"status": "forbidden", "message": "writes are disabled for central"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is False
+        assert env["status"] == 403
+        assert env["message"] == "writes are disabled for central"
+        assert env["data"] == raw  # original payload preserved under data
+
+    @pytest.mark.asyncio
+    async def test_confirmation_required_marks_ok_false_4xx(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        raw = {"status": "confirmation_required", "message": "confirm then retry with confirmed=true"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is False
+        assert 400 <= env["status"] < 500  # never 5xx → can't trip retry's 5xx path
+
+    @pytest.mark.asyncio
+    async def test_declined_marks_ok_false(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("translate_wlan_apply")
+        raw = {"status": "declined", "message": "Action declined by user."}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is False
+        assert env["message"] == "Action declined by user."
+
+    @pytest.mark.asyncio
+    async def test_tool_error_prefers_inner_status_code(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("mist_invoke_tool")
+        raw = {"status": "tool_error", "status_code": 503, "message": "upstream 503"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is False
+        assert env["status"] == 503  # the real upstream code, not the 502 default
+
+    @pytest.mark.asyncio
+    async def test_data_record_with_status_field_not_misflagged(self):
+        """A genuine data record whose `status` reads a blocked-word but lacks a
+        string `message` must stay ok=true (no false positive)."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        raw = {"job_id": "j1", "status": "cancelled", "progress": 100}  # no `message`
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is True
+        assert env["data"] == raw
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_string_stays_ok(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        raw = {"status": "active", "message": "device is up"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is True
+
+
 def _text(payload: object) -> list[TextContent]:
     """One JSON TextContent block, the way FastMCP serializes a tool return."""
     return [TextContent(type="text", text=json.dumps(payload))]


### PR DESCRIPTION
First PR of the small-model safety backlog (safety/security group, per the agreed order). Closes #520 and #521.

## #520 — envelope marked blocked/error states as `ok: true`
`ResponseEnvelopeMiddleware` wrapped any non-envelope payload with `ok: true`, **including** the structured control payloads our own layers return: `forbidden`, `not_found`, `invalid_params`, `tool_error` (from `<platform>_invoke_tool`) and `confirmation_required`, `confirmation_unavailable`, `declined`, `cancelled` (from the confirmation gate). A small/local model branching on the top-level `ok` would treat a **refused or confirmation-pending write as success** and tell the operator a change was made.

**Fix:** these surface as a failed envelope — `ok: false`, the mapped HTTP `status`, and a promoted top-level `message`:
- forbidden→403, not_found→404, invalid_params→400, tool_error→inner `status_code` or 502.
- user-choice / pending states (confirmation_required/unavailable, declined, cancelled)→409 — deliberately 4xx so they can't trip RetryMiddleware's 5xx path.
- Detection requires **both** a known string `status` AND a string `message`, so a genuine data record whose `status` field happens to read e.g. `"cancelled"` is not mis-flagged.

## #521 — retry could re-fire writes hidden behind `<platform>_invoke_tool`
`RetryMiddleware` classified write-safety from the *visible* tool's tags. `<platform>_invoke_tool` carries only `<platform>_meta`, so a destructive write dispatched through it (the path small models are told to use) looked retry-safe — a 5xx-shaped structured error could be retried, re-firing a non-idempotent write.

**Fix:** for `*_invoke_tool`, resolve the underlying target from the `name` argument via `REGISTRIES[platform][name]` and classify by **its** capability/tags. Only `READ`/`DIAGNOSTIC` are 5xx-retry-safe; `WRITE`/`WRITE_DELETE`/`OPERATIONAL` are not. If the target can't be resolved (no `name`, unknown platform, missing spec) it **fails closed** → no 5xx retry. 429 stays retried for everything (server-requested backoff is always safe).

## Tests
- Envelope: forbidden/confirmation_required/declined/tool_error(503) → `ok:false` + status/message; false-positive guard (data record with `status:"cancelled"` but no `message` stays `ok:true`); unknown status string stays `ok:true`.
- Retry meta-invoke: write target 503 → not retried; read target 503 → retried; unknown target / missing `name` → not retried (fail closed); read-or-write 429 → retried.
- Full suite green in Docker: ruff + format + mypy + 1708 passed / 1 skipped.

Patch bump 3.4.5.1 → 3.4.5.2.

---
Remaining backlog from the small-model audit (separate PRs): #523+#534 (redaction), #513+#532+#514–#518 (sandbox hints), #522+#533 (envelope consistency), #524–#527 (discovery), #519/#528/#529/#531 (docs). Note: **#530 is obsolete** — its target files (`translations/AUTHORING.md`, `targets/central/*.json`) were deleted in #510.