### PR TITLE
docs(skills): runbook state-machine ledger + Generative-UI fallback guard (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.5.10] - 2026-06-29
+
+**Patch — docs(skills): runbook state-machine + Generative-UI fallback guard (#531).** Last item of the small-model robustness audit (#513–#534).
+
+### Added
+- **`aos-migration.md` checkpoint ledger** — a compact "state machine at a glance" table near the top of the 2100-line runbook: per stage, the required inputs, the cached artifact it produces, allowed next stages, and stop/branch conditions, plus the hard-stops collected in one place. Keeps a small/local model from losing its place or re-collecting Act I data.
+- **`tests/unit/test_genui_skill_fallbacks.py`** — discovers every skill referencing `generate_prefab_ui` and asserts each teaches the safe render contract: call it as a TOP-LEVEL tool (not from inside `execute()`), describe a no-Generative-UI fallback, and mandate a text summary regardless of render. Both current Generative-UI skills (`central-site-dashboard`, `central-ucc-quality`) already comply; the test locks it in for future ones.
+
 ## [3.4.5.9] - 2026-06-26
 
 **Patch — docs(code-mode): refresh code-mode docs to current behavior (#528, #519).** Group G docs cleanup, re-scoped: several original premises were mooted by the v3.4.5.x fixes (bare per-platform calls and top-level `return` both work now), so this corrects what's genuinely stale rather than applying obsolete rewrites.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.5.9"
+version = "3.4.5.10"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/skills/aos-migration.md
+++ b/src/hpe_networking_mcp/skills/aos-migration.md
@@ -108,6 +108,24 @@ The skill's job is to prove the in-chat workflow produces credible readiness fin
 
 ## Procedure — 10 numbered stages across two acts (plus the Stage 6.5 questionnaire between the acts)
 
+### State machine at a glance (checkpoint ledger)
+
+This runbook is long — anchor on this table so you don't lose your place. You are always in **exactly one** stage. Before acting, confirm the named inputs exist (each is the cached artifact of an earlier stage); if a required artifact is missing, go back to the stage that produces it — **never re-fetch what an earlier stage already cached.**
+
+| Stage | Needs (inputs) | Produces / caches | Allowed next | Stop / branch |
+|---|---|---|---|---|
+| **-2 Source** | — | `source` = api / upload / paste | `-1` (api) · `1-ALT` (upload/paste) | — |
+| **-1 Reachability** (api) | AOS 8 creds | reachability OK | `1` | unreachable → stop, or fall back to upload/paste |
+| **1 Collect** (api) | reachable | `config_by_scope` (full `/md` walk) | `2` | — |
+| **1-ALT Parse** (offline) | uploaded/pasted config | parsed subset (+ `inconclusive` marks) | `2` | nothing parsed → EMPTY-SOURCE |
+| **2–5 Analyze** | `config_by_scope` / parsed subset | parity + prerequisite findings, target-arch detections | `6` | — |
+| **6 Verdict** | findings | **verdict** (GO / PARTIAL / EMPTY-SOURCE / BLOCKED) + report | GATE | **BLOCKED → end (no gate)** |
+| **GATE** | verdict report | operator `yes` / `no` / `edit-context` | `6.5` on `yes` | `no` → end · `edit-context` → re-run 3+6 |
+| **6.5 Questionnaire** | verdict ≠ EMPTY-SOURCE, detections | `runtime_values` (per-SSID forward-mode, gateway topology) | `7` | EMPTY-SOURCE → skip 6.5, Act II on defaults |
+| **7–10 Plan (Act II)** | Act I data + `runtime_values` | disposition matrix + ordered Central API sequence + validation checklist | done | plan only — never executes `central_manage_*` writes |
+
+Hard stops, in one place: **BLOCKED verdict** (no Act II), operator **`no`** at the gate, and **AOS 8 unreachable** with no offline source. Act II never re-collects — if you find yourself re-fetching effective-config or re-pasting, you've lost the ledger; the Act I artifacts are already in context.
+
 **Data-source gate (Stage -2) — ALWAYS FIRST.** Before any collection, ask the operator how to obtain the AOS 8 config — (1) API, (2) upload, (3) paste — and route accordingly. See Stage -2.
 
 **Act I (Stages -1 through 6) — readiness audit.** Runs in full on the **API path** (Stage -1 → Stage 1). On the **upload / paste paths** it runs in reduced form against the offline-parsed subset (Stage 1-ALT replaces Stage -1 + Stage 1; object classes the parser doesn't cover are marked `inconclusive — offline source`). Ends with a verdict + combined report.

--- a/tests/unit/test_genui_skill_fallbacks.py
+++ b/tests/unit/test_genui_skill_fallbacks.py
@@ -1,0 +1,65 @@
+"""Guard that every Generative-UI skill teaches the safe render contract (#531).
+
+Skills that render via ``generate_prefab_ui`` must, for small/local models:
+1. call it as a TOP-LEVEL tool (not from inside an ``execute()`` block),
+2. describe a no-Generative-UI fallback (it no-ops in non-apps clients), and
+3. mandate a text summary regardless of whether the widget renders.
+
+Discovered dynamically (any skill referencing ``generate_prefab_ui``) so a new
+Generative-UI skill is covered automatically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_SKILLS = Path("src/hpe_networking_mcp/skills")
+
+pytestmark = pytest.mark.unit
+
+
+def _genui_skills() -> list[str]:
+    out: list[str] = []
+    for p in sorted(_SKILLS.glob("*.md")):
+        if p.name == "TEMPLATE.md":
+            continue
+        if "generate_prefab_ui" in p.read_text(encoding="utf-8"):
+            out.append(p.name)
+    return out
+
+
+_GENUI = _genui_skills()
+
+_FALLBACK_KEYWORDS = ("fallback", "no-op", "isn't available", "not available", "unavailable")
+_TEXT_SUMMARY_KEYWORDS = ("text summary", "walkthrough", "markdown summary", "regardless of render", "always emit")
+
+
+def test_discovery_finds_known_genui_skills() -> None:
+    """Guard the guard: the parametrized checks can't degrade to a vacuous pass."""
+    assert {"central-site-dashboard.md", "central-ucc-quality.md"}.issubset(_GENUI), _GENUI
+
+
+@pytest.mark.parametrize("name", _GENUI)
+def test_top_level_call_reminder(name: str) -> None:
+    text = (_SKILLS / name).read_text(encoding="utf-8").lower()
+    assert "top-level" in text, (
+        f"{name}: must state generate_prefab_ui is a TOP-LEVEL tool (not called from inside execute())."
+    )
+
+
+@pytest.mark.parametrize("name", _GENUI)
+def test_no_tool_fallback_described(name: str) -> None:
+    text = (_SKILLS / name).read_text(encoding="utf-8").lower()
+    assert any(k in text for k in _FALLBACK_KEYWORDS), (
+        f"{name}: must describe a no-Generative-UI fallback (the tool no-ops in non-apps clients)."
+    )
+
+
+@pytest.mark.parametrize("name", _GENUI)
+def test_mandatory_text_summary(name: str) -> None:
+    text = (_SKILLS / name).read_text(encoding="utf-8").lower()
+    assert any(k in text for k in _TEXT_SUMMARY_KEYWORDS), (
+        f"{name}: must mandate a text summary regardless of whether the widget renders."
+    )


### PR DESCRIPTION
Final item of the small-model robustness audit (#513–#534). Closes #531.

Re-scoped against reality (like the rest of group G): the audit found that **both** Generative-UI skills (`central-site-dashboard`, `central-ucc-quality`) **already** teach the safe render contract — top-level call, no-GenUI fallback, and a mandatory text summary (worded variously across Steps 4/5). So the real gaps were the missing runbook ledger and the absence of a *guard* to keep it that way.

## Added
- **`aos-migration.md` checkpoint ledger** — a compact "state machine at a glance" table near the top of the 2100-line runbook. Per stage: required inputs, the cached artifact it produces, allowed next stages, and stop/branch conditions — plus the hard-stops (BLOCKED verdict, gate `no`, AOS 8 unreachable) collected in one place, and an explicit "Act II never re-collects" reminder. Keeps a small/local model from losing its place or re-fetching Act I data.
- **`test_genui_skill_fallbacks.py`** — discovers every skill referencing `generate_prefab_ui` and asserts each teaches: (1) call it as a TOP-LEVEL tool (not inside `execute()`), (2) a no-Generative-UI fallback, (3) a text summary regardless of render. Both current GenUI skills pass; the test locks it in for future ones (dynamic discovery + a guard-the-guard sanity check).

## Not changed
- The GenUI skills' render sections already satisfy the contract, so no rewrite — the test pins the existing behavior.

Docs/test only; ruff + format + mypy + 1794 passed / 1 skipped. Patch bump 3.4.5.9 → 3.4.5.10.

**This closes the entire small-model robustness audit (#513–#534).**