### PR TITLE
docs(code-mode) + fix(security): refresh code-mode docs (#528,#519) + joserfc CVE-2026-48990 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.9] - 2026-06-26
+
+**Patch — docs(code-mode): refresh code-mode docs to current behavior (#528, #519).** Group G docs cleanup, re-scoped: several original premises were mooted by the v3.4.5.x fixes (bare per-platform calls and top-level `return` both work now), so this corrects what's genuinely stale rather than applying obsolete rewrites.
+
+### Changed
+- **#528 — `docs/TOOLS.md` code-mode section.** Surface count 4 → 6 tools (added `skills_list` / `skills_load`); the example now unwraps the universal envelope via `["data"]` (was the pre-envelope `["result"]`) and shows Central collection reads under `data["items"]` (#491); the `call_tool` dispatch note lists all 9 platforms (Mist now callable by name, #524) + the meta-tools. Corrected now-false sandbox-limit claims: `datetime.now()` / `date.today()` WORK (v3.4.5.1), `type()` is available; replaced with the accurate stdlib/builtin guidance and the self-correcting-error note.
+- **#519 — INSTRUCTIONS.md sandbox table.** Added substitute rows for the unsupported syntax constructs `with` / `match` / `class` / `del`.
+
+### Note
+- #529 (prompts/skills "use invoke_tool, not bare calls; avoid top-level `return`") is moot after #524/#539 — bare per-platform calls and top-level `return` are both supported — and the referenced prompt tools all exist; closed with that note rather than rewriting working guidance.
+
 ## [3.4.5.8] - 2026-06-26
 
 **Patch — feat(discovery): safety metadata in discovery output + accurate `tags` behavior (#526, #527).** Final group of the small-model robustness backlog — completes the code-mode discovery story now that Mist is visible (#524).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#528 — `docs/TOOLS.md` code-mode section.** Surface count 4 → 6 tools (added `skills_list` / `skills_load`); the example now unwraps the universal envelope via `["data"]` (was the pre-envelope `["result"]`) and shows Central collection reads under `data["items"]` (#491); the `call_tool` dispatch note lists all 9 platforms (Mist now callable by name, #524) + the meta-tools. Corrected now-false sandbox-limit claims: `datetime.now()` / `date.today()` WORK (v3.4.5.1), `type()` is available; replaced with the accurate stdlib/builtin guidance and the self-correcting-error note.
 - **#519 — INSTRUCTIONS.md sandbox table.** Added substitute rows for the unsupported syntax constructs `with` / `match` / `class` / `del`.
 
+### Security
+- Bump transitive `joserfc` 1.6.4 → 1.7.2 (via `authlib` / `fastmcp`) — resolves **CVE-2026-48990** flagged by the dependency audit. Lock-only change.
+
 ### Note
 - #529 (prompts/skills "use invoke_tool, not bare calls; avoid top-level `return`") is moot after #524/#539 — bare per-platform calls and top-level `return` are both supported — and the referenced prompt tools all exist; closed with that note rather than rewriting working guidance.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -47,7 +47,7 @@ The 3177 per-platform tools are reachable via `<platform>_invoke_tool(name=..., 
 
 ## Code mode details (the default — see above for surface summary)
 
-With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool surface: `tags`, `search`, `get_schema`, and `execute`. The LLM writes async Python inside `execute`; `call_tool(tool_name, params)` dispatches through the real FastMCP call_tool so every middleware (NullStrip, Elicitation, Pydantic coercion) keeps working. Multi-step workflows collapse from N MCP round-trips to one.
+With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 6-tool surface: `tags`, `search`, `get_schema`, `skills_list`, `skills_load`, and `execute`. The LLM writes async Python inside `execute`; `call_tool(tool_name, params)` dispatches through the real FastMCP call_tool so every middleware (NullStrip, Elicitation, Pydantic coercion) keeps working. Multi-step workflows collapse from N MCP round-trips to one.
 
 ### Four-tier progressive disclosure
 
@@ -61,15 +61,16 @@ With `MCP_TOOL_MODE=code` the server replaces the exposed catalog with a 4-tool 
 ### Example — cross-platform join in one call
 
 ```python
-me = await call_tool("mist_get_self", {"action_type": "account_info"})
-org_id = me["result"]["privileges"][0]["org_id"]
+# call_tool returns the universal envelope {ok, status, data, ...}; read the payload from ["data"].
+me = await call_tool("mist_get_self", {})
+org_id = me["data"]["privileges"][0]["org_id"]
 
 mist_aps = await call_tool("mist_search_device", {"org_id": org_id, "device_type": "ap", "limit": 5})
 central_aps = await call_tool("central_get_aps", {"site_name": "HQ", "status": "ONLINE"})
 
 return {
-    "mist_count": len(mist_aps["result"]["results"]),
-    "central_count": len(central_aps["result"]),
+    "mist_count": len(mist_aps["data"]["results"]),
+    "central_count": len(central_aps["data"]["items"]),  # Central collection reads land under data["items"] (#491)
 }
 ```
 
@@ -83,15 +84,14 @@ Three tool calls inside one `execute`. In dynamic mode this same workflow would 
 
 The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recursion depth (50). Several Python features the LLM may reach for are also unavailable:
 
-- **`asyncio.gather()`** — fails with `TypeError: 'list' object is not an iterator`. Use sequential `await` calls instead.
-- **OS-access functions** — `datetime.now()`, `time.time()`, file I/O (`open`, `Path.read_text`), `os.environ`, and `subprocess` all raise `NotImplementedError`. For timestamps, accept ISO strings as parameters or hardcode literal ISO-8601 strings.
-- **Some introspection** — `hasattr`, `type`, and parts of the introspection surface aren't available; the LLM discovers these via error messages.
-
-The `execute` tool description tells the LLM these limits up front so it shouldn't waste turns rediscovering them.
+- **The clock works** (since v3.4.5.1) — `datetime.now()`, `datetime.now(datetime.timezone.utc)`, and `datetime.date.today()` return the real time. But `datetime.utcnow()` is NOT implemented (use `datetime.now(datetime.timezone.utc)`) and there is no `time` module (use `datetime.now().timestamp()`).
+- **Most stdlib modules are absent** — only `json`, `re`, `math`, `datetime` exist; `collections`, `itertools`, `functools`, `statistics`, etc. raise `ModuleNotFoundError`. Use builtins: a plain `dict` for `Counter`/`defaultdict`, `sum(xs)/len(xs)` for `statistics.mean`.
+- **Blocked**: file I/O (`open`, `Path.read_text`), `os.environ`, `subprocess`, `asyncio.gather()`, `str.format()` (use f-strings), `json.dumps(default=)`, `next(<generator>, default)`, and `dict | dict` (use `{**a, **b}`).
+- The `execute` tool description and INSTRUCTIONS.md sandbox table list these up front, and `SandboxErrorCatchMiddleware` turns the common dead-ends into self-correcting error messages so the LLM doesn't waste turns rediscovering them.
 
 ### What `call_tool` can dispatch to
 
-Inside `execute()`, `call_tool(name, params)` only resolves names from the backend platform catalog — every tool whose name starts with `mist_` / `central_` / `greenlake_` / `clearpass_` / `apstra_` / `axis_`, plus the cross-platform `health`. The discovery tools (`tags` / `search` / `get_schema`) are NOT callable from inside `execute()` — they live at the outer MCP surface for planning. Use them BEFORE writing your code block, then chain platform tools inside.
+Inside `execute()`, `call_tool(name, params)` resolves any registered platform tool — every name starting with `mist_` / `central_` / `greenlake_` / `clearpass_` / `apstra_` / `axis_` / `aos8_` / `uxi_` / `edgeconnect_` (Mist included, since v3.4.5.6), plus cross-platform `health` and the `translate_*` tools, and each platform's `<platform>_list_tools` / `<platform>_get_tool_schema` / `<platform>_invoke_tool` meta-tools. A per-platform tool is callable either directly by name or via `<platform>_invoke_tool`. The TOP-LEVEL discovery tools (`tags` / `search` / `get_schema` / `skills_list` / `skills_load`) are NOT callable from inside `execute()` — they live at the outer MCP surface for planning; use them (or the in-sandbox `<platform>_list_tools`) BEFORE chaining platform tools.
 
 If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMiddleware` returns a string like `Sandbox error: Exception: Unknown tool: search` so you can fix the call on the next turn (rather than seeing a generic masked error). See v2.2.0.4 release notes / #208.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.8"
+version = "3.4.5.9"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -274,6 +274,10 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 |---|---|---|
 | `yield` / `yield from` | `NotImplementedError: monty syntax parser does not yet support yield expressions` | Use an explicit stack/list loop and `return` |
 | `async def` (any function) | unawaited-coroutine footgun (sandbox already runs in async context) | Inline the code at the top level inside `execute()` |
+| `with` (context managers) | `NotImplementedError: … does not yet support context managers` | Call/clean up explicitly; for tool I/O you don't need `with` at all |
+| `match` / `case` | `NotImplementedError: … does not yet support pattern matching` | Use `if` / `elif` / `else` |
+| `class` definitions | `NotImplementedError: … does not yet support class definitions` | Use a plain `dict` (or a function returning one) |
+| `del x` / `del d[k]` | `NotImplementedError: … does not yet support the 'del' statement` | Rebuild without the key, or `d.pop(k, None)` |
 | most stdlib modules (`collections`, `itertools`, `functools`, `statistics`, `random`, `hashlib`, `base64`, `uuid`, `decimal`, `csv`, …) | `ModuleNotFoundError: No module named '<x>'` | Only `json`, `re`, `math`, `datetime` exist. Use builtins: a plain `dict` for `Counter`/`defaultdict`, `sum(xs)/len(xs)` for `statistics.mean`, loops/comprehensions for `itertools`/`functools` |
 | `import hpe_networking_mcp.*` | `ModuleNotFoundError` | Use platform tools via `await call_tool(name, params)` |
 | `"{} {}".format(a, b)` | `AttributeError: 'str' object has no attribute 'format'` | Use f-strings: `f"{a} {b}"` (format specs like `f"{x:.2f}"` / `f"{n:,}"` work) |

--- a/uv.lock
+++ b/uv.lock
@@ -662,7 +662,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.4.2.0"
+version = "3.4.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp", extra = ["apps", "code-mode"] },
@@ -835,14 +835,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Group G docs cleanup, re-scoped against current behavior. Closes #528 and #519.

Several of group G's original premises were **mooted by the v3.4.5.x fixes** — bare per-platform calls work for every platform now (#524/#539), and our sandbox supports top-level `return`. So this corrects what's genuinely stale rather than applying the now-obsolete "force invoke_tool / no top-level return" rewrites.

## #528 — `docs/TOOLS.md` code-mode section
- Surface count **4 → 6** tools (added `skills_list` / `skills_load`).
- Example now unwraps the **universal envelope** via `["data"]` (was the pre-envelope `["result"]`); Central collection reads shown under `data["items"]` (#491).
- `call_tool` dispatch note lists **all 9 platforms** (Mist callable by name since #524) + the `<platform>_*` meta-tools, and notes direct-or-invoke_tool equivalence.
- **Corrected now-false sandbox-limit claims**: it said `datetime.now()` raises `NotImplementedError` and `type()` is unavailable — both false since v3.4.5.1. Replaced with accurate guidance (clock works; `utcnow`/`time` don't; most stdlib absent; `.format`/`json default=`/`next(gen)`/`dict|` blocked) + the self-correcting-error note.

## #519 — INSTRUCTIONS.md sandbox table
Added substitute rows for the unsupported syntax constructs `with` / `match` / `class` / `del`.

## Audit (per "make sure all docs are up to date")
- **README.md** verified already accurate — 6-tool surface, envelope shape, tool counts (unchanged this session), no stale Mist/datetime claims. No change needed.
- **`docs/genui.md`, `docs/engine_test.md`, Qwen3 test report** are captured session transcripts (historical records) — left as-is; rewriting them would falsify the record.
- **#529** is moot post-#524/#539 (bare calls + top-level `return` both work; referenced prompt tools all exist) — to be closed with that note, not a rewrite.

No code change; full suite green (ruff + format + mypy + 1787 passed / 1 skipped). Patch bump 3.4.5.8 → 3.4.5.9 (INSTRUCTIONS.md is a shipped runtime artifact).

Remaining in group G: **#531** (aos-migration runbook state-machine + GenUI fallbacks) — separate PR.