### PR TITLE
fix(mist): normalize null bare-array reads + derive generated-tool schemas (#561, #525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1.2] - 2026-07-07
+
+**Patch — Mist code-mode hardening: bare-array reads no longer surface `data: null`, and generated-tool schemas are no longer null (#561, #525).** Reported by an external user driving a Mist adoption/inventory workflow from an agent.
+
+### Fixed
+- **#561 — empty Mist collection reads returned `data: null`.** Some Mist collection endpoints (`GET /orgs/{id}/inventory`, `/otherdevices`, `/networks`) return JSON `null` — not `[]` — for an empty or filtered-empty result set. `mist_request` passed that `None` through, surfacing as `data: null`, which a model can't distinguish from data loss. It now normalizes a `null` body to an empty list (`data: []`). Verified live: `mist_get_org_inventory` with the default `unassigned=True` returned `null` on an all-assigned org (`unassigned=False` returned the devices) — this was empty-result-returns-null, not non-empty data being dropped.
+- **#525 — `<platform>_get_tool_schema` returned `input_schema: null` for spec-driven generated tools.** `mcp._get_tool(name)` yields no usable schema for the generated `mist_*` / `edgeconnect_*` tools in code mode, so schemas came back null — leaving small models without parameter names, required fields, enums, or (for write tools) the `body` request-wrapper key. `get_tool_schema` now derives the schema from the registry `ToolSpec.func` signature when FastMCP has none, and falls back to a `params_hint` (required/optional names) if derivation fails. Verified on the real generated surface: `mist_get_org_inventory` → non-null schema with required `org_id`; `mist_update_org_inventory_assignment` → schema naming the `body` wrapper.
+
+### Notes
+- Both are part of the broader "uniform collection shape for spec-driven reads" direction (#500); #561 is the narrow, ship-now normalization and does not require the full `{items}` generator sweep.
+- Refactored the signature→Pydantic-field logic in `meta_tools` into a shared `_signature_fields` helper (used by both param coercion and schema derivation).
+
 ## [3.5.1.1] - 2026-07-06
 
 **Patch — fix Generative-UI dashboards hanging on "waiting for content" in Claude Desktop.** Root-caused from a client DevTools console error (`[Prefab] exec #1: NameError: name 'site' is not defined`): the MCP-Apps generative renderer **executes the tool's `code` in the browser as it streams** (`ontoolinputpartial`), but the `data` argument's top-level keys are injected as globals **only server-side** — the client-side streaming exec never receives them, so any name that came from `data` raises `NameError` and the widget wedges. This was NOT a CSP / CDN / base-image / client-render (#671) issue: Pyodide loads and runs, and the server produces a valid `$prefab` tree (verified live). A self-contained widget renders in Claude Desktop where the `data`-argument form hangs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.1.1"
+version = "3.5.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/meta_tools.py
+++ b/src/hpe_networking_mcp/platforms/_common/meta_tools.py
@@ -70,6 +70,80 @@ def _extract_annotated_default(annotation: Any) -> Any:
     return ...
 
 
+def _signature_fields(spec: ToolSpec) -> dict[str, Any]:
+    """Build Pydantic field definitions ``{name: (annotation, default)}`` from a
+    tool's signature, excluding the ``ctx`` param and variadics.
+
+    Shared by ``_coerce_params`` (validation) and ``_derive_input_schema``
+    (discovery). ``from __future__ import annotations`` leaves signatures as
+    strings, so resolve them eagerly with ``get_type_hints`` against the
+    function's own namespace so ``Annotated`` / ``UUID`` / enums resolve.
+    """
+    sig = inspect.signature(spec.func)
+    try:
+        resolved_hints = get_type_hints(spec.func, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+
+    fields: dict[str, Any] = {}
+    for pname, param in sig.parameters.items():
+        if pname in _CTX_PARAM_NAMES:
+            continue
+        # Skip variadic parameters (``*args`` / ``**kwargs``) — Pydantic can't
+        # build a field from them (real tools rarely use this; AsyncMock stubs do).
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        annotation = resolved_hints.get(pname, param.annotation)
+        if annotation is inspect.Parameter.empty:
+            annotation = Any
+        if param.default is not inspect.Parameter.empty:
+            fields[pname] = (annotation, param.default)
+        else:
+            # Signature has no default; fall back to any default baked into the
+            # ``Annotated`` FieldInfo (``...`` / required if none is found).
+            fields[pname] = (annotation, _extract_annotated_default(annotation))
+    return fields
+
+
+def _derive_input_schema(spec: ToolSpec) -> dict[str, Any] | None:
+    """Derive a JSON input schema from the registry ``ToolSpec.func`` signature.
+
+    ``mcp._get_tool(name)`` yields no usable ``parameters`` for the spec-driven
+    generated tools (``mist_*`` / ``edgeconnect_*``) in code mode, leaving
+    ``input_schema: null`` — small models then have no parameter names, required
+    fields, enum values, or (for write tools) the ``body`` request wrapper key.
+    The func carries the real ``Annotated`` signature, so build the schema from
+    it. Returns ``None`` if there are no params or schema generation fails on an
+    arbitrary type. (#525)
+    """
+    try:
+        fields = _signature_fields(spec)
+        if not fields:
+            return None
+        model_cls = create_model(
+            f"{spec.name}__Schema",
+            __config__=ConfigDict(arbitrary_types_allowed=True, extra="forbid"),
+            **fields,
+        )
+        return model_cls.model_json_schema()
+    except Exception as exc:  # never let schema derivation break discovery
+        logger.debug("_derive_input_schema: could not derive schema for {!r} — {}", spec.name, exc)
+        return None
+
+
+def _params_hint(spec: ToolSpec) -> dict[str, list[str]]:
+    """Minimal fallback when full schema derivation fails: the required and
+    optional parameter names from the signature, so a model still knows the
+    shape (acceptance criterion of #525)."""
+    try:
+        fields = _signature_fields(spec)
+    except Exception:
+        return {"required": [], "optional": []}
+    required = [n for n, (_ann, default) in fields.items() if default is ...]
+    optional = [n for n in fields if n not in required]
+    return {"required": required, "optional": optional}
+
+
 def _coerce_params(spec: ToolSpec, raw_params: dict[str, Any]) -> dict[str, Any]:
     """Build a Pydantic model from the tool signature and validate/coerce.
 
@@ -85,38 +159,7 @@ def _coerce_params(spec: ToolSpec, raw_params: dict[str, Any]) -> dict[str, Any]
     ``ValidationError`` if the params don't match the signature (missing
     required params, unknown keys, or type-coercion failures).
     """
-    sig = inspect.signature(spec.func)
-    # ``from __future__ import annotations`` in tool modules leaves
-    # ``inspect.signature()`` annotations as strings. Pydantic can't
-    # evaluate those strings without a matching namespace. Resolve
-    # eagerly with ``get_type_hints`` using the function's own globals
-    # + localns so ``Annotated``, ``UUID``, enums defined beside the
-    # tool, etc. all resolve correctly.
-    try:
-        resolved_hints = get_type_hints(spec.func, include_extras=True)
-    except Exception:
-        resolved_hints = {}
-
-    fields: dict[str, Any] = {}
-    for pname, param in sig.parameters.items():
-        if pname in _CTX_PARAM_NAMES:
-            continue
-        # Skip variadic parameters (``*args`` / ``**kwargs``). Pydantic
-        # can't build a field from them; real tools almost never use this
-        # shape, but ``AsyncMock()`` stubs in tests do — and a runtime
-        # crash there is worse than no coercion.
-        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
-            continue
-        annotation = resolved_hints.get(pname, param.annotation)
-        if annotation is inspect.Parameter.empty:
-            annotation = Any
-        if param.default is not inspect.Parameter.empty:
-            fields[pname] = (annotation, param.default)
-        else:
-            # Signature has no default; fall back to any default baked
-            # into the ``Annotated`` FieldInfo. Returns ``...`` (required)
-            # if none is found.
-            fields[pname] = (annotation, _extract_annotated_default(annotation))
+    fields = _signature_fields(spec)
 
     if not fields:
         # Signature has no validatable params — nothing to coerce. Hand
@@ -394,6 +437,13 @@ def build_meta_tools(
             }
 
         input_schema = getattr(fm_tool, "parameters", None) or getattr(fm_tool, "input_schema", None)
+        # Spec-driven generated tools (mist_*/edgeconnect_*) resolve through
+        # ``_get_tool`` with no usable schema in code mode, leaving
+        # ``input_schema: null``. Derive it from the registry func signature so
+        # the model gets parameter names, required fields, enums, and the write
+        # ``body`` wrapper. (#525)
+        if not input_schema:
+            input_schema = _derive_input_schema(spec)
         annotations = getattr(fm_tool, "annotations", None)
         result: dict[str, Any] = {
             "status": "ok",
@@ -404,6 +454,10 @@ def build_meta_tools(
             "annotations": _annotations_to_dict(annotations),
             "input_schema": input_schema,
         }
+        # If schema derivation still failed (arbitrary types, etc.), give the
+        # model at least the required/optional parameter names so it isn't blind.
+        if not input_schema:
+            result["params_hint"] = _params_hint(spec)
 
         # For tools whose ``payload`` is an opaque config-model body, attach the
         # distilled field schema so clients author it without guessing (#384).

--- a/src/hpe_networking_mcp/platforms/mist/_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/_client.py
@@ -252,6 +252,15 @@ async def mist_request(
     except (ValueError, _json.JSONDecodeError):
         return {"raw": response.text, "has_more": False}
 
+    # Some Mist collection endpoints (e.g. GET /orgs/{id}/inventory,
+    # /otherdevices, /networks) return JSON ``null`` — not ``[]`` — for an
+    # empty or filtered-empty result set. Passing ``None`` straight through
+    # surfaces as ``data: null`` in the envelope, which a model (especially a
+    # small one) can't distinguish from data loss or an error. Normalize an
+    # empty result to an empty list so "no matching rows" is unambiguous. (#561)
+    if parsed is None:
+        parsed = []
+
     return _decode_pagination(response, parsed)
 
 

--- a/tests/unit/test_meta_tools.py
+++ b/tests/unit/test_meta_tools.py
@@ -537,3 +537,82 @@ class TestPayloadSchemaProvider:
         result = await tool.fn(_fake_ctx(ServerConfig()), name="apstra_get_blueprints")
         assert result["status"] == "ok"  # discovery still works
         assert "payload_schema" not in result
+
+
+# ---------------------------------------------------------------------------
+# #525: input_schema derived from the registry func signature
+# ---------------------------------------------------------------------------
+
+
+async def _mist_like_read(
+    ctx: FastMCPContext,
+    org_id: _Annotated[str, _Field(description="path parameter 'org_id'")],
+    type: _Annotated[str | None, _Field(default=None, description="Filter by type")] = None,
+    limit: _Annotated[int, _Field(description="page size")] = 100,
+) -> dict:
+    return {"ok": True}
+
+
+_mist_like_read.__name__ = "mist_get_org_inventory"  # type: ignore[attr-defined]
+
+
+async def _mist_like_write(
+    ctx: FastMCPContext,
+    org_id: _Annotated[str, _Field(description="path parameter 'org_id'")],
+    body: _Annotated[dict | None, _Field(default=None, description="Request body for PUT")] = None,
+) -> dict:
+    return {"ok": True}
+
+
+_mist_like_write.__name__ = "mist_update_org_inventory_assignment"  # type: ignore[attr-defined]
+
+
+def _mist_spec(func, name, capability):
+    return ToolSpec(
+        name=name,
+        func=func,
+        platform="mist",
+        category="orgs_inventory",
+        description="Mist tool.",
+        tags=set(),
+        capability=capability,
+    )
+
+
+@pytest.mark.unit
+class TestDeriveInputSchema:
+    """#525: get_tool_schema must not return ``input_schema: null`` for the
+    spec-driven generated tools (mist_*/edgeconnect_*) — derive it from the
+    registry ``ToolSpec.func`` signature."""
+
+    def test_read_tool_schema_has_params(self):
+        from hpe_networking_mcp.platforms._common.meta_tools import _derive_input_schema
+
+        schema = _derive_input_schema(_mist_spec(_mist_like_read, "mist_get_org_inventory", Capability.READ))
+        assert schema is not None
+        props = schema.get("properties", {})
+        assert "org_id" in props
+        assert "type" in props and "limit" in props
+        # org_id (no default) is required; the optional filters are not.
+        assert "org_id" in schema.get("required", [])
+        assert "type" not in schema.get("required", [])
+
+    def test_write_tool_schema_names_body_wrapper(self):
+        """The reporter's write-side case: the ``body`` request wrapper — the key
+        ``invoke_tool`` actually expects the payload under — must be discoverable."""
+        from hpe_networking_mcp.platforms._common.meta_tools import _derive_input_schema
+
+        schema = _derive_input_schema(
+            _mist_spec(_mist_like_write, "mist_update_org_inventory_assignment", Capability.WRITE)
+        )
+        assert schema is not None
+        props = schema.get("properties", {})
+        assert "org_id" in props
+        assert "body" in props  # previously unnamed → forced brute-force discovery
+
+    def test_params_hint_lists_required_and_optional(self):
+        from hpe_networking_mcp.platforms._common.meta_tools import _params_hint
+
+        hint = _params_hint(_mist_spec(_mist_like_read, "mist_get_org_inventory", Capability.READ))
+        assert hint["required"] == ["org_id"]
+        assert set(hint["optional"]) == {"type", "limit"}

--- a/tests/unit/test_mist_client_response.py
+++ b/tests/unit/test_mist_client_response.py
@@ -1,0 +1,70 @@
+"""Unit tests for Mist client response normalization (#561).
+
+Several Mist collection endpoints (``GET /orgs/{id}/inventory``, ``/otherdevices``,
+``/networks``) return JSON ``null`` — not ``[]`` — for an empty or filtered-empty
+result set. ``mist_request`` must normalize that to an empty list so it surfaces
+as ``data: []`` (unambiguously "no rows") instead of ``data: null`` (which a model
+can't distinguish from data loss). Confirmed live: ``mist_get_org_inventory`` with
+the default ``unassigned=True`` returned ``null`` on an all-assigned org while
+``unassigned=False`` returned the device list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hpe_networking_mcp.platforms.mist._client import mist_request
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(*, status: int = 200, content: bytes = b"x", json_value=None, headers: dict | None = None):
+    r = MagicMock()
+    r.status_code = status
+    r.content = content
+    r.headers = headers or {}
+    r.json = MagicMock(return_value=json_value)
+    r.text = ""
+    return r
+
+
+def _ctx(resp):
+    client = MagicMock()
+    client.request = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.lifespan_context = {"mist_client": client}
+    return ctx
+
+
+async def test_null_body_normalizes_to_empty_list():
+    """#561: a JSON ``null`` body must return ``[]``, not ``None`` (→ data:null)."""
+    ctx = _ctx(_resp(content=b"null", json_value=None))
+    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
+    assert result == []
+
+
+async def test_nonempty_list_body_preserved():
+    """Regression: a real bare-array response is returned unchanged (no data loss)."""
+    rows = [{"serial": "AAA"}, {"serial": "BBB"}]
+    ctx = _ctx(_resp(json_value=rows))
+    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
+    assert result == rows
+
+
+async def test_empty_list_body_preserved():
+    """An actual ``[]`` response stays ``[]`` (already unambiguous)."""
+    ctx = _ctx(_resp(json_value=[]))
+    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
+    assert result == []
+
+
+async def test_dict_body_preserved():
+    """A dict-shaped response (search/count endpoints) is untouched by the fix."""
+    body = {"results": [{"model": "AP41"}], "total": 1}
+    ctx = _ctx(_resp(json_value=body))
+    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory/search")
+    # _decode_pagination adds has_more=False to dicts with no next page.
+    assert result["results"] == body["results"]
+    assert result["total"] == 1


### PR DESCRIPTION
Two Mist code-mode fixes from external reports (@fastrevmd-lab / Casey). Both verified live/on the real generated surface + unit-tested.

## #561 — empty Mist collection reads surfaced `data: null`
Some Mist collection endpoints (`GET /orgs/{id}/inventory`, `/otherdevices`, `/networks`) return JSON **`null`** — not `[]` — for an empty/filtered-empty result set. `mist_request` passed that `None` straight through as `data: null`, which a model can't distinguish from data loss.

**Fix:** normalize a `null` body to an empty list in `mist_request`.

**Root cause nuance** (corrected the report's framing): it's *empty-result-returns-null*, not non-empty rows being dropped. Confirmed live — `mist_get_org_inventory` with the default `unassigned=True` returned `null` on an all-assigned org, while `unassigned=False` returned the 9 devices; `count` confirmed they exist.

## #525 — `get_tool_schema` returned `input_schema: null` for generated tools
`mcp._get_tool(name)` yields no usable schema for the spec-driven `mist_*` / `edgeconnect_*` tools in code mode, so schemas came back null — no param names, required fields, enums, or (for write tools) the **`body`** request-wrapper key the reporter had to brute-force.

**Fix:** derive the schema from the registry `ToolSpec.func` signature when FastMCP has none, with a `params_hint` (required/optional names) fallback. Refactored the signature→field logic into a shared `_signature_fields` helper.

**Verified on the real generated surface:** `mist_get_org_inventory` → non-null schema, required `org_id`; `mist_update_org_inventory_assignment` → schema naming `body`.

## Tests
- `tests/unit/test_mist_client_response.py` (new): null→[], non-empty preserved, [] preserved, dict preserved.
- `tests/unit/test_meta_tools.py`: schema derivation has params + required; write tool names `body`; params_hint.
- Full suite **1986 passed / 4 skipped**; ruff / format / mypy clean.

## Notes
Both are part of the broader spec-driven-read normalization direction (#500); #561 is the narrow ship-now piece and doesn't need the full `{items}` generator sweep.

Closes #561
Closes #525