### PR TITLE
fix(edgeconnect): transport errors as 502 + collapse concurrent 401 refreshes (#602, #603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3.5] - 2026-07-13
+
+**Patch — EdgeConnect transport & auth robustness (Casey Jones full-project review: #602, #603).** Two low-severity correctness fixes to the EdgeConnect Orchestrator client.
+
+### Fixed
+- **#602 — transport failures return a 502, not an unclassifiable `0`.** `format_http_error` mapped every non-`HTTPStatusError` exception (DNS failure, TLS error, connect/read timeout, connection reset) to `status_code: 0`, so AI clients and middleware couldn't place EdgeConnect transport failures in the documented 4xx-vs-5xx status domain. Non-HTTP upstream/transport failures now map to `502`; genuine HTTP status errors still preserve the real upstream status and body.
+- **#603 — concurrent 401 refreshes collapse to one login.** In user/password mode a 401 forced an unconditional re-login, so two in-flight calls hitting session expiry each cleared and re-established the shared cookie jar — a sibling retry could be built against a jar another refresh had just cleared, producing intermittent spurious 401s and login bursts. `AsyncTokenManager` now carries a monotonic acquisition `generation`; the client reads `(token, generation)` together (`get_token_with_generation`) and, on a 401, calls `refresh_if_stale(generation)`, which re-acquires only if no sibling has already refreshed. Concurrent victims collapse to a single login serialized under the existing lock, so no retry is built against a jar a sibling cleared.
+
+### Changed
+- `AsyncTokenManager` (shared across all platforms) gains a `generation` property, `get_token_with_generation()`, and `refresh_if_stale(observed_generation)`. Existing `get_token()`/`refresh()` behavior is unchanged.
+
 ## [3.5.3.4] - 2026-07-13
 
 **Patch — ClearPass policy-visualizer correctness, part 2 (Casey Jones full-project review: #595, #598).** The simulation / graph-semantics fixes of the ClearPass visualizer cluster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.3.4"
+version = "3.5.3.5"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/auth.py
+++ b/src/hpe_networking_mcp/platforms/_common/auth.py
@@ -99,6 +99,7 @@ class AsyncTokenManager:
         self._buffer = expiry_buffer
         self._token: str | None = None
         self._expires_at: float | None = None  # Unix timestamp; None = no expiry
+        self._generation = 0  # bumped on every successful acquisition (see refresh_if_stale)
         self._lock = asyncio.Lock()
 
     @classmethod
@@ -130,6 +131,17 @@ class AsyncTokenManager:
         """Unix timestamp the cached token expires at, or ``None`` for no expiry."""
         return self._expires_at
 
+    @property
+    def generation(self) -> int:
+        """Monotonic counter incremented on every successful acquisition.
+
+        Callers that must collapse concurrent post-401 refreshes read this
+        alongside the token (via :meth:`get_token_with_generation`) and pass it
+        back to :meth:`refresh_if_stale` so a sibling that already re-acquired
+        wins instead of every 401-victim forcing its own login.
+        """
+        return self._generation
+
     def prime(self, token: str, expires_in: float | None = None) -> None:
         """Seed the cache directly (static tokens, tests).
 
@@ -156,16 +168,27 @@ class AsyncTokenManager:
 
     async def get_token(self) -> str:
         """Return the cached token, acquiring one under the lock if stale."""
+        token, _ = await self.get_token_with_generation()
+        return token
+
+    async def get_token_with_generation(self) -> tuple[str, int]:
+        """Return ``(token, generation)`` atomically, acquiring one if stale.
+
+        The pair is read without an intervening ``await`` so it is internally
+        consistent: the ``generation`` is exactly the one that produced
+        ``token``. Pass the generation back to :meth:`refresh_if_stale` on a
+        401 so concurrent victims collapse to a single re-acquisition.
+        """
         if self._is_fresh():
             assert self._token is not None
-            return self._token
+            return self._token, self._generation
         async with self._lock:
             # Re-check inside the lock — another coroutine may have fetched.
             if not self._is_fresh():
                 await self._fetch_locked()
-        if self._token is None:  # guard: assert is stripped under python -O
-            raise AuthError(f"{self._name}: token fetch succeeded but no token is cached")
-        return self._token
+            if self._token is None:  # guard: assert is stripped under python -O
+                raise AuthError(f"{self._name}: token fetch succeeded but no token is cached")
+            return self._token, self._generation
 
     async def refresh(self) -> str:
         """Force re-acquisition under the lock (e.g. after a 401) and return it."""
@@ -176,6 +199,25 @@ class AsyncTokenManager:
             raise AuthError(f"{self._name}: token refresh succeeded but no token is cached")
         return self._token
 
+    async def refresh_if_stale(self, observed_generation: int) -> str:
+        """Re-acquire only if no sibling has refreshed since ``observed_generation``.
+
+        Collapses concurrent post-401 refreshes to a single acquisition: the
+        first victim to win the lock advances the generation and re-fetches;
+        every later victim sees ``self._generation != observed_generation`` and
+        returns the already-fresh token without triggering another login (which,
+        for cookie-session platforms, would clear the jar a sibling retry still
+        needs). Callers obtain ``observed_generation`` from
+        :meth:`get_token_with_generation`.
+        """
+        async with self._lock:
+            if self._generation == observed_generation:
+                self.invalidate()
+                await self._fetch_locked()
+            if self._token is None:
+                raise AuthError(f"{self._name}: token refresh succeeded but no token is cached")
+            return self._token
+
     async def _fetch_locked(self) -> None:
         """Run the fetch strategy and cache its result. Caller holds the lock."""
         result = await self._fetch()
@@ -183,6 +225,7 @@ class AsyncTokenManager:
             raise AuthError(f"{self._name}: fetch strategy returned an empty token")
         self._token = result.token
         self._expires_at = time.time() + result.expires_in if result.expires_in is not None else None
+        self._generation += 1
 
 
 def oauth2_client_credentials(

--- a/src/hpe_networking_mcp/platforms/edgeconnect/client.py
+++ b/src/hpe_networking_mcp/platforms/edgeconnect/client.py
@@ -235,7 +235,7 @@ class EdgeConnectClient:
         Returns:
             The httpx.Response after ``raise_for_status()``.
         """
-        token = await self._tokens.get_token()
+        token, generation = await self._tokens.get_token_with_generation()
         merged_params = {**_SOURCE_PARAM, **(params or {})}
 
         def _build_kwargs(tok: str) -> dict[str, Any]:
@@ -266,7 +266,11 @@ class EdgeConnectClient:
         response = await self._http.request(method, path, **_build_kwargs(token))
         if response.status_code == 401:
             logger.info("EdgeConnect: 401 on {} {} — refreshing auth once", method, path)
-            token = await self._tokens.refresh()
+            # Collapse concurrent 401s to one login: refresh_if_stale re-logs in
+            # only if no sibling already re-acquired since we read our token, so a
+            # sibling's login never clears the cookie jar out from under this
+            # retry (user/pass mode) — see #603.
+            token = await self._tokens.refresh_if_stale(generation)
             response = await self._http.request(method, path, **_build_kwargs(token))
         response.raise_for_status()
         return response
@@ -359,9 +363,12 @@ async def edgeconnect_request(
 def format_http_error(exc: BaseException) -> dict[str, Any]:
     """Shape any exception into a consistent dict for tool returns.
 
-    Surfaces status code and response body for ``httpx.HTTPStatusError``;
-    everything else falls back to a generic shape. Same pattern as every other
-    platform.
+    Surfaces the real status code and response body for
+    ``httpx.HTTPStatusError``; any other exception (DNS failure, TLS error,
+    connect/read timeout, connection reset) is a transport/upstream failure with
+    no HTTP status, so it maps to ``502`` — keeping EdgeConnect inside the
+    documented 4xx-vs-5xx status domain instead of an unclassifiable ``0``
+    (#602). Same pattern as every other platform.
     """
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
@@ -371,4 +378,4 @@ def format_http_error(exc: BaseException) -> dict[str, Any]:
         except (ValueError, json.JSONDecodeError):
             body = text
         return {"status_code": status, "message": str(exc), "body": body}
-    return {"status_code": 0, "message": str(exc), "body": None}
+    return {"status_code": 502, "message": f"EdgeConnect upstream/transport failure: {exc}", "body": None}

--- a/tests/unit/test_common_auth.py
+++ b/tests/unit/test_common_auth.py
@@ -175,6 +175,25 @@ class TestGenerationAndCollapse:
         # Fresh path returns the same pair without re-fetching.
         assert await mgr.get_token_with_generation() == ("t1", 1)
 
+    async def test_concurrent_get_token_with_generation_from_stale_cache(self):
+        """N concurrent callers from an empty cache: exactly one fetch, all get the same pair.
+
+        Guards the locked-re-check fall-through: the sibling that finds the token
+        fresh under the lock must still return ``(token, generation)`` — never
+        ``None`` (which would blow up the ``token, gen = ...`` unpack).
+        """
+        calls: list[int] = []
+
+        async def slow_fetch() -> TokenResult:
+            calls.append(1)
+            await asyncio.sleep(0.01)  # hold the lock so siblings pile up behind it
+            return TokenResult("tok-1", expires_in=None)
+
+        mgr = AsyncTokenManager(slow_fetch, name="test")
+        results = await asyncio.gather(*(mgr.get_token_with_generation() for _ in range(4)))
+        assert len(calls) == 1  # double-checked locking: one fetch
+        assert all(r == ("tok-1", 1) for r in results)  # no None fall-through
+
     async def test_refresh_if_stale_collapses_concurrent_401s(self):
         """Two victims observing the same generation trigger exactly one re-login."""
         results = [

--- a/tests/unit/test_common_auth.py
+++ b/tests/unit/test_common_auth.py
@@ -155,6 +155,70 @@ class TestAsyncTokenManagerLifecycle:
 
 
 @pytest.mark.unit
+class TestGenerationAndCollapse:
+    """generation + refresh_if_stale: collapse concurrent post-401 refreshes (#603)."""
+
+    async def test_generation_advances_on_each_acquisition(self):
+        fetch, _ = _counting_fetch([TokenResult("t1", expires_in=None), TokenResult("t2", expires_in=None)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        assert mgr.generation == 0
+        _, gen1 = await mgr.get_token_with_generation()
+        assert gen1 == 1
+        await mgr.refresh()
+        assert mgr.generation == 2
+
+    async def test_get_token_with_generation_is_consistent(self):
+        fetch, _ = _counting_fetch([TokenResult("t1", expires_in=None)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        token, gen = await mgr.get_token_with_generation()
+        assert (token, gen) == ("t1", 1)
+        # Fresh path returns the same pair without re-fetching.
+        assert await mgr.get_token_with_generation() == ("t1", 1)
+
+    async def test_refresh_if_stale_collapses_concurrent_401s(self):
+        """Two victims observing the same generation trigger exactly one re-login."""
+        results = [
+            TokenResult("t1", expires_in=None),
+            TokenResult("t2", expires_in=None),
+            TokenResult("t3", expires_in=None),
+        ]
+        calls: list[int] = []
+
+        async def fetch() -> TokenResult:
+            calls.append(1)
+            await asyncio.sleep(0)  # force the second caller to block on the lock
+            return results[len(calls) - 1]
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        _, gen = await mgr.get_token_with_generation()  # calls=1, gen=1
+        both = await asyncio.gather(mgr.refresh_if_stale(gen), mgr.refresh_if_stale(gen))
+        assert len(calls) == 2  # one initial + exactly one collapse re-acquisition
+        assert both == ["t2", "t2"]  # the loser returns the winner's fresh token
+        assert mgr.generation == 2
+
+    async def test_refresh_if_stale_reacquires_when_generation_matches(self):
+        results = [TokenResult("t1", expires_in=None), TokenResult("t2", expires_in=None)]
+        calls: list[int] = []
+
+        async def fetch() -> TokenResult:
+            calls.append(1)
+            return results[len(calls) - 1]
+
+        mgr = AsyncTokenManager(fetch, name="test")
+        _, gen = await mgr.get_token_with_generation()
+        assert await mgr.refresh_if_stale(gen) == "t2"
+        assert len(calls) == 2
+
+    async def test_refresh_if_stale_skips_when_already_advanced(self):
+        fetch, calls = _counting_fetch([TokenResult("t1", expires_in=None)])
+        mgr = AsyncTokenManager(fetch, name="test")
+        _, gen = await mgr.get_token_with_generation()  # gen=1
+        # A sibling already refreshed → generation is now ahead of what we saw.
+        assert await mgr.refresh_if_stale(gen - 1) == "t1"
+        assert len(calls) == 1  # no extra fetch
+
+
+@pytest.mark.unit
 class TestOAuth2ClientCredentials:
     """The OAuth2 fetcher extracted from UXI's `_fetch_token_locked`."""
 

--- a/tests/unit/test_edgeconnect_client.py
+++ b/tests/unit/test_edgeconnect_client.py
@@ -6,6 +6,7 @@ event hooks — see issue #233) rather than replacing the AsyncClient.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 
 import httpx
@@ -13,7 +14,18 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from hpe_networking_mcp.config import EdgeConnectSecrets
-from hpe_networking_mcp.platforms.edgeconnect.client import EdgeConnectClient
+from hpe_networking_mcp.platforms.edgeconnect.client import (
+    EdgeConnectClient,
+    edgeconnect_request,
+    format_http_error,
+)
+
+
+class _FakeCtx:
+    """Minimal stand-in for the FastMCP request context (only lifespan_context)."""
+
+    def __init__(self, client: EdgeConnectClient | None) -> None:
+        self.lifespan_context = {"edgeconnect_client": client}
 
 
 def _api_key_secrets(**overrides) -> EdgeConnectSecrets:
@@ -163,3 +175,84 @@ class TestBodyEncoding:
         _install_mock_transport(client, lambda r: httpx.Response(200, json={}))
         with pytest.raises(ToolError):
             await client.request("POST", "/brandCustomization/image", json_body={"f": 1}, body_mode="multipart")
+
+
+@pytest.mark.unit
+class TestTransportErrorFormatting:
+    """format_http_error must keep EdgeConnect inside the 4xx/5xx status domain (#602)."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectTimeout("connect timed out"),
+            httpx.ReadTimeout("read timed out"),
+            httpx.ConnectError("name resolution failed"),
+            RuntimeError("something odd"),
+        ],
+    )
+    def test_non_http_failures_map_to_502(self, exc: BaseException):
+        shaped = format_http_error(exc)
+        assert shaped["status_code"] == 502
+        assert shaped["body"] is None
+        assert str(exc) in shaped["message"]
+
+    def test_http_status_error_preserves_status_and_json_body(self):
+        request = httpx.Request("GET", "https://orch.example.com/gms/rest/appliance")
+        response = httpx.Response(404, json={"error": "not found"}, request=request)
+        shaped = format_http_error(httpx.HTTPStatusError("404", request=request, response=response))
+        assert shaped["status_code"] == 404
+        assert shaped["body"] == {"error": "not found"}
+
+    async def test_edgeconnect_request_wraps_transport_error_as_502(self):
+        client = EdgeConnectClient(_api_key_secrets())
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("boom")
+
+        _install_mock_transport(client, handler)
+        with pytest.raises(ToolError) as excinfo:
+            await edgeconnect_request(_FakeCtx(client), "GET", "/appliance")
+        assert excinfo.value.args[0]["status_code"] == 502
+
+
+@pytest.mark.unit
+class TestConcurrentRefresh:
+    """Simultaneous 401s in user/pass mode collapse to one login (#603)."""
+
+    async def test_concurrent_401s_collapse_to_one_relogin(self):
+        client = EdgeConnectClient(_user_pass_secrets())
+        login_count = 0
+        data_seen = 0
+        both_initial_arrived = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal login_count, data_seen
+            if request.url.path.endswith("/authentication/login"):
+                login_count += 1
+                return httpx.Response(
+                    200,
+                    json={"ok": True},
+                    headers={"set-cookie": f"orchCsrfToken=csrf{login_count}; Path=/"},
+                )
+            # Data endpoint. Before any re-login the session is "expired" → 401,
+            # but hold both initial requests at a barrier so the two victims enter
+            # the refresh path concurrently (the exact #603 race).
+            data_seen += 1
+            if login_count < 2:
+                if data_seen >= 2:
+                    both_initial_arrived.set()
+                await both_initial_arrived.wait()
+                return httpx.Response(401, json={"error": "expired"})
+            return httpx.Response(200, json={"ok": True})
+
+        # MockTransport awaits an async handler's return value.
+        client._http._transport = httpx.MockTransport(handler)
+
+        results = await asyncio.gather(
+            client.request("GET", "/appliance"),
+            client.request("GET", "/interfaces"),
+        )
+        assert all(r.status_code == 200 for r in results)
+        # The two concurrent 401s collapse: initial login + exactly ONE re-login.
+        # Without the collapse each victim forces its own login → 3.
+        assert login_count == 2


### PR DESCRIPTION
Cluster D of Casey Jones's full-project review — the two EdgeConnect Orchestrator client findings.

## Fixes

**#602 (low) — transport failures return a 502, not an unclassifiable `0`.** `format_http_error` mapped every non-`HTTPStatusError` exception (DNS failure, TLS error, connect/read timeout, connection reset) to `status_code: 0`, so AI clients and middleware couldn't place EdgeConnect transport failures in the documented 4xx-vs-5xx status domain. Non-HTTP upstream/transport failures now map to **502**; genuine HTTP status errors still preserve the real upstream status and body.

**#603 (low) — concurrent 401 refreshes collapse to one login.** In user/password mode a 401 forced an *unconditional* re-login, so two in-flight calls hitting session expiry each cleared and re-established the **shared** cookie jar — a sibling retry could be built against a jar another refresh had just cleared, producing intermittent spurious 401s and login bursts.

`AsyncTokenManager` (shared by all platforms) now carries a monotonic acquisition **`generation`**. The EdgeConnect client reads `(token, generation)` together via `get_token_with_generation()` and, on a 401, calls `refresh_if_stale(generation)` — which re-acquires **only if no sibling has already refreshed** since that generation. Concurrent victims serialize on the existing lock and collapse to a single login, so no retry is ever built against a jar a sibling just cleared. `get_token()` / `refresh()` behavior is unchanged.

## Acceptance criteria
- #602: non-HTTP transport failures → 502 ToolError ✅; HTTP status errors preserve status/body ✅; timeout/connect formatting covered by tests ✅.
- #603: concurrent 401 refreshes collapse to one effective login ✅; retries cannot be built against a jar a sibling cleared (single serialized login) ✅; concurrency test covers simultaneous 401s in user/pass mode ✅.

## Testing
- **Manager-level (`test_common_auth.py`)**: generation advances per acquisition; `get_token_with_generation` consistency; `refresh_if_stale` collapses two concurrent victims to exactly one re-fetch; still re-acquires when generation matches; skips when already advanced.
- **Client-level (`test_edgeconnect_client.py`)**: transport errors (`ConnectTimeout`/`ReadTimeout`/`ConnectError`/generic) → 502; HTTP status error preserves status+JSON body; `edgeconnect_request` wraps a transport error as a 502 ToolError; a barrier-synchronized two-request concurrency test proves simultaneous 401s produce exactly one re-login (would be 3 without the collapse).
- Full gate: ruff / format / mypy clean; **2032 passed**, 2 skipped.

Closes #602
Closes #603