### PR TITLE
feat(server): Kubernetes/Docker-friendly HTTP health endpoints (#582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.2.0] - 2026-07-08
+
+**Minor — Kubernetes- and Docker-friendly HTTP health endpoints (#582).** The MCP protocol endpoint (`/mcp`) is not a clean `httpGet` probe target — a bare `GET` can return `406` and `HEAD` can return `405`, neither of which Kubernetes treats as success (only `200`–`399` pass), so Docker healthchecks had to special-case tolerated non-2xx statuses from `/mcp`. New plain HTTP endpoints give orchestrators a normal probe surface that never requires MCP stream negotiation.
+
+### Added
+- **`GET /livez`** — `200` whenever the process is alive and serving HTTP. Lightweight; makes **no** external-platform calls, so a transient Mist/Central/GreenLake outage can never mark the container unhealthy or trigger a pod restart.
+- **`GET /readyz`** — `503` until the FastMCP lifespan startup completes, then `200`. Also independent of upstream platform reachability (readiness means "started and can accept MCP traffic", never "every platform is reachable").
+- **`GET /healthz`** — non-sensitive operator JSON: `service`, `version`, `status`, enabled platform **names**, and `uptime_seconds`. No secrets, hosts, or counts.
+- Registered in **every** tool mode and regardless of `MCP_APP_ENABLE` — deployment plumbing, not model-facing tools. They ride outside the FastMCP tool-middleware chain (plain HTTP, never enveloped), and the DNS-rebinding `OriginValidationMiddleware` passes header-less probe traffic through untouched. The deeper per-platform reachability check remains the MCP `health` tool (deliberately not wired into liveness).
+- README section documenting the endpoints plus copy-paste Kubernetes `startupProbe`/`livenessProbe`/`readinessProbe` examples.
+
+### Changed
+- **Dockerfile `HEALTHCHECK` and Docker Compose healthcheck now call `/livez`** (`== 200`) instead of tolerating `/mcp` returning `405`/`406` — a clearer `healthy`/`unhealthy` signal for Docker and a normal probe target for Kubernetes.
+
 ## [3.5.1.4] - 2026-07-07
 
 **Patch — apply the `generate_prefab_ui` guidance + code-mode re-expose event-loop-safely (#578).** `create_server()` mutated the `generate_prefab_ui` description (the self-contained-code steer from v3.5.1.1) and re-exposed the MCP-Apps tools in code mode via a bare `asyncio.run(mcp.get_tool(...))`. That works at synchronous CLI startup but raises inside an already-running event loop (embedded/async startup, async tests); the broad handler swallowed the failure, so the tool silently fell back to the upstream Prefab description and steered models back toward the broken `data=` pattern.

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,10 @@ RUN uv run --no-sync python -m hpe_networking_mcp.prefab_prewarm
 
 EXPOSE 8000
 
-# Health check
+# Health check — hits the plain /livez probe (200 when the process is alive).
+# Liveness is intentionally decoupled from upstream platform reachability, so a
+# transient Mist/Central/GreenLake outage never marks the container unhealthy.
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
-    CMD uv run --no-sync python -c "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5); assert r.status_code < 500" || exit 1
+    CMD uv run --no-sync python -c "import httpx; r = httpx.get('http://localhost:8000/livez', timeout=5); assert r.status_code == 200" || exit 1
 
 CMD ["uv", "run", "--no-sync", "python", "-m", "hpe_networking_mcp"]

--- a/README.md
+++ b/README.md
@@ -203,6 +203,39 @@ docker compose logs
 
 Look for lines like `Mist: 1037 underlying tools registered (code mode)`, `ClearPass: 142 underlying tools registered (code mode)`, `Axis: 25 underlying tools registered (code mode)`, `AOS8: 48 underlying tools (code mode)`, `UXI: 21 underlying tools (code mode)`, `EdgeConnect: registered 187 generated tool module(s) (code mode)`, `GreenLake: registered 959 tools across 169 tool module(s) (code mode)`, `Tool mode: code`, and `Uvicorn running on http://0.0.0.0:8000`. Your MCP server is running at `http://localhost:8000/mcp`. In the default code mode (since v3.0.0.0), only `execute` + 5 discovery tools (`tags`, `search`, `get_schema`, `skills_list`, `skills_load`) are exposed at the top level; all 4126 underlying tools are reachable via `await call_tool(name, params)` inside a sandboxed Python `execute()` block. Set `MCP_TOOL_MODE=dynamic` to use the v2.x meta-tool surface instead. Mist registers 2 guided prompts; Central registers 12; AOS8 registers 9.
 
+### Health & readiness probes
+
+The server exposes plain HTTP endpoints for container/orchestrator health checks. They require **no** MCP stream negotiation (unlike `/mcp`, which can return `405`/`406` to a naive probe) and never call external platforms, so a transient upstream outage can't mark the process unhealthy:
+
+| Endpoint | Success | Purpose |
+|----------|---------|---------|
+| `GET /livez` | `200 ok` | Process is alive and serving HTTP. Use for liveness. |
+| `GET /readyz` | `200 ok` (else `503 starting`) | Startup complete and ready for MCP traffic. Use for readiness/startup. |
+| `GET /healthz` | `200` + JSON | Operator info: `service`, `version`, `status`, enabled platform names, `uptime_seconds`. No secrets. |
+
+The deeper per-platform reachability check remains the MCP `health` tool — it is intentionally **not** used for liveness, so an upstream platform being unreachable never restarts the container.
+
+The Docker/Compose healthcheck already targets `/livez`. Kubernetes example:
+
+```yaml
+startupProbe:
+  httpGet: { path: /livez, port: 8000 }
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet: { path: /livez, port: 8000 }
+  periodSeconds: 20
+  timeoutSeconds: 2
+  failureThreshold: 3
+readinessProbe:
+  httpGet: { path: /readyz, port: 8000 }
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+```
+
+> Kubernetes probes reach the pod IP, so keep the default `MCP_HOST=0.0.0.0` bind (loopback-only binds are unreachable by the kubelet). Probes send no `Origin` header and are allowed through origin validation.
+
 ### Docker Image
 
 The pre-built image is available on GitHub Container Registry:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - edgeconnect_verify_ssl
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "uv", "run", "--no-sync", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/mcp', timeout=5); assert r.status_code in (200, 405, 406)"]
+      test: ["CMD", "uv", "run", "--no-sync", "python", "-c", "import httpx; r = httpx.get('http://localhost:8000/livez', timeout=5); assert r.status_code == 200"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.1.4"
+version = "3.5.2.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/health_routes.py
+++ b/src/hpe_networking_mcp/health_routes.py
@@ -1,0 +1,103 @@
+"""Plain HTTP health/probe endpoints for Kubernetes and Docker.
+
+The MCP protocol endpoint (``/mcp``) is not a clean ``httpGet`` probe target — a
+bare ``GET`` can return ``406 Not Acceptable`` and ``HEAD`` can return ``405``,
+neither of which Kubernetes treats as success (only ``200``–``399`` pass). These
+routes give orchestrators a normal HTTP surface that never requires MCP stream
+negotiation:
+
+* ``GET /livez``  — ``200`` whenever the process is alive and serving HTTP.
+  Lightweight; makes **no** external-platform calls. Liveness must stay
+  decoupled from upstream reachability so a transient Mist/Central/GreenLake
+  outage never triggers a pod restart.
+* ``GET /readyz`` — ``200`` once server startup (the FastMCP lifespan) has
+  completed; ``503`` before that. Also independent of upstream platform health.
+* ``GET /healthz`` — non-sensitive operator JSON (service, version, enabled
+  platform *names*, readiness, uptime). No secrets, no hostnames, no counts.
+
+The deep per-platform reachability check remains the MCP ``health`` tool; it is
+deliberately **not** wired into liveness for the reason above.
+
+Readiness/uptime is tracked per-server in a ``WeakKeyDictionary`` keyed by the
+``FastMCP`` instance, so multiple servers built in one process (e.g. the test
+suite) never share state and entries are collected with their server.
+"""
+
+from __future__ import annotations
+
+import time
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
+from weakref import WeakKeyDictionary
+
+from starlette.responses import JSONResponse, PlainTextResponse
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from hpe_networking_mcp.config import ServerConfig
+
+# Per-server readiness/uptime state. Weak keys so a server that goes out of
+# scope (test suite builds many) is not pinned in memory.
+_STATE: WeakKeyDictionary = WeakKeyDictionary()
+
+
+def _service_version() -> str:
+    """Best-effort package version for the operator payload."""
+    try:
+        return version("hpe-networking-mcp")
+    except PackageNotFoundError:  # pragma: no cover — installed in all real runs
+        return "unknown"
+
+
+def init_state(mcp: FastMCP) -> None:
+    """Register a server's probe state; call once at build time (not ready yet)."""
+    _STATE[mcp] = {"ready": False, "started": time.monotonic()}
+
+
+def mark_ready(mcp: FastMCP) -> None:
+    """Flip a server to ready; call from the lifespan once startup completes."""
+    state = _STATE.get(mcp)
+    if state is not None:
+        state["ready"] = True
+
+
+def register_health_routes(mcp: FastMCP, config: ServerConfig) -> None:
+    """Register ``/livez``, ``/readyz`` and ``/healthz`` on *mcp*.
+
+    Registered in every tool mode and regardless of ``MCP_APP_ENABLE`` — these
+    are deployment-plumbing endpoints, not model-facing tools. Custom routes sit
+    outside the FastMCP tool-middleware chain, so responses are plain HTTP (never
+    wrapped by the response envelope). Probes send no ``Origin`` header, so the
+    ASGI ``OriginValidationMiddleware`` passes them through untouched.
+    """
+    init_state(mcp)
+
+    @mcp.custom_route("/livez", methods=["GET"])
+    async def livez(request: Request) -> Response:  # noqa: ARG001 — Starlette signature
+        return PlainTextResponse("ok\n")
+
+    @mcp.custom_route("/readyz", methods=["GET"])
+    async def readyz(request: Request) -> Response:  # noqa: ARG001 — Starlette signature
+        state = _STATE.get(mcp)
+        if state is not None and state["ready"]:
+            return PlainTextResponse("ok\n")
+        return PlainTextResponse("starting\n", status_code=503)
+
+    @mcp.custom_route("/healthz", methods=["GET"])
+    async def healthz(request: Request) -> Response:  # noqa: ARG001 — Starlette signature
+        state = _STATE.get(mcp) or {}
+        ready = bool(state.get("ready"))
+        started = state.get("started")
+        uptime = round(time.monotonic() - started, 3) if started is not None else None
+        return JSONResponse(
+            {
+                "service": "hpe-networking-mcp",
+                "version": _service_version(),
+                "status": "ok" if ready else "starting",
+                "platforms": config.enabled_platforms,
+                "uptime_seconds": uptime,
+            }
+        )

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -11,6 +11,7 @@ from fastmcp.tools.tool import ToolResult
 from loguru import logger
 
 from hpe_networking_mcp.config import ServerConfig
+from hpe_networking_mcp.health_routes import mark_ready, register_health_routes
 
 _INSTRUCTIONS = (Path(__file__).parent / "INSTRUCTIONS.md").read_text(encoding="utf-8")
 
@@ -218,6 +219,14 @@ async def lifespan(server: FastMCP):
                     )
         except Exception as e:
             logger.warning("Startup probe loop raised unexpectedly — {}", e)
+
+    # Startup is complete: flip the /readyz probe to ready. Deliberately after
+    # the (best-effort, non-fatal) platform probes but NOT gated on their
+    # result — readiness means "the server finished starting and can accept MCP
+    # traffic", never "every upstream platform is reachable" (that would let a
+    # transient upstream outage trigger a pod restart). Deep reachability stays
+    # in the MCP `health` tool.
+    mark_ready(server)
 
     try:
         yield context
@@ -599,6 +608,11 @@ def create_server(config: ServerConfig) -> FastMCP:
         # (health + translate_wlan_* ARE registered in every mode — they wrap
         # engines/probes the sandbox can't import, so they must be call_tool-able.)
         _register_code_mode(mcp, config.code_sandbox_max_duration_secs)
+
+    # Plain HTTP liveness/readiness/health endpoints for Kubernetes probes and
+    # Docker healthchecks. Registered in every tool mode and independent of
+    # MCP_APP_ENABLE — deployment plumbing, not a model-facing tool.
+    register_health_routes(mcp, config)
 
     return mcp
 

--- a/tests/unit/test_health_routes.py
+++ b/tests/unit/test_health_routes.py
@@ -1,0 +1,126 @@
+"""Unit tests for the plain HTTP health/probe endpoints (#582).
+
+These drive the REAL Starlette app produced by ``FastMCP.http_app`` — the same
+ASGI app the server serves — so the routes, status codes, and payloads are
+exercised exactly as Kubernetes probes and the Docker healthcheck will see them.
+
+Readiness is asserted WITHOUT entering the lifespan (which would create platform
+clients and run best-effort startup probes): ``/readyz`` starts at ``503`` right
+after build and flips to ``200`` when ``mark_ready`` runs — the precise call the
+lifespan makes once startup completes — so no network or event loop is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from hpe_networking_mcp.config import MistSecrets, ServerConfig
+from hpe_networking_mcp.health_routes import mark_ready
+from hpe_networking_mcp.middleware.origin_validation import OriginValidationMiddleware
+from hpe_networking_mcp.server import create_server
+
+pytestmark = pytest.mark.unit
+
+
+def _build(tool_mode: str = "code") -> object:
+    """Build a real Mist-only server in the given tool mode."""
+    cfg = ServerConfig(tool_mode=tool_mode, mist=MistSecrets(api_token="x", host="y"))
+    return create_server(cfg)
+
+
+def _app(mcp: object):
+    return mcp.http_app(transport="streamable-http")  # type: ignore[attr-defined]
+
+
+def test_livez_always_ok() -> None:
+    """/livez returns 200 as soon as the process serves HTTP — no lifespan needed,
+    no platform calls. This is the property Kubernetes liveness relies on."""
+    client = TestClient(_app(_build()))
+    resp = client.get("/livez")
+    assert resp.status_code == 200
+    assert resp.text.strip() == "ok"
+
+
+def test_livez_independent_of_platform_reachability() -> None:
+    """Liveness must not depend on upstream platforms. The Mist host here ('y') is
+    unresolvable, yet /livez is 200 because the handler makes no platform call —
+    so a real upstream outage can never mark the container unhealthy."""
+    client = TestClient(_app(_build()))
+    assert client.get("/livez").status_code == 200
+
+
+def test_readyz_503_before_startup_then_200_after_mark_ready() -> None:
+    """/readyz is 503 until startup completes, then 200. mark_ready() is exactly
+    what the lifespan calls once it finishes starting."""
+    mcp = _build()
+    client = TestClient(_app(mcp))
+
+    before = client.get("/readyz")
+    assert before.status_code == 503
+    assert before.text.strip() == "starting"
+
+    mark_ready(mcp)
+
+    after = client.get("/readyz")
+    assert after.status_code == 200
+    assert after.text.strip() == "ok"
+
+
+def test_healthz_payload_shape_and_no_secrets() -> None:
+    """/healthz returns non-sensitive operator JSON: service, version, status,
+    enabled platform NAMES, uptime. No secrets, tokens, hosts, or counts."""
+    mcp = _build()
+    client = TestClient(_app(mcp))
+
+    body = client.get("/healthz").json()
+    assert body["service"] == "hpe-networking-mcp"
+    assert isinstance(body["version"], str) and body["version"]
+    assert body["status"] == "starting"  # not ready until mark_ready
+    assert body["platforms"] == ["mist"]  # names only
+    assert isinstance(body["uptime_seconds"], (int, float))
+
+    mark_ready(mcp)
+    assert client.get("/healthz").json()["status"] == "ok"
+
+    # Defense-in-depth: the serialized payload must expose no secret-bearing keys.
+    raw = client.get("/healthz").text.lower()
+    for forbidden in ("api_token", "secret", "password", "client_secret", "token"):
+        assert forbidden not in raw
+
+
+def test_healthz_platforms_is_enabled_platforms_passthrough() -> None:
+    """/healthz reports config.enabled_platforms verbatim. Asserted with a
+    Mist-only build to keep this unit test from registering other platforms'
+    tools (building a multi-platform server here perturbs the module-level tool
+    registries that reload-based dispatch tests depend on). The verbatim
+    pass-through is the contract; enabled_platforms' multi-platform behavior is
+    covered in the config tests."""
+    cfg = ServerConfig(tool_mode="code", mist=MistSecrets(api_token="x", host="y"))
+    client = TestClient(_app(create_server(cfg)))
+    assert client.get("/healthz").json()["platforms"] == cfg.enabled_platforms == ["mist"]
+
+
+def test_probes_pass_origin_validation_without_origin_header() -> None:
+    """Kubernetes/Docker probes send no Origin header. The DNS-rebinding
+    OriginValidationMiddleware must let them through so the probe path is 200,
+    not a 403 the orchestrator would read as unhealthy."""
+    app = OriginValidationMiddleware(_app(_build()), allowed_origins=["http://localhost:8000"])
+    client = TestClient(app)
+
+    # No Origin header (the probe case) → allowed through → 200.
+    assert client.get("/livez").status_code == 200
+
+    # A disallowed browser Origin is still rejected — the guard is active, it
+    # simply doesn't apply to header-less probe traffic.
+    blocked = client.get("/livez", headers={"Origin": "http://evil.example"})
+    assert blocked.status_code == 403
+
+
+def test_health_routes_registered_in_dynamic_mode() -> None:
+    """Health endpoints are deployment plumbing — present in every tool mode,
+    not just code mode."""
+    client = TestClient(_app(_build("dynamic")))
+    assert client.get("/livez").status_code == 200
+    assert client.get("/readyz").status_code == 503
+    assert client.get("/healthz").json()["service"] == "hpe-networking-mcp"


### PR DESCRIPTION
Closes #582

## Summary
Adds plain HTTP probe endpoints so Kubernetes `httpGet` probes and Docker healthchecks get clean `200`s without MCP stream negotiation (a naive probe to `/mcp` gets `405`/`406`, which Kubernetes reads as failure).

| Endpoint | Success | Purpose |
|----------|---------|---------|
| `GET /livez` | `200 ok` | Process alive & serving HTTP. **No platform calls** — a transient Mist/Central/GreenLake outage never marks the container unhealthy. |
| `GET /readyz` | `200 ok` / `503 starting` | Startup (lifespan) complete & ready for MCP traffic. Also independent of upstream reachability. |
| `GET /healthz` | `200` + JSON | Non-sensitive operator info: `service`, `version`, `status`, enabled platform **names**, `uptime_seconds`. No secrets. |

Deep per-platform reachability stays in the MCP `health` tool — deliberately **not** wired into liveness, so an upstream platform outage cannot restart the pod.

## Design
- New `health_routes.py` registers the three routes via FastMCP `custom_route`. Readiness/uptime tracked per-server in a `WeakKeyDictionary` (test-safe; no shared globals). `mark_ready()` fires at the end of the lifespan startup, after the best-effort platform probes but **not** gated on their result.
- Registered in **every** tool mode and regardless of `MCP_APP_ENABLE` — deployment plumbing, not model-facing tools. Custom routes sit outside the FastMCP tool-middleware chain, so responses are plain HTTP (never enveloped). Probes send no `Origin`, so `OriginValidationMiddleware` passes them through (asserted in a test).
- Dockerfile `HEALTHCHECK` + Docker Compose healthcheck now target `/livez` (`== 200`).

## Testing
- `tests/unit/test_health_routes.py` (7 tests) drives the real `http_app` via Starlette `TestClient`: livez always-200, liveness independent of platform reachability, readyz 503→200 on `mark_ready`, healthz payload shape + no-secrets, enabled-platforms pass-through, origin-validation passthrough (no Origin → 200; disallowed Origin → 403), and registration in dynamic mode.
- **Live smoke** through real uvicorn: `/livez` 200, `/readyz` 200 (held green even though the Mist startup probe failed — proving the liveness/upstream decoupling), `/healthz` JSON, `HEAD /livez` 200.
- Full local gate green: `ruff check .`, `ruff format --check .`, `mypy src/`, `pytest tests/unit` (1966 passed, 2 skipped).

## Docs
- README "Health & readiness probes" section with the endpoint table + copy-paste Kubernetes `startupProbe`/`livenessProbe`/`readinessProbe` examples.
- CHANGELOG `3.5.2.0`; version bumped in `pyproject.toml`.