### PR TITLE
fix(gate): strip gate-control 'confirmed' before tool dispatch (422 on popup-less fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0.4] - 2026-07-01
+
+**Patch — make the popup-less `confirmed=true` fallback actually work (follow-up to #558).** After the structural gate landed, a client that can't render the elicitation prompt (e.g. Claude Desktop, which now reports "elicitation not supported" for the required-boolean schema) correctly falls back to the `confirmed=true` chat-confirm path — but the flag **leaked into the target tool's arguments**. The gate consumed `confirmed` for its decision but never stripped it, so the tool's strict schema (`additionalProperties: false`) rejected it with a `422`, and the write could never be confirmed.
+
+### Fixed
+- **Strip the gate-control `confirmed` key before dispatch on both paths:** `_invoke_tool` removes it from params before coercion/`spec.func`, and `ElicitationMiddleware.on_call_tool` removes it from the forwarded arguments before `call_next`. The gate still reads it for the fallback decision; the tool never sees it.
+- **Clearer `confirmation_required` guidance:** the message now tells the AI to re-invoke via `<platform>_invoke_tool` with `"confirmed": true` **inside the params object** (the free-form field that carries it), and explicitly NOT to add `confirmed` to a direct by-name call — the tool's own schema rejects unknown fields, which is the `422` operators were hitting.
+
+### Notes
+- No tool/count/signature changes. New tests: `_invoke_tool` strip is regression-guarded by a strict fake tool (no `confirmed` kwarg) driven through the confirmed=true fallback, plus a `on_call_tool` unit test asserting `confirmed` is stripped before forwarding.
+
 ## [3.5.0.3] - 2026-07-01
 
 **Patch — SECURITY: close the direct-by-name confirmation bypass (all platforms, code mode). Closes #558.** The confirmation gate (`confirm_gated_invoke`) was only wired into the `<platform>_invoke_tool` dispatcher (and the two translate-apply tools). But in code mode (the default), the sandbox can call any tool **directly by name** — and the `execute` description said that was equivalent to `invoke_tool`. A direct-by-name write therefore skipped the gate entirely and ran with no confirmation. This affected every platform's write/destructive tools whenever that platform's writes were enabled. (Dynamic mode was unaffected — underlying tools are hidden and direct calls blocked, so only the gated `invoke_tool` path exists.) This is the deeper cause behind the Claude Desktop "no prompt" reports; the v3.5.0.2 elicit-form fix hardened the `invoke_tool` path but not this one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.0.3"
+version = "3.5.0.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/elicitation.py
+++ b/src/hpe_networking_mcp/middleware/elicitation.py
@@ -130,6 +130,15 @@ class ElicitationMiddleware(Middleware):
                     )
                     return ToolResult(content=gate.get("message", ""), structured_content=envelope)
 
+                # Proceeding via the popup-less fallback: ``confirmed`` was
+                # consumed by the gate but is NOT a tool parameter. Strip it so a
+                # direct-by-name call doesn't leak it into the tool's strict
+                # schema (422) — the invoke_tool path strips it symmetrically.
+                if "confirmed" in params:
+                    cleaned = {k: v for k, v in params.items() if k != "confirmed"}
+                    new_message = context.message.model_copy(update={"arguments": cleaned})
+                    context = context.copy(message=new_message)
+
         return await call_next(context)  # type: ignore[no-any-return]
 
     async def on_initialize(
@@ -317,8 +326,12 @@ async def confirm_gated_invoke(
             "status": "confirmation_required",
             "message": (
                 f"{description} requires user confirmation and this client cannot show a "
-                f"confirmation prompt. Params: {param_summary}. Confirm with the user in "
-                "chat, then call again with confirmed=true in params."
+                f"confirmation prompt. Params: {param_summary}. Confirm with the user in chat, "
+                "then re-invoke through the platform's <platform>_invoke_tool meta-tool with "
+                '"confirmed": true placed INSIDE the params object — e.g. '
+                'invoke_tool(name="<tool>", params={..., "confirmed": true}). Do NOT add '
+                '"confirmed" to a direct by-name call: the tool\'s own schema rejects unknown '
+                "fields, so the flag only travels via invoke_tool's free-form params."
             ),
         }
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -479,6 +479,12 @@ def build_meta_tools(
             len(safe_params),
         )
 
+        # ``confirmed`` is a gate-control key (consumed by confirm_gated_invoke
+        # above for the popup-less chat fallback), NOT a tool parameter. Strip it
+        # before coercion/dispatch or the target tool's strict schema rejects it
+        # (422) / spec.func gets an unexpected kwarg (#558 follow-up).
+        dispatch_params = {k: v for k, v in safe_params.items() if k != "confirmed"}
+
         # Replicate the Pydantic coercion FastMCP would do on a direct
         # tool call: turn string enum values into ``Enum`` instances,
         # strings into ``UUID`` objects, etc. Without this, any tool that
@@ -486,7 +492,7 @@ def build_meta_tools(
         # attribute 'value'`` because the meta-tool bypasses FastMCP's
         # normal dispatch wrapper.
         try:
-            coerced = _coerce_params(spec, safe_params)
+            coerced = _coerce_params(spec, dispatch_params)
         except ValidationError as exc:
             return {
                 "status": "invalid_params",

--- a/tests/unit/test_gate_end_to_end.py
+++ b/tests/unit/test_gate_end_to_end.py
@@ -30,7 +30,11 @@ def gated_server():
     """A FastMCP server exposing gatetest_invoke_tool over a fake registry."""
     calls: list[dict[str, Any]] = []
 
-    async def fake_write_tool(ctx, target: str = "", confirmed: bool = False) -> dict:
+    async def fake_write_tool(ctx, target: str = "") -> dict:
+        # NOTE: deliberately does NOT accept a ``confirmed`` kwarg — mirrors a real
+        # strict-schema tool. If _invoke_tool failed to strip the gate-control
+        # ``confirmed`` flag before dispatch, this would raise TypeError, so the
+        # confirmed=true fallback test below regression-guards that strip (#558).
         calls.append({"target": target})
         return {"status": "written", "target": target}
 

--- a/tests/unit/test_universal_confirmation_gate.py
+++ b/tests/unit/test_universal_confirmation_gate.py
@@ -24,9 +24,15 @@ from fastmcp.server.elicitation import (
     DeclinedElicitation,
 )
 from mcp.shared.exceptions import McpError
-from mcp.types import ErrorData
+from mcp.types import CallToolRequestParams, ErrorData
 
-from hpe_networking_mcp.middleware.elicitation import _sanitized_param_summary, confirm_gated_invoke
+from hpe_networking_mcp.middleware.elicitation import (
+    ElicitationMiddleware,
+    _sanitized_param_summary,
+    confirm_gated_invoke,
+)
+from hpe_networking_mcp.platforms._common.annotations import Capability
+from hpe_networking_mcp.platforms._common.tool_registry import REGISTRIES, ToolSpec
 
 
 def _no_elicitation_error() -> McpError:
@@ -110,7 +116,10 @@ class TestConfirmGatedInvoke:
         result = await confirm_gated_invoke(ctx, "central tool 'x'", {})
         assert result is not None
         assert result["status"] == "confirmation_required"
-        assert "confirmed=true" in result["message"]
+        # Steers the AI to the path that actually carries the flag: invoke_tool
+        # with "confirmed" inside the free-form params object.
+        assert '"confirmed"' in result["message"]
+        assert "invoke_tool" in result["message"]
 
     async def test_other_mcp_errors_fail_closed_even_with_confirmed(self):
         """An McpError that is NOT the no-capability signal (e.g. transport
@@ -181,6 +190,55 @@ class TestConfirmGatedInvoke:
     def test_param_summary_caps_length(self):
         summary = _sanitized_param_summary({"payload": {"x" * 10: "y" * 1000}})
         assert len(summary) <= 300
+
+
+class TestOnCallToolStripsConfirmed:
+    """The structural on_call_tool gate must consume ``confirmed`` for the
+    popup-less fallback but STRIP it before forwarding — else it leaks into the
+    target tool's strict schema (422). (#558 follow-up.)"""
+
+    async def test_confirmed_stripped_before_forwarding_on_approve(self):
+        REGISTRIES["apstra"]["apstra_zap"] = ToolSpec(
+            name="apstra_zap",
+            func=lambda ctx: None,
+            platform="apstra",
+            category="w",
+            tags={"requires_confirmation"},
+            capability=Capability.WRITE,
+        )
+        try:
+            mw = ElicitationMiddleware()
+
+            ctx = MagicMock()
+            ctx.lifespan_context = {"config": SimpleNamespace(disable_elicitation=False)}
+            # No-capability client → elicit raises → confirmed=true fallback proceeds.
+            ctx.elicit = AsyncMock(side_effect=_no_elicitation_error())
+
+            message = CallToolRequestParams(name="apstra_zap", arguments={"x": 1, "confirmed": True})
+            context = MagicMock()
+            context.message = message
+            context.fastmcp_context = ctx
+
+            def _copy(*, message):
+                c2 = MagicMock()
+                c2.message = message
+                c2.fastmcp_context = ctx
+                return c2
+
+            context.copy = _copy
+
+            forwarded: dict = {}
+
+            async def call_next(c):
+                forwarded["arguments"] = dict(c.message.arguments or {})
+                return "dispatched"
+
+            result = await mw.on_call_tool(context, call_next)
+            assert result == "dispatched"  # proceeded (confirmed honored)
+            assert forwarded["arguments"] == {"x": 1}  # confirmed stripped
+            assert "confirmed" not in forwarded["arguments"]
+        finally:
+            REGISTRIES["apstra"].pop("apstra_zap", None)
 
 
 class TestInvokeToolGating:


### PR DESCRIPTION
Follow-up to #558 (reported from a Claude Desktop transcript).

## Problem

After the structural gate (#559) landed, a client that can't render the elicitation prompt — Claude Desktop reports "elicitation not supported" for the required-boolean schema — correctly falls back to the `confirmed=true` chat-confirm path. But the flag **leaked into the target tool's arguments**: the gate consumed `confirmed` for its decision but never stripped it, so the tool's strict schema (`additionalProperties: false`) rejected it with a **`422`**. Net effect: on such clients, a gated write could *never* be confirmed.

## Fix

- **`_invoke_tool`** strips `confirmed` from params before coercion / `spec.func(...)`.
- **`ElicitationMiddleware.on_call_tool`** strips `confirmed` from the forwarded arguments before `call_next`. The gate still *reads* it for the fallback decision; the tool never *sees* it.
- **Clearer `confirmation_required` message:** steer the AI to re-invoke via `<platform>_invoke_tool` with `"confirmed": true` **inside the params object** (the free-form field that carries it), and explicitly *not* to add `confirmed` to a direct by-name call — the tool's own schema rejects unknown fields, which is the `422` operators hit. (Direct-by-name can't carry the flag; `invoke_tool` is the confirmable path on no-elicit clients.)

## Testing
- Full suite: **1976 passed, 2 skipped**. ruff + mypy clean.
- `fake_write_tool` is now strict (no `confirmed` kwarg), so the existing invoke-path `confirmed=true` fallback test regression-guards the `_invoke_tool` strip (a leak → `TypeError`).
- New `on_call_tool` unit test asserts `confirmed` is consumed by the gate but stripped from the forwarded args.

## Follow-up
Maintainer to re-test in Claude Desktop: on the `confirmation_required` response, re-invoke via `<platform>_invoke_tool(name=…, params={…, "confirmed": true})` and confirm the dry-run now returns instead of `422`.