### PR TITLE
fix(envelope): bypass wrap-result tools via meta marker (fixes list_files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6.1] - 2026-06-29
+
+**Patch — fix `list_files` / `read_file` failing with "'result' is a required property" under the response envelope.** Restores the MCP-Apps file-upload discovery UX: after a user uploads a CSV via the `file_manager` widget, the model can call `list_files` to discover the uploaded filename for `greenlake_bulk_add_devices` instead of being told the name. Closes #544.
+
+### Fixed
+- `ResponseEnvelopeMiddleware` now bypasses **wrap-result** tools structurally via FastMCP's `meta={"fastmcp": {"wrap_result": True}}` marker (the same approach as the existing `$prefab` UI bypass), instead of a hand-maintained name list. Tools that return a non-dict (e.g. `list_files` → `list[dict]`, `read_file` → `dict`) get auto-wrapped by FastMCP as `structured_content={"result": ...}` with an `x-fastmcp-wrap-result` output schema; enveloping them stripped the top-level `result` and FastMCP's own output validation rejected the call with "'result' is a required property" (same failure class as #293 / #302, which the FileUpload tools were missing from `_NO_ENVELOPE_TOOLS`). The marker covers every current and future wrap-result tool with no list to keep in sync.
+
+### Notes
+- No tool/parameter/count changes. Internal middleware fix only.
+- Validated against the real `FileUpload` provider through the real middleware chain (the tool is intentionally not name-listed, so it passes purely via the marker), plus an over-bypass guard ensuring a `{"result": ...}` dict *without* the marker is still enveloped normally.
+
 ## [3.4.6.0] - 2026-06-29
 
 **Minor — GreenLake bulk device onboarding (`greenlake_bulk_add_devices`) with a choose-your-source data flow.** First GreenLake write tool: onboard up to 10,000 devices from a CSV in one call, with rate-limiting, resume-on-failure, and optional subscription/service/location/tags assignment. The operator chooses how to provide the list — **file upload** (read server-side; never enters model context — best for large lists), **copy/paste**, or a local path. Builds on PR #379.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.6.0"
+version = "3.4.6.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/response_envelope.py
+++ b/src/hpe_networking_mcp/middleware/response_envelope.py
@@ -247,6 +247,26 @@ class ResponseEnvelopeMiddleware(Middleware):
             logger.debug("response_envelope: {} is a discovery tool, pass-through", tool_name)
             return result  # type: ignore[return-value]
 
+        # Wrap-result tools — detected structurally, NOT by name. When a tool
+        # returns a non-dict (a bare ``list``/``str``) and declares an output
+        # schema, FastMCP wraps the value as ``structured_content={"result": ...}``
+        # and stamps ``meta={"fastmcp": {"wrap_result": True}}`` on the ToolResult
+        # (see fastmcp ``tools/base.py``). Enveloping such a result strips the
+        # top-level ``result`` key, so FastMCP's own output-schema validation then
+        # rejects it with "'result' is a required property". The MCP-Apps
+        # ``FileUpload`` tools (``list_files`` returns ``list[dict]``, ``read_file``
+        # returns ``dict`` via the same path) and the discovery/prefab tools are all
+        # of this kind. Detecting the marker (like the ``$prefab`` check below)
+        # covers every current and future wrap-result tool without a name list to
+        # keep in sync — the ``list_files`` regression that motivated this slipped
+        # through precisely because ``_NO_ENVELOPE_TOOLS`` was hand-maintained.
+        meta = getattr(result, "meta", None)
+        if isinstance(meta, dict):
+            fastmcp_meta = meta.get("fastmcp")
+            if isinstance(fastmcp_meta, dict) and fastmcp_meta.get("wrap_result"):
+                logger.debug("response_envelope: {} is a wrap-result tool, pass-through", tool_name)
+                return result  # type: ignore[return-value]
+
         # Determine the raw structured payload, if any.
         raw = getattr(result, "structured_content", None)
 

--- a/tests/unit/test_generative_ui.py
+++ b/tests/unit/test_generative_ui.py
@@ -95,6 +95,27 @@ def test_search_prefab_components_not_enveloped(monkeypatch: pytest.MonkeyPatch)
     assert "ok" not in sc, "prefab tool got enveloped; it must be in _NO_ENVELOPE_TOOLS"
 
 
+def test_list_files_not_enveloped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression (v3.4.6.1): the FileUpload provider's ``list_files`` declares the
+    same ``x-fastmcp-wrap-result`` output schema requiring a top-level ``result``
+    key. Calling it through the real server stack must succeed — the envelope must
+    NOT wrap it, or FastMCP's own output validation raises "'result' is a required
+    property" (observed live in an MCP-Apps client when the model called list_files
+    to discover an uploaded CSV's name for greenlake_bulk_add_devices).
+
+    This drives the REAL FileUpload tool through the REAL middleware chain (no
+    mock) so it actually reproduces the production failure if the bypass regresses.
+    """
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
+    mcp = _build("code")
+    # Empty session store → the provider returns {"result": []}; the point is that
+    # the call completes through output validation rather than raising.
+    res = asyncio.run(mcp.call_tool("list_files", {}))  # type: ignore[attr-defined]
+    sc = getattr(res, "structured_content", None) or {}
+    assert "result" in sc, "wrap-result 'result' key stripped — envelope wrapped list_files"
+    assert "ok" not in sc, "list_files got enveloped; it must be in _NO_ENVELOPE_TOOLS"
+
+
 def test_description_augmented_with_dashboard_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
     """The tool description (not INSTRUCTIONS.md) is what steers tool selection, so
     generate_prefab_ui's description must carry the dashboard guidance AND keep the

--- a/tests/unit/test_response_envelope_middleware.py
+++ b/tests/unit/test_response_envelope_middleware.py
@@ -38,11 +38,16 @@ def _make_context(tool_name: str):
     return context
 
 
-def _make_tool_result(structured: object | None, content: list | None = None) -> ToolResult:
-    """Build a ToolResult with the given structured_content."""
+def _make_tool_result(
+    structured: object | None,
+    content: list | None = None,
+    meta: dict | None = None,
+) -> ToolResult:
+    """Build a ToolResult with the given structured_content (and optional meta)."""
     return ToolResult(
         content=content if content is not None else [],
         structured_content=structured,
+        meta=meta,
     )
 
 
@@ -678,6 +683,50 @@ class TestDiscoveryToolBypass:
         assert "ok" not in result.structured_content
         assert "data" not in result.structured_content
         assert "tool" not in result.structured_content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool_name", ["list_files", "read_file", "some_future_tool"])
+    async def test_wrap_result_tool_passes_through_via_meta_marker(self, tool_name: str):
+        """v3.4.6.1: wrap-result tools are bypassed STRUCTURALLY, not by name.
+
+        FastMCP stamps ``meta={"fastmcp": {"wrap_result": True}}`` on the
+        ToolResult of any tool whose output schema carries
+        ``x-fastmcp-wrap-result`` (a non-dict return wrapped as
+        ``{"result": ...}``). The MCP-Apps FileUpload tools (``list_files`` ->
+        ``list[dict]``, ``read_file`` -> ``dict``) are of this kind. Enveloping
+        strips the top-level ``result`` and FastMCP's output validation then
+        fails with "'result' is a required property" — observed live when the
+        model called ``list_files`` to discover an uploaded CSV's name for
+        ``greenlake_bulk_add_devices``. Detecting the marker means an arbitrary
+        future wrap-result tool name passes through too (no name list to forget).
+        """
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context(tool_name)
+        native = {"result": [{"name": "devices.csv", "size": 1234}]}
+        original = _make_tool_result(structured=native, meta={"fastmcp": {"wrap_result": True}})
+        call_next = AsyncMock(return_value=original)
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result is original
+        assert result.structured_content == native
+        assert "ok" not in result.structured_content
+        assert "data" not in result.structured_content
+
+    @pytest.mark.asyncio
+    async def test_result_shaped_dict_without_marker_still_wrapped(self):
+        """Guard against over-bypass: a tool that legitimately returns a dict with
+        a ``result`` key but is NOT a wrap-result tool (no meta marker) must still
+        be enveloped. The bypass keys on the marker, not on the payload shape."""
+        middleware = ResponseEnvelopeMiddleware()
+        ctx = _make_context("central_get_result")
+        raw = {"result": "a real data field that happens to be named result"}
+        call_next = AsyncMock(return_value=_make_tool_result(structured=raw, meta=None))
+
+        result = await middleware.on_call_tool(ctx, call_next)
+
+        assert result.structured_content["ok"] is True
+        assert result.structured_content["data"] == raw
 
     @pytest.mark.asyncio
     async def test_non_discovery_tool_still_gets_wrapped(self):


### PR DESCRIPTION
## Problem
With `MCP_APP_ENABLE=true`, calling the MCP-Apps **FileUpload** tools `list_files` / `read_file` fails with:

```
Output validation error: 'result' is a required property
```

This breaks the upload discovery UX — after a user uploads a CSV via the `file_manager` widget, the model can't call `list_files` to find the uploaded filename to feed `greenlake_bulk_add_devices`. Reproduced live in an MCP-Apps client (Claude desktop) against the deployed v3.4.6.0 image.

## Root cause
`list_files` returns a bare `list[dict]` (and `read_file` a bare `dict`). FastMCP auto-wraps non-dict returns into `structured_content = {"result": <value>}`, stamps the output schema with `x-fastmcp-wrap-result`, and marks the `ToolResult` with `meta={"fastmcp": {"wrap_result": True}}` (`fastmcp/tools/base.py:334-339`).

`ResponseEnvelopeMiddleware` then rewraps that into `{ok, status, data, ...}`, dropping the top-level `result`. FastMCP's output-schema validation runs *after* the middleware and rejects it — same failure class as #293 / #302.

The middleware already bypasses wrap-result tools, but via a **hand-maintained name list** (`_NO_ENVELOPE_TOOLS`) that the FileUpload tools were never added to.

## Fix
Detect the wrap-result tool **structurally** via the `meta={"fastmcp": {"wrap_result": True}}` marker — mirroring the existing `$prefab` UI bypass — so every current and future wrap-result tool passes through with no name list to keep in sync.

## Validation
- **Negative control:** deployed v3.4.6.0 fails live with the error above.
- **Positive:** a new real-stack test drives the actual `FileUpload.list_files` through the real middleware chain and passes. The tool is intentionally **not** name-listed, so it passes purely via the marker.
- **Over-bypass guard:** a tool returning a `{"result": ...}` dict *without* the marker is still enveloped normally.
- Full gate green: ruff + format + mypy (681 files) + 1945 passed / 1 skipped.

## Scope
Internal middleware fix only — no tool/parameter/count changes. Patch bump 3.4.6.0 → 3.4.6.1.

Closes #544