### PR TITLE
fix(clearpass): policy-visualizer data-model correctness (#596, #599, #600, #601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3.3] - 2026-07-13
+
+**Patch — ClearPass policy-visualizer correctness, part 1 (Casey Jones full-project review: #596, #599, #600, #601).** The data-model / classification fixes of the ClearPass visualizer cluster; the flow-graph simulation-semantics fixes (#595/#597/#598) follow separately.
+
+### Fixed
+- **#596 (high) — action-less side-effect profiles are no longer classified as deny.** A generic/TACACS enforcement profile with no (or a non-accept, non-reject) action was mapped to `generic_reject` / `tacacs_other` and read as DENY, so a rule that actually grants access while applying a side-effect profile (logging, attribute push) reported DENY. Classification now keys off explicit action: `accept` → `*_accept`, an explicit `deny`/`reject`/`drop` → the reject type, anything else → a neutral `*_sideeffect` type the flow graph does not treat as deny.
+- **#599 (medium) — per-rule details reflect evaluate-all.** `PolicyRule.flow.on_match` was always the default `stop`; `build()` never propagated the policy's combine algorithm. Rules of an `evaluate-all` role-mapping / enforcement policy now report `continue`; first-applicable still reports `stop`.
+- **#600 (low) — an unknown operator no longer fails the whole compile.** `Op.from_raw` raised `ValueError` for any operator not in the local map, so one exotic operator in an unrelated policy failed `clearpass_compile_policy_flow` for every requested service. Unknown operators now map to an `Op.unknown` sentinel (logged), keep their `raw_operator` for display, and evaluate as uncertain (`None`).
+- **#601 (low) — enforcement profile names containing commas survive.** The adapter comma-joined the profile-name list and the model split it back on every comma, so `Allow, Log Session` became two bogus placeholder profiles. The adapter now also emits a verbatim `values` list which the model consumes directly; `displayValue` stays human-readable.
+
 ## [3.5.3.2] - 2026-07-10
 
 **Patch — GreenLake bulk-add robustness (Casey Jones full-project review: #591–#594).** Four write-path integrity fixes in `greenlake_bulk_add_devices`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.3.2"
+version = "3.5.3.3"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/api_adapter.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/api_adapter.py
@@ -110,7 +110,15 @@ def _adapt_enf_rule(rest_rule: dict, index: int) -> dict:
     return {
         "index": index,
         "expression": expression,
-        "results": [{"name": "Enforcement-Profile", "displayValue": ", ".join(profile_names)}],
+        # ``values`` carries the name list verbatim so a profile name containing
+        # a comma survives; ``displayValue`` stays human-readable (#601).
+        "results": [
+            {
+                "name": "Enforcement-Profile",
+                "displayValue": ", ".join(profile_names),
+                "values": list(profile_names),
+            }
+        ],
     }
 
 

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/conditions.py
@@ -10,9 +10,12 @@ compiler can walk.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from enum import StrEnum
+
+logger = logging.getLogger(__name__)
 
 
 class Op(StrEnum):
@@ -51,6 +54,10 @@ class Op(StrEnum):
     not_matches_all = "not_matches_all"
     not_matches_any = "not_matches_any"
     in_range = "in_range"
+    # Sentinel for an operator not in the local map. Contained rather than
+    # fatal (#600): the predicate keeps its ``raw_operator`` for display and
+    # evaluates as uncertain (None) instead of failing the whole compile.
+    unknown = "unknown"
 
     @classmethod
     def from_raw(cls, raw: str) -> Op:
@@ -92,9 +99,11 @@ class Op(StrEnum):
             "IN_RANGE": cls.in_range,
         }
         upper = raw.upper()
-        if upper not in mapping:
-            raise ValueError(f"Unknown ClearPass operator: {raw!r}")
-        return mapping[upper]
+        # Contain unrecognized operators (#600): return the ``unknown`` sentinel
+        # instead of raising, so one exotic operator in an unrelated policy can't
+        # fail compile for every requested service. The predicate keeps
+        # ``raw_operator`` for display and evaluates as uncertain (None).
+        return mapping.get(upper, cls.unknown)
 
 
 @dataclass
@@ -308,6 +317,8 @@ def evaluate(expr: BooleanExpr | None, context: dict[str, str | list[str]]) -> b
 def _evaluate_predicate(predicate: Predicate, context: dict[str, str | list[str]]) -> bool | None:
     """Evaluate a single predicate. Returns None when the attribute is unknown."""
     op = predicate.op
+    if op is Op.unknown:
+        return None  # unrecognized operator — uncertain, never a false match (#600)
     # Exists / not_exists are special — they only need to know presence
     if op is Op.exists:
         return _attribute_path(predicate) in context
@@ -353,13 +364,17 @@ def _eval_or(results: list[bool | None]) -> bool | None:
 
 
 def _normalize_predicate(raw_attr: dict) -> Predicate:
+    raw_op = raw_attr.get("operator", "EQUALS")
+    op = Op.from_raw(raw_op)
+    if op is Op.unknown:
+        logger.warning("Unknown ClearPass operator %r — condition treated as uncertain (#600)", raw_op)
     return Predicate(
         namespace=raw_attr.get("type", ""),
         attribute=raw_attr.get("name", ""),
-        op=Op.from_raw(raw_attr.get("operator", "EQUALS")),
+        op=op,
         rhs_raw=raw_attr.get("value", ""),
         rhs_display=raw_attr.get("displayValue", ""),
-        raw_operator=raw_attr.get("operator", ""),
+        raw_operator=raw_op,
     )
 
 

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_model.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/policy_model.py
@@ -130,8 +130,11 @@ class EnforcementProfile:
     id: str
     name: str
     # profile_type is one of: radius_accept, radius_reject, tacacs_accept,
-    # tacacs_other, radius_coa, generic_accept, generic_reject, post_auth,
-    # builtin (last one is used for placeholder objects).
+    # tacacs_other, tacacs_sideeffect, radius_coa, generic_accept,
+    # generic_reject, generic_sideeffect, post_auth, builtin (last one is used
+    # for placeholder objects). Only the *_reject / tacacs_other types (assigned
+    # on an explicit deny action) are treated as deny by the flow graph; the
+    # *_sideeffect types are action-less side-effects (not a deny — #596).
     profile_type: str
     action: str = ""
     description: str = ""
@@ -172,6 +175,26 @@ class PolicyModel:
 # ---------------------------------------------------------------------------
 # Builder
 # ---------------------------------------------------------------------------
+
+# Explicit deny/reject action words. A TACACS / generic enforcement profile is
+# classified as a deny type ONLY when its action is one of these — a missing /
+# other action is a side-effect profile (logging, attribute push), not a deny
+# (#596). ``flow_graph._DENY_PROFILE_TYPES`` keys off the resulting reject types.
+_DENY_ACTION_WORDS = frozenset({"deny", "reject", "drop"})
+
+
+def _classify_action_type(action: str, accept_type: str, deny_type: str, neutral_type: str) -> str:
+    """Map an enforcement-profile action to a profile_type (accept/deny/neutral).
+
+    ``accept`` → ``accept_type``; an explicit deny/reject/drop → ``deny_type``;
+    anything else (empty, side-effect, unknown) → ``neutral_type`` — which is
+    NOT a deny type, so an action-less side-effect profile no longer reads DENY.
+    """
+    if action == "accept":
+        return accept_type
+    if action in _DENY_ACTION_WORDS:
+        return deny_type
+    return neutral_type
 
 
 def build(raw: dict[str, Any]) -> PolicyModel:
@@ -244,7 +267,9 @@ def build(raw: dict[str, Any]) -> PolicyModel:
         model.enforcement_profiles[pid] = EnforcementProfile(
             id=pid,
             name=tp["name"],
-            profile_type="tacacs_accept" if action == "accept" else "tacacs_other",
+            # Only an explicit deny action → tacacs_other (deny); an action-less
+            # TACACS side-effect profile is neutral, not a deny (#596).
+            profile_type=_classify_action_type(action, "tacacs_accept", "tacacs_other", "tacacs_sideeffect"),
             action=action,
             description=tp.get("description", ""),
             attributes=list(tp.get("attributes") or []),
@@ -265,16 +290,23 @@ def build(raw: dict[str, Any]) -> PolicyModel:
         model.enforcement_profiles[pid] = EnforcementProfile(
             id=pid,
             name=gp["name"],
-            profile_type="generic_accept" if action == "accept" else "generic_reject",
+            # Only an explicit deny action → generic_reject (deny); an action-less
+            # generic side-effect profile is neutral, not a deny (#596).
+            profile_type=_classify_action_type(action, "generic_accept", "generic_reject", "generic_sideeffect"),
             action=action,
             description=gp.get("description", ""),
             attributes=list(gp.get("attributes") or []),
         )
     profile_by_name = {v.name: v for v in model.enforcement_profiles.values()}
 
-    def _resolve_profiles(display_value: str, context: str = "") -> tuple[list[str], list[str]]:
-        """Parse a comma-separated displayValue of profile names into (ids, names)."""
-        names = [n.strip() for n in display_value.split(",") if n.strip()]
+    def _resolve_profiles(raw_names: list[str], context: str = "") -> tuple[list[str], list[str]]:
+        """Resolve a LIST of profile names into (ids, names).
+
+        Takes a real list rather than a comma-joined string so a profile name
+        that itself contains a comma (e.g. ``Allow, Log Session``) survives
+        intact instead of being split into bogus placeholders (#601).
+        """
+        names = [n.strip() for n in raw_names if n and n.strip()]
         ids = []
         for n in names:
             if n in profile_by_name:
@@ -323,7 +355,14 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             else:
                 then = SetRole(role_id="unknown", role_name="Unknown")
             rule_id = f"{rmid}_rule_{raw_rule['index']}"
-            rules.append(PolicyRule(id=rule_id, index=raw_rule["index"], when=expr, then=then))
+            # Propagate the policy's combine algorithm to per-rule flow so
+            # details report continue for evaluate-all policies (#599).
+            rm_on_match = "continue" if rm.get("ruleCombineAlgo") == "evaluate-all" else "stop"
+            rules.append(
+                PolicyRule(
+                    id=rule_id, index=raw_rule["index"], when=expr, then=then, flow=RuleFlow(on_match=rm_on_match)
+                )
+            )
 
         default_role_name = rm.get("defaultRole", "")
         default_role = role_by_name.get(default_role_name)
@@ -368,10 +407,21 @@ def build(raw: dict[str, Any]) -> PolicyModel:
             profile_names: list[str] = []
             if enf_result:
                 ctx = f"rule in EnforcementPolicy '{ep['name']}'"
-                profile_ids, profile_names = _resolve_profiles(enf_result.get("displayValue", ""), ctx)
+                # Prefer the verbatim ``values`` list (adapter-provided, #601);
+                # fall back to comma-splitting displayValue for legacy sources.
+                enf_names = enf_result.get("values")
+                if enf_names is None:
+                    enf_names = enf_result.get("displayValue", "").split(",")
+                profile_ids, profile_names = _resolve_profiles(enf_names, ctx)
             then = ApplyProfiles(profile_ids=profile_ids, profile_names=profile_names)
             rule_id = f"{epid}_rule_{raw_rule['index']}"
-            rules.append(PolicyRule(id=rule_id, index=raw_rule["index"], when=expr, then=then))
+            # Propagate the policy's combine algorithm to per-rule flow (#599).
+            ep_on_match = "continue" if ep.get("ruleCombineAlgo") == "evaluate-all" else "stop"
+            rules.append(
+                PolicyRule(
+                    id=rule_id, index=raw_rule["index"], when=expr, then=then, flow=RuleFlow(on_match=ep_on_match)
+                )
+            )
 
         default_profile_name = ep.get("defaultProfile", "")
         default_profile = profile_by_name.get(default_profile_name)

--- a/tests/unit/test_clearpass_policy_visualizer_adapter.py
+++ b/tests/unit/test_clearpass_policy_visualizer_adapter.py
@@ -46,9 +46,10 @@ class TestOpFromRaw:
     def test_known_operators(self, raw, expected):
         assert Op.from_raw(raw) is expected
 
-    def test_unknown_operator_raises(self):
-        with pytest.raises(ValueError, match="Unknown ClearPass operator"):
-            Op.from_raw("DOES_NOT_EXIST")
+    def test_unknown_operator_is_contained_as_sentinel(self):
+        # #600: an unrecognized operator no longer raises (which failed the whole
+        # compile) — it maps to the ``unknown`` sentinel and evaluates uncertain.
+        assert Op.from_raw("DOES_NOT_EXIST") is Op.unknown
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +328,14 @@ class TestAdapterRules:
         assert ep["policyType"] == "RADIUS"
         assert ep["defaultProfile"] == "[AirGroup Response]"
         rule = ep["rules"][0]
-        assert rule["results"] == [{"name": "Enforcement-Profile", "displayValue": "[Profile A], [Profile B]"}]
+        # #601: results now also carry a verbatim ``values`` list (comma-safe).
+        assert rule["results"] == [
+            {
+                "name": "Enforcement-Profile",
+                "displayValue": "[Profile A], [Profile B]",
+                "values": ["[Profile A]", "[Profile B]"],
+            }
+        ]
         expr = rule["expression"]
         # 2 conditions, no match_type → default AND
         assert expr["operator"] == "and"

--- a/tests/unit/test_clearpass_policy_visualizer_hardening.py
+++ b/tests/unit/test_clearpass_policy_visualizer_hardening.py
@@ -1,0 +1,184 @@
+"""Tests for the ClearPass policy-visualizer hardening batch (data-model fixes).
+
+Covers the localized model/classification/adapter findings from Casey Jones's
+full-project review: #596 (action-less side-effect profiles), #599 (per-rule
+evaluate-all flow), #600 (unknown-operator containment), #601 (comma-safe
+profile names).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.conditions import Op, evaluate, normalize
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.flow_graph import _is_deny
+from hpe_networking_mcp.platforms.clearpass.policy_visualizer.policy_model import build
+
+pytestmark = pytest.mark.unit
+
+
+def _raw(*, generic=None, tacacs=None, radius=None, rms=None, eps=None) -> dict:
+    return {
+        "roles": [{"name": "[Employee]", "description": ""}],
+        "authMethods": [],
+        "authSources": [],
+        "radiusEnfProfiles": radius or [],
+        "tacacsEnfProfiles": tacacs or [],
+        "radiusCoaEnfProfiles": [],
+        "postAuthEnfProfiles": [],
+        "genericEnfProfiles": generic or [],
+        "roleMappings": rms or [],
+        "enforcementPolicies": eps or [],
+        "services": [],
+    }
+
+
+def _profile_by_name(model, name):
+    return next(p for p in model.enforcement_profiles.values() if p.name == name)
+
+
+# ---------------------------------------------------------------------------
+# #596 — action-less side-effect profiles are not deny
+# ---------------------------------------------------------------------------
+
+
+class TestSideEffectNotDeny:
+    def test_actionless_generic_is_neutral_not_deny(self) -> None:
+        model = build(_raw(generic=[{"name": "Log Session", "action": "", "description": ""}]))
+        p = _profile_by_name(model, "Log Session")
+        assert p.profile_type == "generic_sideeffect"
+        assert not _is_deny([p.id], [p.name], model.enforcement_profiles)
+
+    def test_actionless_tacacs_is_neutral_not_deny(self) -> None:
+        model = build(_raw(tacacs=[{"name": "Shell Profile", "action": "", "description": ""}]))
+        p = _profile_by_name(model, "Shell Profile")
+        assert p.profile_type == "tacacs_sideeffect"
+        assert not _is_deny([p.id], [p.name], model.enforcement_profiles)
+
+    def test_explicit_reject_generic_still_deny(self) -> None:
+        model = build(_raw(generic=[{"name": "Block", "action": "Reject", "description": ""}]))
+        p = _profile_by_name(model, "Block")
+        assert p.profile_type == "generic_reject"
+        assert _is_deny([p.id], [p.name], model.enforcement_profiles)
+
+    def test_accept_generic_is_allow(self) -> None:
+        model = build(_raw(generic=[{"name": "Grant", "action": "Accept", "description": ""}]))
+        p = _profile_by_name(model, "Grant")
+        assert p.profile_type == "generic_accept"
+        assert not _is_deny([p.id], [p.name], model.enforcement_profiles)
+
+
+# ---------------------------------------------------------------------------
+# #599 — per-rule flow reflects evaluate-all
+# ---------------------------------------------------------------------------
+
+
+def _enf_policy(name, algo, rules):
+    return {"name": name, "policyType": "RADIUS", "ruleCombineAlgo": algo, "defaultProfile": "", "rules": rules}
+
+
+def _rm_policy(name, algo, rules):
+    return {"name": name, "ruleCombineAlgo": algo, "defaultRole": "", "rules": rules}
+
+
+_ENF_RULE = {
+    "index": 0,
+    "expression": {
+        "operator": "and",
+        "attributes": [{"type": "Tips", "name": "Role", "operator": "EQUALS", "value": "x"}],
+    },
+    "results": [{"name": "Enforcement-Profile", "values": ["Grant"]}],
+}
+_RM_RULE = {
+    "index": 0,
+    "expression": {
+        "operator": "and",
+        "attributes": [{"type": "Tips", "name": "Role", "operator": "EQUALS", "value": "x"}],
+    },
+    "results": [{"name": "Role", "displayValue": "[Employee]"}],
+}
+
+
+class TestEvaluateAllFlow:
+    def test_enforcement_evaluate_all_rule_is_continue(self) -> None:
+        model = build(
+            _raw(generic=[{"name": "Grant", "action": "Accept"}], eps=[_enf_policy("EP", "evaluate-all", [_ENF_RULE])])
+        )
+        ep = next(iter(model.enforcement_policies.values()))
+        assert ep.rules[0].flow.on_match == "continue"
+
+    def test_enforcement_first_applicable_rule_is_stop(self) -> None:
+        model = build(
+            _raw(
+                generic=[{"name": "Grant", "action": "Accept"}],
+                eps=[_enf_policy("EP", "first-applicable", [_ENF_RULE])],
+            )
+        )
+        ep = next(iter(model.enforcement_policies.values()))
+        assert ep.rules[0].flow.on_match == "stop"
+
+    def test_role_mapping_evaluate_all_rule_is_continue(self) -> None:
+        model = build(_raw(rms=[_rm_policy("RM", "evaluate-all", [_RM_RULE])]))
+        rm = next(iter(model.role_mapping_policies.values()))
+        assert rm.rules[0].flow.on_match == "continue"
+
+
+# ---------------------------------------------------------------------------
+# #600 — unknown operators are contained
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownOperatorContained:
+    def test_from_raw_returns_sentinel(self) -> None:
+        assert Op.from_raw("SOME_EXOTIC_OP") is Op.unknown
+
+    def test_build_does_not_raise_on_unknown_operator(self) -> None:
+        rule = {
+            "index": 0,
+            "expression": {
+                "operator": "and",
+                "attributes": [{"type": "Tips", "name": "Role", "operator": "SOME_EXOTIC_OP", "value": "x"}],
+            },
+            "results": [{"name": "Enforcement-Profile", "values": ["Grant"]}],
+        }
+        # Must not raise — the exotic operator can't fail the whole compile (#600).
+        model = build(
+            _raw(generic=[{"name": "Grant", "action": "Accept"}], eps=[_enf_policy("EP", "first-applicable", [rule])])
+        )
+        assert model.enforcement_policies
+
+    def test_unknown_operator_evaluates_uncertain(self) -> None:
+        expr = normalize(
+            {"operator": "and", "attributes": [{"type": "Tips", "name": "Role", "operator": "WAT", "value": "x"}]}
+        )
+        # Even with the attribute present, an unknown operator is uncertain (None).
+        assert evaluate(expr, {"Tips:Role": "x"}) is None
+
+
+# ---------------------------------------------------------------------------
+# #601 — comma-containing profile names survive
+# ---------------------------------------------------------------------------
+
+
+class TestCommaSafeProfileNames:
+    def test_profile_name_with_comma_not_split(self) -> None:
+        rule = {
+            "index": 0,
+            "expression": {
+                "operator": "and",
+                "attributes": [{"type": "Tips", "name": "Role", "operator": "EQUALS", "value": "x"}],
+            },
+            "results": [{"name": "Enforcement-Profile", "values": ["Allow, Log Session"]}],
+        }
+        model = build(
+            _raw(
+                generic=[{"name": "Allow, Log Session", "action": "Accept"}],
+                eps=[_enf_policy("EP", "first-applicable", [rule])],
+            )
+        )
+        ep = next(iter(model.enforcement_policies.values()))
+        then = ep.rules[0].then
+        # One profile, name preserved verbatim — not split into two placeholders.
+        assert then.profile_names == ["Allow, Log Session"]
+        assert len(then.profile_ids) == 1
+        assert not model.warnings  # the real profile resolved; no placeholder warning


### PR DESCRIPTION
Cluster C (ClearPass policy visualizer) is 7 interconnected findings. To keep each change reviewable, I split it: **this PR is part 1 — the data-model / classification fixes**; the flow-graph simulation-semantics fixes (**#595, #597, #598**) follow in a second PR.

## Fixes

**#596 (high) — action-less side-effect profiles are no longer read as DENY.** A generic/TACACS enforcement profile with no action (or a non-accept, non-reject action) was mapped to `generic_reject` / `tacacs_other` and classified as deny by the flow graph — so a rule that *grants* access while applying a side-effect profile (logging, attribute push) reported DENY. Classification now keys off the explicit action: `accept` → `*_accept`; an explicit `deny`/`reject`/`drop` → the reject type; anything else → a neutral `*_sideeffect` type that is **not** a deny type. (Fix is entirely in `policy_model`; `flow_graph._DENY_PROFILE_TYPES` is unchanged.)

**#599 (medium) — per-rule details reflect evaluate-all.** `PolicyRule.flow.on_match` was always the default `stop`; `build()` never propagated the policy combine algorithm. Rules of an `evaluate-all` role-mapping/enforcement policy now report `continue`; first-applicable still reports `stop`.

**#600 (low) — an exotic operator no longer fails the whole compile.** `Op.from_raw` raised `ValueError` for any operator not in the local map, so one uncommon operator in an *unrelated* policy failed `clearpass_compile_policy_flow` for every requested service. Unknown operators now map to an `Op.unknown` sentinel (logged), preserve their `raw_operator` for display, and evaluate as uncertain (`None`).

**#601 (low) — profile names with commas survive.** The adapter comma-joined the profile-name list and the model split it back on every comma, so `Allow, Log Session` became two bogus placeholders (losing the real profiles type/action). The adapter now also emits a verbatim `values` list which the model consumes directly; `displayValue` stays human-readable.

## Testing
- **11 new tests** (`test_clearpass_policy_visualizer_hardening.py`): side-effect-not-deny (generic/TACACS/explicit-reject/accept), evaluate-all vs first-applicable per-rule flow, unknown-operator containment (no raise + uncertain eval), comma-safe profile name.
- **2 existing tests updated** to the corrected behavior (unknown-operator no longer raises; adapter result now carries `values`).
- Full gate: `ruff` / `format` / `mypy` clean; **2017 passed**, 2 skipped. All 174 existing ClearPass tests green.

Closes #596
Closes #599
Closes #600
Closes #601