### PR TITLE
fix(central): kebab-case query params on MRT usage/trend tools (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0.5] - 2026-07-06
+
+**Patch — fix Central MRT usage/trend tools sending query params the gateway rejects (#563).** Central's `network-monitoring/v1` gateway enforces kebab-case query params (`HPE_GL_NETWORKING_ERROR_INVALID_QUERY_PARAMETER` → "Query parameter must be in kebab-case: topN") and rejects unknown params ("Unknown query parameter: end"). Four tools shipped with camelCase / unsupported params and 400'd in live dashboard use. Verified live against the tenant.
+
+### Fixed
+- **`central_get_top_aps_by_usage`** and **`central_get_clients_topn_usage`**: send the row count as `limit` (was camelCase `topN`, → HTTP 400). Removed the `filter` param — these endpoints do not accept it.
+- **`central_get_clients_trend`**: send the time window as `start-at` / `end-at` (was `start` / `end`, → HTTP 400 "Unknown query parameter"). Removed the `filter` param — this endpoint does not accept it.
+- **`central_get_switches_topn_interface_trends`**: send the count as kebab-case `limit` (was camelCase `topN`). `filter` remains — it is a supported param on this endpoint.
+
+### Notes
+- No tool-count change. Three tools dropped an unsupported `filter` parameter; no other signature changes. New tests (`tests/unit/test_central_mrt_param_kebab.py`) pin the outgoing param names for all four tools by capturing each module's `_get` call.
+- Live-checked and **not** changed: `central_get_applications` paginates correctly with `offset`; `central_get_devices` returns populated serials across AP/GW/SW device types.
+
 ## [3.5.0.4] - 2026-07-01
 
 **Patch — make the popup-less `confirmed=true` fallback actually work (follow-up to #558).** After the structural gate landed, a client that can't render the elicitation prompt (e.g. Claude Desktop, which now reports "elicitation not supported" for the required-boolean schema) correctly falls back to the `confirmed=true` chat-confirm path — but the flag **leaked into the target tool's arguments**. The gate consumed `confirmed` for its decision but never stripped it, so the tool's strict schema (`additionalProperties: false`) rejected it with a `422`, and the write could never be confirmed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.0.4"
+version = "3.5.0.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -326,7 +326,6 @@ async def central_get_top_aps_by_usage(
         ),
     ],
     top_n: Annotated[int, Field(ge=1, le=100, description="Number of APs to return (default 10).")] = 10,
-    filter: str | None = None,
 ) -> dict | str:
     """Get top-N APs by usage — metric ``'wireless'`` / ``'wired'`` / ``'usage'``
     (``'usage'`` = combined wired+wireless; ``'combined'`` is accepted as an alias).
@@ -339,9 +338,11 @@ async def central_get_top_aps_by_usage(
         "usage": "top-aps-by-usage",
     }
     conn = get_central_conn(ctx)
-    params: dict = {"topN": top_n}
-    if filter:
-        params["filter"] = filter
+    # The API rejects camelCase query params (``topN`` → HTTP 400 "must be in
+    # kebab-case") and these endpoints have no ``filter`` param — the row count
+    # is controlled by ``limit`` (see network-monitoring/v1 spec). Surfaced by
+    # live dashboard testing.
+    params: dict = {"limit": top_n}
     return await _get(conn, f"network-monitoring/v1/{path_seg(suffix_map[metric])}", params)
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
@@ -39,17 +39,17 @@ async def central_get_clients_trend(
     ctx: Context,
     start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
     end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
-    filter: str | None = None,
 ) -> dict | str:
     """Get tenant-wide client-count trend over a time window."""
     conn = get_central_conn(ctx)
+    # The endpoint's time-window params are ``start-at`` / ``end-at`` (kebab-case);
+    # ``start`` / ``end`` are rejected with HTTP 400 "Unknown query parameter", and
+    # this endpoint has no ``filter`` param. Surfaced by live dashboard testing.
     params: dict = {}
     if start:
-        params["start"] = start
+        params["start-at"] = start
     if end:
-        params["end"] = end
-    if filter:
-        params["filter"] = filter
+        params["end-at"] = end
     return await _get(conn, "network-monitoring/v1/clients-trend", params)
 
 
@@ -57,13 +57,13 @@ async def central_get_clients_trend(
 async def central_get_clients_topn_usage(
     ctx: Context,
     top_n: Annotated[int, Field(ge=1, le=100, description="Number of top-clients to return (default 10).")] = 10,
-    filter: str | None = None,
 ) -> dict | str:
     """Get the top-N clients by usage."""
     conn = get_central_conn(ctx)
-    params: dict = {"topN": top_n}
-    if filter:
-        params["filter"] = filter
+    # ``topN`` is rejected (HTTP 400 "must be in kebab-case"); the row count is
+    # controlled by ``limit`` and this endpoint has no ``filter`` param. Surfaced
+    # by live dashboard testing.
+    params: dict = {"limit": top_n}
     return await _get(conn, "network-monitoring/v1/clients-topn-usage", params)
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
@@ -109,7 +109,10 @@ async def central_get_switches_topn_interface_trends(
 ) -> dict | str:
     """Get the top-N busiest switch interfaces across the tenant."""
     conn = get_central_conn(ctx)
-    params: dict = {"topN": top_n}
+    # Use kebab-case ``limit`` for the row count, never camelCase ``topN`` (the
+    # sibling top-aps / clients-topn endpoints 400 on ``topN``). Surfaced by live
+    # dashboard testing.
+    params: dict = {"limit": top_n}
     if filter:
         params["filter"] = filter
     return await _get(conn, "network-monitoring/v1/switches/topn-interface-trends", params)

--- a/tests/unit/test_central_mrt_param_kebab.py
+++ b/tests/unit/test_central_mrt_param_kebab.py
@@ -1,0 +1,96 @@
+"""Unit tests pinning kebab-case query params on the Central MRT usage tools.
+
+Central's ``network-monitoring/v1`` gateway rejects camelCase query params with
+HTTP 400 ("Query parameter must be in kebab-case: topN") and rejects unknown
+params ("Unknown query parameter: end"). Four tools shipped with the wrong param
+names and were surfaced by live dashboard testing:
+
+* ``central_get_top_aps_by_usage`` sent ``topN`` (+ an unsupported ``filter``)
+* ``central_get_clients_topn_usage`` sent ``topN`` (+ an unsupported ``filter``)
+* ``central_get_clients_trend`` sent ``start`` / ``end`` (+ an unsupported ``filter``)
+* ``central_get_switches_topn_interface_trends`` sent ``topN``
+
+The row-count control on these endpoints is ``limit`` and the time window is
+``start-at`` / ``end-at`` (per the network-monitoring/v1 spec, verified live).
+These tests patch each module's ``_get`` to capture the outgoing (path, params).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hpe_networking_mcp.platforms.central.tools import mrt_ap, mrt_clients, mrt_switch
+
+pytestmark = pytest.mark.unit
+
+
+class _Ctx:
+    lifespan_context: dict[str, Any] = {"central_conn": object()}
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch, module: Any) -> dict[str, Any]:
+    """Patch the given module's ``_get`` to record (path, params) and return {}."""
+    captured: dict[str, Any] = {}
+
+    async def fake_get(conn: Any, path: str, params: dict | None = None) -> dict:
+        captured["path"] = path
+        captured["params"] = params or {}
+        return {}
+
+    monkeypatch.setattr(module, "_get", fake_get)
+    return captured
+
+
+_top_aps = getattr(mrt_ap.central_get_top_aps_by_usage, "fn", mrt_ap.central_get_top_aps_by_usage)
+_clients_topn = getattr(mrt_clients.central_get_clients_topn_usage, "fn", mrt_clients.central_get_clients_topn_usage)
+_clients_trend = getattr(mrt_clients.central_get_clients_trend, "fn", mrt_clients.central_get_clients_trend)
+_switches_topn = getattr(
+    mrt_switch.central_get_switches_topn_interface_trends,
+    "fn",
+    mrt_switch.central_get_switches_topn_interface_trends,
+)
+
+
+async def test_top_aps_by_usage_uses_limit_not_topn(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch, mrt_ap)
+    await _top_aps(ctx=_Ctx(), metric="usage", top_n=7)
+    assert captured["path"].endswith("/top-aps-by-usage")
+    assert captured["params"] == {"limit": 7}
+    assert "topN" not in captured["params"]
+    assert "filter" not in captured["params"]
+
+
+async def test_clients_topn_usage_uses_limit_not_topn(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch, mrt_clients)
+    await _clients_topn(ctx=_Ctx(), top_n=5)
+    assert captured["path"].endswith("/clients-topn-usage")
+    assert captured["params"] == {"limit": 5}
+    assert "topN" not in captured["params"]
+
+
+async def test_clients_trend_uses_kebab_start_at_end_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch, mrt_clients)
+    await _clients_trend(ctx=_Ctx(), start="2026-07-05T00:00:00Z", end="2026-07-06T00:00:00Z")
+    assert captured["path"].endswith("/clients-trend")
+    assert captured["params"] == {"start-at": "2026-07-05T00:00:00Z", "end-at": "2026-07-06T00:00:00Z"}
+    # The camelCase / unknown params that the API 400s on must be gone.
+    for bad in ("start", "end", "filter"):
+        assert bad not in captured["params"]
+
+
+async def test_clients_trend_omits_unset_times(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch, mrt_clients)
+    await _clients_trend(ctx=_Ctx())
+    assert captured["params"] == {}
+
+
+async def test_switches_topn_uses_limit_and_keeps_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _capture(monkeypatch, mrt_switch)
+    await _switches_topn(ctx=_Ctx(), top_n=3, filter="siteId eq '1'")
+    assert captured["path"].endswith("/switches/topn-interface-trends")
+    assert captured["params"]["limit"] == 3
+    assert "topN" not in captured["params"]
+    # filter IS a supported param on this endpoint — it must be preserved.
+    assert captured["params"]["filter"] == "siteId eq '1'"


### PR DESCRIPTION
## Summary
Central's `network-monitoring/v1` gateway rejects camelCase query params (`HPE_GL_NETWORKING_ERROR_INVALID_QUERY_PARAMETER` → "Query parameter must be in kebab-case: topN") and unknown params ("Unknown query parameter: end"). Four MRT usage/trend tools shipped with wrong param names and returned HTTP 400 in live dashboard use. **Verified live against the tenant** (probed each endpoint read-only through the running server).

## Fixes
| Tool | Was | Now |
|------|-----|-----|
| `central_get_top_aps_by_usage` | `topN` + unsupported `filter` | `limit` |
| `central_get_clients_topn_usage` | `topN` + unsupported `filter` | `limit` |
| `central_get_clients_trend` | `start` / `end` + unsupported `filter` | `start-at` / `end-at` |
| `central_get_switches_topn_interface_trends` | `topN` | `limit` (`filter` kept — supported here) |

The count control on these endpoints is `limit` and the time window is `start-at`/`end-at` per the network-monitoring/v1 spec; `limit` was confirmed accepted live on the endpoint family. The two top-N endpoints and clients-trend do not accept `filter`, so that param was removed from those three tools.

## Not reproduced (checked live, no change)
- `central_get_applications` paginates correctly with `offset`.
- `central_get_devices` returns populated serials across AP/GW/SW device types (23 devices, 0 empty serials).

## Testing
- New `tests/unit/test_central_mrt_param_kebab.py` pins the outgoing param names for all four tools (captures each module's `_get`).
- Full checklist green in Docker: ruff, ruff format, mypy, `pytest` (1981 passed, 2 skipped).

Closes #563