### PR TITLE
fix(code-mode): self-correcting hint for Mist search arrays (unhashable type: list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.7.1] - 2026-06-30
+
+**Patch — self-correcting sandbox hint for Mist search arrays (`unhashable type: 'list'`).** Mist org-level search/aggregation endpoints (`mist_search_org_wireless_clients`, `mist_search_org_devices`, …) return **arrays** for window-aggregated fields — `ssid`, `hostname`, `ap`, `device` — because a client/device can have several over the search window (`mac`/`band` stay scalar; verified live). Code-mode models routinely use one of these directly as a dict key and crash with `cannot use 'list' as a dict key (unhashable type: 'list')`.
+
+### Fixed
+- `SandboxErrorCatchMiddleware` now appends a hint when an `execute()` block raises `unhashable type: 'list'`: it names the Mist search array fields and says to index (`value[0]`) or join (`', '.join(value)`) them, not to expect a scalar. Delivered through the error channel — the one place models reliably self-correct (unlike advisory docs). The arrays are **not** unwrapped server-side: they're intentional aggregation arrays and collapsing them would be lossy and diverge from the Mist spec.
+
+### Notes
+- No tool/parameter/count changes; middleware-only. Reported by a code-mode operator running a small model.
+
 ## [3.4.7.0] - 2026-06-30
 
 **Minor — `greenlake-device-onboarding` runbook + batch-uniform assignment params.** "Add devices to GreenLake" is a lifecycle, not a single write — operators want to add, subscribe, and assign devices to a service in one flow, not add now and come back later. A bare `greenlake_bulk_add_devices` call also skipped the choose-your-source step and never warned that pasted data is visible to the AI. This adds a guided skill and the tool support it needs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.4.7.0"
+version = "3.4.7.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
+++ b/src/hpe_networking_mcp/middleware/sandbox_error_catch.py
@@ -218,6 +218,31 @@ def _dict_union_hint(cause_text: str) -> str | None:
     return "Hint: the sandbox doesn't support `dict | dict`. Merge with `{**a, **b}`."
 
 
+def _unhashable_list_hint(cause_text: str) -> str | None:
+    """A list used as a dict key / set member — usually a Mist search array.
+
+    Mist org-level search/aggregation endpoints (``mist_search_org_wireless_clients``,
+    ``mist_search_org_devices``, ...) return ARRAYS for fields that can vary over the
+    search window — ``ssid`` / ``hostname`` / ``ap`` / ``device`` — because a client or
+    device may have several across the window (``mac`` / ``band`` stay scalar). Models
+    routinely use one of these directly as a dict key and hit ``unhashable type: 'list'``
+    (Zach report). Verified live against the Mist API. The fix is to index or join the
+    array, NOT to expect a scalar.
+    """
+    if "unhashable type: 'list'" not in cause_text and "'list' as a dict key" not in cause_text:
+        return None
+    return (
+        "Hint: a list was used as a dict key or set member (lists are unhashable). This "
+        "commonly comes from Mist org-level search results: `mist_search_org_wireless_clients` / "
+        "`mist_search_org_devices` (and other `*_search_org_*` tools) return ARRAYS for "
+        "window-aggregated fields — `ssid`, `hostname`, `ap`, `device` — since a client/device "
+        "can have several over the window (`mac` and `band` stay scalar). Index the array "
+        "(`value[0]`) or join it (`', '.join(value)`) before using it as a key; iterate it for "
+        "set membership. Do NOT assume these fields are scalars — a value that's one element "
+        "today can be several tomorrow."
+    )
+
+
 _SHAPE_RE = re.compile(r"'(\w+)' object has no attribute '(get|keys|items|values)'")
 
 
@@ -248,6 +273,7 @@ _HINT_FNS = (
     _json_default_hint,
     _next_iter_hint,
     _dict_union_hint,
+    _unhashable_list_hint,
     _shape_hint,
 )
 

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -440,6 +440,39 @@ class TestSandboxErrorCatchMiddleware:
         assert "datetime.now" not in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_unhashable_list_key_gets_mist_array_hint(self):
+        """A model using a Mist search array (ssid/hostname/ap) as a dict key hits
+        `unhashable type: 'list'`. The hint must explain these search fields are
+        arrays and to index/join them — the Zach report. Uses real failing sandbox
+        code so the message matches what the sandbox actually raises.
+        """
+        import pydantic_monty
+
+        monty = pydantic_monty.Monty("d = {}\nd[[1, 2]] = 1\nreturn d")
+        cause = None
+        try:
+            await monty.run_async()
+        except pydantic_monty.MontyError as e:
+            cause = e
+        assert cause is not None and "unhashable type: 'list'" in str(cause)
+
+        middleware = SandboxErrorCatchMiddleware()
+        ctx = _make_call_tool_context("execute")
+
+        async def _raise(_ctx):
+            raise _wrap_in_tool_error(cause)
+
+        with pytest.raises(ToolError) as exc_info:
+            await middleware.on_call_tool(ctx, _raise)
+
+        text = str(exc_info.value)
+        assert "Hint:" in text
+        assert "mist_search_org" in text.lower()
+        assert "ssid" in text and "ap" in text  # names the array fields
+        # gives the actionable fix
+        assert "value[0]" in text or "join" in text
+
+    @pytest.mark.asyncio
     async def test_nameerror_gets_statelessness_hint(self):
         """A model referencing a variable from a previous execute() block
         (each call is a FRESH sandbox) hits NameError. The hint must name the

--- a/uv.lock
+++ b/uv.lock
@@ -671,7 +671,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.4.7.0"
+version = "3.4.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## Report (Zach, code-mode small model)
Building a client-distribution dict crashed with:
```
TypeError: cannot use 'list' as a dict key (unhashable type: 'list')
```
…using `ssid` / `ap` from `mist_search_org_wireless_clients` as dict keys. The reporting model concluded these are "accidentally list-wrapped scalars" and asked to unwrap them.

## Findings — verified live against the Mist API
`mist_search_org_*` are **search/aggregation** endpoints; they return **arrays** for window-aggregated fields:

| field | shape |
|---|---|
| `ssid` / `hostname` / `ap` / `device` | `list` |
| `mac` / `band` | `str` |

A client genuinely can use multiple SSIDs / roam APs / report multiple hostnames in the window. These are **intentional aggregation arrays**.

## Fix
**Do not unwrap server-side** — collapsing to `[0]` is lossy (drops the other values), an intermittent prod bug (works until a client roams), and diverges from the Mist spec passthrough.

Instead, `SandboxErrorCatchMiddleware` appends a self-correcting hint when an `execute()` block raises `unhashable type: 'list'`: it names the Mist search array fields and says to index (`value[0]`) or join (`', '.join(value)`) them. This is the channel models reliably act on — advisory INSTRUCTIONS.md isn't trusted by small models, so no doc note was added (per maintainer).

## Validation
- New `test_unhashable_list_key_gets_mist_array_hint` uses **real failing sandbox code** (`d[[1,2]]=1`) so the message matches what the sandbox actually raises (confirmed: `cannot use 'list' as a dict key (unhashable type: 'list')`).
- Full gate green: ruff + format + mypy (682 files) + **1967 passed / 1 skipped**.

Middleware-only; no tool/parameter/count change. Patch bump 3.4.7.0 → 3.4.7.1 (uv.lock re-locked).

Closes #551