### PR TITLE
fix(server): apply generate_prefab_ui guidance + code-mode re-expose loop-safely (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.1.4] - 2026-07-07
+
+**Patch — apply the `generate_prefab_ui` guidance + code-mode re-expose event-loop-safely (#578).** `create_server()` mutated the `generate_prefab_ui` description (the self-contained-code steer from v3.5.1.1) and re-exposed the MCP-Apps tools in code mode via a bare `asyncio.run(mcp.get_tool(...))`. That works at synchronous CLI startup but raises inside an already-running event loop (embedded/async startup, async tests); the broad handler swallowed the failure, so the tool silently fell back to the upstream Prefab description and steered models back toward the broken `data=` pattern.
+
+### Fixed
+- **New `_get_registered_tool_blocking()` helper** runs the tool lookup directly when no loop is running and in a short-lived worker thread (own loop) when one is — so the guidance mutation and the code-mode app-tool re-expose both apply in either startup path. Replaces both `asyncio.run(mcp.get_tool(...))` sites.
+- Regression test builds `create_server()` from **inside** a running event loop and asserts the guidance is present, with no `coroutine 'FastMCP.get_tool' was never awaited` warning.
+
 ## [3.5.1.3] - 2026-07-07
 
 **Patch — complete the #561 empty-collection fix (v3.5.1.2 was insufficient).** v3.5.1.2 normalized a `null` Mist body to a bare `[]`, but an empty **list** *also* collapses to `data: null` through `ResponseEnvelopeMiddleware` — an empty list yields no recoverable content block, so the envelope can't distinguish it from `None`. Caught in post-deploy live verification: `mist_get_org_inventory` (empty) still returned `data: null` on v3.5.1.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.1.3"
+version = "3.5.1.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -1,5 +1,6 @@
 """FastMCP server setup, lifespan management, and tool loading."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -323,6 +324,37 @@ _GENERATIVE_UI_GUIDANCE = (
 )
 
 
+def _get_registered_tool_blocking(mcp: FastMCP, name: str) -> Any:
+    """Fetch a registered tool by name in an event-loop-safe way.
+
+    ``FastMCP.get_tool`` is a coroutine, and ``asyncio.run`` raises
+    ``RuntimeError`` if called from inside an already-running event loop
+    (embedded/async startup, async tests). ``create_server`` mutates a couple of
+    tools at build time — the ``generate_prefab_ui`` guidance and the code-mode
+    app-tool re-expose — so the lookup must work in BOTH contexts: run it
+    directly when no loop is running, and in a short-lived worker thread (with
+    its own loop) when one is. Returns the live Tool instance — mutations persist
+    to ``list_tools`` — or raises so callers can log the failure. Previously this
+    used a bare ``asyncio.run``, which failed silently inside a running loop and
+    dropped the guidance/re-expose (#578).
+    """
+
+    async def _lookup() -> Any:
+        return await mcp.get_tool(name)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop in this thread — safe to drive the coroutine directly.
+        return asyncio.run(_lookup())
+
+    # A loop is already running here; drive the lookup in its own thread/loop.
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(_lookup())).result()
+
+
 def create_server(config: ServerConfig) -> FastMCP:
     """Create and configure the FastMCP server with all enabled platform tools."""
     from hpe_networking_mcp.middleware.elicitation import (
@@ -430,8 +462,6 @@ def create_server(config: ServerConfig) -> FastMCP:
     # sites) — a `search_prefab_components` discovery tool, and a `ui://` streaming
     # renderer resource. Server-side validation uses Deno (baked into the image).
     if _mcp_apps_enabled():
-        import asyncio
-
         from fastmcp.apps.file_upload import FileUpload
         from fastmcp.apps.generative import GenerativeUI
 
@@ -463,10 +493,10 @@ def create_server(config: ServerConfig) -> FastMCP:
         # networking-specific guidance to its description (preserving the upstream
         # Prefab authoring instructions). get_tool returns the live instance and the
         # change persists to list_tools, so this covers BOTH code and dynamic mode.
-        # create_server runs before the event loop, so a one-shot asyncio.run is safe
-        # (same justification as the code-mode re-expose below).
+        # Loop-safe fetch so the guidance is applied whether create_server runs
+        # synchronously (CLI startup) or inside an existing loop (#578).
         try:
-            _gen_tool = asyncio.run(mcp.get_tool("generate_prefab_ui"))
+            _gen_tool = _get_registered_tool_blocking(mcp, "generate_prefab_ui")
             if _gen_tool is not None:
                 _gen_tool.description = _GENERATIVE_UI_GUIDANCE + (_gen_tool.description or "")
                 logger.info("Generative UI: generate_prefab_ui description augmented with dashboard guidance")
@@ -983,11 +1013,10 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     # A discovery factory is `(get_catalog) -> Tool`; ours ignores the catalog and
     # returns the already-registered Tool unchanged, so the `ui` render metadata
     # survives the transform. The `ui://` renderer resources are not tools, so the
-    # CodeMode tool transform leaves them untouched. create_server() runs before the
-    # event loop starts, so a one-shot asyncio.run to fetch each tool is safe.
+    # CodeMode tool transform leaves them untouched. Loop-safe fetch so the
+    # re-expose works whether create_server runs synchronously or inside an
+    # existing loop (#578).
     if _mcp_apps_enabled():
-        import asyncio
-
         for app_tool_name in (
             "file_manager",
             "list_files",
@@ -995,7 +1024,7 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
             "search_prefab_components",
         ):
             try:
-                app_tool = asyncio.run(mcp.get_tool(app_tool_name))
+                app_tool = _get_registered_tool_blocking(mcp, app_tool_name)
                 discovery_tools.append(lambda get_catalog, _t=app_tool: _t)
                 logger.info("MCP Apps: {} re-exposed top-level in code mode", app_tool_name)
             except Exception as e:  # pragma: no cover - defensive

--- a/tests/unit/test_generative_ui.py
+++ b/tests/unit/test_generative_ui.py
@@ -138,6 +138,30 @@ def test_list_files_not_enveloped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "ok" not in sc, "list_files got enveloped; it must be in _NO_ENVELOPE_TOOLS"
 
 
+async def test_guidance_applied_when_create_server_runs_inside_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#578: ``create_server()`` called from INSIDE a running event loop must
+    still apply the HPE guidance. The old code fetched the tool with a bare
+    ``asyncio.run(mcp.get_tool(...))``, which raises inside a running loop; the
+    failure was swallowed and the tool kept the upstream description. This test
+    runs from pytest-asyncio's loop (``async def``), exercising the loop-running
+    branch of the loop-safe helper — and must NOT emit the
+    ``coroutine 'FastMCP.get_tool' was never awaited`` RuntimeWarning."""
+    import warnings
+
+    monkeypatch.setenv("MCP_APP_ENABLE", "true")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=r".*never awaited")
+        cfg = ServerConfig(tool_mode="code", mist=MistSecrets(api_token="x", host="y"))
+        mcp = create_server(cfg)  # built inside THIS async test's event loop
+
+    descriptions = {t.name: (t.description or "") for t in await mcp.list_tools()}  # type: ignore[attr-defined]
+    gen = descriptions.get("generate_prefab_ui", "")
+    assert "DATA CONTRACT" in gen, "HPE guidance missing when create_server ran inside a loop"
+    assert "SELF-CONTAINED" in gen
+    # The code-mode re-expose (same asyncio.run pattern, #578) must also have run.
+    assert "generate_prefab_ui" in descriptions
+
+
 def test_description_augmented_with_dashboard_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
     """The tool description (not INSTRUCTIONS.md) is what steers tool selection, so
     generate_prefab_ui's description must carry the dashboard guidance AND keep the


### PR DESCRIPTION
Fixes Casey's #578.

## Problem
`create_server()` mutates the `generate_prefab_ui` description (the self-contained-code steer from v3.5.1.1) and re-exposes the MCP-Apps tools in code mode via a bare `asyncio.run(mcp.get_tool(...))`. That works at synchronous CLI startup, but `asyncio.run` **raises inside an already-running event loop** (embedded/async startup, async tests). The broad `except Exception` swallowed it, so the tool silently kept the **upstream** Prefab description — steering models back toward the broken `data=` pattern the guidance exists to prevent.

Two sites shared the bug: the guidance mutation and the code-mode app-tool re-expose.

## Fix
New **`_get_registered_tool_blocking(mcp, name)`** helper:
- No loop running → `asyncio.run` directly (unchanged CLI behavior).
- Loop already running → run the lookup in a short-lived worker thread with its own loop and block for the result.

Both `asyncio.run(mcp.get_tool(...))` call sites now use it. FastMCP exposes no synchronous tool accessor (checked), and I avoided reaching into framework internals.

## Test (Casey's acceptance criteria)
- New `test_guidance_applied_when_create_server_runs_inside_event_loop` — an **async** test (pytest-asyncio AUTO mode) that builds `create_server()` from inside a running loop and asserts `DATA CONTRACT` / `SELF-CONTAINED` are in the `generate_prefab_ui` description. It would fail on the old code (guidance dropped), and it promotes the `.*never awaited` RuntimeWarning to an error so the coroutine-leak can't regress.
- Existing synchronous startup tests unchanged and green.
- test_generative_ui.py: 9 passed; ruff/format/mypy clean; full unit suite 1959 passed / 2 skipped.

Closes #578