### PR TITLE
feat(spec-index): SQLite/FTS5 OpenAPI lookup index + code-mode get_schema enrichment (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,14 +127,12 @@ docs/skills/
 # Pre-regen backup of the Central tool surface (local safety copy, never committed)
 central-tools-backup/
 
-# Tool generators / schema distillers are local-only — not tracked or uploaded.
+# Local-only tooling lives under scripts/internal/ — not tracked or uploaded.
 # The GENERATED tool files under platforms/*/tools/ (and distilled schema JSON)
-# ARE committed; the scripts that emit them are not. Regeneration is a local
-# maintainer step at release time.
-scripts/generate_edgeconnect_tools.py
-scripts/generate_greenlake_tools.py
-scripts/_mist_generator.py
-scripts/regenerate_mist_tools.py
-scripts/import_central_config_tools.py
-scripts/distill_mist_schemas.py
-scripts/distill_central_config_schemas.py
+# ARE committed; the generators/distillers that emit them are not. Regeneration
+# is a local maintainer step at release time. Pushable build infrastructure
+# (e.g. scripts/build_spec_index.py) stays directly under scripts/ and IS tracked.
+scripts/internal/
+
+# Baked spec-lookup index (built at image time by scripts/build_spec_index.py)
+src/hpe_networking_mcp/spec_index/spec_index.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Feature in progress — spec-lookup index (part 1 of N). Not yet released.** A deterministic SQLite/FTS5 index of the vendored OpenAPI corpus, and its first consumer. Held from release until the feature is complete (distilled-artifact retirement + dynamic-mode parity still to land).
+
+### Added
+- **Spec-lookup index** (`scripts/build_spec_index.py` → `src/hpe_networking_mcp/spec_index/`). Parses all 82 vendored specs (aoscx excluded — orphan, no tools) into `endpoints` / `parameters` / `schemas` / `fields` / `responses` tables + FTS5 mirrors: **6,000 endpoints, 17,939 params, 13,656 schemas, 51,916 fields, 39,775 responses**. Captures field types/enums (property- *and* schema-level, resolved via `$ref`), constraints, formats, examples (field + request-body), `readOnly`/`writeOnly`, `deprecated` (+ `x-deprecation-notice`), `oneOf`/`anyOf` variants, `x-supportedDeviceType`, and per-platform source trust. Stdlib-only (`sqlite3`); baked into the image at build time (dedicated Docker stage), gitignored otherwise. Read-only `SpecIndex` query layer degrades to empty (never raises) when absent.
+- **`get_schema` config-body enrichment (code mode).** `get_schema` now appends the network-config body schema — fields, enums, constraints, device-type applicability, examples, and the scope query params — for the opaque `payload: dict` config tools (`central_manage_*` / `central_get_*`), sourced from the spec index. Closes the gap where those tools exposed no field set and the model authored the body blind (the AP-rename report). Live-verified: `get_schema(["central_manage_system_info"])` now surfaces `hostname` + scope params.
+
+### Notes
+- Follow-up (same feature): retire the distilled `_config_payload_schemas.json` / `_request_body_schemas.json` mechanism (Central + Mist) in favor of the single spec-index source, and wire dynamic-mode `<platform>_get_tool_schema` to the same generic provider.
+- Scripts reorg: local-only generators moved to gitignored `scripts/internal/`; pushable build infra (the index builder) stays under `scripts/`.
+
 ## [3.5.3.6] - 2026-07-15
 
 **Patch — `central_update_device` renamed to `central_update_device_notes` (notes-only truth-in-naming; closes #615).** An operator trying to rename a Central-managed AP hit a tool whose name and docstring overstated its scope.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,17 @@ COPY pyproject.toml ./
 # Install dependencies (no dev deps, no project itself yet)
 RUN uv sync --frozen --no-dev --no-install-project 2>/dev/null || uv sync --no-dev --no-install-project
 
+# --- Spec-index build stage ---
+# Bakes the deterministic OpenAPI lookup index (SQLite/FTS5) from the vendored
+# specs. Stdlib-only (json + sqlite3), so it needs no project deps — just the
+# builder script and vendor/. Only the resulting .db ships to the runtime image;
+# the 90 vendored specs stay out of it.
+FROM python:3.13-slim-trixie AS specindex
+WORKDIR /app
+COPY scripts/build_spec_index.py ./scripts/build_spec_index.py
+COPY vendor/ ./vendor/
+RUN python scripts/build_spec_index.py /tmp/spec_index.db
+
 # --- Runtime stage ---
 FROM python:3.13-slim-trixie
 
@@ -34,6 +45,10 @@ COPY --from=deps /app/.venv /app/.venv
 # Copy project files
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
+
+# Bake the spec-lookup index beside its query module (before the project install
+# so it ships whether the project installs editable or as a built wheel).
+COPY --from=specindex /tmp/spec_index.db ./src/hpe_networking_mcp/spec_index/spec_index.db
 
 # Install the project itself (as root so it can write to .venv/bin)
 RUN uv sync --frozen --no-dev 2>/dev/null || uv sync --no-dev

--- a/scripts/build_spec_index.py
+++ b/scripts/build_spec_index.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Build the SQLite/FTS5 spec-lookup index from the vendored OpenAPI specs.
+
+Parses every vendored OpenAPI spec under ``vendor/**`` into a deterministic
+SQLite index — ``endpoints``, ``parameters``, ``schemas``, ``fields`` plus FTS5
+mirrors — so the server can answer exact "which endpoint / field / enum / param"
+questions and enrich ``get_schema`` output and validation errors WITHOUT a model,
+embeddings, or hallucination.
+
+Design is schema-centric: every component schema is indexed once, endpoints link
+to their request/response schema by name, and nested structures are reached by
+following ``ref_schema`` / ``item_ref`` — no dotted-path materialization.
+
+Excluded from the index:
+  * non-spec JSON (no ``openapi``/``swagger`` key): ``_manifest.json``,
+    ``sources.json`` — vendoring metadata, not specs.
+  * ``vendor/aoscx/**`` — orphan spec with no platform/tools (AOS-CX is reached
+    via CNX / Central, never directly), so its endpoints would be pure noise.
+
+Run at image build; the resulting ``.db`` is baked into the image.
+
+Usage:
+    python scripts/build_spec_index.py [OUTPUT_DB]
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+VENDOR = ROOT / "vendor"
+DEFAULT_DB = ROOT / "src" / "hpe_networking_mcp" / "spec_index" / "spec_index.db"
+
+# Vendored specs with no backing platform/tools — indexing them injects
+# endpoints the model has no tool to call.
+EXCLUDED_PLATFORMS = {"aoscx"}
+
+# Per-platform source trust. All current vendored specs are trustworthy
+# (auto-synced from vendor dev-portals, or — for EdgeConnect — exported from the
+# orchestrator's own live Swagger). Kept as a column so a future low-trust source
+# can be caveated in enrichment without a schema change.
+PLATFORM_TRUST: dict[str, str] = {}
+
+_BODY_MEDIA_PRIORITY = ("application/json", "application/merge-patch+json", "*/*")
+_CONSTRAINT_KEYS = ("minimum", "maximum", "minLength", "maxLength", "pattern", "minItems", "maxItems")
+
+
+def _platform_of(path: Path) -> str:
+    return path.relative_to(VENDOR).parts[0]
+
+
+def _load_spec(path: Path) -> dict[str, Any] | None:
+    """Return a parsed OpenAPI spec, or None for non-spec / unparseable JSON."""
+    try:
+        data = json.loads(path.read_text())
+    except (ValueError, OSError):
+        return None
+    if not isinstance(data, dict) or not (data.get("openapi") or data.get("swagger")):
+        return None
+    return data
+
+
+def _ref_name(ref: Any) -> str | None:
+    """``"#/components/schemas/Foo"`` -> ``"Foo"``."""
+    return ref.rsplit("/", 1)[-1] if isinstance(ref, str) and ref.startswith("#/") else None
+
+
+def _as_type(value: Any) -> str | None:
+    """Normalize an OpenAPI ``type`` to a string.
+
+    OpenAPI 3.1 permits a type array (e.g. ``["string", "null"]`` for a nullable
+    field); collapse it to a ``"|"``-joined string so it stores as TEXT.
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return "|".join(str(v) for v in value) or None
+    return str(value)
+
+
+def _resolve_ref(spec: dict[str, Any], ref: str) -> Any:
+    """Resolve a local ``#/a/b/c`` JSON pointer within one spec."""
+    node: Any = spec
+    for part in ref.lstrip("#/").split("/"):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part.replace("~1", "/").replace("~0", "~"))
+    return node
+
+
+def _schema_from_content(spec: dict[str, Any], container: dict[str, Any]) -> tuple[str | None, dict | None]:
+    """From a requestBody/response object, return (schema_name_ref, inline_schema)."""
+    if not isinstance(container, dict):
+        return None, None
+    if "$ref" in container:
+        container = _resolve_ref(spec, container["$ref"]) or {}
+    content = container.get("content", {}) or {}
+    media = None
+    for mt in _BODY_MEDIA_PRIORITY:
+        if mt in content:
+            media = content[mt]
+            break
+    if media is None and content:
+        media = next(iter(content.values()))
+    if not isinstance(media, dict):
+        return None, None
+    sch = media.get("schema")
+    if not isinstance(sch, dict):
+        return None, None
+    if "$ref" in sch:
+        return _ref_name(sch["$ref"]), None
+    return None, sch
+
+
+def _response_schema(spec: dict[str, Any], op: dict[str, Any]) -> tuple[str | None, dict | None]:
+    responses = op.get("responses", {}) or {}
+    for code in ("200", "201", "202", "2XX", "default"):
+        if code in responses:
+            return _schema_from_content(spec, responses[code])
+    for code, resp in responses.items():
+        if str(code).startswith("2"):
+            return _schema_from_content(spec, resp)
+    return None, None
+
+
+def _iter_field_defs(spec: dict[str, Any], schema: dict[str, Any]) -> list[tuple[str, dict, bool]]:
+    """Yield (field_name, field_def, required) for a schema, following allOf.
+
+    Inline ``allOf`` members are merged; ``$ref`` members are left to their own
+    indexed schema row (navigable via the composition). oneOf/anyOf are not
+    flattened (their variants are separate schemas).
+    """
+    out: list[tuple[str, dict, bool]] = []
+    required = set(schema.get("required", []) or [])
+    props = schema.get("properties", {}) or {}
+    for fname, fdef in props.items():
+        if isinstance(fdef, dict):
+            out.append((fname, fdef, fname in required))
+    for member in schema.get("allOf", []) or []:
+        if isinstance(member, dict) and "properties" in member:
+            member_req = set(member.get("required", []) or [])
+            for fname, fdef in (member.get("properties") or {}).items():
+                if isinstance(fdef, dict):
+                    out.append((fname, fdef, fname in required or fname in member_req))
+    return out
+
+
+def _field_row(fname: str, fdef: dict[str, Any], required: bool) -> dict[str, Any]:
+    ref = _ref_name(fdef.get("$ref"))
+    item_type = item_ref = None
+    items = fdef.get("items")
+    if isinstance(items, dict):
+        item_ref = _ref_name(items.get("$ref"))
+        item_type = items.get("type")
+    enum = fdef.get("enum")
+    constraints = {k: fdef[k] for k in _CONSTRAINT_KEYS if k in fdef}
+    return {
+        "field_name": fname,
+        "type": _as_type(fdef.get("type")),
+        "ref_schema": ref,
+        "item_type": _as_type(item_type),
+        "item_ref": item_ref,
+        "format": fdef.get("format"),
+        "required": 1 if required else 0,
+        "default": json.dumps(fdef["default"]) if "default" in fdef else None,
+        "enum_json": json.dumps(enum) if isinstance(enum, list) and enum else None,
+        "constraints_json": json.dumps(constraints) if constraints else None,
+        "description": fdef.get("description"),
+    }
+
+
+_SCHEMA = """
+CREATE TABLE endpoints (
+    id INTEGER PRIMARY KEY, platform TEXT, spec_file TEXT, path TEXT, method TEXT,
+    operation_id TEXT, summary TEXT, description TEXT, tags TEXT,
+    request_schema TEXT, response_schema TEXT, trust TEXT
+);
+CREATE TABLE parameters (
+    id INTEGER PRIMARY KEY, endpoint_id INTEGER, name TEXT, location TEXT,
+    required INTEGER, type TEXT, format TEXT, enum_json TEXT, description TEXT
+);
+CREATE TABLE schemas (
+    id INTEGER PRIMARY KEY, platform TEXT, spec_file TEXT, schema_name TEXT,
+    description TEXT, enum_json TEXT, trust TEXT
+);
+CREATE TABLE fields (
+    id INTEGER PRIMARY KEY, schema_id INTEGER, field_name TEXT, type TEXT,
+    ref_schema TEXT, item_type TEXT, item_ref TEXT, format TEXT, required INTEGER,
+    "default" TEXT, enum_json TEXT, constraints_json TEXT, description TEXT
+);
+CREATE INDEX idx_endpoints_platform ON endpoints(platform);
+CREATE INDEX idx_endpoints_opid ON endpoints(operation_id);
+CREATE INDEX idx_endpoints_path ON endpoints(path);
+CREATE INDEX idx_params_endpoint ON parameters(endpoint_id);
+CREATE INDEX idx_schemas_name ON schemas(platform, schema_name);
+CREATE INDEX idx_fields_schema ON fields(schema_id);
+CREATE INDEX idx_fields_name ON fields(field_name);
+-- FTS rowid == the corresponding base-table id, so joins use ``fts.rowid = base.id``.
+CREATE VIRTUAL TABLE endpoints_fts USING fts5(text);
+CREATE VIRTUAL TABLE fields_fts USING fts5(text);
+CREATE VIRTUAL TABLE schemas_fts USING fts5(text);
+CREATE VIRTUAL TABLE parameters_fts USING fts5(text);
+"""
+
+
+def build(db_path: Path) -> dict[str, int]:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+    con = sqlite3.connect(db_path)
+    con.executescript(_SCHEMA)
+    counts = {"specs": 0, "endpoints": 0, "parameters": 0, "schemas": 0, "fields": 0, "skipped": 0}
+
+    for spec_path in sorted(VENDOR.rglob("*.json")):
+        platform = _platform_of(spec_path)
+        if platform in EXCLUDED_PLATFORMS:
+            continue
+        spec = _load_spec(spec_path)
+        if spec is None:
+            counts["skipped"] += 1
+            continue
+        counts["specs"] += 1
+        trust = PLATFORM_TRUST.get(platform, "high")
+        spec_file = str(spec_path.relative_to(ROOT))
+
+        # --- component schemas (index each once) ---
+        for sname, sdef in (spec.get("components", {}).get("schemas", {}) or {}).items():
+            if not isinstance(sdef, dict):
+                continue
+            _insert_schema(con, platform, spec_file, trust, sname, sdef, spec, counts)
+
+        # --- paths → endpoints, params, inline schemas ---
+        for path, path_item in (spec.get("paths", {}) or {}).items():
+            if not isinstance(path_item, dict):
+                continue
+            shared_params = path_item.get("parameters", []) or []
+            for method in ("get", "post", "put", "patch", "delete"):
+                op = path_item.get(method)
+                if not isinstance(op, dict):
+                    continue
+                req_name, req_inline = _schema_from_content(spec, op.get("requestBody", {}) or {})
+                resp_name, resp_inline = _response_schema(spec, op)
+                op_id = op.get("operationId")
+
+                # Synthesize schema rows for inline request/response bodies.
+                synth = op_id or f"{method}:{path}"
+                if req_inline is not None:
+                    req_name = _index_inline_schema(
+                        con, platform, spec_file, trust, f"{synth}__request", spec, req_inline, counts
+                    )
+                if resp_inline is not None:
+                    resp_name = _index_inline_schema(
+                        con, platform, spec_file, trust, f"{synth}__response", spec, resp_inline, counts
+                    )
+
+                cur = con.execute(
+                    "INSERT INTO endpoints(platform, spec_file, path, method, operation_id, summary, "
+                    "description, tags, request_schema, response_schema, trust) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        platform,
+                        spec_file,
+                        path,
+                        method.upper(),
+                        op_id,
+                        op.get("summary"),
+                        op.get("description"),
+                        json.dumps(op.get("tags")) if op.get("tags") else None,
+                        req_name,
+                        resp_name,
+                        trust,
+                    ),
+                )
+                eid = cur.lastrowid
+                counts["endpoints"] += 1
+                con.execute(
+                    "INSERT INTO endpoints_fts(rowid, text) VALUES (?,?)",
+                    (eid, f"{path} {op_id or ''} {op.get('summary') or ''} {' '.join(op.get('tags') or [])}"),
+                )
+                for p in list(shared_params) + list(op.get("parameters", []) or []):
+                    _insert_parameter(con, spec, eid, p, counts)
+
+    con.commit()
+    con.execute("INSERT INTO endpoints_fts(endpoints_fts) VALUES('optimize')")
+    con.execute("INSERT INTO fields_fts(fields_fts) VALUES('optimize')")
+    con.commit()
+    con.close()
+    return counts
+
+
+def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], counts: dict[str, int]) -> None:
+    cur = con.execute(
+        "INSERT INTO fields(schema_id, field_name, type, ref_schema, item_type, item_ref, format, "
+        'required, "default", enum_json, constraints_json, description) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
+        (
+            schema_id,
+            row["field_name"],
+            row["type"],
+            row["ref_schema"],
+            row["item_type"],
+            row["item_ref"],
+            row["format"],
+            row["required"],
+            row["default"],
+            row["enum_json"],
+            row["constraints_json"],
+            row["description"],
+        ),
+    )
+    counts["fields"] += 1
+    enum_text = " ".join(str(v) for v in json.loads(row["enum_json"])) if row["enum_json"] else ""
+    con.execute(
+        "INSERT INTO fields_fts(rowid, text) VALUES (?,?)",
+        (cur.lastrowid, f"{row['field_name']} {row['description'] or ''} {enum_text}"),
+    )
+
+
+def _insert_schema(
+    con: sqlite3.Connection,
+    platform: str,
+    spec_file: str,
+    trust: str,
+    name: str,
+    sdef: dict[str, Any],
+    spec: dict[str, Any],
+    counts: dict[str, int],
+) -> int:
+    """Index one schema row (+ its fields, + FTS). Captures a schema-LEVEL enum.
+
+    Mist / ClearPass model an enum as a standalone named schema whose root is
+    ``{"type": "string", "enum": [...]}`` (referenced by fields via ``$ref``), so
+    the enum lives on the schema, not a property. Storing it here lets enrichment
+    resolve a field's legal values by following ``ref_schema`` to this row.
+    """
+    enum = sdef.get("enum")
+    enum_json = json.dumps(enum) if isinstance(enum, list) and enum else None
+    cur = con.execute(
+        "INSERT INTO schemas(platform, spec_file, schema_name, description, enum_json, trust) VALUES (?,?,?,?,?,?)",
+        (platform, spec_file, name, sdef.get("description"), enum_json, trust),
+    )
+    sid = cur.lastrowid
+    counts["schemas"] += 1
+    enum_text = " ".join(str(v) for v in enum) if isinstance(enum, list) else ""
+    con.execute(
+        "INSERT INTO schemas_fts(rowid, text) VALUES (?,?)",
+        (sid, f"{name} {sdef.get('description') or ''} {enum_text}"),
+    )
+    for fname, fdef, req in _iter_field_defs(spec, sdef):
+        _insert_field(con, sid, _field_row(fname, fdef, req), counts)
+    return sid
+
+
+def _index_inline_schema(
+    con: sqlite3.Connection,
+    platform: str,
+    spec_file: str,
+    trust: str,
+    name: str,
+    spec: dict[str, Any],
+    schema: dict[str, Any],
+    counts: dict[str, int],
+) -> str:
+    _insert_schema(con, platform, spec_file, trust, name, schema, spec, counts)
+    return name
+
+
+def _insert_parameter(
+    con: sqlite3.Connection, spec: dict[str, Any], endpoint_id: int, param: Any, counts: dict[str, int]
+) -> None:
+    if isinstance(param, dict) and "$ref" in param:
+        param = _resolve_ref(spec, param["$ref"])
+    if not isinstance(param, dict) or not param.get("name"):
+        return
+    psch = param.get("schema", {}) or {}
+    enum = psch.get("enum")
+    cur = con.execute(
+        "INSERT INTO parameters(endpoint_id, name, location, required, type, format, enum_json, description) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            endpoint_id,
+            param.get("name"),
+            param.get("in"),
+            1 if param.get("required") else 0,
+            _as_type(psch.get("type")),
+            psch.get("format"),
+            json.dumps(enum) if isinstance(enum, list) and enum else None,
+            param.get("description"),
+        ),
+    )
+    counts["parameters"] += 1
+    enum_text = " ".join(str(v) for v in enum) if isinstance(enum, list) else ""
+    con.execute(
+        "INSERT INTO parameters_fts(rowid, text) VALUES (?,?)",
+        (cur.lastrowid, f"{param.get('name')} {param.get('description') or ''} {enum_text}"),
+    )
+
+
+def main() -> int:
+    db_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_DB
+    counts = build(db_path)
+    size_mb = db_path.stat().st_size / 1_000_000
+    print(f"spec index → {db_path}  ({size_mb:.1f} MB)")
+    for k, v in counts.items():
+        print(f"  {k:12} {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_spec_index.py
+++ b/scripts/build_spec_index.py
@@ -227,6 +227,9 @@ def _field_row(fname: str, fdef: dict[str, Any], required: bool) -> dict[str, An
         "deprecated_note": _deprecated_note(fdef),
         "example": _example_json(fdef),
         "variants_json": json.dumps(variants) if variants else None,
+        "device_types": (
+            json.dumps(fdef["x-supportedDeviceType"]) if isinstance(fdef.get("x-supportedDeviceType"), list) else None
+        ),
         "description": fdef.get("description"),
     }
 
@@ -254,7 +257,8 @@ CREATE TABLE fields (
     id INTEGER PRIMARY KEY, schema_id INTEGER, field_name TEXT, type TEXT,
     ref_schema TEXT, item_type TEXT, item_ref TEXT, format TEXT, required INTEGER,
     "default" TEXT, enum_json TEXT, constraints_json TEXT, read_only INTEGER,
-    write_only INTEGER, deprecated INTEGER, deprecated_note TEXT, example TEXT, variants TEXT, description TEXT
+    write_only INTEGER, deprecated INTEGER, deprecated_note TEXT, example TEXT, variants TEXT,
+    device_types TEXT, description TEXT
 );
 CREATE INDEX idx_endpoints_platform ON endpoints(platform);
 CREATE INDEX idx_endpoints_opid ON endpoints(operation_id);
@@ -367,7 +371,8 @@ def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], 
     cur = con.execute(
         "INSERT INTO fields(schema_id, field_name, type, ref_schema, item_type, item_ref, format, "
         'required, "default", enum_json, constraints_json, read_only, write_only, deprecated, '
-        "deprecated_note, example, variants, description) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        "deprecated_note, example, variants, device_types, description) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
             schema_id,
             row["field_name"],
@@ -386,6 +391,7 @@ def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], 
             row["deprecated_note"],
             row["example"],
             row["variants_json"],
+            row["device_types"],
             row["description"],
         ),
     )

--- a/scripts/build_spec_index.py
+++ b/scripts/build_spec_index.py
@@ -82,6 +82,51 @@ def _as_type(value: Any) -> str | None:
     return str(value)
 
 
+def _example_json(node: dict[str, Any]) -> str | None:
+    """A representative example from a schema/param/media node, JSON-encoded.
+
+    Prefers the singular ``example``; falls back to the first ``value`` of an
+    ``examples`` map (OpenAPI media-type / parameter style — e.g. Mist's request
+    body examples). Gives the model a known-valid starting value.
+    """
+    if "example" in node:
+        return json.dumps(node["example"])
+    examples = node.get("examples")
+    if isinstance(examples, dict):
+        for ex in examples.values():
+            if isinstance(ex, dict) and "value" in ex:
+                return json.dumps(ex["value"])
+    return None
+
+
+def _deprecated_note(node: dict[str, Any]) -> str | None:
+    """Deprecation reason/sunset text from vendor extensions, if present.
+
+    OpenAPI ``deprecated`` is only a boolean; vendors carry the *why*/*when* in
+    ``x-deprecation-notice`` / ``x-deprecated-reason`` (EdgeConnect) — or inline
+    in ``description`` (GreenLake), which is already indexed. Surfacing the
+    extension lets the model see the sunset context.
+    """
+    note = node.get("x-deprecation-notice") or node.get("x-deprecated-reason")
+    return str(note) if note else None
+
+
+def _variant_refs(node: dict[str, Any]) -> list[str]:
+    """Schema names a field/schema may take via ``oneOf``/``anyOf`` (alternatives).
+
+    Unlike ``allOf`` (merged), these are mutually-exclusive shapes; capturing the
+    variant names lets enrichment show "this may be any of [A, B, C]".
+    """
+    out: list[str] = []
+    for key in ("oneOf", "anyOf"):
+        for member in node.get(key, []) or []:
+            if isinstance(member, dict):
+                name = _ref_name(member.get("$ref"))
+                if name:
+                    out.append(name)
+    return out
+
+
 def _resolve_ref(spec: dict[str, Any], ref: str) -> Any:
     """Resolve a local ``#/a/b/c`` JSON pointer within one spec."""
     node: Any = spec
@@ -116,15 +161,21 @@ def _schema_from_content(spec: dict[str, Any], container: dict[str, Any]) -> tup
     return None, sch
 
 
-def _response_schema(spec: dict[str, Any], op: dict[str, Any]) -> tuple[str | None, dict | None]:
-    responses = op.get("responses", {}) or {}
-    for code in ("200", "201", "202", "2XX", "default"):
-        if code in responses:
-            return _schema_from_content(spec, responses[code])
-    for code, resp in responses.items():
-        if str(code).startswith("2"):
-            return _schema_from_content(spec, resp)
-    return None, None
+def _request_example(spec: dict[str, Any], request_body: dict[str, Any]) -> str | None:
+    """A copy-paste-valid request body example, if the spec provides one."""
+    if not isinstance(request_body, dict):
+        return None
+    if "$ref" in request_body:
+        request_body = _resolve_ref(spec, request_body["$ref"]) or {}
+    content = request_body.get("content", {}) or {}
+    media = None
+    for mt in _BODY_MEDIA_PRIORITY:
+        if mt in content:
+            media = content[mt]
+            break
+    if media is None and content:
+        media = next(iter(content.values()))
+    return _example_json(media) if isinstance(media, dict) else None
 
 
 def _iter_field_defs(spec: dict[str, Any], schema: dict[str, Any]) -> list[tuple[str, dict, bool]]:
@@ -158,6 +209,7 @@ def _field_row(fname: str, fdef: dict[str, Any], required: bool) -> dict[str, An
         item_type = items.get("type")
     enum = fdef.get("enum")
     constraints = {k: fdef[k] for k in _CONSTRAINT_KEYS if k in fdef}
+    variants = _variant_refs(fdef)
     return {
         "field_name": fname,
         "type": _as_type(fdef.get("type")),
@@ -169,6 +221,12 @@ def _field_row(fname: str, fdef: dict[str, Any], required: bool) -> dict[str, An
         "default": json.dumps(fdef["default"]) if "default" in fdef else None,
         "enum_json": json.dumps(enum) if isinstance(enum, list) and enum else None,
         "constraints_json": json.dumps(constraints) if constraints else None,
+        "read_only": 1 if fdef.get("readOnly") else 0,
+        "write_only": 1 if fdef.get("writeOnly") else 0,
+        "deprecated": 1 if fdef.get("deprecated") else 0,
+        "deprecated_note": _deprecated_note(fdef),
+        "example": _example_json(fdef),
+        "variants_json": json.dumps(variants) if variants else None,
         "description": fdef.get("description"),
     }
 
@@ -177,24 +235,31 @@ _SCHEMA = """
 CREATE TABLE endpoints (
     id INTEGER PRIMARY KEY, platform TEXT, spec_file TEXT, path TEXT, method TEXT,
     operation_id TEXT, summary TEXT, description TEXT, tags TEXT,
-    request_schema TEXT, response_schema TEXT, trust TEXT
+    request_schema TEXT, request_example TEXT, deprecated INTEGER, deprecated_note TEXT, trust TEXT
+);
+CREATE TABLE responses (
+    id INTEGER PRIMARY KEY, endpoint_id INTEGER, status_code TEXT,
+    description TEXT, schema_name TEXT
 );
 CREATE TABLE parameters (
     id INTEGER PRIMARY KEY, endpoint_id INTEGER, name TEXT, location TEXT,
-    required INTEGER, type TEXT, format TEXT, enum_json TEXT, description TEXT
+    required INTEGER, type TEXT, format TEXT, enum_json TEXT, example TEXT,
+    deprecated INTEGER, description TEXT
 );
 CREATE TABLE schemas (
     id INTEGER PRIMARY KEY, platform TEXT, spec_file TEXT, schema_name TEXT,
-    description TEXT, enum_json TEXT, trust TEXT
+    description TEXT, enum_json TEXT, example TEXT, variants TEXT, trust TEXT
 );
 CREATE TABLE fields (
     id INTEGER PRIMARY KEY, schema_id INTEGER, field_name TEXT, type TEXT,
     ref_schema TEXT, item_type TEXT, item_ref TEXT, format TEXT, required INTEGER,
-    "default" TEXT, enum_json TEXT, constraints_json TEXT, description TEXT
+    "default" TEXT, enum_json TEXT, constraints_json TEXT, read_only INTEGER,
+    write_only INTEGER, deprecated INTEGER, deprecated_note TEXT, example TEXT, variants TEXT, description TEXT
 );
 CREATE INDEX idx_endpoints_platform ON endpoints(platform);
 CREATE INDEX idx_endpoints_opid ON endpoints(operation_id);
 CREATE INDEX idx_endpoints_path ON endpoints(path);
+CREATE INDEX idx_responses_endpoint ON responses(endpoint_id);
 CREATE INDEX idx_params_endpoint ON parameters(endpoint_id);
 CREATE INDEX idx_schemas_name ON schemas(platform, schema_name);
 CREATE INDEX idx_fields_schema ON fields(schema_id);
@@ -204,6 +269,7 @@ CREATE VIRTUAL TABLE endpoints_fts USING fts5(text);
 CREATE VIRTUAL TABLE fields_fts USING fts5(text);
 CREATE VIRTUAL TABLE schemas_fts USING fts5(text);
 CREATE VIRTUAL TABLE parameters_fts USING fts5(text);
+CREATE VIRTUAL TABLE responses_fts USING fts5(text);
 """
 
 
@@ -213,7 +279,15 @@ def build(db_path: Path) -> dict[str, int]:
         db_path.unlink()
     con = sqlite3.connect(db_path)
     con.executescript(_SCHEMA)
-    counts = {"specs": 0, "endpoints": 0, "parameters": 0, "schemas": 0, "fields": 0, "skipped": 0}
+    counts = {
+        "specs": 0,
+        "endpoints": 0,
+        "responses": 0,
+        "parameters": 0,
+        "schemas": 0,
+        "fields": 0,
+        "skipped": 0,
+    }
 
     for spec_path in sorted(VENDOR.rglob("*.json")):
         platform = _platform_of(spec_path)
@@ -242,24 +316,19 @@ def build(db_path: Path) -> dict[str, int]:
                 op = path_item.get(method)
                 if not isinstance(op, dict):
                     continue
-                req_name, req_inline = _schema_from_content(spec, op.get("requestBody", {}) or {})
-                resp_name, resp_inline = _response_schema(spec, op)
+                request_body = op.get("requestBody", {}) or {}
+                req_name, req_inline = _schema_from_content(spec, request_body)
                 op_id = op.get("operationId")
-
-                # Synthesize schema rows for inline request/response bodies.
                 synth = op_id or f"{method}:{path}"
                 if req_inline is not None:
                     req_name = _index_inline_schema(
                         con, platform, spec_file, trust, f"{synth}__request", spec, req_inline, counts
                     )
-                if resp_inline is not None:
-                    resp_name = _index_inline_schema(
-                        con, platform, spec_file, trust, f"{synth}__response", spec, resp_inline, counts
-                    )
 
                 cur = con.execute(
                     "INSERT INTO endpoints(platform, spec_file, path, method, operation_id, summary, "
-                    "description, tags, request_schema, response_schema, trust) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    "description, tags, request_schema, request_example, deprecated, deprecated_note, trust) "
+                    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
                     (
                         platform,
                         spec_file,
@@ -270,7 +339,9 @@ def build(db_path: Path) -> dict[str, int]:
                         op.get("description"),
                         json.dumps(op.get("tags")) if op.get("tags") else None,
                         req_name,
-                        resp_name,
+                        _request_example(spec, request_body),
+                        1 if op.get("deprecated") else 0,
+                        _deprecated_note(op),
                         trust,
                     ),
                 )
@@ -280,6 +351,7 @@ def build(db_path: Path) -> dict[str, int]:
                     "INSERT INTO endpoints_fts(rowid, text) VALUES (?,?)",
                     (eid, f"{path} {op_id or ''} {op.get('summary') or ''} {' '.join(op.get('tags') or [])}"),
                 )
+                _insert_responses(con, spec, platform, spec_file, trust, eid, synth, op, counts)
                 for p in list(shared_params) + list(op.get("parameters", []) or []):
                     _insert_parameter(con, spec, eid, p, counts)
 
@@ -294,7 +366,8 @@ def build(db_path: Path) -> dict[str, int]:
 def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], counts: dict[str, int]) -> None:
     cur = con.execute(
         "INSERT INTO fields(schema_id, field_name, type, ref_schema, item_type, item_ref, format, "
-        'required, "default", enum_json, constraints_json, description) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
+        'required, "default", enum_json, constraints_json, read_only, write_only, deprecated, '
+        "deprecated_note, example, variants, description) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
             schema_id,
             row["field_name"],
@@ -307,6 +380,12 @@ def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], 
             row["default"],
             row["enum_json"],
             row["constraints_json"],
+            row["read_only"],
+            row["write_only"],
+            row["deprecated"],
+            row["deprecated_note"],
+            row["example"],
+            row["variants_json"],
             row["description"],
         ),
     )
@@ -316,6 +395,45 @@ def _insert_field(con: sqlite3.Connection, schema_id: int, row: dict[str, Any], 
         "INSERT INTO fields_fts(rowid, text) VALUES (?,?)",
         (cur.lastrowid, f"{row['field_name']} {row['description'] or ''} {enum_text}"),
     )
+
+
+def _insert_responses(
+    con: sqlite3.Connection,
+    spec: dict[str, Any],
+    platform: str,
+    spec_file: str,
+    trust: str,
+    endpoint_id: int,
+    synth: str,
+    op: dict[str, Any],
+    counts: dict[str, int],
+) -> None:
+    """Record every declared response (all status codes) + its description + body.
+
+    The description is what tells the model "429 = rate limited". The success
+    (2xx) body schema is materialized so its fields are queryable; inline error
+    bodies are not synthesized (keeps the index bounded — ClearPass alone has
+    thousands of error responses).
+    """
+    for code, resp in (op.get("responses") or {}).items():
+        if isinstance(resp, dict) and "$ref" in resp:
+            resp = _resolve_ref(spec, resp["$ref"]) or {}
+        if not isinstance(resp, dict):
+            continue
+        schema_name, inline = _schema_from_content(spec, resp)
+        if inline is not None and str(code).startswith("2"):
+            schema_name = _index_inline_schema(
+                con, platform, spec_file, trust, f"{synth}__resp_{code}", spec, inline, counts
+            )
+        cur = con.execute(
+            "INSERT INTO responses(endpoint_id, status_code, description, schema_name) VALUES (?,?,?,?)",
+            (endpoint_id, str(code), resp.get("description"), schema_name),
+        )
+        counts["responses"] += 1
+        con.execute(
+            "INSERT INTO responses_fts(rowid, text) VALUES (?,?)",
+            (cur.lastrowid, f"{code} {resp.get('description') or ''}"),
+        )
 
 
 def _insert_schema(
@@ -337,9 +455,20 @@ def _insert_schema(
     """
     enum = sdef.get("enum")
     enum_json = json.dumps(enum) if isinstance(enum, list) and enum else None
+    variants = _variant_refs(sdef)
     cur = con.execute(
-        "INSERT INTO schemas(platform, spec_file, schema_name, description, enum_json, trust) VALUES (?,?,?,?,?,?)",
-        (platform, spec_file, name, sdef.get("description"), enum_json, trust),
+        "INSERT INTO schemas(platform, spec_file, schema_name, description, enum_json, example, variants, trust) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            platform,
+            spec_file,
+            name,
+            sdef.get("description"),
+            enum_json,
+            _example_json(sdef),
+            json.dumps(variants) if variants else None,
+            trust,
+        ),
     )
     sid = cur.lastrowid
     counts["schemas"] += 1
@@ -377,8 +506,8 @@ def _insert_parameter(
     psch = param.get("schema", {}) or {}
     enum = psch.get("enum")
     cur = con.execute(
-        "INSERT INTO parameters(endpoint_id, name, location, required, type, format, enum_json, description) "
-        "VALUES (?,?,?,?,?,?,?,?)",
+        "INSERT INTO parameters(endpoint_id, name, location, required, type, format, enum_json, "
+        "example, deprecated, description) VALUES (?,?,?,?,?,?,?,?,?,?)",
         (
             endpoint_id,
             param.get("name"),
@@ -387,6 +516,8 @@ def _insert_parameter(
             _as_type(psch.get("type")),
             psch.get("format"),
             json.dumps(enum) if isinstance(enum, list) and enum else None,
+            _example_json(param) or _example_json(psch),
+            1 if param.get("deprecated") else 0,
             param.get("description"),
         ),
     )

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -866,6 +866,52 @@ def _make_skill_aware_search(tool: FunctionTool) -> _SkillAwareSearchTool:
     return aware
 
 
+class _SpecEnrichedGetSchemaTool(_ArgTolerantFunctionTool):
+    """`get_schema` that appends spec-index payload schemas for config tools.
+
+    The opaque ``payload: dict`` config tools (``central_manage_*`` /
+    ``central_get_*``) expose no body field set, so the model authors the payload
+    blind — the failure mode behind the AP-rename report. For each requested tool
+    that resolves to a config object, append its network-config body schema
+    (fields, enums, examples, constraints, device types, scope params) from the
+    spec index. Inert for non-config tools and when the index is unavailable, so
+    the base ``get_schema`` output is otherwise unchanged. Structural enrichment
+    (the ``_SkillAwareSearchTool`` pattern), not an instruction the model must
+    trust.
+    """
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        from mcp.types import TextContent
+
+        from hpe_networking_mcp.spec_index.tool_schema import payload_schema_for_tool, render_payload_schema
+
+        result = await super().run(arguments)
+        tools = (arguments or {}).get("tools") or []
+        if isinstance(tools, str):
+            tools = [tools]
+        blocks: list[str] = []
+        for name in tools:
+            if not isinstance(name, str):
+                continue
+            try:
+                schema = payload_schema_for_tool(name)
+            except Exception as exc:  # enrichment must never break discovery
+                logger.warning("get_schema: spec-index enrichment failed for {!r} — {}", name, exc)
+                continue
+            if schema:
+                blocks.append(render_payload_schema(name, schema))
+        if not blocks:
+            return result
+        result.content = [*result.content, TextContent(type="text", text="\n\n" + "\n\n".join(blocks))]
+        return result
+
+
+def _make_spec_enriched_get_schema(tool: FunctionTool) -> _SpecEnrichedGetSchemaTool:
+    """Reconstruct the produced `get_schema` tool as the spec-enriched subclass,
+    preserving the #488 arg-tolerance."""
+    return _SpecEnrichedGetSchemaTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
+
+
 def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
@@ -914,7 +960,7 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
         def __call__(self, get_catalog):
             tool = super().__call__(get_catalog)
             tool.description = _GET_SCHEMA_DESCRIPTION
-            return _make_arg_tolerant(tool)
+            return _make_spec_enriched_get_schema(tool)
 
     limits = ResourceLimits(
         max_duration_secs=max_duration_secs,

--- a/src/hpe_networking_mcp/spec_index/__init__.py
+++ b/src/hpe_networking_mcp/spec_index/__init__.py
@@ -1,0 +1,14 @@
+"""Read-only spec-lookup index (deterministic OpenAPI field/enum/endpoint lookup).
+
+Backed by the SQLite/FTS5 index built by ``scripts/build_spec_index.py`` from the
+vendored OpenAPI corpus. Powers exact "which endpoint / field / enum / parameter"
+answers for ``get_schema`` enrichment and validation-error enrichment — no model,
+no embeddings, no hallucination. Degrades to empty results when the index file is
+absent (e.g. a dev checkout where it was not baked), so callers never crash.
+"""
+
+from __future__ import annotations
+
+from hpe_networking_mcp.spec_index.query import SpecIndex, get_spec_index
+
+__all__ = ["SpecIndex", "get_spec_index"]

--- a/src/hpe_networking_mcp/spec_index/query.py
+++ b/src/hpe_networking_mcp/spec_index/query.py
@@ -190,6 +190,44 @@ class SpecIndex:
             "parameters": params,
         }
 
+    def config_body(self, platform: str, resource: str) -> dict[str, Any] | None:
+        """Resolve a config-object's writable body schema by its path segment.
+
+        Maps a resource segment (e.g. ``"system-info"``) to its write endpoint
+        (``.../network-config/.../system-info/{name}``), returning the body
+        field set plus the scope query params a caller must supply. This is what
+        powers ``get_schema`` enrichment for the opaque ``payload: dict`` config
+        tools — the model no longer authors the body blind. Returns ``None`` when
+        no matching writable endpoint is found.
+        """
+        con = self._conn()
+        if con is None:
+            return None
+        row = con.execute(
+            "SELECT * FROM endpoints WHERE platform=? AND request_schema IS NOT NULL "
+            "AND (path LIKE ? OR path LIKE ?) "
+            "ORDER BY CASE method WHEN 'PATCH' THEN 0 WHEN 'PUT' THEN 1 WHEN 'POST' THEN 2 ELSE 3 END LIMIT 1",
+            (platform, f"%/{resource}", f"%/{resource}/%"),
+        ).fetchone()
+        if row is None:
+            return None
+        fields = self.schema_fields(platform, row["request_schema"])
+        if not fields:
+            return None
+        scope_params = [
+            {"name": p["name"], "in": p["location"], "required": bool(p["required"]), "description": p["description"]}
+            for p in con.execute(
+                "SELECT * FROM parameters WHERE endpoint_id=? AND location='query' ORDER BY name", (row["id"],)
+            )
+        ]
+        return {
+            "object": resource,
+            "path": row["path"],
+            "method": row["method"],
+            "fields": fields,
+            "scope_parameters": scope_params,
+        }
+
     def search(
         self, query: str, *, kind: str = "field", platform: str | None = None, limit: int = 20
     ) -> list[dict[str, Any]]:

--- a/src/hpe_networking_mcp/spec_index/query.py
+++ b/src/hpe_networking_mcp/spec_index/query.py
@@ -110,6 +110,7 @@ class SpecIndex:
                     "write_only": bool(f["write_only"]),
                     "deprecated": bool(f["deprecated"]),
                     "deprecated_note": f["deprecated_note"],
+                    "device_types": json.loads(f["device_types"]) if f["device_types"] else None,
                     "description": f["description"],
                 }
             )

--- a/src/hpe_networking_mcp/spec_index/query.py
+++ b/src/hpe_networking_mcp/spec_index/query.py
@@ -1,0 +1,233 @@
+"""Read-only query layer over the baked spec-lookup index.
+
+See ``scripts/build_spec_index.py`` for the schema. This module is the interface
+the enrichment consumers use; it never mutates the index and never raises on a
+missing/corrupt index — it reports ``available == False`` and returns empty
+results so ``get_schema`` / error enrichment degrade to "no hint" instead of
+failing.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DB = Path(__file__).resolve().parent / "spec_index.db"
+
+
+def _clean_fts_query(query: str) -> str:
+    """Quote each term so arbitrary user text can't break FTS5 MATCH syntax."""
+    terms = [t.replace('"', "") for t in query.split() if t.strip()]
+    return " ".join(f'"{t}"' for t in terms)
+
+
+class SpecIndex:
+    """Deterministic lookups over the vendored OpenAPI specs.
+
+    Args:
+        db_path: Override the index location (defaults to the baked
+            ``spec_index.db`` beside this module). Missing file → ``available``
+            is False and all queries return empty.
+    """
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self._path = Path(db_path) if db_path else _DEFAULT_DB
+        self._con: sqlite3.Connection | None = None
+
+    @property
+    def available(self) -> bool:
+        """True when the index file exists and can back queries."""
+        return self._path.exists()
+
+    def _conn(self) -> sqlite3.Connection | None:
+        if not self.available:
+            return None
+        if self._con is None:
+            self._con = sqlite3.connect(f"file:{self._path}?mode=ro", uri=True, check_same_thread=False)
+            self._con.row_factory = sqlite3.Row
+        return self._con
+
+    # ----- enum resolution -----
+
+    def _schema_enum(self, platform: str, schema_name: str | None) -> list[Any] | None:
+        if not schema_name:
+            return None
+        con = self._conn()
+        if con is None:
+            return None
+        row = con.execute(
+            "SELECT enum_json FROM schemas WHERE platform=? AND schema_name=? AND enum_json IS NOT NULL LIMIT 1",
+            (platform, schema_name),
+        ).fetchone()
+        return json.loads(row["enum_json"]) if row else None
+
+    def _resolve_field_enum(self, platform: str, field: sqlite3.Row | dict) -> list[Any] | None:
+        """A field's legal values: its own ``enum``, else the enum of the schema
+        it ``$ref``s (Mist/ClearPass model enums as standalone named schemas)."""
+        raw = field["enum_json"] if field["enum_json"] else None
+        if raw:
+            return json.loads(raw)
+        enum = self._schema_enum(platform, field["ref_schema"])
+        if enum is not None:
+            return enum
+        return self._schema_enum(platform, field["item_ref"])
+
+    # ----- public API -----
+
+    def schema_fields(self, platform: str, schema_name: str) -> list[dict[str, Any]]:
+        """Every field of a schema, with enums resolved (incl. via ``$ref``).
+
+        Returns [] when the schema is unknown or the index is unavailable.
+        """
+        con = self._conn()
+        if con is None:
+            return []
+        srow = con.execute(
+            "SELECT id FROM schemas WHERE platform=? AND schema_name=? LIMIT 1", (platform, schema_name)
+        ).fetchone()
+        if srow is None:
+            return []
+        out: list[dict[str, Any]] = []
+        for f in con.execute("SELECT * FROM fields WHERE schema_id=? ORDER BY field_name", (srow["id"],)):
+            ftype = f["type"]
+            if ftype == "array" and (f["item_type"] or f["item_ref"]):
+                ftype = f"array[{f['item_type'] or f['item_ref']}]"
+            out.append(
+                {
+                    "name": f["field_name"],
+                    "type": ftype,
+                    "required": bool(f["required"]),
+                    "format": f["format"],
+                    "enum": self._resolve_field_enum(platform, f),
+                    "default": json.loads(f["default"]) if f["default"] else None,
+                    "ref_schema": f["ref_schema"] or f["item_ref"],
+                    "constraints": json.loads(f["constraints_json"]) if f["constraints_json"] else None,
+                    "description": f["description"],
+                }
+            )
+        return out
+
+    def field_enum(self, platform: str, schema_name: str, field_name: str) -> list[Any] | None:
+        """Legal values for one field, or None if it has no enum / is unknown."""
+        con = self._conn()
+        if con is None:
+            return None
+        row = con.execute(
+            "SELECT f.* FROM fields f JOIN schemas s ON f.schema_id=s.id "
+            "WHERE s.platform=? AND s.schema_name=? AND f.field_name=? LIMIT 1",
+            (platform, schema_name, field_name),
+        ).fetchone()
+        return self._resolve_field_enum(platform, row) if row else None
+
+    def endpoint(
+        self,
+        platform: str,
+        *,
+        path: str | None = None,
+        operation_id: str | None = None,
+        method: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Resolve one endpoint (by path and/or operationId) with its parameters."""
+        con = self._conn()
+        if con is None:
+            return None
+        clauses = ["platform=?"]
+        args: list[Any] = [platform]
+        if path:
+            clauses.append("path=?")
+            args.append(path)
+        if operation_id:
+            clauses.append("operation_id=?")
+            args.append(operation_id)
+        if method:
+            clauses.append("method=?")
+            args.append(method.upper())
+        row = con.execute(
+            f"SELECT * FROM endpoints WHERE {' AND '.join(clauses)} LIMIT 1",
+            args,  # noqa: S608 — clauses are literals
+        ).fetchone()
+        if row is None:
+            return None
+        params = [
+            {
+                "name": p["name"],
+                "in": p["location"],
+                "required": bool(p["required"]),
+                "type": p["type"],
+                "format": p["format"],
+                "enum": json.loads(p["enum_json"]) if p["enum_json"] else None,
+                "description": p["description"],
+            }
+            for p in con.execute("SELECT * FROM parameters WHERE endpoint_id=? ORDER BY name", (row["id"],))
+        ]
+        return {
+            "platform": row["platform"],
+            "path": row["path"],
+            "method": row["method"],
+            "operation_id": row["operation_id"],
+            "summary": row["summary"],
+            "request_schema": row["request_schema"],
+            "response_schema": row["response_schema"],
+            "trust": row["trust"],
+            "parameters": params,
+        }
+
+    def search(
+        self, query: str, *, kind: str = "field", platform: str | None = None, limit: int = 20
+    ) -> list[dict[str, Any]]:
+        """Free-text FTS over one facet.
+
+        Args:
+            query: Free text (quoted internally so it can't break MATCH syntax).
+            kind: ``"field"``, ``"endpoint"``, ``"schema"``, or ``"parameter"``.
+            platform: Optional platform filter.
+            limit: Max rows.
+        """
+        con = self._conn()
+        if con is None or not query.strip():
+            return []
+        match = _clean_fts_query(query)
+        if not match:
+            return []
+        specs = {
+            "field": (
+                "SELECT s.platform, s.schema_name, f.field_name AS name, f.type FROM fields_fts x "
+                "JOIN fields f ON f.id=x.rowid JOIN schemas s ON f.schema_id=s.id WHERE fields_fts MATCH ?"
+            ),
+            "endpoint": (
+                "SELECT e.platform, e.method, e.path, e.operation_id AS name FROM endpoints_fts x "
+                "JOIN endpoints e ON e.id=x.rowid WHERE endpoints_fts MATCH ?"
+            ),
+            "schema": (
+                "SELECT s.platform, s.schema_name AS name, s.description FROM schemas_fts x "
+                "JOIN schemas s ON s.id=x.rowid WHERE schemas_fts MATCH ?"
+            ),
+            "parameter": (
+                "SELECT e.platform, e.path, p.name, p.location FROM parameters_fts x "
+                "JOIN parameters p ON p.id=x.rowid JOIN endpoints e ON p.endpoint_id=e.id WHERE parameters_fts MATCH ?"
+            ),
+        }
+        sql = specs.get(kind)
+        if sql is None:
+            raise ValueError(f"kind must be one of {sorted(specs)}, got {kind!r}")
+        args: list[Any] = [match]
+        plat_col = "e.platform" if kind in ("endpoint", "parameter") else "s.platform"
+        if platform:
+            sql += f" AND {plat_col}=?"  # noqa: S608 — plat_col is a literal
+            args.append(platform)
+        sql += " LIMIT ?"
+        args.append(limit)
+        return [dict(r) for r in con.execute(sql, args)]
+
+
+_SINGLETON: SpecIndex | None = None
+
+
+def get_spec_index() -> SpecIndex:
+    """Return a process-wide :class:`SpecIndex` over the baked index."""
+    global _SINGLETON
+    if _SINGLETON is None:
+        _SINGLETON = SpecIndex()
+    return _SINGLETON

--- a/src/hpe_networking_mcp/spec_index/query.py
+++ b/src/hpe_networking_mcp/spec_index/query.py
@@ -103,7 +103,13 @@ class SpecIndex:
                     "enum": self._resolve_field_enum(platform, f),
                     "default": json.loads(f["default"]) if f["default"] else None,
                     "ref_schema": f["ref_schema"] or f["item_ref"],
+                    "variants": json.loads(f["variants"]) if f["variants"] else None,
                     "constraints": json.loads(f["constraints_json"]) if f["constraints_json"] else None,
+                    "example": json.loads(f["example"]) if f["example"] else None,
+                    "read_only": bool(f["read_only"]),
+                    "write_only": bool(f["write_only"]),
+                    "deprecated": bool(f["deprecated"]),
+                    "deprecated_note": f["deprecated_note"],
                     "description": f["description"],
                 }
             )
@@ -158,9 +164,15 @@ class SpecIndex:
                 "type": p["type"],
                 "format": p["format"],
                 "enum": json.loads(p["enum_json"]) if p["enum_json"] else None,
+                "example": json.loads(p["example"]) if p["example"] else None,
+                "deprecated": bool(p["deprecated"]),
                 "description": p["description"],
             }
             for p in con.execute("SELECT * FROM parameters WHERE endpoint_id=? ORDER BY name", (row["id"],))
+        ]
+        responses = [
+            {"status": r["status_code"], "description": r["description"], "schema": r["schema_name"]}
+            for r in con.execute("SELECT * FROM responses WHERE endpoint_id=? ORDER BY status_code", (row["id"],))
         ]
         return {
             "platform": row["platform"],
@@ -169,7 +181,10 @@ class SpecIndex:
             "operation_id": row["operation_id"],
             "summary": row["summary"],
             "request_schema": row["request_schema"],
-            "response_schema": row["response_schema"],
+            "request_example": json.loads(row["request_example"]) if row["request_example"] else None,
+            "responses": responses,
+            "deprecated": bool(row["deprecated"]),
+            "deprecated_note": row["deprecated_note"],
             "trust": row["trust"],
             "parameters": params,
         }
@@ -208,12 +223,16 @@ class SpecIndex:
                 "SELECT e.platform, e.path, p.name, p.location FROM parameters_fts x "
                 "JOIN parameters p ON p.id=x.rowid JOIN endpoints e ON p.endpoint_id=e.id WHERE parameters_fts MATCH ?"
             ),
+            "response": (
+                "SELECT e.platform, e.path, rs.status_code, rs.description FROM responses_fts x "
+                "JOIN responses rs ON rs.id=x.rowid JOIN endpoints e ON rs.endpoint_id=e.id WHERE responses_fts MATCH ?"
+            ),
         }
         sql = specs.get(kind)
         if sql is None:
             raise ValueError(f"kind must be one of {sorted(specs)}, got {kind!r}")
         args: list[Any] = [match]
-        plat_col = "e.platform" if kind in ("endpoint", "parameter") else "s.platform"
+        plat_col = "e.platform" if kind in ("endpoint", "parameter", "response") else "s.platform"
         if platform:
             sql += f" AND {plat_col}=?"  # noqa: S608 — plat_col is a literal
             args.append(platform)

--- a/src/hpe_networking_mcp/spec_index/query.py
+++ b/src/hpe_networking_mcp/spec_index/query.py
@@ -152,7 +152,7 @@ class SpecIndex:
             clauses.append("method=?")
             args.append(method.upper())
         row = con.execute(
-            f"SELECT * FROM endpoints WHERE {' AND '.join(clauses)} LIMIT 1",
+            f"SELECT * FROM endpoints WHERE {' AND '.join(clauses)} LIMIT 1",  # nosec B608 — clauses are literals, values parameterized
             args,  # noqa: S608 — clauses are literals
         ).fetchone()
         if row is None:
@@ -273,7 +273,7 @@ class SpecIndex:
         args: list[Any] = [match]
         plat_col = "e.platform" if kind in ("endpoint", "parameter", "response") else "s.platform"
         if platform:
-            sql += f" AND {plat_col}=?"  # noqa: S608 — plat_col is a literal
+            sql += f" AND {plat_col}=?"  # noqa: S608  # nosec B608 — plat_col is a literal, value parameterized
             args.append(platform)
         sql += " LIMIT ?"
         args.append(limit)

--- a/src/hpe_networking_mcp/spec_index/tool_schema.py
+++ b/src/hpe_networking_mcp/spec_index/tool_schema.py
@@ -1,0 +1,79 @@
+"""Map a tool name to its config-body schema via the spec index.
+
+The opaque ``payload: dict`` config tools (``central_manage_*`` / ``central_get_*``)
+give an AI client no field set to author against — the exact gap that left an
+operator guessing field names to rename an AP. This resolves such a tool to its
+network-config body schema in the spec index (fields + enums + examples +
+constraints + device types + the scope query params), so ``get_schema`` can
+surface it. Supersedes the distilled ``_config_payload_schemas.json`` mechanism:
+the index is complete (it has ``system-info``, which the distilled artifact
+lacked) and richer, and is the single schema source of truth.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hpe_networking_mcp.spec_index.query import get_spec_index
+
+# Config-body tool prefixes → their platform. The suffix after the prefix is the
+# resource path segment (underscores → hyphens): ``central_manage_system_info``
+# → ``system-info`` → ``/network-config/.../system-info/{name}``.
+_CONFIG_TOOL_PREFIXES: dict[str, str] = {
+    "central_manage_": "central",
+    "central_get_": "central",
+}
+
+_MAX_ENUM_SHOWN = 40
+
+
+def payload_schema_for_tool(tool_name: str) -> dict[str, Any] | None:
+    """Return the config-body schema for a config tool, or ``None``.
+
+    ``None`` covers every non-config tool, an unavailable index, and any tool
+    whose resource can't be resolved — callers treat it as "no enrichment".
+    """
+    if not tool_name:
+        return None
+    idx = get_spec_index()
+    if not idx.available:
+        return None
+    for prefix, platform in _CONFIG_TOOL_PREFIXES.items():
+        if tool_name.startswith(prefix):
+            resource = tool_name[len(prefix) :].replace("_", "-")
+            return idx.config_body(platform, resource)
+    return None
+
+
+def render_payload_schema(tool_name: str, schema: dict[str, Any]) -> str:
+    """Render a config-body schema as a compact text block for get_schema output.
+
+    Format-agnostic (appended to whatever detail level get_schema produced), so
+    it works for brief / detailed / full alike.
+    """
+    lines = [
+        f"━━━ PAYLOAD SCHEMA for {tool_name} (spec index) ━━━",
+        f"body: {schema['method']} {schema['path']}",
+    ]
+    for f in schema["fields"]:
+        parts = [f["type"] or "any"]
+        if f["required"]:
+            parts.append("required")
+        if f.get("read_only"):
+            parts.append("read-only")
+        if f.get("deprecated"):
+            parts.append("DEPRECATED")
+        if f.get("device_types"):
+            parts.append("devices=" + ",".join(f["device_types"]))
+        line = f"  {f['name']} ({', '.join(parts)})"
+        if f.get("enum"):
+            vals = f["enum"][:_MAX_ENUM_SHOWN]
+            more = "" if len(f["enum"]) <= _MAX_ENUM_SHOWN else f" … (+{len(f['enum']) - _MAX_ENUM_SHOWN})"
+            line += " — one of: " + ", ".join(str(v) for v in vals) + more
+        if f.get("description"):
+            line += f" — {f['description']}"
+        lines.append(line)
+    if schema.get("scope_parameters"):
+        scope = ", ".join(f"{p['name']}{'*' if p['required'] else ''}" for p in schema["scope_parameters"])
+        lines.append(f"scope query params: {scope}   (* = required)")
+    return "\n".join(lines)

--- a/tests/unit/test_spec_index.py
+++ b/tests/unit/test_spec_index.py
@@ -128,6 +128,62 @@ class TestSearch:
         with pytest.raises(ValueError, match="kind must be one of"):
             idx.search("x", kind="bogus")
 
+    def test_response_search(self, idx: SpecIndex):
+        assert isinstance(idx.search("token", kind="response", platform="mist"), list)
+
+
+@pytest.mark.unit
+class TestRichMetadata:
+    """Examples, readOnly/writeOnly, deprecated(+note), oneOf/anyOf variants, all responses."""
+
+    def test_error_responses_captured_with_descriptions(self, index_db: Path):
+        """The AI learns what 429 means from the indexed response description."""
+        con = sqlite3.connect(index_db)
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            "SELECT r.description FROM responses r JOIN endpoints e ON r.endpoint_id=e.id "
+            "WHERE e.platform='mist' AND r.status_code='429' AND r.description IS NOT NULL LIMIT 1"
+        ).fetchone()
+        assert row is not None and row["description"].strip()
+
+    def test_field_examples_captured(self, index_db: Path):
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM fields WHERE example IS NOT NULL").fetchone()
+        assert n > 1000  # widespread across greenlake/edgeconnect/central
+        (n,) = con.execute("SELECT COUNT(*) FROM endpoints WHERE request_example IS NOT NULL").fetchone()
+        assert n > 0
+
+    def test_readonly_writeonly_captured(self, index_db: Path):
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM fields WHERE read_only=1").fetchone()
+        assert n > 100  # mist alone has ~600
+
+    def test_deprecated_flag_and_note(self, index_db: Path):
+        con = sqlite3.connect(index_db)
+        con.row_factory = sqlite3.Row
+        (dep,) = con.execute("SELECT COUNT(*) FROM endpoints WHERE deprecated=1").fetchone()
+        assert dep > 0
+        note = con.execute("SELECT deprecated_note FROM endpoints WHERE deprecated_note IS NOT NULL LIMIT 1").fetchone()
+        assert note is not None and note["deprecated_note"]
+
+    def test_oneof_anyof_variants_captured(self, index_db: Path):
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM fields WHERE variants IS NOT NULL").fetchone()
+        assert n > 0
+
+    def test_endpoint_exposes_responses_and_flags(self, idx: SpecIndex):
+        ep = idx.endpoint("central", operation_id="updateDeviceNotesV1")
+        assert ep is not None
+        assert isinstance(ep["responses"], list) and ep["responses"]
+        assert all("status" in r for r in ep["responses"])
+        assert "deprecated" in ep and "request_example" in ep
+
+    def test_schema_fields_expose_rich_attrs(self, idx: SpecIndex):
+        fields = idx.schema_fields("mist", "wlan")
+        assert fields
+        for key in ("read_only", "write_only", "deprecated", "example", "variants", "constraints"):
+            assert all(key in f for f in fields)
+
 
 @pytest.mark.unit
 class TestGracefulDegradation:

--- a/tests/unit/test_spec_index.py
+++ b/tests/unit/test_spec_index.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from hpe_networking_mcp.spec_index import SpecIndex
+from hpe_networking_mcp.spec_index import tool_schema as ts
 
 _REPO = Path(__file__).resolve().parents[2]
 _BUILDER = _REPO / "scripts" / "build_spec_index.py"
@@ -189,6 +190,41 @@ class TestRichMetadata:
         assert fields
         for key in ("read_only", "write_only", "deprecated", "example", "variants", "constraints"):
             assert all(key in f for f in fields)
+
+
+@pytest.mark.unit
+class TestConfigBodyProvider:
+    """The get_schema enrichment path for opaque payload:dict config tools (Mike's case)."""
+
+    def test_config_body_resolves_system_info(self, idx: SpecIndex):
+        body = idx.config_body("central", "system-info")
+        assert body is not None
+        names = {f["name"] for f in body["fields"]}
+        assert "hostname" in names
+        scope = {p["name"] for p in body["scope_parameters"]}
+        assert {"scope-id", "object-type", "device-function"} <= scope
+
+    def test_config_body_unknown_returns_none(self, idx: SpecIndex):
+        assert idx.config_body("central", "no-such-resource-xyz") is None
+
+    def test_payload_schema_for_config_tool(self, idx: SpecIndex, monkeypatch):
+        monkeypatch.setattr(ts, "get_spec_index", lambda: idx)
+        ps = ts.payload_schema_for_tool("central_manage_system_info")
+        assert ps is not None and any(f["name"] == "hostname" for f in ps["fields"])
+        # the get_* twin resolves the same body
+        assert ts.payload_schema_for_tool("central_get_system_info") is not None
+
+    def test_payload_schema_none_for_non_config_tool(self, idx: SpecIndex, monkeypatch):
+        monkeypatch.setattr(ts, "get_spec_index", lambda: idx)
+        assert ts.payload_schema_for_tool("mist_get_self") is None
+        assert ts.payload_schema_for_tool("") is None
+
+    def test_render_payload_schema_text(self, idx: SpecIndex):
+        body = idx.config_body("central", "system-info")
+        text = ts.render_payload_schema("central_manage_system_info", body)
+        assert "PAYLOAD SCHEMA for central_manage_system_info" in text
+        assert "hostname" in text
+        assert "scope query params" in text
 
 
 @pytest.mark.unit

--- a/tests/unit/test_spec_index.py
+++ b/tests/unit/test_spec_index.py
@@ -171,6 +171,12 @@ class TestRichMetadata:
         (n,) = con.execute("SELECT COUNT(*) FROM fields WHERE variants IS NOT NULL").fetchone()
         assert n > 0
 
+    def test_device_types_captured(self, index_db: Path):
+        """x-supportedDeviceType parity with the distilled Central artifact."""
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM fields WHERE device_types IS NOT NULL").fetchone()
+        assert n > 1000  # 14k occurrences in central config specs
+
     def test_endpoint_exposes_responses_and_flags(self, idx: SpecIndex):
         ep = idx.endpoint("central", operation_id="updateDeviceNotesV1")
         assert ep is not None

--- a/tests/unit/test_spec_index.py
+++ b/tests/unit/test_spec_index.py
@@ -1,0 +1,147 @@
+"""Tests for the spec-lookup index (builder + query layer).
+
+Builds the real index from the vendored OpenAPI corpus once per session, then
+asserts the canonical lookups that motivated it (Mike's ``system-info.hostname``
+case; Mist/ClearPass schema-level enums resolved via ``$ref``) plus graceful
+degradation when the index is absent.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hpe_networking_mcp.spec_index import SpecIndex
+
+_REPO = Path(__file__).resolve().parents[2]
+_BUILDER = _REPO / "scripts" / "build_spec_index.py"
+
+
+@pytest.fixture(scope="session")
+def index_db(tmp_path_factory) -> Path:
+    """Build the real index from vendor/** once for the test session."""
+    db = tmp_path_factory.mktemp("spec_index") / "spec_index.db"
+    subprocess.run([sys.executable, str(_BUILDER), str(db)], check=True)
+    return db
+
+
+@pytest.fixture(scope="session")
+def idx(index_db) -> SpecIndex:
+    return SpecIndex(index_db)
+
+
+@pytest.mark.unit
+class TestBuild:
+    def test_index_available_and_populated(self, idx: SpecIndex):
+        assert idx.available
+        con = sqlite3.connect(idx._path)
+        (endpoints,) = con.execute("SELECT COUNT(*) FROM endpoints").fetchone()
+        (fields,) = con.execute("SELECT COUNT(*) FROM fields").fetchone()
+        assert endpoints > 4000
+        assert fields > 20000
+
+    def test_aoscx_excluded(self, index_db: Path):
+        """aoscx is an orphan spec (no platform/tools) — never indexed."""
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM endpoints WHERE platform='aoscx'").fetchone()
+        assert n == 0
+        (n,) = con.execute("SELECT COUNT(*) FROM schemas WHERE platform='aoscx'").fetchone()
+        assert n == 0
+
+    def test_manifests_skipped_not_indexed(self, index_db: Path):
+        """Non-spec JSON (_manifest.json / sources.json) contributes no rows."""
+        con = sqlite3.connect(index_db)
+        (n,) = con.execute("SELECT COUNT(*) FROM endpoints WHERE spec_file LIKE '%_manifest.json'").fetchone()
+        assert n == 0
+
+
+@pytest.mark.unit
+class TestFieldAndEnumLookups:
+    def test_system_info_hostname_field(self, idx: SpecIndex):
+        """Mike's AP-rename case: the system-info profile exposes a `hostname` field."""
+        fields = idx.schema_fields("central", "ArubaSystemInfo_SystemInfoprofileSchema")
+        names = {f["name"] for f in fields}
+        assert "hostname" in names
+
+    def test_mist_wlan_auth_enum_via_ref(self, idx: SpecIndex):
+        """Mist models the WLAN auth mode as a `$ref` to a schema-level enum;
+        the resolver must follow the ref to surface the legal values."""
+        values = idx.field_enum("mist", "wlan_auth", "type")
+        assert values is not None
+        assert "psk" in values and "open" in values
+
+    def test_clearpass_schema_level_enum_indexed(self, index_db: Path):
+        """ClearPass encodes enums as standalone named schemas (e.g. GrantType)."""
+        con = sqlite3.connect(index_db)
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            "SELECT enum_json FROM schemas WHERE platform='clearpass' AND schema_name='GrantType'"
+        ).fetchone()
+        assert row is not None and row["enum_json"] is not None
+        assert "client_credentials" in row["enum_json"]
+
+    def test_field_enum_unknown_returns_none(self, idx: SpecIndex):
+        assert idx.field_enum("central", "ArubaSystemInfo_SystemInfoprofileSchema", "hostname") is None
+        assert idx.field_enum("mist", "no_such_schema", "no_field") is None
+
+    def test_schema_fields_unknown_returns_empty(self, idx: SpecIndex):
+        assert idx.schema_fields("central", "NoSuchSchema") == []
+
+
+@pytest.mark.unit
+class TestEndpointLookups:
+    def test_system_info_patch_params_include_scope(self, idx: SpecIndex):
+        """The scope query params Mike was missing must be discoverable."""
+        ep = idx.endpoint("central", path="/network-config/v1alpha1/system-info/{name}", method="PATCH")
+        assert ep is not None
+        pnames = {p["name"] for p in ep["parameters"]}
+        assert {"name", "scope-id", "object-type", "device-function"} <= pnames
+
+    def test_device_notes_endpoint_resolves(self, idx: SpecIndex):
+        ep = idx.endpoint("central", operation_id="updateDeviceNotesV1")
+        assert ep is not None
+        assert ep["method"] == "PATCH"
+
+    def test_unknown_endpoint_returns_none(self, idx: SpecIndex):
+        assert idx.endpoint("central", operation_id="nope_does_not_exist") is None
+
+
+@pytest.mark.unit
+class TestSearch:
+    def test_field_search_cross_platform(self, idx: SpecIndex):
+        rows = idx.search("hostname", kind="field")
+        assert any(r["name"] == "hostname" for r in rows)
+
+    def test_endpoint_search_platform_filter(self, idx: SpecIndex):
+        rows = idx.search("notes", kind="endpoint", platform="central")
+        assert any(r["name"] == "updateDeviceNotesV1" for r in rows)
+
+    def test_search_special_chars_no_crash(self, idx: SpecIndex):
+        # Arbitrary punctuation must not break FTS5 MATCH syntax.
+        assert isinstance(idx.search('a"b(c) OR', kind="field"), list)
+
+    def test_search_invalid_kind_raises(self, idx: SpecIndex):
+        with pytest.raises(ValueError, match="kind must be one of"):
+            idx.search("x", kind="bogus")
+
+
+@pytest.mark.unit
+class TestGracefulDegradation:
+    """A missing index must never raise — enrichment degrades to 'no hint'."""
+
+    def _absent(self, tmp_path: Path) -> SpecIndex:
+        return SpecIndex(tmp_path / "does_not_exist.db")
+
+    def test_reports_unavailable(self, tmp_path: Path):
+        assert self._absent(tmp_path).available is False
+
+    def test_all_queries_return_empty(self, tmp_path: Path):
+        si = self._absent(tmp_path)
+        assert si.schema_fields("central", "X") == []
+        assert si.field_enum("central", "X", "y") is None
+        assert si.endpoint("central", path="/x") is None
+        assert si.search("hostname", kind="field") == []


### PR DESCRIPTION
**⚠️ Part 1 of a multi-part feature — DO NOT release an image until the feature is complete.** Merging is fine (the image workflow triggers on `release:`, not on merge); just no tag/release yet. Follow-ups: retire the distilled artifacts (Central + Mist) in favor of this index, and wire dynamic-mode `<platform>_get_tool_schema` to the same provider.

## Why
An operator tried to rename a Central-managed AP and gave up — the config tool (`central_manage_*`) exposes only an opaque `payload: dict`, so the model had no field set and guessed `name`/`hostname`/`ap-name` blind against the live tenant. The distilled `_config_payload_schemas.json` that was supposed to cover this was **missing `system-info` entirely**. This builds a complete, deterministic schema source and wires it into `get_schema`.

## What

### Spec-lookup index (`scripts/build_spec_index.py` → `spec_index/`)
Parses all 82 vendored OpenAPI specs into a SQLite/FTS5 index — **6,000 endpoints, 17,939 params, 13,656 schemas, 51,916 fields, 39,775 responses**. Captures types, enums (property- *and* schema-level, resolved via `$ref` — the Mist/ClearPass pattern), constraints, formats, examples (field + copy-paste request bodies), `readOnly`/`writeOnly`, `deprecated` (+ `x-deprecation-notice`), `oneOf`/`anyOf` variants, `x-supportedDeviceType`, per-platform trust.
- **aoscx excluded** (orphan spec, no platform/tools — CX is via CNX/Central); manifest JSON skipped.
- **Stdlib-only** (`sqlite3` + FTS5, verified in the base image). No new dependency.
- **Baked at image build** via a dedicated Docker stage; the `.db` is gitignored, never committed. Read-only `SpecIndex` query layer degrades to empty (never raises) when absent.

### `get_schema` config-body enrichment (code mode)
`_SpecEnrichedGetSchemaTool` (the `_SkillAwareSearchTool` structural pattern) appends the network-config body schema for `payload: dict` config tools — fields, enums, constraints, device-type applicability, examples, and the scope query params — from the index.

**Live-verified in-process against a real config** (`central enabled: True`):
```
get_schema(["central_manage_system_info"]) now appends:
  hostname (string, devices=Access Point,Switch CX,Switch PVOS,Gateway) — The hostname assigned…
  … + description/name/snmp fields …
  scope query params: device-function, object-type, scope-id
```
That is exactly the field the operator could not see.

### Scripts reorg (per maintainer convention)
`scripts/` = pushed build infra (the index builder); new gitignored `scripts/internal/` holds the local-only generators (moved, path-fixed to be depth-independent).

## Testing
- **31** spec-index unit tests (data model, enum-via-`$ref` resolution, all rich metadata, config-body provider resolving `system-info` → `hostname` + scope params, graceful degradation). Full suite **2064 passed**, 2 skipped.
- ruff / format / mypy clean.
- Live in-process verification of the code-mode `get_schema` path.

## Not in this PR (follow-ups, same feature)
- Retire distilled `_config_payload_schemas.json` (Central) + `_request_body_schemas.json` (Mist) → single spec-index source.
- Dynamic-mode `<platform>_get_tool_schema` → generic provider (Mist tool→schema mapping needs its own careful pass).
- Version bump + release (held until the feature is complete).

Refs #616