### PR TITLE
chore(deps): bump CI actions (checkout v7, setup-qemu v4, login v4, metadata v6, build-push v7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen --no-dev --no-install-project 2>/dev/null || uv sync --no-dev --no-install-project
       - run: uv run ruff check .
@@ -21,7 +21,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - run: uv run mypy src/ --ignore-missing-imports
@@ -30,7 +30,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - name: Run tests
@@ -40,7 +40,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build Docker image
         run: docker build -t hpe-networking-mcp:ci .
       - name: Smoke test (no secrets — should exit with error)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,16 +16,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/greenlake-specs-refresh.yml
+++ b/.github/workflows/greenlake-specs-refresh.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
     name: Bandit Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --frozen 2>/dev/null || uv sync
       - run: uv run bandit -r src/ -c pyproject.toml
@@ -22,7 +22,7 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - name: Run pip-audit against the locked environment
         run: uv run --frozen pip-audit
@@ -31,7 +31,7 @@ jobs:
     name: Secret Detection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v3
@@ -48,7 +48,7 @@ jobs:
     name: Image Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build runtime image
         run: docker build -t hpe-networking-mcp:scan .
       - name: Trivy scan (fail on fixable HIGH/CRITICAL)

--- a/.github/workflows/sync-mist-openapi.yml
+++ b/.github/workflows/sync-mist-openapi.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
 

--- a/.github/workflows/sync-new-central-oas.yml
+++ b/.github/workflows/sync-new-central-oas.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.MIST_SYNC_PAT }}
 


### PR DESCRIPTION
Bumps the GitHub Actions the private mirror's Dependabot had flagged — done **upstream** (where the workflows live) so the mirror's workflows stay byte-identical to public and merges stay conflict-free (the private repo no longer runs its own Dependabot).

| Action | From | To (verified latest) |
|--------|------|----------------------|
| actions/checkout | v4 | **v7** (v7.0.0) — bumped across all workflows |
| docker/setup-qemu-action | v3 | **v4** (v4.2.0) |
| docker/login-action | v3 | **v4** (v4.4.0) |
| docker/metadata-action | v5 | **v6** (v6.2.0) |
| docker/build-push-action | v6 | **v7** (v7.3.0) |

Targets verified against each action's `releases/latest` tag. CI-only; no runtime artifact or version change. The Docker Build / CI / Security jobs exercise these actions, so green CI validates the bumps.