### PR TITLE
fix(deps): bump mcp 1.27.0 → 1.28.1 (clears 3 published CVEs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - **Bump `mcp` 1.27.0 → 1.28.1** to clear three advisories published against the locked version: CVE-2026-52869 and CVE-2026-52870 (fixed in 1.27.2) and CVE-2026-59950 (fixed in 1.28.1). The dependency floor is raised from `>=1.20.0` to `>=1.28.1` so a future resolve can't fall back to a vulnerable release. `pip-audit` reports no known vulnerabilities; full suite green on 1.28.1 with no code changes required.
-- Refreshes the stale `hpe-networking-mcp` self-version in `uv.lock` (3.4.7.1 → 3.6.0.0) as a side effect of re-locking.
+- Refreshes the stale `hpe-networking-mcp` self-version in `uv.lock` (3.4.7.1 → 3.6.0.1) as a side effect of re-locking.
 
 ## [3.6.0.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0.1] - 2026-07-17
+
+### Security
+- **Bump `mcp` 1.27.0 → 1.28.1** to clear three advisories published against the locked version: CVE-2026-52869 and CVE-2026-52870 (fixed in 1.27.2) and CVE-2026-59950 (fixed in 1.28.1). The dependency floor is raised from `>=1.20.0` to `>=1.28.1` so a future resolve can't fall back to a vulnerable release. `pip-audit` reports no known vulnerabilities; full suite green on 1.28.1 with no code changes required.
+- Refreshes the stale `hpe-networking-mcp` self-version in `uv.lock` (3.4.7.1 → 3.6.0.0) as a side effect of re-locking.
+
 ## [3.6.0.0] - 2026-07-16
 
 **Minor — spec-lookup index (substantial new subsystem): the single schema source of truth for tool-body + error enrichment in both tool modes.** A deterministic SQLite/FTS5 index of the vendored OpenAPI corpus that supersedes the distilled per-platform schema artifacts. It closes the failure that started this — an operator (via a peer's report) couldn't rename a Central-managed AP because the config tools exposed an opaque `payload: dict` with no field set to author against, so field names got guessed against the live tenant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.0.0"
+version = "3.6.0.1"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"
@@ -19,8 +19,10 @@ dependencies = [
     "fastmcp[code-mode,apps]>=3.4.0",
     # Async rate limiter -- used by greenlake bulk_add.py batch loop
     "aiolimiter>=1.2.1",
-    # MCP protocol — GreenLake requires >=1.20.0
-    "mcp[cli]>=1.20.0",
+    # MCP protocol — GreenLake requires >=1.20.0; floor raised to 1.28.1 to
+    # clear CVE-2026-52869 / CVE-2026-52870 (fixed 1.27.2) and CVE-2026-59950
+    # (fixed 1.28.1). Keep at/above 1.28.1 so a resolve can't fall back.
+    "mcp[cli]>=1.28.1",
     # Async HTTP client — used by all platforms (Central since v3.3.11.0,
     # replacing pycentral; Mist since v3.1.0.0, replacing mistapi)
     "httpx>=0.28.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -671,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.4.7.1"
+version = "3.6.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -705,7 +708,7 @@ requires-dist = [
     { name = "fastmcp", extras = ["code-mode", "apps"], specifier = ">=3.4.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "python-dotenv", specifier = ">=1.2.0" },
@@ -1022,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1040,9 +1043,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Unblocks CI. **Not specific to any branch — `main` carries the same vulnerable pin**, so this currently fails every PR.

## Why now

`main`'s last Security run passed at 2026-07-16 19:23Z; #624's run failed at 2026-07-17 03:40Z. Nothing changed in the dependency between those times — the advisories were **published in between**. Re-running Security on `main` today would fail identically.

## The advisories

| CVE | Fixed in |
|---|---|
| CVE-2026-52869 | 1.27.2 |
| CVE-2026-52870 | 1.27.2 |
| CVE-2026-59950 | **1.28.1** |

1.28.1 (current latest) is the floor that clears all three.

## The change

- `mcp[cli]` floor raised **`>=1.20.0` → `>=1.28.1`**, not just re-locked — otherwise a future resolve could quietly fall back to a vulnerable release while the lockfile looked fine.
- `uv.lock` re-locked: `mcp 1.27.0 → 1.28.1`.
- Also refreshes a stale self-version in `uv.lock` (`3.4.7.1` → `3.6.0.1`) that had drifted from `pyproject.toml`.

## Verification

```
uv run --frozen pip-audit   -> No known vulnerabilities found
uv run --frozen pytest      -> 2085 passed, 2 skipped
```

No code changes were required for 1.28.1. The lock diff is narrow — only `mcp`, its constraint, and the self-version; no mass re-resolve.

Patch bump to **3.6.0.1** so the fix is identifiable and releasable on its own rather than waiting to ride along with a feature.

Kept separate from #624 deliberately: a security bump shouldn't be buried in a 28-file feature PR, and merging this fixes `main` for everyone. I'll rebase #624 on top once this lands.