### PR TITLE
fix(envelope): shared status extraction + partial-envelope normalization (#522, #533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.5] - 2026-06-25
+
+**Patch — fix(envelope): consistent status extraction + partial-envelope normalization (#522, #533).** Group E of the small-model robustness backlog — keeps the response-envelope contract uniform so small/local models can branch on it reliably.
+
+### Fixed
+- **#522** — `ResponseEnvelopeMiddleware` and `RetryMiddleware` now share one HTTP-status extractor (`middleware/status_extraction.py`), so the envelope's `status` matches what Retry sees — including ClearPass-style `{"status": 503}` payloads (the envelope previously missed the `status` key). `_PLATFORM_PREFIXES` now includes `uxi_` and `edgeconnect_`, so wrapped UXI/EdgeConnect responses carry the correct `platform`.
+- **#533** — a partial envelope-shaped payload (only `{ok, data, tool}`) is now **normalized** to the full `{ok, status, data, message, tool, platform}` shape (preserving provided values, inferring `tool`/`platform`) instead of bypassing the middleware and shipping a contract-incomplete shape. Complete envelopes still pass through untouched.
+
 ## [3.4.5.4] - 2026-06-25
 
 **Patch — fix(code-mode): self-correcting hints for the common small-model sandbox dead-ends + fix the #513 regression (introduced in v3.4.5.1 / #512) (#513, #514, #515, #516, #517, #518, #532).** `SandboxErrorCatchMiddleware`'s hint logic is now an ordered rule table; each common raw sandbox error is turned into an actionable, self-correcting message in the error result (the channel models reliably act on).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.4"
+version = "3.4.5.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -39,8 +39,11 @@ from fastmcp.tools.tool import ToolResult
 from loguru import logger
 from mcp.types import TextContent
 
+from hpe_networking_mcp.middleware.status_extraction import extract_http_status
+
 # Platform prefixes used to derive the ``platform`` envelope field. Cross-platform
 # tools (those without one of these prefixes) end up with ``platform: null``.
+# Must cover every registered platform — UXI and EdgeConnect were missing (#522).
 _PLATFORM_PREFIXES: tuple[str, ...] = (
     "mist_",
     "central_",
@@ -49,6 +52,8 @@ _PLATFORM_PREFIXES: tuple[str, ...] = (
     "apstra_",
     "axis_",
     "aos8_",
+    "uxi_",
+    "edgeconnect_",
 )
 
 # Discovery tools that ship with their own ``x-fastmcp-wrap-result`` output
@@ -82,10 +87,8 @@ _NO_ENVELOPE_TOOLS: frozenset[str] = frozenset(
 # Keys an existing envelope-shaped dict must contain (idempotency check).
 _ENVELOPE_REQUIRED_KEYS: frozenset[str] = frozenset({"ok", "data", "tool"})
 
-# Keys to inspect when extracting an HTTP status code from a raw tool result.
-# Mirrors ``retry.py:_extract_status_code`` so the envelope's ``status`` field
-# is populated consistently with what RetryMiddleware would see.
-_STATUS_CODE_KEYS: tuple[str, ...] = ("status_code", "code", "http_status")
+# Canonical envelope keys, in order, used to normalize partial envelopes (#533).
+_ENVELOPE_KEYS: tuple[str, ...] = ("ok", "status", "data", "message", "tool", "platform")
 
 # Known blocked/error string-statuses our own layers return as plain dicts
 # (``<platform>_invoke_tool`` and the ``confirm_gated_invoke`` gate), mapped to
@@ -141,17 +144,11 @@ def _infer_platform(tool_name: str) -> str | None:
 def _extract_status(raw: Any) -> int | None:
     """Best-effort HTTP-status extraction from a raw tool result.
 
-    Looks for ``status_code`` / ``code`` / ``http_status`` at the top level.
-    Returns ``None`` when the tool's response doesn't carry an HTTP status
-    (most non-HTTP-bound tools).
+    Delegates to the shared :func:`extract_http_status` so the envelope's
+    ``status`` field stays aligned with what RetryMiddleware sees (#522) —
+    including ClearPass-style ``{"status": 503}`` payloads.
     """
-    if not isinstance(raw, dict):
-        return None
-    for key in _STATUS_CODE_KEYS:
-        value = raw.get(key)
-        if isinstance(value, int):
-            return value
-    return None
+    return extract_http_status(raw)
 
 
 def _is_envelope_shape(value: Any) -> bool:
@@ -275,9 +272,25 @@ class ResponseEnvelopeMiddleware(Middleware):
             raw = _payload_from_content(result.content)
 
         if raw is not None and _is_envelope_shape(raw):
-            # Tool already returned an envelope — respect it.
-            logger.debug("response_envelope: {} already enveloped, pass-through", tool_name)
-            return result  # type: ignore[return-value]
+            if set(_ENVELOPE_KEYS).issubset(raw.keys()):
+                # Complete envelope already — respect it untouched.
+                logger.debug("response_envelope: {} already enveloped, pass-through", tool_name)
+                return result  # type: ignore[return-value]
+            # PARTIAL envelope (only {ok, data, tool}) would otherwise skip
+            # normalization and ship a shape missing status/message/platform,
+            # which the small-model contract relies on (#533). Complete it:
+            # preserve provided values, fill the missing canonical keys
+            # (tool/platform inferred).
+            normalized = {
+                "ok": raw.get("ok"),
+                "status": raw.get("status"),
+                "data": raw.get("data"),
+                "message": raw.get("message"),
+                "tool": raw.get("tool", tool_name),
+                "platform": raw.get("platform", platform),
+            }
+            logger.debug("response_envelope: {} partial envelope, normalized", tool_name)
+            return ToolResult(content=result.content, structured_content=normalized)
 
         # Known blocked/error control payloads (forbidden / not_found /
         # confirmation_required / declined / ...) must surface as a FAILED

--- a/src/hpe_networking_mcp/middleware/retry.py
+++ b/src/hpe_networking_mcp/middleware/retry.py
@@ -38,6 +38,8 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.tools.tool import ToolResult
 from loguru import logger
 
+from hpe_networking_mcp.middleware.status_extraction import extract_http_status
+
 # Status codes we treat as transient. 5xx = server failure; 429 = rate limit.
 _TRANSIENT_STATUS_CODES = frozenset({500, 502, 503, 504})
 _RATE_LIMIT_STATUS_CODE = 429
@@ -68,16 +70,12 @@ def _get_float_env(name: str, default: float) -> float:
 def _extract_status_code(value: Any) -> int | None:
     """Return the HTTP status code from a tool-result dict, or None if absent.
 
-    Looks for the three response-dict shapes our platforms use:
-    Mist/GreenLake (``status_code``), Central (``code``), ClearPass (``status``).
+    Delegates to the shared :func:`extract_http_status` so Retry and the
+    response envelope read status identically (#522): Mist/GreenLake
+    (``status_code``), Central (``code``), ClearPass (``status``),
+    ``http_status``.
     """
-    if not isinstance(value, dict):
-        return None
-    for key in ("status_code", "code", "status"):
-        candidate = value.get(key)
-        if isinstance(candidate, int) and 100 <= candidate < 600:
-            return candidate
-    return None
+    return extract_http_status(value)
 
 
 def _extract_retry_after_seconds(value: Any, max_delay: float) -> float | None:

--- a/src/hpe_networking_mcp/middleware/status_extraction.py
+++ b/src/hpe_networking_mcp/middleware/status_extraction.py
@@ -1,0 +1,35 @@
+"""Shared HTTP-status extraction for the middleware chain (#522).
+
+``RetryMiddleware`` (transient-failure decisions) and
+``ResponseEnvelopeMiddleware`` (the envelope's ``status`` field) must read a
+status code out of a raw tool-result dict the SAME way, or their views of the
+same response drift — e.g. an envelope reporting ``status: null`` for a payload
+Retry already classified as a 503. One helper, one key set, one place.
+
+Platforms surface the code under different keys:
+``status_code`` (Mist / GreenLake), ``code`` (Central), ``status`` (ClearPass).
+``http_status`` is accepted defensively.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Keys checked, in priority order, for an integer HTTP status code.
+_STATUS_KEYS: tuple[str, ...] = ("status_code", "code", "status", "http_status")
+
+
+def extract_http_status(value: Any) -> int | None:
+    """Return the HTTP status code from a tool-result dict, or ``None``.
+
+    Only accepts an integer in the valid HTTP range (100–599) — a string
+    ``status`` (e.g. ClearPass ``"forbidden"`` control payloads) is ignored
+    here and handled by the envelope's blocked-state path instead.
+    """
+    if not isinstance(value, dict):
+        return None
+    for key in _STATUS_KEYS:
+        candidate = value.get(key)
+        if isinstance(candidate, int) and 100 <= candidate < 600:
+            return candidate
+    return None

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -74,6 +74,12 @@ class TestInferPlatform:
     def test_cross_platform_translate_wlan(self):
         assert _infer_platform("translate_wlan_apply") is None
 
+    def test_uxi_tool(self):
+        assert _infer_platform("uxi_list_sensors") == "uxi"
+
+    def test_edgeconnect_tool(self):
+        assert _infer_platform("edgeconnect_get_appliances") == "edgeconnect"
+
 
 # ---------------------------------------------------------------------------
 # _extract_status
@@ -90,6 +96,14 @@ class TestExtractStatus:
 
     def test_http_status_key(self):
         assert _extract_status({"http_status": 503}) == 503
+
+    def test_status_key_int_clearpass(self):
+        # #522 — ClearPass-style `{"status": 503}` is now picked up too.
+        assert _extract_status({"status": 503}) == 503
+
+    def test_status_key_string_ignored(self):
+        # A string `status` (control payload like "forbidden") is NOT a code.
+        assert _extract_status({"status": "forbidden"}) is None
 
     def test_priority_status_code_over_others(self):
         # Should pick status_code first (mirrors retry.py's _extract_status_code)
@@ -364,6 +378,76 @@ class TestBlockedStateEnvelope:
 
         env = (await middleware.on_call_tool(ctx, call_next)).structured_content
         assert env["ok"] is True
+
+
+@pytest.mark.unit
+class TestPartialEnvelopeNormalization:
+    """#533 — a partial envelope (only {ok, data, tool}) must be completed, not
+    passed through with status/message/platform missing."""
+
+    @pytest.mark.asyncio
+    async def test_partial_envelope_is_completed(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_get_sites")
+        partial = {"ok": True, "data": {"sites": []}, "tool": "central_get_sites"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=partial))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert set(env.keys()) == {"ok", "status", "data", "message", "tool", "platform"}
+        assert env["ok"] is True
+        assert env["data"] == {"sites": []}
+        assert env["status"] is None
+        assert env["message"] is None
+        assert env["platform"] == "central"  # inferred from tool name
+
+    @pytest.mark.asyncio
+    async def test_partial_envelope_preserves_provided_values(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_invoke_tool")
+        partial = {"ok": False, "data": None, "tool": "central_invoke_tool", "message": "boom"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=partial))
+
+        env = (await middleware.on_call_tool(ctx, call_next)).structured_content
+        assert env["ok"] is False
+        assert env["message"] == "boom"
+        assert env["status"] is None  # filled
+
+    @pytest.mark.asyncio
+    async def test_complete_envelope_passes_through_unchanged(self):
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("health")
+        complete = {
+            "ok": True,
+            "data": {},
+            "status": None,
+            "message": None,
+            "tool": "health",
+            "platform": None,
+        }
+        original = _make_tool_result(structured=complete)
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+        assert result is original  # untouched
+
+
+@pytest.mark.unit
+class TestStatusExtractionAlignment:
+    """#522 — Retry and the envelope must read HTTP status identically."""
+
+    def test_retry_and_envelope_agree(self):
+        from hpe_networking_mcp.middleware.retry import _extract_status_code
+
+        for payload in (
+            {"status_code": 503},
+            {"code": 404},
+            {"status": 500},
+            {"http_status": 502},
+            {"status": "forbidden"},
+            {"no": "status"},
+            {"status_code": "200"},
+        ):
+            assert _extract_status(payload) == _extract_status_code(payload)
 
 
 def _text(payload: object) -> list[TextContent]:


### PR DESCRIPTION
Group E of the small-model backlog. Closes #522 and #533.

## #522 — envelope/Retry status drift + missing platforms
- `ResponseEnvelopeMiddleware` and `RetryMiddleware` extracted HTTP status from raw payloads with **different** key sets (envelope: `status_code`/`code`/`http_status`; retry: `status_code`/`code`/`status`). So a ClearPass `{"status": 503}` was retried but then enveloped as `status: null`. Now both delegate to one shared helper — `middleware/status_extraction.py` (`extract_http_status`, key set `status_code`/`code`/`status`/`http_status`, int 100–599 only; a string `status` like `"forbidden"` is left to the #520 blocked-state path).
- `_PLATFORM_PREFIXES` was missing `uxi_` and `edgeconnect_`, so those tools enveloped with `platform: null`. Added both.

## #533 — partial envelopes bypassed normalization
`_is_envelope_shape` treats any dict with `{ok, data, tool}` as already-enveloped and passed it through. A partial/malformed envelope could thus ship **missing** `status`/`message`/`platform` — fields the small-model contract relies on. Now: if the dict has the full canonical key set it passes through untouched (unchanged behavior); if it's partial it's **completed** (provided values preserved, `tool`/`platform` inferred, missing fields filled).

## Tests
- `status` int key picked up (ClearPass); string `status` ignored.
- UXI / EdgeConnect platform inference.
- Partial-envelope completion; complete-envelope pass-through (identity preserved).
- Retry vs envelope status-extractor alignment across all key shapes.
- Full Docker suite green: ruff + format + mypy + 1756 passed / 1 skipped.

Patch bump 3.4.5.4 → 3.4.5.5.

---
Remaining: #524–#527 (discovery), #519/#528/#529/#531 (docs). **#530 obsolete** (files deleted in #510).