### PR TITLE
release: v3.6.0.0 — spec-lookup index + tool-body/error enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.6.0.0] - 2026-07-16
 
-**Feature in progress — spec-lookup index. Not yet released.** A deterministic SQLite/FTS5 index of the vendored OpenAPI corpus, now the single schema source of truth for tool-body enrichment in both tool modes. Held from release until the maintainer signs off on the complete feature.
+**Minor — spec-lookup index (substantial new subsystem): the single schema source of truth for tool-body + error enrichment in both tool modes.** A deterministic SQLite/FTS5 index of the vendored OpenAPI corpus that supersedes the distilled per-platform schema artifacts. It closes the failure that started this — an operator (via a peer's report) couldn't rename a Central-managed AP because the config tools exposed an opaque `payload: dict` with no field set to author against, so field names got guessed against the live tenant.
 
 ### Added
 - **Spec-lookup index** (`scripts/build_spec_index.py` → `src/hpe_networking_mcp/spec_index/`). Parses all 82 vendored specs (aoscx excluded — orphan, no tools) into `endpoints` / `parameters` / `schemas` / `fields` / `responses` tables + FTS5 mirrors: **6,000 endpoints, 17,939 params, 13,656 schemas, 51,916 fields, 39,775 responses**. Captures field types/enums (property- *and* schema-level, resolved via `$ref`), constraints, formats, examples (field + request-body), `readOnly`/`writeOnly`, `deprecated` (+ `x-deprecation-notice`), `oneOf`/`anyOf` variants, `x-supportedDeviceType`, and per-platform source trust. Stdlib-only (`sqlite3`); baked into the image at build time (dedicated Docker stage), gitignored otherwise. Read-only `SpecIndex` query layer degrades to empty (never raises) when absent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.5.3.6"
+version = "3.6.0.0"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump **3.5.3.6 → 3.6.0.0** and CHANGELOG finalization (`[Unreleased]` → `[3.6.0.0]`) for the completed spec-lookup feature (merged across #618, #620, #621).

**Why 3.6.0.0 (Minor, not Major):** per this repo's scheme, Major (1st digit) is reserved for fundamental behavioral breaking changes (only precedent: 3.0.0.0, the static→dynamic mode flip). This is a "substantial new subsystem" — the 2nd-digit Minor category (like 3.1.0.0 Mist spec-driven rewrite, 3.4.0.0 EdgeConnect). It's additive enrichment + a transparent internal refactor (distilled→index): no tools removed or renamed, no behavior flipped.

## The feature (recap of #618/#620/#621)
- **Spec-lookup index** — SQLite/FTS5 over all 82 vendored OpenAPI specs (6,000 endpoints / 51,916 fields / 39,775 responses + enums, constraints, examples, deprecations, device-types). Stdlib-only, baked at image build, gitignored.
- **Proactive `get_schema` enrichment** (both modes) — opaque-body Central config + Mist write tools now surface their field set (fixes the AP-rename blind-body gap). 100% parity with, and more complete than, the retired distilled artifacts.
- **Reactive all-non-2xx enrichment** — failed calls get the API's documented meaning of the status code (+ legal body fields for 400/422), so the model self-corrects.
- **Single source of truth** — distilled `_config_payload_schemas.json` / `_request_body_schemas.json` (+ loaders + distillers) retired.

## Post-merge
Tag `v3.6.0.0` + `gh release create` (this is the one image that ships the whole feature). No code changes here — the feature is already on main and CI-green; this PR is only the version/CHANGELOG bump.

Follow-up (separate): INSTRUCTIONS.md handshake-weight trim.