### PR TITLE
fix(code-mode): self-correcting sandbox hints + #513 regression fix (#513,#514,#515,#516,#517,#518,#532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.4.5.4] - 2026-06-25
 
-**Patch — fix(code-mode): self-correcting hints for the common small-model sandbox dead-ends + fix a #512 regression (#513, #514, #515, #516, #517, #518, #532).** `SandboxErrorCatchMiddleware`'s hint logic is now an ordered rule table; each common raw sandbox error is turned into an actionable, self-correcting message in the error result (the channel models reliably act on).
+**Patch — fix(code-mode): self-correcting hints for the common small-model sandbox dead-ends + fix the #513 regression (introduced in v3.4.5.1 / #512) (#513, #514, #515, #516, #517, #518, #532).** `SandboxErrorCatchMiddleware`'s hint logic is now an ordered rule table; each common raw sandbox error is turned into an actionable, self-correcting message in the error result (the channel models reliably act on).
 
 ### Fixed
 - **#513 (regression in v3.4.5.1)** — the `NameError` hint no longer misfires on unavailable builtins. `object` / `open` / `eval` / … now get an "unavailable builtin" message instead of the misleading "recompute from a previous block" advice; genuine cross-block variables still get the statelessness hint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.4] - 2026-06-25
+
+**Patch — fix(code-mode): self-correcting hints for the common small-model sandbox dead-ends + fix a #512 regression (#513, #514, #515, #516, #517, #518, #532).** `SandboxErrorCatchMiddleware`'s hint logic is now an ordered rule table; each common raw sandbox error is turned into an actionable, self-correcting message in the error result (the channel models reliably act on).
+
+### Fixed
+- **#513 (regression in v3.4.5.1)** — the `NameError` hint no longer misfires on unavailable builtins. `object` / `open` / `eval` / … now get an "unavailable builtin" message instead of the misleading "recompute from a previous block" advice; genuine cross-block variables still get the statelessness hint.
+- **#514** — `ModuleNotFoundError` now explains most stdlib modules are absent and gives builtin substitutes for the common ones (`collections`→plain dict, `statistics.mean`→`sum/len`, `itertools`/`functools`→loops).
+- **#515** — `str.format()` → points at f-strings.
+- **#516** — `json.dumps(default=…)` → drop `default=`, pre-convert values.
+- **#517** — `next(<generator>, default)` → use a comprehension + index or `next(iter(seq), default)`.
+- **#518** — `dict | dict` → use `{**a, **b}`.
+- **#532** — `'<type>' object has no attribute 'get'` → explains the envelope (`result["data"]`) and collection-shape navigation (`["tools"]` / `["items"]` / bare list); the #1 code-mode shape trap (reported by Zach, twice).
+
+### Changed
+- INSTRUCTIONS.md sandbox "known-blocked" table expanded to match the new hints (stdlib modules, `.format()`, `json default=`, `next(gen)`, `dict |`, missing builtins, envelope/shape navigation).
+
 ## [3.4.5.3] - 2026-06-25
 
 **Patch — fix(security): low-noise, secret-safe error envelopes for validation + PII middleware (#523, #534).** Validation failures and PII-token errors could echo secret-bearing or oversized inputs into model-visible text and debug logs, and unknown-token errors were text-only (code-mode callers crashed on them).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.3"
+version = "3.4.5.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -274,12 +274,18 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 |---|---|---|
 | `yield` / `yield from` | `NotImplementedError: monty syntax parser does not yet support yield expressions` | Use an explicit stack/list loop and `return` |
 | `async def` (any function) | unawaited-coroutine footgun (sandbox already runs in async context) | Inline the code at the top level inside `execute()` |
-| `import hashlib` | `ModuleNotFoundError` | Accept a pre-computed digest as an input parameter |
+| most stdlib modules (`collections`, `itertools`, `functools`, `statistics`, `random`, `hashlib`, `base64`, `uuid`, `decimal`, `csv`, …) | `ModuleNotFoundError: No module named '<x>'` | Only `json`, `re`, `math`, `datetime` exist. Use builtins: a plain `dict` for `Counter`/`defaultdict`, `sum(xs)/len(xs)` for `statistics.mean`, loops/comprehensions for `itertools`/`functools` |
 | `import hpe_networking_mcp.*` | `ModuleNotFoundError` | Use platform tools via `await call_tool(name, params)` |
+| `"{} {}".format(a, b)` | `AttributeError: 'str' object has no attribute 'format'` | Use f-strings: `f"{a} {b}"` (format specs like `f"{x:.2f}"` / `f"{n:,}"` work) |
+| `json.dumps(obj, default=str)` | `TypeError: JSONEncoder.__init__() got an unexpected keyword argument 'default'` | Drop `default=`; pre-convert non-serializable values (e.g. `str(x)`) before dumping |
+| `next((x for x in xs if c), default)` | `TypeError: '<x>' object is not an iterator` | Use `hits = [x for x in xs if c]; hits[0] if hits else default`, or `next(iter(seq), default)` |
+| `a \| b` (dict union) | `TypeError: unsupported operand type(s) for \|: 'dict' and 'dict'` | Merge with `{**a, **b}` |
 | `datetime.utcnow()` | `AttributeError: 'datetime.datetime' object has no attribute 'utcnow'` | Use `datetime.now(datetime.timezone.utc)` — the sandbox clock works; `utcnow` simply isn't implemented |
 | `time.time()` / `import time` | `ModuleNotFoundError: No module named 'time'` | Use `datetime.now().timestamp()`; the `time` module doesn't exist in the sandbox |
+| missing builtins (`object`, `open`, `eval`, `exec`, …) | `NameError: name '<x>' is not defined` | File/OS and reflection builtins are unavailable — use plain data + `call_tool` |
 | `os.environ`, `subprocess`, file I/O | `RuntimeError: OS access blocked` | Accept config values as parameters |
 | `asyncio.gather()` | unavailable | Use sequential `await` calls — same wall-clock cost matters less here than in production async code |
+| `.get()` on a `call_tool` result (or a list/string) | `AttributeError: '<type>' object has no attribute 'get'` | Results are envelope-wrapped — read `result["data"]`. Collections vary: `<platform>_list_tools` → `result["data"]["tools"]`; many monitoring reads → `result["data"]["items"]`; some are a bare list. `isinstance(x, dict)` before `.get()` |
 
 **This list grows as more failures surface.** If you hit a sandbox error not listed here, file an issue with the exact error message — both the documented blocklist and the `tests/unit/test_skill_snippet_sandbox_compat.py` lint update from the same evidence.
 

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -97,28 +97,159 @@ def _clock_error_hint(cause_text: str) -> str | None:
 
 _NAMEERROR_RE = re.compile(r"name ['\"]([^'\"]+)['\"] is not defined")
 
+# Python builtins monty does NOT provide in the sandbox. A NameError on one of
+# these is an "unavailable builtin", not a cross-block-state slip — telling them
+# apart keeps the hint accurate (#513: `getattr(object(), ...)` raises NameError
+# on `object`, which previously got the misleading "recompute from a previous
+# block" advice).
+_UNAVAILABLE_BUILTINS: frozenset[str] = frozenset(
+    {
+        "object",
+        "open",
+        "eval",
+        "exec",
+        "compile",
+        "input",
+        "globals",
+        "locals",
+        "vars",
+        "help",
+        "breakpoint",
+        "__import__",
+        "memoryview",
+        "bytearray",
+    }
+)
+
 
 def _nameerror_hint(cause_text: str) -> str | None:
     """Return guidance for a sandbox ``NameError``.
 
-    The single most common cause is a model splitting work across multiple
-    ``execute()`` calls and referencing a variable defined in an earlier
-    block — but each ``execute()`` runs in a FRESH, stateless sandbox, so
-    nothing persists between calls (observed: Haiku 4.5 referencing an
-    `org_id` set in a prior block). The hint also covers the plain-typo case.
+    Two distinct causes share the ``NameError`` shape:
+
+    * An **unavailable builtin** (``object`` / ``open`` / ...) — the sandbox
+      doesn't bind it (#513).
+    * A **cross-block-state slip** — the model referenced a variable defined in
+      a PREVIOUS ``execute()`` call, but each call is a fresh, stateless sandbox
+      (observed: Haiku 4.5 referencing an `org_id` from a prior block).
+
     Returns ``None`` for non-NameError causes.
     """
     m = _NAMEERROR_RE.search(cause_text)
     if m is None:
         return None
     name = m.group(1)
+    if name in _UNAVAILABLE_BUILTINS:
+        return (
+            f"Hint: `{name}` is a Python builtin the sandbox does NOT provide "
+            "(file/OS and reflection builtins are unavailable). Use plain data, "
+            "literals, and the injected `call_tool` instead."
+        )
     return (
-        f"Hint: `{name}` is undefined. Each `execute()` call runs in a FRESH, "
-        "stateless sandbox — variables defined in a PREVIOUS `execute()` block "
-        "do NOT carry over. Do all the work for one task inside a SINGLE "
-        f"`execute()` block, or recompute/re-fetch `{name}` at the top of this "
-        "block before using it. (If it's simply a typo, fix the name.)"
+        f"Hint: `{name}` is undefined. Most often this is because each `execute()` "
+        "call runs in a FRESH, stateless sandbox — variables defined in a PREVIOUS "
+        "`execute()` block do NOT carry over. Do all the work for one task inside a "
+        f"SINGLE block, or recompute/re-fetch `{name}` here first. (It could also be "
+        "an unsupported builtin or a typo.)"
     )
+
+
+_MODULE_RE = re.compile(r"no module named ['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+# Targeted builtin substitutes for the stdlib modules small models reach for
+# most (#514). Anything not listed falls back to the generic guidance.
+_MODULE_SUBSTITUTES: dict[str, str] = {
+    "collections": "use a plain dict (`d[k] = d.get(k, 0) + 1` for Counter, "
+    "`d.setdefault(k, []).append(v)` for defaultdict)",
+    "statistics": "compute directly (mean = `sum(xs) / len(xs)`)",
+    "itertools": "use loops / comprehensions",
+    "functools": "use an explicit loop instead of reduce",
+    "random": "not available; take the first N items instead of sampling",
+}
+
+
+def _module_hint(cause_text: str) -> str | None:
+    """``ModuleNotFoundError`` — most stdlib modules are absent (#514)."""
+    m = _MODULE_RE.search(cause_text)
+    if m is None:
+        return None
+    module = m.group(1)
+    sub = _MODULE_SUBSTITUTES.get(module)
+    tail = f" For `{module}`, {sub}." if sub else " Most stdlib modules are absent."
+    return (
+        f"Hint: the sandbox has no `{module}` module.{tail} Available modules: `json`, "
+        "`re`, `math`, `datetime`. Otherwise use builtins (`dict`/`set`/`sorted`/`sum`/"
+        "`min`/`max`/`enumerate`/`zip`) and f-strings."
+    )
+
+
+def _strformat_hint(cause_text: str) -> str | None:
+    """``str.format()`` is unsupported — only f-strings work (#515)."""
+    if "object has no attribute 'format'" not in cause_text:
+        return None
+    return "Hint: the sandbox supports f-strings, not `str.format()`. Rewrite `'{} {}'.format(a, b)` as `f'{a} {b}'`."
+
+
+def _json_default_hint(cause_text: str) -> str | None:
+    """``json.dumps(default=...)`` is unsupported (#516)."""
+    if "unexpected keyword argument 'default'" not in cause_text:
+        return None
+    return (
+        "Hint: the sandbox `json.dumps` does not accept `default=`. Drop it and "
+        "pre-convert non-serializable values (e.g. `str(x)`) before dumping."
+    )
+
+
+def _next_iter_hint(cause_text: str) -> str | None:
+    """``next(<generator>, default)`` fails in the sandbox (#517)."""
+    if "object is not an iterator" not in cause_text:
+        return None
+    return (
+        "Hint: `next(<generator/list>, default)` doesn't work in the sandbox. Use a "
+        "comprehension + index (`hits = [x for x in xs if cond]; hits[0] if hits else "
+        "default`) or `next(iter(seq), default)`."
+    )
+
+
+def _dict_union_hint(cause_text: str) -> str | None:
+    """``dict | dict`` is unsupported — use spread (#518)."""
+    if "unsupported operand type(s) for |: 'dict' and 'dict'" not in cause_text:
+        return None
+    return "Hint: the sandbox doesn't support `dict | dict`. Merge with `{**a, **b}`."
+
+
+_SHAPE_RE = re.compile(r"'(\w+)' object has no attribute '(get|keys|items|values)'")
+
+
+def _shape_hint(cause_text: str) -> str | None:
+    """Dict-method on a non-dict — usually envelope/collection mis-navigation (#532)."""
+    m = _SHAPE_RE.search(cause_text)
+    if m is None:
+        return None
+    typ = m.group(1)
+    return (
+        f"Hint: you're calling a dict method on a `{typ}` (often a string from "
+        "iterating a dict's keys). `call_tool` results are wrapped in an envelope — "
+        "read the payload via `result['data']`. Collection shape varies: "
+        "`<platform>_list_tools` → `result['data']['tools']`; many monitoring reads → "
+        "`result['data']['items']`; some reads are a bare list under `result['data']`. "
+        "Check `isinstance(x, dict)` before calling `.get()`."
+    )
+
+
+# Ordered hint rules — first match wins. Order matters where causes overlap:
+# clock runs before module (the absent `time` module is a clock dead-end), and
+# the NameError builtin/state split is handled inside `_nameerror_hint`.
+_HINT_FNS = (
+    _clock_error_hint,
+    _nameerror_hint,
+    _module_hint,
+    _strformat_hint,
+    _json_default_hint,
+    _next_iter_hint,
+    _dict_union_hint,
+    _shape_hint,
+)
 
 
 class SandboxErrorCatchMiddleware(Middleware):
@@ -171,11 +302,12 @@ class SandboxErrorCatchMiddleware(Middleware):
             else:
                 error_text = f"Sandbox error: {cause}"
                 # Append a self-correcting hint for the common small-model
-                # sandbox-model mistakes (clock dead-ends, cross-block state).
-                # The error result is the one channel the model reliably acts
-                # on, unlike advisory INSTRUCTIONS.md content. The causes are
-                # mutually exclusive, so the first match wins.
-                for hint_fn in (_clock_error_hint, _nameerror_hint):
+                # sandbox mistakes (clock/time, cross-block state, missing
+                # modules/builtins, str.format, json default=, next(gen),
+                # dict|, envelope/shape navigation). The error result is the one
+                # channel the model reliably acts on, unlike advisory
+                # INSTRUCTIONS.md content. First matching rule wins.
+                for hint_fn in _HINT_FNS:
                     hint = hint_fn(str(cause))
                     if hint is not None:
                         error_text = f"{error_text}\n\n{hint}"

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -555,6 +555,96 @@ class TestSandboxErrorCatchMiddleware:
         assert "line 4" in text
 
 
+async def _monty_error_from_code(code: str):
+    """Run real failing code in monty (production os=OSAccess()) and return the
+    raised MontyError, so hint tests pin behavior against actual sandbox errors.
+    """
+    import pydantic_monty
+    from pydantic_monty import OSAccess
+
+    try:
+        await pydantic_monty.Monty(code).run_async(os=OSAccess())
+    except pydantic_monty.MontyError as e:
+        return e
+    raise AssertionError(f"expected MontyError from: {code!r}")  # pragma: no cover
+
+
+@pytest.mark.unit
+class TestSandboxHintRules:
+    """#513/#514/#515/#516/#517/#518/#532 — each common sandbox dead-end gets a
+    self-correcting hint in the error result (the channel the model acts on).
+    Driven by REAL monty errors, not synthetic strings.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("code", "needle"),
+        [
+            ("return object()", "builtin the sandbox does NOT provide"),  # #513
+            ("import collections\nreturn 1", "no `collections` module"),  # #514
+            ("return '{}'.format(1)", "f-strings, not `str.format()`"),  # #515
+            ("import json\nreturn json.dumps({}, default=str)", "does not accept `default=`"),  # #516
+            ("return next((x for x in [] if x > 1), 'd')", "doesn't work in the sandbox"),  # #517
+            ("return {'a': 1} | {'b': 2}", "doesn't support `dict | dict`"),  # #518
+            ("return 'x'.get('y')", "dict method on a `str`"),  # #532
+        ],
+    )
+    async def test_dead_end_gets_hint(self, code: str, needle: str):
+        cause = await _monty_error_from_code(code)
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+        assert needle in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_collections_hint_includes_substitute(self):
+        cause = await _monty_error_from_code("import collections\nreturn 1")
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+        assert "plain dict" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_builtin_not_given_statelessness_advice(self):
+        """#513 regression — `object` must NOT get the cross-block-state hint."""
+        cause = await _monty_error_from_code("return object()")
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+        text = str(exc_info.value)
+        assert "stateless" not in text.lower()
+        assert "builtin" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_real_undefined_variable_still_gets_statelessness_hint(self):
+        """A genuine cross-block variable (not a builtin) keeps the state hint."""
+        cause = await _monty_error_from_code("return org_id")
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+        assert "stateless" in str(exc_info.value).lower()
+
+
 # ---------------------------------------------------------------------------
 # RetryMiddleware
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Group C/D of the small-model backlog — the sandbox self-correcting hints from the audit. Closes #513, #514, #515, #516, #517, #518, #532.

`SandboxErrorCatchMiddleware`'s hint logic is now an **ordered rule table** (first match wins). Each common raw sandbox error becomes an actionable hint in the error result — the one channel small/local models reliably act on (INSTRUCTIONS.md is advisory). All hints are driven/tested against **real monty errors**, not synthetic strings.

| # | Dead-end | Hint |
|---|---|---|
| **#513** (regression) | `NameError` on a missing builtin (`object`/`open`/…) | "unavailable builtin" message instead of the misleading "recompute from a previous block" advice. Genuine undefined vars still get the statelessness hint. |
| **#514** | `ModuleNotFoundError` | most stdlib absent + builtin substitutes (`collections`→dict, `statistics.mean`→`sum/len`, `itertools`/`functools`→loops) |
| **#515** | `str.format()` | use f-strings |
| **#516** | `json.dumps(default=…)` | drop `default=`, pre-convert |
| **#517** | `next(<generator>, default)` | comprehension+index / `next(iter(seq), default)` |
| **#518** | `dict \| dict` | `{**a, **b}` |
| **#532** | `'<type>' object has no attribute 'get'` | envelope (`result["data"]`) + collection shape (`["tools"]`/`["items"]`/bare list) — the #1 shape trap, reported by Zach twice |

### #513 detail (the regression I shipped in v3.4.5.1)
Missing builtins raise the *same* `NameError` shape as a cross-block-state slip, so the v3.4.5.1 hint told the model to "recompute `object` from a previous block." Now a curated set of unavailable builtins gets a distinct message; everything else keeps the statelessness lead (with builtin/typo mentioned).

### Also
- INSTRUCTIONS.md "known-blocked" table expanded to match (stdlib modules, `.format()`, `json default=`, `next(gen)`, `dict |`, missing builtins, envelope/shape navigation).
- Tests: parametrized real-error → hint coverage for all seven, plus a #513 regression guard (`object`→builtin msg, `org_id`→statelessness msg).
- Full Docker suite green: ruff + format + mypy + 1748 passed / 1 skipped.

Patch bump 3.4.5.3 → 3.4.5.4.

---
Remaining: #522+#533 (envelope consistency), #524–#527 (discovery), #519/#528/#529/#531 (docs). **#530 obsolete** (files deleted in #510).