### PR TITLE
fix(security): secret-safe error envelopes for validation + PII middleware (#523, #534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.3] - 2026-06-25
+
+**Patch — fix(security): low-noise, secret-safe error envelopes for validation + PII middleware (#523, #534).** Validation failures and PII-token errors could echo secret-bearing or oversized inputs into model-visible text and debug logs, and unknown-token errors were text-only (code-mode callers crashed on them).
+
+### Added
+- **`redaction/safe_summary.py`** — one shared secret-safe summarizer: `is_sensitive_key` (normalized suffix match), `safe_value_summary` (redacts sensitive field values, summarizes dict/list by shape, caps long scalars), and `summarize_validation_errors`. The sensitive-key suffix list (previously duplicated in `middleware/elicitation.py`) now lives here; elicitation imports it.
+- **`redaction/walker.scan_free_text`** — public pattern-based free-text sweep (PEM/email tokenization + MAC normalization) for non-JSON content blocks.
+
+### Fixed
+- **#534 / #523 — validation errors no longer leak secrets to responses or logs.** `ValidationCatchMiddleware` builds its message via the shared summarizer, and the SAME redacted text feeds both the model-visible response and the `logger.debug` call — so a rejected `password` / `token` / `psk` value is never echoed, and large rejected payloads are summarized by type/shape instead of dumped.
+- **#523 — unknown PII-token errors return a structured envelope** (`ok: false`, `status: 400`, `message`, `tool`, `platform`, `data.unknown_tokens`) instead of a text-only result, so code-mode `call_tool(...)` callers branch cleanly instead of hitting `'str' object has no attribute 'get'`.
+- **#523 — non-JSON content blocks now get the free-text PII sweep.** Bare prose blocks (diagram source, error fallback strings) previously passed through untokenized; they now run through `scan_free_text` (pattern-based, so ordinary prose is untouched).
+
 ## [3.4.5.2] - 2026-06-25
 
 **Patch — fix(safety): two small-model safety bugs in the middleware chain (#520, #521).** Both are most dangerous for small/local models that branch literally on the envelope contract and lean on the universal `<platform>_invoke_tool` dispatch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.2"
+version = "3.4.5.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -26,29 +26,9 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from loguru import logger
 from mcp.shared.exceptions import McpError
 
-# Normalized suffixes whose VALUES are redacted from confirmation-prompt
-# parameter summaries. Keys are normalized (lowercased, separators stripped)
-# before matching, so ``api_key`` / ``apiKey`` / ``api-key`` all redact; the
-# suffix match catches compound names (``clientSecret``, ``refreshToken``,
-# ``radiusSharedSecret``). Over-redaction is acceptable; leaking is not.
-_SENSITIVE_KEY_SUFFIXES = (
-    "password",
-    "secret",
-    "token",
-    "key",
-    "psk",
-    "passphrase",
-    "community",
-    "credential",
-    "credentials",
-)
+from hpe_networking_mcp.redaction.safe_summary import is_sensitive_key as _is_sensitive_key
+
 _PARAM_SUMMARY_MAX_LEN = 300
-
-
-def _is_sensitive_key(key: str) -> bool:
-    """True when a (normalized) parameter key names secret material."""
-    normalized = "".join(ch for ch in key.lower() if ch.isalnum())
-    return any(normalized == suffix or normalized.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES)
 
 
 def _sanitized_param_summary(params: dict | None) -> str:

--- a/src/hpe_networking_mcp/middleware/pii_tokenization.py
+++ b/src/hpe_networking_mcp/middleware/pii_tokenization.py
@@ -34,10 +34,12 @@ from fastmcp.tools.tool import ToolResult
 from loguru import logger
 from mcp.types import TextContent
 
+from hpe_networking_mcp.middleware.response_envelope import _build_envelope, _infer_platform
 from hpe_networking_mcp.redaction.tokenizer import Tokenizer
 from hpe_networking_mcp.redaction.walker import (
     detokenize_arguments,
     iter_kinds_in_string,
+    scan_free_text,
     tokenize_response,
 )
 
@@ -96,7 +98,7 @@ class PIITokenizationMiddleware(Middleware):
                         tool_name,
                         sorted(set(unknown)),
                     )
-                    return _make_unknown_token_error(unknown)
+                    return _make_unknown_token_error(unknown, tool_name)
 
                 if new_args is not context.message.arguments:
                     logger.info(
@@ -207,23 +209,26 @@ def _process_content_blocks(
 
 
 def _process_text_block(text: str, tokenizer: Tokenizer | None) -> str:
-    """Parse text as JSON; if it parses, walk + re-serialize; else return as-is.
+    """Parse text as JSON; if it parses to a structure, walk + re-serialize.
+    Otherwise (non-JSON prose or a JSON scalar) run the free-text sweep.
 
     Mist / Central / etc. tools serialize structured responses with
-    ``json.dumps(data)`` so most text blocks ARE JSON. The free-text
-    sweep would still catch in-text secrets even when the block is
-    plain prose, but we apply it only on the JSON-parsed path so we
-    don't re-tokenize values that the structured walker already
-    handled.
+    ``json.dumps(data)`` so most text blocks ARE JSON and go through the
+    structured walker. Bare prose blocks (diagram source, error fallback
+    strings) previously passed through untouched (issue #523); they now get
+    the pattern-based free-text sweep (PEM / email tokenization + MAC
+    normalization), which is safe on arbitrary prose because it only matches
+    those structured patterns, not ordinary words.
     """
     try:
         parsed = json.loads(text)
     except (ValueError, TypeError):
-        return text
+        return scan_free_text(text, tokenizer)
 
     if not isinstance(parsed, (dict, list)):
-        # JSON scalar — no structure to walk
-        return text
+        # JSON scalar (e.g. a bare quoted string) — no structure to walk, but
+        # still sweep the literal text for embedded PII.
+        return scan_free_text(text, tokenizer)
 
     walked = tokenize_response(parsed, tokenizer)
     return json.dumps(walked)
@@ -258,13 +263,15 @@ def _kinds_used_in_args(arguments: dict) -> set[str]:
     return kinds
 
 
-def _make_unknown_token_error(unknown_tokens: list[str]) -> ToolResult:
+def _make_unknown_token_error(unknown_tokens: list[str], tool_name: str) -> ToolResult:
     """Build a ToolResult error when the AI references unknown tokens.
 
-    The model gets a short string explanation in the tool's content
-    block. We deliberately list the unknown tokens (they're not
-    sensitive — they don't map to anything) so the model can correct
-    itself if it copy-pasted from a stale conversation.
+    Returns a structured envelope (``ok: false``, ``status: 400``) so code-mode
+    callers receive a dict via ``call_tool(...)`` and branch cleanly instead of
+    hitting ``'str' object has no attribute 'get'`` on a text-only result
+    (issue #523). The unknown tokens are listed (they're not sensitive — they
+    map to nothing) so the model can self-correct after copy-pasting from a
+    stale conversation.
     """
     distinct = sorted(set(unknown_tokens))
     msg = (
@@ -273,4 +280,12 @@ def _make_unknown_token_error(unknown_tokens: list[str]) -> ToolResult:
         f"previous session that has ended: {distinct}. "
         "Re-fetch the source data so a fresh tokenization can be issued."
     )
-    return ToolResult(content=[TextContent(type="text", text=msg)])
+    envelope = _build_envelope(
+        ok=False,
+        data={"unknown_tokens": distinct},
+        status=400,
+        message=msg,
+        tool=tool_name,
+        platform=_infer_platform(tool_name),
+    )
+    return ToolResult(content=[TextContent(type="text", text=msg)], structured_content=envelope)

--- a/src/hpe_networking_mcp/middleware/validation_catch.py
+++ b/src/hpe_networking_mcp/middleware/validation_catch.py
@@ -33,6 +33,7 @@ from loguru import logger
 from pydantic import ValidationError
 
 from hpe_networking_mcp.middleware.response_envelope import _build_envelope, _infer_platform
+from hpe_networking_mcp.redaction.safe_summary import summarize_validation_errors
 
 # HTTP-style status code for parameter validation failures. Matches what
 # the envelope's ``status`` field would carry if the tool itself had
@@ -60,18 +61,12 @@ class ValidationCatchMiddleware(Middleware):
             return await call_next(context)  # type: ignore[no-any-return]
         except ValidationError as e:
             tool_name = getattr(context.message, "name", "unknown")
-            # Format the ValidationError details into a readable string —
-            # mirrors what Pydantic's ``str(e)`` gives us but trimmed.
-            error_lines = [f"Error: validation failed for tool '{tool_name}':"]
-            for err in e.errors():
-                loc = ".".join(str(x) for x in err.get("loc", []))
-                msg = err.get("msg", "invalid")
-                err_input = err.get("input")
-                if err_input is not None:
-                    error_lines.append(f"  - {loc}: {msg} (got: {err_input!r})")
-                else:
-                    error_lines.append(f"  - {loc}: {msg}")
-            error_text = "\n".join(error_lines)
+            # Build the message via the shared redactor (#523/#534): sensitive
+            # field VALUES are redacted by name and complex/long inputs are
+            # summarized by type/shape. The SAME redacted text feeds both the
+            # model-visible response AND the log, so neither channel can leak a
+            # password / token / PSK or dump a huge rejected payload.
+            error_text = summarize_validation_errors(tool_name, e.errors())
             logger.debug("ValidationCatchMiddleware: caught {} → {}", tool_name, error_text)
 
             # Build a proper envelope so code-mode callers receive a dict

--- a/src/hpe_networking_mcp/redaction/safe_summary.py
+++ b/src/hpe_networking_mcp/redaction/safe_summary.py
@@ -1,0 +1,84 @@
+"""Shared, secret-safe summarization for error messages and logs.
+
+Used by ``ValidationCatchMiddleware`` (#523/#534) and the elicitation
+confirmation-prompt summary so model-visible error text AND debug logs never
+echo raw secret-bearing or oversized validation inputs. One policy, one place —
+the sensitive-key suffix list previously lived (duplicated) in
+``middleware/elicitation.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+# Normalized suffixes whose VALUES are redacted. Keys are normalized
+# (lowercased, non-alphanumerics stripped) before matching, so ``api_key`` /
+# ``apiKey`` / ``api-key`` all redact; the suffix match catches compound names
+# (``clientSecret``, ``radiusSharedSecret``). Over-redaction is acceptable;
+# leaking is not.
+_SENSITIVE_KEY_SUFFIXES: tuple[str, ...] = (
+    "password",
+    "secret",
+    "token",
+    "key",
+    "psk",
+    "passphrase",
+    "community",
+    "credential",
+    "credentials",
+)
+
+REDACTED = "***redacted***"  # nosec B105 — redaction marker, not a credential
+
+# Cap for a single rendered scalar value in error text / logs. Long inputs
+# (huge payloads, base64 blobs) are elided so a validation failure can't dump
+# an unbounded value into model-visible text or the logs.
+_MAX_VALUE_LEN = 120
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True when a (normalized) parameter key names secret material."""
+    normalized = "".join(ch for ch in key.lower() if ch.isalnum())
+    return any(normalized == suffix or normalized.endswith(suffix) for suffix in _SENSITIVE_KEY_SUFFIXES)
+
+
+def safe_value_summary(value: Any, *, field_name: str | None = None, max_len: int = _MAX_VALUE_LEN) -> str:
+    """Render a value compactly without leaking secrets or dumping huge blobs.
+
+    - A sensitive ``field_name`` → ``REDACTED`` (regardless of value).
+    - ``dict`` / list-like → a shape summary (type + size), never the contents.
+    - Long scalars → capped with an elision marker.
+    """
+    if field_name is not None and is_sensitive_key(field_name):
+        return REDACTED
+    if isinstance(value, dict):
+        return f"<dict: {len(value)} field(s)>"
+    if isinstance(value, (list, tuple, set)):
+        return f"<{type(value).__name__}: {len(value)} item(s)>"
+    text = repr(value)
+    if len(text) > max_len:
+        return text[: max_len - 1] + "…"
+    return text
+
+
+def summarize_validation_errors(tool_name: str, errors: Sequence[Mapping[str, Any]]) -> str:
+    """Build a readable, redacted validation-failure message.
+
+    Shared by the model-visible response AND the debug log (#534) so the two
+    can't diverge — neither echoes a raw secret-bearing or oversized rejected
+    input. The rejected input is shown only via :func:`safe_value_summary`.
+    """
+    lines = [f"Error: validation failed for tool '{tool_name}':"]
+    for err in errors:
+        loc_parts = [str(x) for x in err.get("loc", [])]
+        loc = ".".join(loc_parts)
+        msg = err.get("msg", "invalid")
+        err_input = err.get("input")
+        if err_input is not None:
+            field = loc_parts[-1] if loc_parts else None
+            got = safe_value_summary(err_input, field_name=field)
+            lines.append(f"  - {loc}: {msg} (got: {got})")
+        else:
+            lines.append(f"  - {loc}: {msg}")
+    return "\n".join(lines)

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -159,6 +159,29 @@ def _scan_free_text(text: str, tokenizer: Tokenizer) -> str:
     return result
 
 
+def scan_free_text(text: str, tokenizer: Tokenizer | None) -> str:
+    """Public free-text sweep for non-JSON content blocks (issue #523).
+
+    ``tokenize_response`` only walks dict/list structures, so a tool that
+    returns a bare prose string (diagram source, error fallback strings) never
+    had its embedded PII swept. This applies the same pattern-based sweep used
+    for description-style fields:
+
+    - With a ``tokenizer``: PEM blocks, emails (tokenized), and MACs
+      (normalized). Pattern-based — ordinary prose words are untouched, so this
+      is safe to run over arbitrary text.
+    - Without one (PII tokenization disabled): MAC normalization only, which is
+      always-on.
+
+    Returns ``text`` unchanged for non-strings / empties.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    if tokenizer is not None:
+        return _scan_free_text(text, tokenizer)
+    return normalize_macs_in_value(text)
+
+
 def _rewrite_wrapper_key(key: str, tokenizer: Tokenizer) -> str:
     """Rewrite a wrapper dict key by tokenizing any embedded sensitive
     substring matching one of ``WRAPPER_KEY_PATTERNS``.

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -1795,3 +1795,64 @@ class TestShowCommandOutputSweep:
         swept = out["results"][0]["output"]
         assert "aa:bb:cc:dd:ee:ff" in swept
         assert "AABB.CCDD.EEFF" not in swept
+
+
+# ---------------------------------------------------------------------------
+# #523 — unknown-token error envelope + non-JSON free-text sweep
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownTokenEnvelope:
+    """#523 — referencing tokens from a dead session must return a structured
+    envelope (ok:false, status:400), not a text-only result that code-mode
+    callers crash on with ``'str' object has no attribute 'get'``."""
+
+    def test_unknown_token_error_is_structured_envelope(self) -> None:
+        from hpe_networking_mcp.middleware.pii_tokenization import _make_unknown_token_error
+
+        result = _make_unknown_token_error(["[[PSK:dead-uuid]]"], "central_invoke_tool")
+        env = result.structured_content
+        assert env is not None
+        assert env["ok"] is False
+        assert env["status"] == 400
+        assert env["tool"] == "central_invoke_tool"
+        assert env["platform"] == "central"
+        assert env["data"]["unknown_tokens"] == ["[[PSK:dead-uuid]]"]
+        # text channel still carries the readable message
+        assert result.content and "[[PSK:dead-uuid]]" in result.content[0].text
+
+
+class TestFreeTextNonJsonSweep:
+    """#523 — bare prose content blocks (non-JSON) now get the pattern-based
+    free-text sweep instead of passing through untouched."""
+
+    def _tokenizer(self) -> Tokenizer:
+        return Tokenizer(SessionKeymap(), session_id="test-session-523-freetext", max_entries=100)
+
+    def test_scan_free_text_tokenizes_email_with_tokenizer(self) -> None:
+        from hpe_networking_mcp.redaction.walker import scan_free_text
+
+        out = scan_free_text("contact admin@example.com for access", self._tokenizer())
+        assert "admin@example.com" not in out
+        assert "[[EMAIL:" in out
+
+    def test_scan_free_text_normalizes_mac_without_tokenizer(self) -> None:
+        from hpe_networking_mcp.redaction.walker import scan_free_text
+
+        out = scan_free_text("seen AABB.CCDD.EEFF on port 1", None)
+        assert "aa:bb:cc:dd:ee:ff" in out
+        assert "AABB.CCDD.EEFF" not in out
+
+    def test_process_text_block_sweeps_non_json_prose(self) -> None:
+        from hpe_networking_mcp.middleware.pii_tokenization import _process_text_block
+
+        # Non-JSON prose with an embedded MAC — previously passed through as-is.
+        out = _process_text_block("device AABB.CCDD.EEFF rebooted", None)
+        assert "aa:bb:cc:dd:ee:ff" in out
+
+    def test_process_text_block_still_walks_json(self) -> None:
+        from hpe_networking_mcp.middleware.pii_tokenization import _process_text_block
+
+        text = json.dumps({"results": [{"output": "mac AABB.CCDD.EEFF"}]})
+        out = _process_text_block(text, self._tokenizer())
+        assert "aa:bb:cc:dd:ee:ff" in out

--- a/tests/unit/test_safe_summary.py
+++ b/tests/unit/test_safe_summary.py
@@ -1,0 +1,66 @@
+"""Unit tests for the shared secret-safe summarizer (#523/#534)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.redaction.safe_summary import (
+    REDACTED,
+    is_sensitive_key,
+    safe_value_summary,
+    summarize_validation_errors,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestIsSensitiveKey:
+    @pytest.mark.parametrize(
+        "key",
+        ["password", "secret", "api_key", "apiKey", "api-key", "clientSecret", "radiusSharedSecret", "psk", "token"],
+    )
+    def test_sensitive(self, key: str) -> None:
+        assert is_sensitive_key(key) is True
+
+    @pytest.mark.parametrize("key", ["org_id", "site_name", "ssid", "vlan", "hostname", "limit"])
+    def test_not_sensitive(self, key: str) -> None:
+        assert is_sensitive_key(key) is False
+
+
+class TestSafeValueSummary:
+    def test_sensitive_field_redacts_value(self) -> None:
+        assert safe_value_summary("hunter2", field_name="password") == REDACTED
+
+    def test_dict_summarized_by_shape(self) -> None:
+        assert safe_value_summary({"a": 1, "b": 2}, field_name="payload") == "<dict: 2 field(s)>"
+
+    def test_list_summarized_by_shape(self) -> None:
+        assert safe_value_summary([1, 2, 3], field_name="items") == "<list: 3 item(s)>"
+
+    def test_long_scalar_capped(self) -> None:
+        out = safe_value_summary("x" * 500, field_name="note", max_len=50)
+        assert len(out) <= 50
+        assert out.endswith("…")
+
+    def test_short_scalar_passes_through(self) -> None:
+        assert safe_value_summary(42, field_name="count") == "42"
+
+
+class TestSummarizeValidationErrors:
+    def test_redacts_sensitive_field_value(self) -> None:
+        errors = [{"loc": ("password",), "msg": "Input should be valid", "input": "supersecret-value"}]
+        out = summarize_validation_errors("central_invoke_tool", errors)
+        assert "supersecret-value" not in out
+        assert REDACTED in out
+        assert "central_invoke_tool" in out
+
+    def test_summarizes_complex_input(self) -> None:
+        errors = [{"loc": ("payload",), "msg": "x", "input": {"a": 1, "b": 2, "c": 3}}]
+        out = summarize_validation_errors("t", errors)
+        assert "<dict: 3 field(s)>" in out
+
+    def test_no_input_key_omits_got(self) -> None:
+        errors = [{"loc": ("org_id",), "msg": "Field required"}]
+        out = summarize_validation_errors("t", errors)
+        assert "got:" not in out
+        assert "org_id: Field required" in out

--- a/tests/unit/test_validation_catch.py
+++ b/tests/unit/test_validation_catch.py
@@ -155,3 +155,49 @@ class TestValidationCatchEnvelope:
 
         result = await middleware.on_call_tool(ctx, succeeding_next)
         assert result is expected
+
+
+class _SecretModel(BaseModel):
+    """Model with a sensitive field name to test value redaction."""
+
+    password: int
+
+
+def _trigger_secret_validation_error(secret_value: str) -> ValidationError:
+    try:
+        _SecretModel(password=secret_value)  # type: ignore[arg-type]
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
+class TestValidationCatchRedaction:
+    """#523/#534 — a validation failure must not echo a secret-bearing or
+    oversized rejected input into the model-visible response OR the logs.
+    """
+
+    async def test_secret_value_redacted_in_response(self):
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        err = _trigger_secret_validation_error("supersecret-value")
+
+        async def raising_next(_: Any) -> Any:
+            raise err
+
+        result = await middleware.on_call_tool(ctx, raising_next)
+        message = result.structured_content["message"]
+        assert "supersecret-value" not in message
+        assert "***redacted***" in message
+
+    async def test_secret_value_not_in_logs(self, loguru_capture):
+        """#534 — the log channel must not leak the rejected secret either."""
+        middleware = ValidationCatchMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        err = _trigger_secret_validation_error("supersecret-value")
+
+        async def raising_next(_: Any) -> Any:
+            raise err
+
+        await middleware.on_call_tool(ctx, raising_next)
+        joined = "\n".join(loguru_capture)
+        assert "supersecret-value" not in joined


### PR DESCRIPTION
Second PR of the small-model safety backlog (security group B). Closes #523 and #534.

## The exposures
Validation failures and PII-token errors could leak secret-bearing or oversized inputs to the two channels small/local models and operators rely on:
- **#534** — `ValidationCatchMiddleware` embedded raw `err_input!r` in the message and then **logged the whole message**. A rejected `password` / `psk` / `token` value (or a huge customer payload) landed in debug logs before any response redaction.
- **#523** — same raw input reached the **model-visible** response; unknown PII-token errors were **text-only** (code-mode `call_tool` callers crash on them with `'str' object has no attribute 'get'`); and non-JSON content blocks bypassed PII redaction entirely.

## Fix
- **New `redaction/safe_summary.py`** — one shared, secret-safe policy:
  - `is_sensitive_key` (normalized suffix match: `password`/`secret`/`token`/`key`/`psk`/…),
  - `safe_value_summary` (redacts sensitive field values, summarizes dict/list by **shape**, caps long scalars),
  - `summarize_validation_errors`.
  The sensitive-key suffix list previously **duplicated** in `middleware/elicitation.py` now lives here — elicitation imports it (dedup, identical behavior).
- **`ValidationCatchMiddleware`** builds its message via the shared summarizer; the **same redacted text** feeds the response AND the `logger.debug` call, so the two can't diverge (#523 + #534).
- **Unknown PII-token error → structured envelope** (`ok:false`, `status:400`, `tool`, `platform`, `data.unknown_tokens`) instead of text-only (#523).
- **`walker.scan_free_text`** — non-JSON content blocks now get the pattern-based PEM/email/MAC sweep instead of passing through untokenized (#523). Pattern-based, so ordinary prose is untouched; MAC normalization runs even when tokenization is disabled.

## Tests
- `test_safe_summary.py` — sensitive-key detection, value redaction/shape-summary/capping, validation-error summarizer.
- `test_validation_catch.py` — secret value redacted in **response** AND absent from **logs** (`loguru_capture`, #534).
- `test_pii_redaction.py` — unknown-token structured envelope; non-JSON free-text sweep (email tokenized, MAC normalized).
- Full suite green in Docker: ruff + format + mypy + 1738 passed / 1 skipped.

Patch bump 3.4.5.2 → 3.4.5.3.

---
Remaining backlog: #513+#532+#514–#518 (sandbox hints), #522+#533 (envelope consistency), #524–#527 (discovery), #519/#528/#529/#531 (docs). **#530 is obsolete** (its files were deleted in #510).