### PR TITLE
fix(security): confirmation gate used deprecated empty-schema elicit (auto-accepted by some clients)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0.2] - 2026-07-01
+
+**Patch — SECURITY: universal confirmation gate could be silently auto-accepted by some clients (all platforms).** The gate used the **deprecated** `ctx.elicit(prompt, response_type=None)` form, which produces an *empty* object schema. Clients render that inconsistently: some (observed: Claude Desktop) silently answer `accept` with an empty payload — so a write-gated / destructive tool executed with **no visible confirmation prompt**. Because the gate is universal (`confirm_gated_invoke` at the `<platform>_invoke_tool` chokepoint), this affected **every platform's** gated tools. Exposure required a write-enabled deployment (`ENABLE_<platform>_WRITE_TOOLS=true`, which is **off by default**) *and* an auto-accepting client; clients that auto-*cancel* the empty elicit blocked the write instead. This was a client-side auto-accept, not the `confirmed=true` self-authorization hole (#415, which remains closed).
+
+### Fixed
+- The gate now elicits a **required boolean** (`ctx.elicit(prompt, bool, response_title="Approve", ...)`) instead of the empty-schema deprecated form. A real client must render an approval dialog; a client that auto-accepts with an empty payload now **fails schema validation → fails closed** (the gate returns `confirmation_unavailable`, the tool does not run). Only an explicit `approve=true` proceeds; `approve=false`/decline/cancel block. Verified end-to-end with a real FastMCP `Client`: an `accept` carrying no value does not dispatch the write.
+
+### Notes
+- No tool/count/signature changes; gate-internal. New tests: `test_elicit_uses_required_bool_schema_not_deprecated_none`, `test_accept_without_true_is_not_a_proceed` (unit) and `test_accept_without_value_fails_closed` (end-to-end round-trip).
+
 ## [3.5.0.1] - 2026-07-01
 
 **Patch — fix misleading GreenLake registration log (said "169 tools", meant 169 modules).** `_register_greenlake_tools` logged `GreenLake: registered 169 tools`, but `169` is the number of tool *module files* — the spec-generated surface is **959 tools** (one module holds many). The line read as if the platform only exposed 169 tools. No behavior change; the 959 tools were always registered and reachable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.0.1"
+version = "3.5.0.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -153,9 +153,14 @@ async def confirm_gated_invoke(
     The decision sequence, per the agreed design:
 
     1. ``DISABLE_ELICITATION=true`` → auto-accept (operator opt-out).
-    2. Attempt a REAL ``ctx.elicit()`` prompt — it round-trips transparently
-       from the code-mode sandbox (verified live; #414's contrary premise was
-       false). Accept proceeds; decline/cancel return structured results.
+    2. Attempt a REAL ``ctx.elicit()`` prompt with a REQUIRED ``approve``
+       boolean schema — it round-trips transparently from the code-mode
+       sandbox (verified live; #414's contrary premise was false). Only an
+       explicit ``approve=true`` proceeds; decline/cancel/approve-false return
+       structured results. The required field also closes a live safety gap:
+       the old empty-schema (``response_type=None``) form was silently
+       auto-accepted by some clients (Claude Desktop), letting writes run with
+       no visible confirmation; a missing ``approve`` now fails closed.
     3. Only when the prompt RAISES (client genuinely cannot present one) is
        ``confirmed=true`` honored as the popup-less chat fallback. An AI
        cannot self-authorize while a human-facing prompt is available.
@@ -182,7 +187,27 @@ async def confirm_gated_invoke(
     param_summary = _sanitized_param_summary(params)
     prompt = f"Confirm: {description}\nParams: {param_summary}"
     try:
-        result = await ctx.elicit(prompt, response_type=None)
+        # Use a REQUIRED boolean response schema rather than the deprecated
+        # ``response_type=None`` (empty-object) form. The empty schema is
+        # rendered inconsistently by clients: some (e.g. Claude Desktop)
+        # silently auto-ACCEPT it — so a gated write executes with no visible
+        # confirmation — while others auto-cancel. A required ``approve`` field
+        # forces the client to render a real dialog; and critically, a client
+        # that auto-accepts with an EMPTY payload now fails schema validation
+        # (``approve`` missing) → the ``except Exception`` below fails closed,
+        # instead of silently proceeding. Only an explicit ``approve=true``
+        # from a human proceeds.
+        result = await ctx.elicit(
+            prompt,
+            # mypy can't bind `bool` to elicit's generic scalar overload `type[T]`
+            # and falls back to the deprecated `response_type: None` overload;
+            # the scalar form is correct and runtime-verified (schema requires a
+            # boolean `value`; empty auto-accept raises ValidationError → fails
+            # closed below). Hence the targeted ignore.
+            bool,  # type: ignore[arg-type]
+            response_title="Approve",
+            response_description="Approve this action? Must be set to true to proceed.",
+        )
     except McpError as e:
         # Only the specific no-capability signal opens the fallback path:
         # "Elicitation not supported" / METHOD_NOT_FOUND (verified against
@@ -240,8 +265,13 @@ async def confirm_gated_invoke(
         }
 
     match result:
-        case AcceptedElicitation():
+        case AcceptedElicitation(data=True):
             return None
+        case AcceptedElicitation():
+            # Accepted the dialog but did NOT set approve=true (unchecked, or a
+            # client that auto-accepts with a default-false payload) → treat as
+            # a refusal, never a proceed.
+            return {"status": "declined", "message": "Action not approved (approve was not set to true)."}
         case DeclinedElicitation():
             return {"status": "declined", "message": "Action declined by user."}
         case CancelledElicitation():

--- a/tests/unit/test_gate_end_to_end.py
+++ b/tests/unit/test_gate_end_to_end.py
@@ -83,7 +83,9 @@ class TestGateEndToEnd:
             prompts.append(message)
             from fastmcp.client.elicitation import ElicitResult
 
-            return ElicitResult(action="accept")
+            # The gate now elicits a REQUIRED boolean; a human who approves
+            # supplies value=True.
+            return ElicitResult(action="accept", content={"value": True})
 
         async with Client(server, elicitation_handler=handler) as client:
             result = await client.call_tool(
@@ -92,6 +94,26 @@ class TestGateEndToEnd:
         assert calls == [{"target": "HQ"}]
         assert len(prompts) == 1 and "gatetest_manage_thing" in prompts[0]
         assert result.data["status"] == "written"
+
+    async def test_accept_without_value_fails_closed(self, gated_server):
+        """SAFETY: a client that ACCEPTS the elicitation but supplies no payload
+        (the Claude Desktop silent-auto-accept of the old empty schema) must NOT
+        dispatch the write — the required `value` field is missing, server-side
+        validation fails, and the gate fails closed."""
+        server, calls = gated_server
+
+        async def handler(message: str, response_type, params, context):
+            from fastmcp.client.elicitation import ElicitResult
+
+            return ElicitResult(action="accept")  # no content — empty auto-accept
+
+        async with Client(server, elicitation_handler=handler) as client:
+            result = await client.call_tool(
+                f"{_PLATFORM}_invoke_tool",
+                {"name": "gatetest_manage_thing", "params": {"target": "HQ"}},
+            )
+        assert calls == []  # the write must NOT have run
+        assert result.data["status"] != "written"
 
     async def test_decline_blocks_dispatch_even_with_confirmed_true(self, gated_server):
         """#415: confirmed=true must not bypass a live prompt the human declined."""
@@ -118,7 +140,7 @@ class TestGateEndToEnd:
             prompts.append(message)
             from fastmcp.client.elicitation import ElicitResult
 
-            return ElicitResult(action="accept")
+            return ElicitResult(action="accept", content={"value": True})
 
         async with Client(server, elicitation_handler=counting_handler) as client:
             result = await client.call_tool(f"{_PLATFORM}_invoke_tool", {"name": "gatetest_get_thing", "params": {}})

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -39,7 +39,8 @@ pytestmark = pytest.mark.unit
 def _ctx(*, disable_elicitation: bool = False, elicit: AsyncMock | None = None) -> MagicMock:
     ctx = MagicMock()
     ctx.lifespan_context = {"config": SimpleNamespace(disable_elicitation=disable_elicitation)}
-    ctx.elicit = elicit if elicit is not None else AsyncMock(return_value=AcceptedElicitation(data=None))
+    # The gate now elicits a REQUIRED boolean; only ``data=True`` proceeds.
+    ctx.elicit = elicit if elicit is not None else AsyncMock(return_value=AcceptedElicitation(data=True))
     return ctx
 
 
@@ -54,6 +55,29 @@ class TestConfirmGatedInvoke:
         ctx = _ctx()
         assert await confirm_gated_invoke(ctx, "central tool 'x'", {}) is None
         ctx.elicit.assert_awaited_once()
+
+    async def test_elicit_uses_required_bool_schema_not_deprecated_none(self):
+        """Regression: the gate must NOT use the deprecated empty-schema
+        ``response_type=None`` form, which some clients (Claude Desktop) silently
+        auto-accept — letting a gated write run with no visible confirmation. It
+        must send a required boolean so clients render a real dialog and an
+        empty auto-accept fails closed."""
+        ctx = _ctx()
+        await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        args, kwargs = ctx.elicit.await_args
+        # response_type is passed positionally (args[1]) or by keyword; either
+        # way it must be bool (a required field), never None (empty schema).
+        response_type = kwargs.get("response_type", args[1] if len(args) > 1 else None)
+        assert response_type is bool, "gate must elicit a required bool, not response_type=None"
+
+    async def test_accept_without_true_is_not_a_proceed(self):
+        """The safety case: a client that ACCEPTS the dialog but supplies a
+        default/false payload (``data=False``) must NOT proceed — only an
+        explicit approve=true does."""
+        ctx = _ctx(elicit=AsyncMock(return_value=AcceptedElicitation(data=False)))
+        result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
+        assert result is not None
+        assert result["status"] == "declined"
 
     async def test_decline_returns_declined(self):
         ctx = _ctx(elicit=AsyncMock(return_value=DeclinedElicitation()))
@@ -110,9 +134,9 @@ class TestConfirmGatedInvoke:
         """The human must see WHAT they approve — targets shown, secrets redacted."""
         captured: list[str] = []
 
-        async def grab(message, response_type=None):
+        async def grab(message, response_type=None, response_title=None, response_description=None):
             captured.append(message)
-            return AcceptedElicitation(data=None)
+            return AcceptedElicitation(data=True)
 
         ctx = _ctx(elicit=AsyncMock(side_effect=grab))
         await confirm_gated_invoke(
@@ -129,9 +153,9 @@ class TestConfirmGatedInvoke:
         """api_key / apiKey / clientSecret / refreshToken / private-key all redact."""
         captured: list[str] = []
 
-        async def grab(message, response_type=None):
+        async def grab(message, response_type=None, response_title=None, response_description=None):
             captured.append(message)
-            return AcceptedElicitation(data=None)
+            return AcceptedElicitation(data=True)
 
         ctx = _ctx(elicit=AsyncMock(side_effect=grab))
         # Bind leak markers to variables (not literals in secret-named


### PR DESCRIPTION
## Summary

The universal confirmation gate (`confirm_gated_invoke`, at the `<platform>_invoke_tool` chokepoint) called the **deprecated** `ctx.elicit(prompt, response_type=None)` form, which produces an **empty** object schema. Clients render that inconsistently:

- **Claude Desktop** (observed live, via prod server logs) silently answers `accept` with an empty payload → a write-gated / destructive tool **executed with no visible confirmation prompt**.
- Agent-driven / headless clients auto-**cancel** it → writes blocked.

Because the gate is universal, this affected **every platform's** gated tools. Exposure required a **write-enabled** deployment (`ENABLE_<platform>_WRITE_TOOLS=true`, which is **off by default**) *and* an auto-accepting client. This is a client-side auto-accept — **not** the `confirmed=true` self-authorization hole (#415), which remains closed.

## Fix

Elicit a **required boolean** instead of the empty-schema form:

```python
result = await ctx.elicit(prompt, bool, response_title="Approve",
                          response_description="Approve this action? Must be set to true to proceed.")
```

- A conformant client must render an approval dialog (non-empty required schema).
- A client that auto-accepts with an **empty** payload now **fails schema validation** → the gate's `except` fails **closed** (`confirmation_unavailable`, tool not run).
- Only an explicit `approve=true` proceeds; `approve=false` / decline / cancel block.

Runtime-verified: `parse_elicit_response_type(bool, ...)` yields `{"properties":{"value":{"type":"boolean",...}},"required":["value"]}`; an empty accept raises `ValidationError`.

## Testing
- Full suite: **1970 passed, 2 skipped**.
- New unit tests: `test_elicit_uses_required_bool_schema_not_deprecated_none`, `test_accept_without_true_is_not_a_proceed`.
- New **end-to-end** test (real FastMCP `Client` round-trip): `test_accept_without_value_fails_closed` — an `accept` with no value does **not** dispatch the write.
- ruff / format / mypy clean (one targeted `# type: ignore[arg-type]` on the elicit call — mypy can't bind `bool` to the generic scalar overload; runtime verified).

## Follow-up
Only a live client can confirm the *rendering* behavior end-to-end; the maintainer will re-test a synthetic dry-run in Claude Desktop to confirm a real dialog now appears.