### PR TITLE
fix(mist): return {items:[]} dict for empty collections — complete #561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1.3] - 2026-07-07
+
+**Patch — complete the #561 empty-collection fix (v3.5.1.2 was insufficient).** v3.5.1.2 normalized a `null` Mist body to a bare `[]`, but an empty **list** *also* collapses to `data: null` through `ResponseEnvelopeMiddleware` — an empty list yields no recoverable content block, so the envelope can't distinguish it from `None`. Caught in post-deploy live verification: `mist_get_org_inventory` (empty) still returned `data: null` on v3.5.1.2.
+
+### Fixed
+- **`mist_request` now returns `{"items": [], "has_more": False}` (a dict) for an empty collection** — from either a JSON `null` body or a bare `[]`. A dict populates `structured_content`, so it survives the envelope as a non-null, unambiguous "no rows" result (and is forward-compatible with the uniform-shape direction in #500). Added an end-to-end test that drives an empty result through the real envelope middleware (the check the isolated `mist_request` unit test in v3.5.1.2 missed).
+
 ## [3.5.1.2] - 2026-07-07
 
 **Patch — Mist code-mode hardening: bare-array reads no longer surface `data: null`, and generated-tool schemas are no longer null (#561, #525).** Reported by an external user driving a Mist adoption/inventory workflow from an agent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.1.2"
+version = "3.5.1.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/mist/_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/_client.py
@@ -252,16 +252,20 @@ async def mist_request(
     except (ValueError, _json.JSONDecodeError):
         return {"raw": response.text, "has_more": False}
 
-    # Some Mist collection endpoints (e.g. GET /orgs/{id}/inventory,
-    # /otherdevices, /networks) return JSON ``null`` — not ``[]`` — for an
-    # empty or filtered-empty result set. Passing ``None`` straight through
-    # surfaces as ``data: null`` in the envelope, which a model (especially a
-    # small one) can't distinguish from data loss or an error. Normalize an
-    # empty result to an empty list so "no matching rows" is unambiguous. (#561)
-    if parsed is None:
-        parsed = []
+    result = _decode_pagination(response, [] if parsed is None else parsed)
 
-    return _decode_pagination(response, parsed)
+    # An empty collection surfaces as ``data: null`` through the response
+    # envelope: some Mist endpoints (GET /orgs/{id}/inventory, /otherdevices,
+    # /networks) return JSON ``null`` (not ``[]``) for an empty/filtered-empty
+    # set, AND a bare ``[]`` return has no recoverable content block, so the
+    # envelope can't distinguish it from ``None`` either — both collapse to
+    # ``null``, which a model can't tell from data loss. Return a dict for an
+    # empty collection so it reads as an unambiguous, non-null ``{"items": []}``
+    # (also forward-compatible with the uniform-shape direction in #500). (#561)
+    if result == []:
+        return {"items": [], "has_more": False}
+
+    return result
 
 
 async def resolve_org_id_from_self(client: httpx.AsyncClient) -> str | None:

--- a/tests/unit/test_mist_client_response.py
+++ b/tests/unit/test_mist_client_response.py
@@ -1,23 +1,32 @@
-"""Unit tests for Mist client response normalization (#561).
+"""Unit tests for Mist client empty-collection normalization (#561).
 
-Several Mist collection endpoints (``GET /orgs/{id}/inventory``, ``/otherdevices``,
-``/networks``) return JSON ``null`` — not ``[]`` — for an empty or filtered-empty
-result set. ``mist_request`` must normalize that to an empty list so it surfaces
-as ``data: []`` (unambiguously "no rows") instead of ``data: null`` (which a model
-can't distinguish from data loss). Confirmed live: ``mist_get_org_inventory`` with
-the default ``unassigned=True`` returned ``null`` on an all-assigned org while
-``unassigned=False`` returned the device list.
+Some Mist collection endpoints (``GET /orgs/{id}/inventory``, ``/otherdevices``,
+``/networks``) return JSON ``null`` — not ``[]`` — for an empty/filtered-empty
+result set. But normalizing that to a bare ``[]`` is NOT enough: an empty list
+has no recoverable content block, so ``ResponseEnvelopeMiddleware`` can't tell it
+from ``None`` and it still collapses to ``data: null``. So ``mist_request`` returns
+a **dict** (``{"items": [], "has_more": False}``) for an empty collection, which
+survives the envelope as a non-null, unambiguous "no rows" result.
+
+Confirmed live: ``mist_get_org_inventory`` with the default ``unassigned=True``
+returned ``null`` on an all-assigned org while ``unassigned=False`` returned the
+device list; ``count`` confirmed the devices existed all along.
 """
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastmcp import Client, FastMCP
 
+from hpe_networking_mcp.middleware.response_envelope import ResponseEnvelopeMiddleware
 from hpe_networking_mcp.platforms.mist._client import mist_request
 
 pytestmark = pytest.mark.unit
+
+_EMPTY = {"items": [], "has_more": False}
 
 
 def _resp(*, status: int = 200, content: bytes = b"x", json_value=None, headers: dict | None = None):
@@ -38,11 +47,19 @@ def _ctx(resp):
     return ctx
 
 
-async def test_null_body_normalizes_to_empty_list():
-    """#561: a JSON ``null`` body must return ``[]``, not ``None`` (→ data:null)."""
+async def test_null_body_normalizes_to_empty_items_dict():
+    """#561: a JSON ``null`` body → a non-null ``{"items": []}`` dict, not ``None``."""
     ctx = _ctx(_resp(content=b"null", json_value=None))
     result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
-    assert result == []
+    assert result == _EMPTY
+
+
+async def test_empty_list_body_normalized_to_dict():
+    """An actual ``[]`` response is ALSO normalized — a bare empty list would still
+    collapse to ``data: null`` through the envelope (see the end-to-end test)."""
+    ctx = _ctx(_resp(json_value=[]))
+    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
+    assert result == _EMPTY
 
 
 async def test_nonempty_list_body_preserved():
@@ -53,18 +70,35 @@ async def test_nonempty_list_body_preserved():
     assert result == rows
 
 
-async def test_empty_list_body_preserved():
-    """An actual ``[]`` response stays ``[]`` (already unambiguous)."""
-    ctx = _ctx(_resp(json_value=[]))
-    result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory")
-    assert result == []
-
-
 async def test_dict_body_preserved():
     """A dict-shaped response (search/count endpoints) is untouched by the fix."""
     body = {"results": [{"model": "AP41"}], "total": 1}
     ctx = _ctx(_resp(json_value=body))
     result = await mist_request(ctx, "GET", "/api/v1/orgs/x/inventory/search")
-    # _decode_pagination adds has_more=False to dicts with no next page.
     assert result["results"] == body["results"]
     assert result["total"] == 1
+
+
+async def test_empty_collection_survives_envelope_end_to_end():
+    """The regression the isolated mist_request test missed: drive an empty result
+    THROUGH ResponseEnvelopeMiddleware and assert ``data`` is a non-null empty
+    collection — a bare ``[]`` return collapses to ``data: null`` here, which is
+    exactly why mist_request returns a dict."""
+    mcp = FastMCP("t", middleware=[ResponseEnvelopeMiddleware()])
+
+    @mcp.tool
+    async def returns_empty_dict() -> Any:
+        return _EMPTY
+
+    @mcp.tool
+    async def returns_empty_list() -> Any:
+        return []
+
+    async with Client(mcp) as client:
+        dict_res = await client.call_tool("returns_empty_dict", {})
+        list_res = await client.call_tool("returns_empty_list", {})
+
+    # The dict shape (what mist_request now returns) survives with real data.
+    assert (dict_res.structured_content or {}).get("data") == _EMPTY
+    # A bare empty list collapses to data:null — documents WHY the dict is needed.
+    assert (list_res.structured_content or {}).get("data") is None


### PR DESCRIPTION
Follow-up to #576 / v3.5.1.2, which was an **incomplete** #561 fix.

## What v3.5.1.2 missed
v3.5.1.2 normalized a `null` Mist body to a bare `[]`. But an empty **list** *also* collapses to `data: null` through `ResponseEnvelopeMiddleware` — an empty list has no recoverable content block, so the envelope can't distinguish it from `None`. **Caught in post-deploy live verification:** `mist_get_org_inventory` (empty) still returned `data: null` on v3.5.1.2.

Proven in a throwaway harness:
- `return []` → `data: null`
- `return {"items": [], "has_more": False}` → `data: {"items": []}` ✓

## Fix
`mist_request` now returns `{"items": [], "has_more": False}` (a dict) for an empty collection — from a JSON `null` body **or** a bare `[]`. A dict populates `structured_content`, so it survives the envelope as a non-null, unambiguous "no rows" result (forward-compatible with #500's uniform shape).

## Tests
- Updated `test_mist_client_response.py` to expect the dict, **plus a new end-to-end test** that drives an empty result through the real `ResponseEnvelopeMiddleware` — the coverage the isolated unit test missed (it verified `mist_request` returned `[]` but not that `[]` survives the envelope).
- ruff / format / mypy clean; unit suite green. (Local `test_wlans_live.py` failures are unrelated live-Central `RemoteProtocolError` flakiness — different platform; those live tests skip in CI.)

References #561