### PR TITLE
fix(clearpass): policy-visualizer simulation semantics (#595, #598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3.4] - 2026-07-13
+
+**Patch — ClearPass policy-visualizer correctness, part 2 (Casey Jones full-project review: #595, #598).** The simulation / graph-semantics fixes of the ClearPass visualizer cluster.
+
+### Fixed
+- **#595 (high) — the simulator no longer reports a confident decision when role mapping is uncertain.** `_apply_simulation` tracked role-mapping uncertainty (`rm_uncertain`) but did not fold it into the final status, so a matched enforcement rule produced a confident `resolved` ALLOW/DENY even though a role-mapping rule it couldn't evaluate might add a role that matches a different (earlier, first-applicable) enforcement rule. Any consulted role-mapping uncertainty now fails the whole decision closed: `status="uncertain"`, `access_decision="UNKNOWN"`. (Deterministic role-mapping no-match — the attribute *was* supplied — still resolves normally.)
+- **#598 (medium) — role-mapping no-match/no-default continues to enforcement in the diagram.** When a role-mapping policy had no default role and no rule matched, the graph terminated at `Access: DENY (no role matched)` while the simulator (and ClearPass) continue to enforcement, where a default/role-independent profile may grant access. The graph now continues the NO path to the enforcement entry, agreeing with the simulation.
+
+### Deferred
+- **#597** (evaluate-all graph routing) is intentionally not in this release: a *static* diagram can't distinguish "matched rule 0 but rule 1 didn't" from "nothing matched" (both traverse the same NO edge) in evaluate-all mode, so a correct fix is a representation-design decision rather than a wiring change. Tracked for a dedicated pass. The machine-readable simulator already handles evaluate-all accumulation correctly.
+
 ## [3.5.3.3] - 2026-07-13
 
 **Patch — ClearPass policy-visualizer correctness, part 1 (Casey Jones full-project review: #596, #599, #600, #601).** The data-model / classification fixes of the ClearPass visualizer cluster; the flow-graph simulation-semantics fixes (#595/#597/#598) follow separately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.3.3"
+version = "3.5.3.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/policy_visualizer/flow_graph.py
@@ -432,14 +432,12 @@ def compile_service(
                 flow.add_edge(current_tail, def_role.id, current_label)
                 flow.add_edge(def_role.id, enf_entry_id)
             else:
-                no_role_end = flow.add_node(
-                    FlowNode(
-                        id=f"{sid}__no_role",
-                        type="end",
-                        label="Access: DENY\n(no role matched)",
-                    )
-                )
-                flow.add_edge(current_tail, no_role_end.id, current_label)
+                # No default role AND no rule matched is NOT a terminal deny —
+                # ClearPass (and the module's own simulator) continue to
+                # enforcement with no role, where a default / role-independent
+                # profile may still grant access. Continue to enforcement so the
+                # diagram agrees with the simulation (#598).
+                flow.add_edge(current_tail, enf_entry_id, current_label)
         else:
             # No role mapping — go straight to enforcement
             flow.add_edge(current_tail, enf_entry_id, current_label)
@@ -539,6 +537,9 @@ def _apply_simulation(
     # ---- Role mapping (skipped for RADIUS_PROXY)
     matching_rm_rules: list[str] = []
     resulting_roles: list[str] = []
+    # Track role-mapping uncertainty at function scope so the final outcome can
+    # fail closed on it (#595) even for RADIUS_PROXY / no-role-mapping services.
+    rm_uncertain = False
     if service.service_type != "RADIUS_PROXY":
         rm = model.role_mapping_policies.get(service.role_mapping_policy_id)
         if rm is None:
@@ -651,7 +652,12 @@ def _apply_simulation(
         matching_ep_rule = f"{ep.id}__default"
 
     # ---- Determine outcome
-    if ep_uncertain or matching_ep_rule is None and unknown_attrs:
+    # ``rm_uncertain`` fails the whole decision closed (#595): a role-mapping
+    # rule we couldn't evaluate might add a role that matches a different
+    # (earlier, in first-applicable) enforcement rule, so a confident ALLOW/DENY
+    # here would be wrong. We don't attempt to prove the missing role is
+    # irrelevant — uncertain is the safe answer.
+    if ep_uncertain or rm_uncertain or (matching_ep_rule is None and unknown_attrs):
         status = "uncertain"
         access = "UNKNOWN"
     elif matching_ep_rule is None:

--- a/tests/unit/test_clearpass_policy_visualizer_flow.py
+++ b/tests/unit/test_clearpass_policy_visualizer_flow.py
@@ -163,10 +163,10 @@ class TestCompileServiceFirstApplicable:
         model = build(_minimal_raw(rm_rules=rm_rules, enf_rules=enf_rules))
         flow = compile_service(next(iter(model.services.values())), model)
         end_nodes = [n for n in flow.nodes if n.type == "end"]
-        # Expected ends (no rm_default, no enf_default — both produce extra
-        # implicit-deny terminations):
-        #   no_match + auth_fail + 2 enf rule ends + enf_implicit_deny + no_role
-        assert len(end_nodes) == 6
+        # Expected ends: no_match + auth_fail + 2 enf rule ends + enf_implicit_deny.
+        # The role-mapping no-default path is NOT a terminal deny anymore — it
+        # continues to enforcement (#598), so there is no separate no_role end.
+        assert len(end_nodes) == 5
         allow_ends = [n for n in end_nodes if "ALLOW" in n.label]
         deny_ends = [n for n in end_nodes if "DENY" in n.label]
         assert len(allow_ends) >= 1
@@ -602,3 +602,88 @@ class TestBuildDetails:
         assert "[Allow Access Profile]" in details["enforcement_rules"][0]["action_text"]
         # Service-match key is always synthesized into rule_index
         assert any(k.endswith("__match") for k in details["rule_index"])
+
+
+def _pred(ns: str, name: str, value: str) -> dict:
+    return {"operator": "and", "attributes": [{"type": ns, "name": name, "operator": "EQUALS", "value": value}]}
+
+
+class TestRoleMappingNoDefaultContinuesToEnforcement:
+    """#598: a role-mapping with no default role and no match is NOT a terminal
+    deny — the graph continues to enforcement (agreeing with the simulator)."""
+
+    def test_no_role_end_removed_and_continues_to_enforcement(self):
+        rm_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("v1"),
+                "results": [{"name": "Role", "displayValue": "[Contractor]"}],
+            }
+        ]
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("X"),
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            }
+        ]
+        model = build(_minimal_raw(rm_rules=rm_rules, rm_default="", enf_rules=enf_rules))
+        flow = compile_service(next(iter(model.services.values())), model)
+        assert not any("no role" in n.label.lower() for n in flow.nodes if n.type == "end")
+        rm_dec = next(n for n in flow.nodes if n.id.endswith("__rm_rule_0"))
+        assert any(e.from_id == rm_dec.id and e.to_id.endswith("__enf_rule_0") and e.label == "NO" for e in flow.edges)
+
+
+class TestRoleMappingUncertaintyFailsClosed:
+    """#595: role-mapping uncertainty makes the whole simulation uncertain, even
+    when an enforcement rule matched on an explicitly-provided role."""
+
+    def test_uncertain_rm_rule_forces_unknown(self):
+        rm_rules = [
+            {
+                "index": 0,
+                "expression": _pred("Authorization", "memberOf", "Admins"),
+                "results": [{"name": "Role", "displayValue": "[Contractor]"}],
+            }
+        ]
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("[Employee]"),
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            }
+        ]
+        model = build(_minimal_raw(rm_rules=rm_rules, rm_default="", enf_rules=enf_rules))
+        svc = next(iter(model.services.values()))
+        # "AirGroup" satisfies the service match; "[Employee]" matches the enf rule.
+        # Authorization:memberOf is NOT supplied → the rm rule is uncertain.
+        flow = compile_service(svc, model, simulated_attributes={"Tips:Role": ["AirGroup", "[Employee]"]})
+        assert flow.simulation.status == "uncertain"
+        assert flow.simulation.access_decision == "UNKNOWN"
+
+    def test_deterministic_rm_no_match_still_resolves(self):
+        # Guard against over-marking: when the rm attribute IS provided (rule
+        # deterministically does not match), there is no uncertainty.
+        rm_rules = [
+            {
+                "index": 0,
+                "expression": _pred("Authorization", "memberOf", "Admins"),
+                "results": [{"name": "Role", "displayValue": "[Contractor]"}],
+            }
+        ]
+        enf_rules = [
+            {
+                "index": 0,
+                "expression": _single_predicate("[Employee]"),
+                "results": [{"name": "Enforcement-Profile", "displayValue": "[Allow Access Profile]"}],
+            }
+        ]
+        model = build(_minimal_raw(rm_rules=rm_rules, rm_default="", enf_rules=enf_rules))
+        svc = next(iter(model.services.values()))
+        flow = compile_service(
+            svc,
+            model,
+            simulated_attributes={"Tips:Role": ["AirGroup", "[Employee]"], "Authorization:memberOf": "Users"},
+        )
+        assert flow.simulation.status == "resolved"
+        assert flow.simulation.access_decision == "ALLOW"


### PR DESCRIPTION
Part 2 of the ClearPass policy-visualizer cluster — the simulation / graph-semantics fixes. (Part 1, the data-model fixes, merged as #612 / v3.5.3.3.)

## Fixes

**#595 (high) — the simulator no longer reports a confident decision when role mapping is uncertain.** `_apply_simulation` already tracked `rm_uncertain` (a role-mapping rule that evaluated to `None` because a needed attribute wasnt supplied) but never folded it into the final outcome — so a matched enforcement rule produced a confident `resolved` ALLOW/DENY. Thats wrong: the unevaluable role-mapping rule might add a role that matches a *different* (earlier, in first-applicable) enforcement rule, changing the winner. Any consulted role-mapping uncertainty now fails the whole decision closed → `status="uncertain"`, `access_decision="UNKNOWN"`. Deterministic role-mapping no-match (the attribute *was* supplied, rule cleanly didnt match) still resolves normally — verified by an explicit over-marking guard test.

**#598 (medium) — role-mapping no-match/no-default continues to enforcement in the diagram.** When a role-mapping policy had no default role and no rule matched, the graph terminated at `Access: DENY (no role matched)` — but the simulator (and ClearPass) continue to enforcement, where a default / role-independent profile may grant access. The NO path now continues to the enforcement entry, so the diagram agrees with the simulation.

## #597 deferred (not a wiring bug)
`#597` (evaluate-all graph routing) is intentionally **not** in this PR. In evaluate-all mode a *static* diagram fundamentally cant distinguish "matched rule 0 but rule 1 didnt" from "nothing matched" — both traverse the same `NO` edge — so "distinguish no-match from earlier-matched" is a **representation-design decision**, not a wiring change, and deserves a dedicated pass. The machine-readable simulator already accumulates evaluate-all profiles correctly, so the authoritative decision is unaffected. Left open with this reasoning.

## Testing
- 4 tests added: `#598` graph continues-to-enforcement (no `no_role` end node); `#595` uncertain-rm → UNKNOWN; `#595` over-marking guard (deterministic no-match still resolves).
- 1 existing test updated (the removed `no_role` deny end node).
- Full gate: `ruff` / `format` / `mypy` clean; **2020 passed**, 2 skipped. All ClearPass tests green.

Closes #595
Closes #598