### PR TITLE
feat(discovery): safety metadata + accurate tags behavior (#526, #527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.8] - 2026-06-26
+
+**Patch — feat(discovery): safety metadata in discovery output + accurate `tags` behavior (#526, #527).** Final group of the small-model robustness backlog — completes the code-mode discovery story now that Mist is visible (#524).
+
+### Added
+- **#527 — safety facets in discovery output.** New `tool_safety(spec)` (registry) exposes `capability` (read/diagnostic/write/write_delete/operational), `requires_confirmation`, and `write_gate` (`ENABLE_<PLATFORM>_WRITE_TOOLS`). `<platform>_list_tools` rows now carry a `safety` dict, and top-level `search` brief rows get a compact `[write_delete, confirm]` marker (reads stay unmarked) — so a model sees write/delete/confirmation before selecting a tool.
+
+### Changed
+- **#526 — `tags` description accuracy.** `tags` returns each tag with a tool COUNT by default; the description now says so and points at `detail="full"` to list the tools under each tag (the behavior already existed).
+- **#526 — tags-only search guidance.** `search(tags=[...], query="")` previously returned "No tools matched" (ranking needs query terms). It now returns a clear note: pass a non-empty `query` (tags then narrow it) or use `tags(detail="full")`.
+
 ## [3.4.5.7] - 2026-06-26
 
 **Patch — chore(platforms): future-proof tool registration against the #524 ordering trap.** Follow-up to the Mist registration fix (#524): make sure no future platform can reintroduce the "tools recorded in the registry but never registered with FastMCP" bug.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.7"
+version = "3.4.5.8"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -30,6 +30,7 @@ from hpe_networking_mcp.platforms._common.tool_registry import (
     REGISTRIES,
     ToolSpec,
     is_tool_enabled,
+    tool_safety,
 )
 from hpe_networking_mcp.platforms._common.tool_suggest import suggest_tools
 
@@ -321,6 +322,9 @@ def build_meta_tools(
                     "category": spec.category,
                     "summary": _tool_summary(spec),
                     "params": _param_summary(fm_tool),
+                    # Safety facets so the model can see write/delete/confirmation
+                    # before selecting a tool (#527).
+                    "safety": tool_safety(spec),
                 }
             )
 

--- a/src/hpe_networking_mcp/platforms/_common/tool_registry.py
+++ b/src/hpe_networking_mcp/platforms/_common/tool_registry.py
@@ -141,6 +141,37 @@ def is_tool_enabled(spec: ToolSpec, config: Any) -> bool:
     return bool(getattr(config, gate_attr, False))
 
 
+def tool_safety(spec: ToolSpec) -> dict[str, Any]:
+    """Compact safety facets for a tool, for discovery output (#527).
+
+    Lets a model see — before selecting a tool — whether it writes/deletes,
+    needs confirmation, and which env flag gates it. Keys:
+
+    * ``capability`` — ``read`` / ``diagnostic`` / ``write`` / ``write_delete``
+      / ``operational``. From ``spec.capability`` when set, else inferred from
+      governance tags (so even not-yet-classified tools report something).
+    * ``requires_confirmation`` — the universal gate fires before dispatch.
+    * ``write_gate`` — ``ENABLE_<PLATFORM>_WRITE_TOOLS`` when the tool is
+      write-gated, else ``None``.
+    """
+    tags = spec.tags or set()
+    capability = spec.capability.value if spec.capability is not None else None
+    if capability is None:
+        if any(t.endswith("_write_delete") for t in tags):
+            capability = "write_delete"
+        elif any(t.endswith("_write") for t in tags):
+            capability = "write"
+        else:
+            capability = "read"
+    write_gated = bool(tags & _WRITE_TAG_BY_PLATFORM.get(spec.platform, set()))
+    gate_attr = _GATE_CONFIG_ATTR.get(spec.platform)
+    return {
+        "capability": capability,
+        "requires_confirmation": "requires_confirmation" in tags,
+        "write_gate": f"ENABLE_{spec.platform.upper()}_WRITE_TOOLS" if (write_gated and gate_attr) else None,
+    }
+
+
 def _derive_category(func: Callable[..., Any]) -> str:
     """Short module name as the registry category (e.g. ``connectors``)."""
     module = getattr(func, "__module__", "")

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -572,7 +572,8 @@ _TAGS_DESCRIPTION = _SKILLS_FIRST_GATE + (
     "platform name (mist / central / aos8 / clearpass / apstra / axis / "
     "greenlake / uxi / edgeconnect), read/write classification, or feature area. Use to scope "
     "the tool catalog by category before drilling in with `search` or "
-    "`get_schema`. Returns tag names and the tools registered under each."
+    "`get_schema`. By default returns each tag name with a tool COUNT; pass "
+    '`detail="full"` to list the actual tools under each tag.'
 )
 
 _GET_SCHEMA_DESCRIPTION = _SKILLS_FIRST_GATE + (
@@ -693,18 +694,83 @@ class _SkillAwareSearchTool(_ArgTolerantFunctionTool):
     """
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        from mcp.types import TextContent
+
         result = await super().run(arguments)
+        args = arguments or {}
+        query = args.get("query", "")
+        tags = args.get("tags")
+        detail = args.get("detail", "brief")
+
+        # #527: annotate brief result rows with compact safety markers so a
+        # model sees write/delete/confirmation BEFORE selecting a tool. Only
+        # the brief format is line-oriented (`- name: desc`); detailed/full are
+        # left as-is.
+        if detail == "brief":
+            result.content = [
+                TextContent(type="text", text=_annotate_search_safety(b.text))
+                if isinstance(b, TextContent) and b.text
+                else b
+                for b in result.content
+            ]
+
+        # #526: a tags-only call (tags set, query blank) returns "No tools
+        # matched" because ranking needs query terms. Guide the model to a
+        # usable path instead of a dead end.
+        if tags and isinstance(query, str) and not query.strip():
+            note = (
+                "Tags-only search isn't supported — relevance ranking needs query terms. "
+                "Either pass a non-empty `query` (the `tags` filter then narrows it, e.g. "
+                'search(query="site", tags=["central"])), or call `tags(detail="full")` to '
+                "list every tool under a tag."
+            )
+            result.content = [TextContent(type="text", text=note), *result.content]
+            return result
+
         registry = _SEARCH_SKILL_REGISTRY
-        query = (arguments or {}).get("query", "")
         if registry is None or not isinstance(query, str):
             return result
         matches = registry.match(query)
         if not matches:
             return result
-        from mcp.types import TextContent
-
         result.content = [TextContent(type="text", text=_render_skill_matches(matches)), *result.content]
         return result
+
+
+def _safety_marker(tool_name: str) -> str:
+    """Compact safety marker for a tool name, or '' for a safe read / unknown (#527)."""
+    from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, tool_safety
+
+    for registry in REGISTRIES.values():
+        spec = registry.get(tool_name)
+        if spec is None:
+            continue
+        safety = tool_safety(spec)
+        if safety["capability"] == "read" and not safety["requires_confirmation"]:
+            return ""  # safe read — keep the row clean (absence == safe)
+        bits = [safety["capability"]]
+        if safety["requires_confirmation"]:
+            bits.append("confirm")
+        return f"  [{', '.join(bits)}]"
+    return ""  # cross-platform tool / not in any registry — leave untouched
+
+
+def _annotate_search_safety(text: str) -> str:
+    """Append safety markers to brief search rows (#527).
+
+    Brief rows are ``- <name>: <desc>`` or ``- <name>``. Resolve each name in
+    the registries and append a marker for write/delete/operational or
+    confirmation-gated tools. Rows that don't resolve (headers, cross-platform
+    tools) are left untouched; already-marked rows are skipped (idempotent).
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        if line.startswith("- ") and not line.rstrip().endswith("]"):
+            name = line[2:].split(":", 1)[0].strip()
+            if name and " " not in name:
+                line += _safety_marker(name)
+        out.append(line)
+    return "\n".join(out)
 
 
 def _make_skill_aware_search(tool: FunctionTool) -> _SkillAwareSearchTool:

--- a/tests/unit/test_discovery_safety.py
+++ b/tests/unit/test_discovery_safety.py
@@ -1,0 +1,78 @@
+"""Tests for discovery safety metadata (#527) + tags-only search guidance (#526).
+
+``tool_safety`` (registry) computes compact safety facets; the server's
+``_safety_marker`` / ``_annotate_search_safety`` surface them on brief search
+rows.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import hpe_networking_mcp.server as srv
+from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, tool_safety
+
+pytestmark = pytest.mark.unit
+
+
+class TestToolSafety:
+    def test_read_tool(self):
+        spec = SimpleNamespace(platform="central", tags=set(), capability=Capability.READ)
+        assert tool_safety(spec) == {"capability": "read", "requires_confirmation": False, "write_gate": None}
+
+    def test_write_delete_tool(self):
+        spec = SimpleNamespace(
+            platform="central",
+            tags={"central_write_delete", "requires_confirmation"},
+            capability=Capability.WRITE_DELETE,
+        )
+        s = tool_safety(spec)
+        assert s["capability"] == "write_delete"
+        assert s["requires_confirmation"] is True
+        assert s["write_gate"] == "ENABLE_CENTRAL_WRITE_TOOLS"
+
+    def test_capability_inferred_from_tags_when_unset(self):
+        spec = SimpleNamespace(platform="mist", tags={"mist_write"}, capability=None)
+        s = tool_safety(spec)
+        assert s["capability"] == "write"
+        assert s["write_gate"] == "ENABLE_MIST_WRITE_TOOLS"
+
+
+class TestSearchSafetyAnnotation:
+    def setup_method(self):
+        self._reg = REGISTRIES.setdefault("central", {})
+        self._reg["central_zzz_write_527"] = SimpleNamespace(
+            platform="central",
+            tags={"central_write_delete", "requires_confirmation"},
+            capability=Capability.WRITE_DELETE,
+        )
+        self._reg["central_zzz_read_527"] = SimpleNamespace(platform="central", tags=set(), capability=Capability.READ)
+
+    def teardown_method(self):
+        self._reg.pop("central_zzz_write_527", None)
+        self._reg.pop("central_zzz_read_527", None)
+
+    def test_marker_for_write_tool(self):
+        marker = srv._safety_marker("central_zzz_write_527")
+        assert "write_delete" in marker and "confirm" in marker
+
+    def test_no_marker_for_read_tool(self):
+        assert srv._safety_marker("central_zzz_read_527") == ""
+
+    def test_no_marker_for_unknown_tool(self):
+        assert srv._safety_marker("not_a_real_tool_anywhere") == ""
+
+    def test_annotate_brief_rows(self):
+        text = "- central_zzz_read_527: get stuff\n- central_zzz_write_527: do stuff"
+        lines = srv._annotate_search_safety(text).split("\n")
+        assert lines[0] == "- central_zzz_read_527: get stuff"  # read row untouched
+        assert "write_delete" in lines[1] and lines[1].rstrip().endswith("]")
+
+    def test_annotate_is_idempotent(self):
+        text = "- central_zzz_write_527: do stuff"
+        once = srv._annotate_search_safety(text)
+        twice = srv._annotate_search_safety(once)
+        assert once == twice  # already-marked row not double-marked

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -175,6 +175,25 @@ class TestListTools:
         required_entry = by_name["apstra_fake_required_tool"]
         assert required_entry["params"] == {"required_field": "string"}
 
+    async def test_entries_include_safety_metadata(self, mcp_with_meta_tools):
+        """#527: every list_tools entry carries compact safety facets so a model
+        sees write/delete/confirmation before selecting a tool."""
+        tool = await mcp_with_meta_tools.get_tool("apstra_list_tools")
+        result = await tool.fn(_fake_ctx(ServerConfig(enable_apstra_write_tools=True)))
+        by_name = {e["name"]: e for e in result["tools"]}
+
+        read = by_name["apstra_get_blueprints"]["safety"]
+        assert read["capability"] == "read"
+        assert read["requires_confirmation"] is False
+        assert read["write_gate"] is None
+
+        # The stub sets capability=READ on a write-tagged tool (artificial; in
+        # production classify() keeps them consistent), so assert the meaningful
+        # signal — the write gate is derived from the platform write tag.
+        write = by_name["apstra_create_virtual_network"]["safety"]
+        assert write["write_gate"] == "ENABLE_APSTRA_WRITE_TOOLS"
+        assert set(write) == {"capability", "requires_confirmation", "write_gate"}
+
 
 @pytest.mark.unit
 class TestGetToolSchema:


### PR DESCRIPTION
Final group of the small-model robustness backlog. Closes #526 and #527. Builds on #524 (Mist now visible in discovery).

## #527 — safety metadata in discovery output
A model selecting from thousands of tools should see write/delete/confirmation *before* it picks one. New `tool_safety(spec)` (in `tool_registry`) exposes:
- `capability` — read / diagnostic / write / write_delete / operational (from `spec.capability`, else inferred from governance tags)
- `requires_confirmation` — the universal gate fires before dispatch
- `write_gate` — `ENABLE_<PLATFORM>_WRITE_TOOLS` when write-gated, else null

Surfaced in both selection surfaces:
- **`<platform>_list_tools`** rows get a structured `safety` dict (the in-sandbox path).
- **Top-level `search`** brief rows get a compact suffix marker, e.g. `- central_manage_site: ...  [write_delete, confirm]`. Reads stay unmarked (absence == safe); cross-platform/unknown names untouched; idempotent.

## #526 — accurate `tags` + tags-only search
- `tags` returns each tag with a tool **count** by default; the description now says so and points at `detail="full"` to list the tools under each tag (that behavior already existed — the description overpromised "the tools registered under each").
- `search(tags=[...], query="")` returned "No tools matched" (BM25 needs query terms). It now returns a clear note: pass a non-empty `query` (tags then narrow it), or use `tags(detail="full")`.

## Tests
- `tool_safety` (read / write_delete / inferred-from-tags) ; `list_tools` carries `safety`; `search` brief-row marker + idempotency; tags-only guidance.
- ruff + format + mypy + 1787 passed / 1 skipped.

Patch bump 3.4.5.7 → 3.4.5.8. **That closes the entire small-model robustness audit** (#513–#534); remaining work is group G docs (#519/#528/#529/#531).