### PR TITLE
fix(security): base image → python 3.13-slim-trixie + image CVE scanning (#565)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,35 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Base-image bumps (Dockerfile FROM). Interpreter/OS CVEs live here, not in
+  # the pip ecosystem — this is what would have surfaced the CPython base-image
+  # CVEs automatically (CVE-2026-3644/4786/6100/7210).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # GitHub Actions version bumps (keeps the CI/security actions current).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,3 +37,29 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trivy:
+    # Image-layer CVE scan (CPython interpreter + Debian OS packages) — the layer
+    # pip-audit and bandit are blind to. Surfaced by a CWPP report of CPython
+    # interpreter CVEs (CVE-2026-3644/4786/6100/7210) that our Python-only
+    # scanners could not see. Builds the runtime image and fails the build on any
+    # HIGH/CRITICAL vuln that has an available fix (`--ignore-unfixed`), so the
+    # gate stays actionable rather than red on Debian's fix-deferred backlog.
+    name: Image Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build runtime image
+        run: docker build -t hpe-networking-mcp:scan .
+      - name: Trivy scan (fail on fixable HIGH/CRITICAL)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:latest image \
+            --scanners vuln \
+            --pkg-types os,library \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --no-progress \
+            hpe-networking-mcp:scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0.6] - 2026-07-06
+
+**Patch — remediate CPython base-image CVEs + close the image-scanning gap.** A CWPP image scan flagged four HIGH CPython **interpreter** CVEs baked into the base image (`python:3.12-slim-bookworm` → CPython 3.12.13): CVE-2026-3644 (http.cookies control-char validation), CVE-2026-4786 (webbrowser command injection), CVE-2026-6100 (decompressor use-after-free), and CVE-2026-7210 (expat XML hash-flooding DoS). Our CI could not see them: `pip-audit` scans PyPI packages (not the interpreter binary), `bandit` is a static analyzer, and there was **no image/OS-layer scanner** at all.
+
+### Changed
+- **Base image `python:3.12-slim-bookworm` → `python:3.13-slim-trixie`** (CPython 3.13.14 on Debian trixie). Resolves CVE-2026-3644 (fixed 3.13.13) and CVE-2026-4786 / CVE-2026-6100 (fixed 3.13.14). The 3.12 branch is security-only and shipped no binary with these fixes (3.12.13 is its latest release), so a 3.13 bump is the remediation. Full test suite (incl. the code-mode / monty sandbox) passes on 3.13.14; the Prefab/Pyodide generative-UI sandbox prewarms cleanly.
+
+### Added
+- **Trivy image-vulnerability scan** in the Security workflow: builds the runtime image and fails on any HIGH/CRITICAL vuln that has an available fix (`--ignore-unfixed`, so the gate stays actionable rather than red on Debian's `fix_deferred` backlog). This is the OS/interpreter layer `pip-audit` cannot cover.
+- **Dependabot `docker` + `github-actions` ecosystems** (was `pip`-only) so base-image and CI-action bumps get automatic PRs — the mechanism that would have surfaced these CPython CVEs on its own.
+
+### Notes
+- **CVE-2026-7210** (expat hash-flooding DoS) has no released interpreter fix on any current branch (the advisory lists only 3.15.0, unreleased) and also requires libexpat ≥ 2.8.0 at the OS layer. It is **tracked, not yet fully closed**; real exposure is low — the server does not parse untrusted XML at runtime. It will clear when CPython backports the fix (Dependabot/Trivy will surface it).
+- The remaining Trivy HIGH/CRITICAL findings on the image are Debian OS packages marked `affected` / `fix_deferred` with no available fix, and are not reachable from the runtime; `--ignore-unfixed` keeps them out of the CI gate until Debian ships fixes.
+
 ## [3.5.0.5] - 2026-07-06
 
 **Patch — fix Central MRT usage/trend tools sending query params the gateway rejects (#563).** Central's `network-monitoring/v1` gateway enforces kebab-case query params (`HPE_GL_NETWORKING_ERROR_INVALID_QUERY_PARAMETER` → "Query parameter must be in kebab-case: topN") and rejects unknown params ("Unknown query parameter: end"). Four tools shipped with camelCase / unsupported params and 400'd in live dashboard use. Verified live against the tenant.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm AS deps
+FROM python:3.13-slim-trixie AS deps
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -12,7 +12,7 @@ COPY pyproject.toml ./
 RUN uv sync --frozen --no-dev --no-install-project 2>/dev/null || uv sync --no-dev --no-install-project
 
 # --- Runtime stage ---
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-trixie
 
 # Install uv in runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -202,7 +202,7 @@ secrets/
 
 | Property | Value |
 |----------|-------|
-| Base image | `python:3.12-slim-bookworm` |
+| Base image | `python:3.13-slim-trixie` |
 | Package manager | `uv` (pinned version) |
 | Runtime user | Non-root (`mcpuser`, uid 1000) |
 | Exposed port | `8000` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.0.5"
+version = "3.5.0.6"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
A CWPP image scan flagged four HIGH **CPython interpreter** CVEs baked into the base image (`python:3.12-slim-bookworm` = CPython 3.12.13). Our CI could not see them: `pip-audit` scans PyPI packages (not the interpreter), `bandit` is a static analyzer, and there was **no image/OS-layer scanner**.

## Changes
- **Base image `python:3.12-slim-bookworm` → `python:3.13-slim-trixie`** (CPython 3.13.14).
- **Trivy image-vuln scan** added to the Security workflow (builds the image, fails on fixable HIGH/CRITICAL via `--ignore-unfixed`).
- **Dependabot** extended to `docker` + `github-actions` ecosystems (was pip-only).

## CVE status (verified with Trivy against the built trixie image)
| CVE | Fixed in | Status after bump |
|-----|----------|-------------------|
| CVE-2026-3644 | 3.13.13 | ✅ resolved |
| CVE-2026-4786 | 3.13.14 | ✅ resolved |
| CVE-2026-6100 | 3.13.14 | ✅ resolved |
| CVE-2026-7210 | 3.15.0 (unreleased; no backport) | ⚠️ tracked — no released interpreter fix on any branch; needs libexpat ≥2.8.0; low exposure (no untrusted-XML parsing at runtime) |

The 3.12 branch is security-only and shipped no binary with these fixes (3.12.13 is its latest release), so a 3.13 bump is the remediation.

## Verification (dev container, on the new base)
- `python --version` → **3.13.14**, OS **Debian 13 (trixie)**, perl 5.40.
- Full suite: **1981 passed, 2 skipped** — including the code-mode / monty sandbox tests.
- Prefab/Pyodide generative-UI sandbox prewarms clean during build.
- ruff / ruff format / mypy: clean.
- Trivy: the four CPython CVEs no longer appear; remaining HIGH/CRITICAL are Debian OS packages marked `fix_deferred` with no available fix (filtered by `--ignore-unfixed`, not runtime-reachable).

Closes #565