### PR TITLE
chore(deps): bump CI actions (consolidated Dependabot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen --no-dev --no-install-project 2>/dev/null || uv sync --no-dev --no-install-project
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - run: uv run mypy src/ --ignore-missing-imports
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - name: Run tests
         run: uv run pytest tests/unit -v --tb=short

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/greenlake-specs-refresh.yml
+++ b/.github/workflows/greenlake-specs-refresh.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.MIST_SYNC_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create or update sync PR
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
           branch: chore/sync-greenlake-oas

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - run: uv run bandit -r src/ -c pyproject.toml
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - name: Run pip-audit against the locked environment
         run: uv run --frozen pip-audit
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/sync-mist-openapi.yml
+++ b/.github/workflows/sync-mist-openapi.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Create or update sync PR
         if: steps.diff.outputs.changed == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
           branch: chore/sync-mist-openapi

--- a/.github/workflows/sync-new-central-oas.yml
+++ b/.github/workflows/sync-new-central-oas.yml
@@ -42,7 +42,7 @@ jobs:
           token: ${{ secrets.MIST_SYNC_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create or update sync PR
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
           branch: chore/sync-new-central-oas


### PR DESCRIPTION
Consolidates the five Dependabot **github-actions** bumps into one PR to avoid serial rebase churn under branch protection (each individual merge would push the others out-of-date).

| Action | Bump | Supersedes |
|--------|------|-----------|
| astral-sh/setup-uv | v6 → v7 | #569 |
| gitleaks/gitleaks-action | v2 → v3 | #572 |
| docker/setup-buildx-action | v3 → v4 | #571 |
| actions/setup-python | v5 → v6 | #567 |
| peter-evans/create-pull-request | v6 → v8 | #568 |

CI-only; no runtime artifact or version change. setup-uv / buildx / gitleaks are exercised by the standard CI + Security suite here (all green on the individual Dependabot PRs, incl. gitleaks v3). setup-python / create-pull-request are used only in the scheduled spec-refresh workflows.

Closes #567
Closes #568
Closes #569
Closes #571
Closes #572