### PR TITLE
chore(platforms): future-proof tool registration against the #524 ordering trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.7] - 2026-06-26
+
+**Patch — chore(platforms): future-proof tool registration against the #524 ordering trap.** Follow-up to the Mist registration fix (#524): make sure no future platform can reintroduce the "tools recorded in the registry but never registered with FastMCP" bug.
+
+### Changed
+- **Template hardened** — `platforms/_template/__init__.py` now carries an explicit ORDER-MATTERS comment: `_registry.mcp = mcp` must be set before importing any tool module (or `@tool` records the spec but skips `mcp.tool()`). The template was already correct; this makes the contract impossible to miss when copying it.
+- **EdgeConnect defensive reorder** — it statically imported its `tools` package before wiring `_registry.mcp` (safe only because its `tools/__init__` is lazy). Wired `mcp` first to remove the latent Mist-class trap if that `__init__` ever eager-imports.
+
+### Added
+- **`tests/unit/test_platform_registration_order.py`** — parametrized over every platform: a static `tools`-package import must come after `_registry.mcp = mcp`, and any eager `tools/__init__` requires mcp to be wired first. Source-level (caching-safe) so a future platform can't silently reintroduce #524.
+
 ## [3.4.5.6] - 2026-06-26
 
 **Patch — fix(mist): register generated tools with FastMCP so they're discoverable (#524, #525).** Group F of the small-model robustness backlog. The ~1037 spec-driven Mist tools were never registered with FastMCP — `search` / `tags` / `get_tool_schema` couldn't see them, `get_tool_schema` returned `input_schema: null`, and a direct `call_tool("mist_...")` raised `Unknown tool`. Root cause: a one-line import-order bug.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.6"
+version = "3.4.5.7"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_template/__init__.py
+++ b/src/hpe_networking_mcp/platforms/_template/__init__.py
@@ -42,6 +42,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
     from hpe_networking_mcp.platforms._template import _registry
 
+    # ORDER MATTERS: wire the FastMCP holder BEFORE importing ANY tool module.
+    # The ``@tool`` decorator records a ToolSpec AND (only if ``_registry.mcp``
+    # is set) calls ``mcp.tool()`` to register with FastMCP. If a tool module is
+    # imported while ``_registry.mcp`` is still None, its tools land in the
+    # platform registry but NEVER register with FastMCP — invisible to
+    # search / tags / get_tool_schema and uncallable by name. This bit Mist
+    # (#524): it imported an eager-loading ``tools`` package before this line.
+    # Always set ``_registry.mcp = mcp`` first; only then import tool modules.
     _registry.mcp = mcp
 
     loaded: list[str] = []

--- a/src/hpe_networking_mcp/platforms/edgeconnect/__init__.py
+++ b/src/hpe_networking_mcp/platforms/edgeconnect/__init__.py
@@ -35,9 +35,14 @@ def register_tools(mcp: FastMCP, config: ServerConfig) -> int:
     """
     from hpe_networking_mcp.platforms._common.meta_tools import build_meta_tools
     from hpe_networking_mcp.platforms.edgeconnect import _registry
-    from hpe_networking_mcp.platforms.edgeconnect import tools as tools_pkg
 
+    # Wire the FastMCP holder BEFORE importing the tools package, so the
+    # ``@tool`` decorators always register with FastMCP (not just record specs).
+    # Safe today because ``tools/__init__`` is lazy, but ordering it correctly
+    # removes the latent Mist-class trap if it ever eager-imports (#524).
     _registry.mcp = mcp
+
+    from hpe_networking_mcp.platforms.edgeconnect import tools as tools_pkg
 
     loaded: list[str] = []
     for _finder, modname, _ispkg in pkgutil.iter_modules(tools_pkg.__path__):

--- a/tests/unit/test_platform_registration_order.py
+++ b/tests/unit/test_platform_registration_order.py
@@ -1,0 +1,79 @@
+"""Future-proofing guard for the Mist registration bug (#524).
+
+Every platform's ``register_tools`` wires its FastMCP holder via
+``_registry.mcp = mcp``. The ``@tool`` decorator records a ``ToolSpec`` AND —
+only if ``_registry.mcp`` is already set — calls ``mcp.tool()`` to register the
+tool with FastMCP. If a tool module is imported while ``_registry.mcp`` is still
+``None``, the tool lands in the platform registry but is NEVER registered with
+FastMCP: invisible to ``search`` / ``tags`` / ``get_tool_schema`` and uncallable
+by name. That's exactly what happened to all ~1037 Mist tools — Mist imported an
+eager-loading ``tools`` package before setting ``_registry.mcp`` (#524).
+
+These tests assert the invariant by source inspection (caching-safe, unlike a
+runtime check that import-caching could mask) so no future platform reintroduces
+the trap.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_PLATFORMS_DIR = Path("src/hpe_networking_mcp/platforms")
+_PLATFORMS = (
+    "mist",
+    "central",
+    "greenlake",
+    "clearpass",
+    "apstra",
+    "axis",
+    "aos8",
+    "uxi",
+    "edgeconnect",
+    "_template",
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("platform", _PLATFORMS)
+def test_mcp_wired_before_static_tools_import(platform: str) -> None:
+    """A static ``from ...<platform> import tools`` import eagerly imports the
+    tools package — so it MUST appear after ``_registry.mcp = mcp``."""
+    init = (_PLATFORMS_DIR / platform / "__init__.py").read_text(encoding="utf-8")
+    if "_registry.mcp = mcp" not in init:
+        pytest.skip(f"{platform}: no _registry.mcp wiring")
+    mcp_pos = init.index("_registry.mcp = mcp")
+    m = re.search(rf"from hpe_networking_mcp\.platforms\.{re.escape(platform)} import tools\b", init)
+    if m is None:
+        return  # no static tools-package import → registration happens via importlib after wiring
+    assert m.start() > mcp_pos, (
+        f"{platform}: register_tools imports the tools package BEFORE setting "
+        f"`_registry.mcp = mcp` — the @tool decorators will skip mcp.tool() and the "
+        f"tools won't register with FastMCP (#524). Move `_registry.mcp = mcp` up."
+    )
+
+
+@pytest.mark.parametrize("platform", _PLATFORMS)
+def test_eager_tools_init_requires_mcp_first(platform: str) -> None:
+    """If a platform's ``tools/__init__`` eager-imports submodules, the decorators
+    fire the moment the package is imported — so ``register_tools`` MUST wire
+    ``_registry.mcp`` before any tools import. (Amplifies the check above for the
+    exact shape that bit Mist.)"""
+    tools_init = _PLATFORMS_DIR / platform / "tools" / "__init__.py"
+    if not tools_init.exists():
+        pytest.skip(f"{platform}: no tools/__init__.py")
+    text = tools_init.read_text(encoding="utf-8")
+    eager = re.search(r"^\s*from \. import\b|^\s*from \.\w+ import\b", text, re.MULTILINE)
+    if eager is None:
+        return  # lazy tools/__init__ → safe regardless of register_tools ordering
+    init = (_PLATFORMS_DIR / platform / "__init__.py").read_text(encoding="utf-8")
+    assert "_registry.mcp = mcp" in init, f"{platform}: eager tools/__init__ but no _registry.mcp wiring"
+    mcp_pos = init.index("_registry.mcp = mcp")
+    imp = re.search(r"import tools as tools_pkg\b|import tools\b", init)
+    assert imp is not None and imp.start() > mcp_pos, (
+        f"{platform}: tools/__init__ eager-imports submodules, so `_registry.mcp = mcp` "
+        f"MUST be set before importing the tools package (#524)."
+    )

--- a/tests/unit/test_platform_registration_order.py
+++ b/tests/unit/test_platform_registration_order.py
@@ -22,20 +22,37 @@ from pathlib import Path
 import pytest
 
 _PLATFORMS_DIR = Path("src/hpe_networking_mcp/platforms")
-_PLATFORMS = (
-    "mist",
-    "central",
-    "greenlake",
-    "clearpass",
-    "apstra",
-    "axis",
-    "aos8",
-    "uxi",
-    "edgeconnect",
-    "_template",
-)
+
+
+def _discover_platforms() -> list[str]:
+    """Every platform package, discovered from the filesystem.
+
+    A new platform must be guarded automatically — hard-coding the list would
+    re-open the exact "future platform forgets the rule" gap this test closes
+    (Casey's review on #540). A platform package is any subdirectory whose
+    ``__init__.py`` defines ``register_tools`` (the wiring point); that excludes
+    shared infra like ``_common`` and includes ``_template``.
+    """
+    found: list[str] = []
+    for child in sorted(_PLATFORMS_DIR.iterdir()):
+        if not child.is_dir() or child.name == "__pycache__":
+            continue
+        init = child / "__init__.py"
+        if init.exists() and "def register_tools" in init.read_text(encoding="utf-8"):
+            found.append(child.name)
+    return found
+
+
+_PLATFORMS = _discover_platforms()
 
 pytestmark = pytest.mark.unit
+
+
+def test_platform_discovery_is_sane() -> None:
+    """Guard the guard: discovery must find the known platforms, so the
+    parametrized checks below can't silently degrade to a vacuous pass."""
+    assert {"mist", "central", "edgeconnect", "_template"}.issubset(_PLATFORMS), _PLATFORMS
+    assert len(_PLATFORMS) >= 9, f"expected all platforms to be discovered, got {_PLATFORMS}"
 
 
 @pytest.mark.parametrize("platform", _PLATFORMS)


### PR DESCRIPTION
Follow-up to #539 (the Mist registration fix). You asked to make sure the platform template registers tools properly so future platforms don't hit the same bug — here's the audit result and the guard.

## Audit (Mist vs Central vs everyone)
The #524 bug needs **two** things together: (a) `tools/__init__` eager-imports its submodules, **and** (b) `register_tools` imports the tools package *before* setting `_registry.mcp = mcp`. Only **Mist** had both.

| platform | `tools/__init__` | mcp before tools import? | status |
|---|---|---|---|
| **template** | lazy | yes (importlib after wiring) | ✅ already safe |
| central / clearpass / apstra / axis / greenlake / aos8 / uxi | lazy | importlib-only | ✅ safe |
| **edgeconnect** | lazy | **no** (static `import tools` before wiring) | ⚠️ safe today, latent |
| mist | eager | yes (fixed in #539) | ✅ |

The **template is already correct** (wires `mcp` first, imports each category via `importlib` after, lazy `__init__`). Mist broke only because it *diverged* into the eager-package + pkgutil pattern.

## Changes
- **Template**: explicit ORDER-MATTERS comment on `_registry.mcp = mcp` so the contract is impossible to miss when copying — especially if a new platform switches to the eager/pkgutil pattern Mist used.
- **EdgeConnect**: defensive reorder — wire `_registry.mcp` before importing its `tools` package, removing the latent trap (it's safe today only because its `__init__` is lazy).
- **New `test_platform_registration_order.py`**: parametrized over all 10 platforms (+ template). Asserts (1) any static `tools`-package import comes after `_registry.mcp = mcp`, and (2) an eager `tools/__init__` requires mcp wired first. Source-level so import caching can't mask it — a future platform that reintroduces the trap fails CI.

## Tests
ruff + format + mypy + 1777 passed / 1 skipped (incl. 20 new parametrized cases).

Patch bump 3.4.5.6 → 3.4.5.7.