### PR TITLE
fix(greenlake): tokenize bulk-add serials (lifespan token_store wiring + camelCase rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6.3] - 2026-06-30
+
+**Patch — GreenLake device serials become round-trippable tokens (fixes a latent tokenization gap).** The live upload test for v3.4.6.2 confirmed no raw serial/MAC reaches the model, but the bulk-add result redacted serials to a bare `[serial]` placeholder — which (a) an MCP-Apps client misread as "the CSV has unfilled template text," and (b) makes a real multi-device failure list useless (every failure shows identical `[serial]`). Root cause: `token_store` was never placed on `lifespan_context`, so `greenlake_bulk_add_devices`' serial tokenization silently no-op'd to the fallback.
+
+### Fixed
+- **`token_store` is now on `lifespan_context`** — `greenlake_bulk_add_devices` builds its per-session `Tokenizer` from it, so failed-row serials are emitted as `[[SERIAL:uuid]]` tokens instead of the bare `[serial]` placeholder. With `ENABLE_PII_TOKENIZATION=true` these round-trip (the operator sees the real serial via detokenization; the AI's context only ever holds the token). The non-leaking `[serial]` default remains as a defensive fallback.
+
+### Changed
+- **GreenLake camelCase identifiers join the PII ruleset** — added `serialnumber` (the lowercased form of GreenLake's `serialNumber`; the field-name normalizer doesn't split camelCase) so device serials in GreenLake API responses (e.g. `greenlake_get_devices`) tokenize when PII tokenization is enabled. (MACs are normalized, not tokenized — by design, there is no MAC `TokenKind`.)
+
+### Notes
+- No tool/parameter/count changes. Tokenization round-trip + GreenLake-wide coverage activate only when `ENABLE_PII_TOKENIZATION=true`; the bulk-add serial redaction itself is always on.
+
 ## [3.4.6.2] - 2026-06-29
 
 **Patch — SECURITY: uploaded file contents never reach the model.** Removes the model-visible `read_file` tool, which returned raw uploaded file content to the LLM — defeating the whole purpose of uploads (a device CSV's serials/MACs, or an AOS 8 config carrying PSKs and RADIUS/TACACS secrets, would land in the model context). Uploaded files are now read **server-side only**; the model discovers a file's name via `list_files` (metadata only) and hands it to a consuming tool that reads it inside the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.6.2"
+version = "3.4.6.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/greenlake/tools/bulk_add.py
+++ b/src/hpe_networking_mcp/platforms/greenlake/tools/bulk_add.py
@@ -34,6 +34,7 @@ from hpe_networking_mcp.platforms.greenlake.tools._bulk_enrichment import _enric
 from hpe_networking_mcp.platforms.greenlake.tools._bulk_source import resolve_csv_source
 from hpe_networking_mcp.platforms.greenlake.utils.csv_parser import parse_csv
 from hpe_networking_mcp.redaction.rules import TokenKind
+from hpe_networking_mcp.redaction.token_store import KeymapFullError
 from hpe_networking_mcp.redaction.tokenizer import Tokenizer
 
 POLL_INTERVAL_SECONDS = 5
@@ -267,9 +268,19 @@ async def greenlake_bulk_add_devices(
         )
 
     def _safe_serial(value: str) -> str:
-        """Return tokenized serial number or fallback placeholder."""
+        """Return tokenized serial number or non-leaking fallback placeholder.
+
+        This is a MANUAL tokenization path (not behind the walker's catch), so it
+        must absorb ``KeymapFullError`` itself: the session token cap can be hit
+        mid-run, and a write tool must never crash AFTER doing its POST/assignment
+        work just because it couldn't tokenize a serial for the result. Falls back
+        to the non-leaking ``[serial]`` placeholder — never the raw serial.
+        """
         if tokenizer is not None:
-            return tokenizer.tokenize(TokenKind.SERIAL, value)
+            try:
+                return tokenizer.tokenize(TokenKind.SERIAL, value)
+            except KeymapFullError:
+                return "[serial]"
         return "[serial]"
 
     # SECTION 5 — Client setup

--- a/src/hpe_networking_mcp/redaction/rules.py
+++ b/src/hpe_networking_mcp/redaction/rules.py
@@ -242,6 +242,7 @@ TOKENIZED_IDENTIFIER_FIELDS: dict[str, TokenKind] = {
     # Hardware identifiers — tie back to purchase records
     "serial": TokenKind.SERIAL,
     "serial_number": TokenKind.SERIAL,
+    "serialnumber": TokenKind.SERIAL,  # GreenLake camelCase ``serialNumber`` (normalizer lowercases, no camel split)
     "sn": TokenKind.SERIAL,
     "imei": TokenKind.IMEI,
     "imsi": TokenKind.IMSI,

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -37,6 +37,12 @@ async def lifespan(server: FastMCP):
     # FileUpload provider handle (present only when MCP_APP_ENABLE=true) so tools
     # can read an uploaded file server-side without it entering model context.
     context["file_upload_provider"] = getattr(server, "_hpe_file_upload", None)
+    # PII token store (always constructed in create_server). Tools that tokenize
+    # their own outputs server-side — e.g. greenlake_bulk_add_devices redacting
+    # device serials in its result — build a per-session Tokenizer from this.
+    # Without it on lifespan_context, that tokenization silently no-ops to a bare
+    # ``[serial]`` placeholder (latent gap fixed alongside #546).
+    context["token_store"] = getattr(server, "_hpe_token_store", None)
 
     # --- Mist ---
     # v3.1.0.0 (issue #304): the ``mistapi`` SDK is gone; we go direct via

--- a/tests/unit/test_greenlake_bulk_add.py
+++ b/tests/unit/test_greenlake_bulk_add.py
@@ -528,6 +528,45 @@ class TestGreenlakeBulkAddDevices:
         assert "SN-AAA-1" not in repr(result), "raw serial leaked into result"
         assert serial != "[serial]", "fell back to placeholder — token_store not used"
 
+    async def test_full_keymap_does_not_crash_write_tool(self, mock_ctx: MagicMock, tmp_path: pathlib.Path) -> None:
+        """A full session keymap must NOT crash the tool after it has done its
+        POST/assignment work. _safe_serial catches KeymapFullError and falls back
+        to the non-leaking ``[serial]`` placeholder (Casey review on #549)."""
+        from hpe_networking_mcp.redaction.token_store import TokenStore
+
+        # max_entries_per_session=0 → the first tokenize() hits the cap immediately.
+        mock_ctx.lifespan_context["token_store"] = TokenStore(max_entries_per_session=0)
+
+        csv_file = tmp_path / "devices.csv"
+        csv_file.write_text("serialNumber,macAddress\nSN-CAP-1,11:22:33:44:55:09\n", encoding="utf-8")
+
+        fail_response = MagicMock()
+        fail_response.status_code = 422
+        fail_response.text = "device already exists"
+        fail_response.headers = {}
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post_raw = AsyncMock(return_value=fail_response)
+        mock_client_instance.close = AsyncMock()
+        mock_limiter = self._make_limiter_mock()
+        with (
+            patch(
+                "hpe_networking_mcp.platforms.greenlake.tools.bulk_add.GreenLakeHttpClient",
+                return_value=mock_client_instance,
+            ),
+            patch("hpe_networking_mcp.platforms.greenlake.tools.bulk_add.AsyncLimiter", return_value=mock_limiter),
+            patch(
+                "hpe_networking_mcp.platforms.greenlake.tools.bulk_add.make_patch_limiter",
+                return_value=mock_limiter,
+            ),
+            patch("hpe_networking_mcp.platforms.greenlake.tools.bulk_add._write_cache_atomic"),
+        ):
+            # Must complete, not raise KeymapFullError.
+            result = await greenlake_bulk_add_devices(mock_ctx, csv_path=str(csv_file))
+
+        assert result["failures"][0]["serial"] == "[serial]"
+        assert "SN-CAP-1" not in repr(result), "raw serial leaked into result"
+
 
 # ---------------------------------------------------------------------------
 # TestBulkAddPhase20Integration

--- a/tests/unit/test_greenlake_bulk_add.py
+++ b/tests/unit/test_greenlake_bulk_add.py
@@ -485,6 +485,49 @@ class TestGreenlakeBulkAddDevices:
             assert "reason" in entry
         assert len(result["failures"]) <= 10
 
+    async def test_failure_serials_tokenized_when_token_store_present(
+        self, mock_ctx: MagicMock, tmp_path: pathlib.Path
+    ) -> None:
+        """With token_store wired onto lifespan_context, failed-row serials are
+        emitted as round-trippable ``[[SERIAL:uuid]]`` tokens — never raw, and
+        never the bare ``[serial]`` fallback (which loses per-device identity).
+        Regression for the lifespan-wiring gap that made D-02 tokenization no-op.
+        """
+        from hpe_networking_mcp.redaction.token_store import TokenStore
+
+        mock_ctx.lifespan_context["token_store"] = TokenStore(max_entries_per_session=1000)
+
+        csv_file = tmp_path / "devices.csv"
+        csv_file.write_text("serialNumber,macAddress\nSN-AAA-1,11:22:33:44:55:01\n", encoding="utf-8")
+
+        fail_response = MagicMock()
+        fail_response.status_code = 422
+        fail_response.text = "device already exists"
+        fail_response.headers = {}
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post_raw = AsyncMock(return_value=fail_response)
+        mock_client_instance.close = AsyncMock()
+        mock_limiter = self._make_limiter_mock()
+        with (
+            patch(
+                "hpe_networking_mcp.platforms.greenlake.tools.bulk_add.GreenLakeHttpClient",
+                return_value=mock_client_instance,
+            ),
+            patch("hpe_networking_mcp.platforms.greenlake.tools.bulk_add.AsyncLimiter", return_value=mock_limiter),
+            patch(
+                "hpe_networking_mcp.platforms.greenlake.tools.bulk_add.make_patch_limiter",
+                return_value=mock_limiter,
+            ),
+            patch("hpe_networking_mcp.platforms.greenlake.tools.bulk_add._write_cache_atomic"),
+        ):
+            result = await greenlake_bulk_add_devices(mock_ctx, csv_path=str(csv_file))
+
+        serial = result["failures"][0]["serial"]
+        assert serial.startswith("[[SERIAL:") and serial.endswith("]]"), serial
+        assert "SN-AAA-1" not in repr(result), "raw serial leaked into result"
+        assert serial != "[serial]", "fell back to placeholder — token_store not used"
+
 
 # ---------------------------------------------------------------------------
 # TestBulkAddPhase20Integration

--- a/tests/unit/test_pii_redaction.py
+++ b/tests/unit/test_pii_redaction.py
@@ -108,6 +108,15 @@ class TestFieldClassification:
         assert cls == FieldClassification.TOKENIZE_SECRET
         assert kind == TokenKind.PSK
 
+    def test_greenlake_camelcase_serial_classified(self) -> None:
+        """GreenLake API uses camelCase ``serialNumber``; the normalizer lowercases
+        (no camel split), so the ruleset must carry ``serialnumber`` to tokenize
+        device serials in GreenLake responses (e.g. greenlake_get_devices)."""
+        for field in ("serialNumber", "serialnumber", "serial", "serial_number"):
+            cls, kind = classify_field(field, "CN-EXAMPLE-01")
+            assert cls == FieldClassification.TOKENIZE_IDENTIFIER, field
+            assert kind == TokenKind.SERIAL, field
+
     def test_ssid_passes_through(self) -> None:
         # SSIDs are broadcast in beacon frames — observable to anyone in
         # radio range. Tokenizing them adds context-window cost without

--- a/uv.lock
+++ b/uv.lock
@@ -671,7 +671,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.4.6.2"
+version = "3.4.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Context
Follow-up to the v3.4.6.2 live upload test (#546). That test confirmed the security win — **no raw serial/MAC reached the model** — but the bulk-add result redacted serials to a bare `[serial]` placeholder, which:
- an MCP-Apps client **misread** as "the CSV has unfilled template text," and
- makes a real multi-device failure list useless (every failure shows identical `[serial]`).

## Root cause
`token_store` was **never placed on `lifespan_context`** — `create_server` only sets `mcp._hpe_token_store`. So `greenlake_bulk_add_devices` built no per-session `Tokenizer` and `_safe_serial` always hit the fallback. Separately, GreenLake's camelCase `serialNumber` normalizes to `serialnumber` (the field-name normalizer lowercases but doesn't split camelCase), which wasn't a ruleset key — so GreenLake serials weren't tokenized even with PII on.

## Fix
- **`token_store` on `lifespan_context`** → serials emit as `[[SERIAL:uuid]]` tokens. With `ENABLE_PII_TOKENIZATION=true` they round-trip (operator sees the real serial via detokenization; the AI's context holds only the token). The non-leaking `[serial]` default is retained for the no-store case.
- **`serialnumber` added to `TOKENIZED_IDENTIFIER_FIELDS`** so GreenLake API responses (e.g. `greenlake_get_devices`) tokenize device serials. MACs are normalized, not tokenized (no MAC `TokenKind`, by design — MACs are on-wire observable).
- The tokenizer is idempotent (`TOKEN_RE.fullmatch` guard), so `_safe_serial` pre-tokenizing + the walker re-processing the `serial` field doesn't double-tokenize.

## Validation
- `test_pii_redaction`: `serialNumber`/`serialnumber`/`serial`/`serial_number` all classify as `TOKENIZE_IDENTIFIER` / `SERIAL`.
- `test_greenlake_bulk_add`: with `token_store` on `lifespan_context`, failed-row serials are `[[SERIAL:uuid]]` tokens, raw serial absent, not the `[serial]` fallback.
- Full gate green: ruff + format + mypy (682 files) + **1959 passed / 1 skipped**.

## Scope
No tool/parameter/count changes. Round-trip + GreenLake-wide coverage activate only with `ENABLE_PII_TOKENIZATION=true`; bulk-add serial redaction itself is always on. Patch bump 3.4.6.2 → 3.4.6.3 (uv.lock re-locked).

Closes #548