### PR TITLE
fix(clearpass,uxi): add dropped query params (cross-platform audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.2] - 2026-07-17
+
+Cross-platform param-gap sweep (hand-curated platforms). A spec-vs-signature audit of every platform found that the generated surfaces (Mist/GreenLake/EdgeConnect) already emit all documented params; only a few hand-curated ClearPass and UXI tools dropped optional query params.
+
+### Fixed
+- **ClearPass** — `clearpass_get_session_action_status` gains `offset`/`limit` (pagination); `clearpass_get_reauth_profiles` gains `template_type`; `clearpass_manage_guest_user` and `clearpass_manage_device` gain `change_of_authorization` (push the network-state change via a RADIUS Disconnect/CoA). CoA is threaded only onto the endpoints that document it — create, and the username-/MAC-based update/delete — not the ID-based variants that don't support it.
+- **UXI** — the 10 list tools (`uxi_list_agents`, `uxi_list_sensors`, `uxi_list_groups`, the four `*_group_assignments`, `uxi_list_wired_networks`, `uxi_list_wireless_networks`, `uxi_list_service_tests`) gain the documented `id` filter via the client's `extra_params` hook.
+
 ## [3.6.1.1] - 2026-07-17
 
 Bug-fix roll-up on top of 3.6.1.0, shipping two PRs as one patch: closes the read-param gaps in the hand-curated readers the #624 sweep missed, fixes three PII-tokenization defects and one code-mode error-handling defect (#626), and remediates the config-write scope-parameter architecture so `SHARED` and scoped writes behave correctly while the spec index stops advertising parameters the wrapper doesn't accept (#627).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.1"
+version = "3.6.1.2"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_guests.py
@@ -21,6 +21,13 @@ async def clearpass_manage_guest_user(
     payload: Annotated[dict, Field(description="Guest config payload. For delete: empty dict {}.")],
     guest_id: Annotated[str | None, Field(description="Guest ID (required for update/delete).")] = None,
     username: Annotated[str | None, Field(description="Guest username (alternative to ID).")] = None,
+    change_of_authorization: Annotated[
+        str | None,
+        Field(
+            description="'true' to push the network-state change via a RADIUS Disconnect/CoA request. "
+            "Honored on create and on the username-based update/delete (the ID-based endpoints don't support it)."
+        ),
+    ] = None,
     confirmed: Annotated[
         bool,
         Field(
@@ -50,8 +57,13 @@ async def clearpass_manage_guest_user(
     try:
         client = await get_clearpass_client()
 
+        # CoA is documented only on POST /guest and the username-based
+        # update/delete (it needs the username to locate the live session),
+        # not on the ID-based endpoints — so it's threaded only where accepted.
+        coa = {"change_of_authorization": change_of_authorization} if change_of_authorization else None
+
         if action_type == "create":
-            return await client.request("post", "/guest", json_body=payload)
+            return await client.request("post", "/guest", params=coa, json_body=payload)
         if not guest_id and not username:
             raise ToolError(
                 {"status_code": 400, "message": "Either guest_id or username is required for update/delete."}
@@ -59,11 +71,11 @@ async def clearpass_manage_guest_user(
         if action_type == "update":
             if guest_id:
                 return await client.request("patch", f"/guest/{path_seg(guest_id)}", json_body=payload)
-            return await client.request("patch", f"/guest/username/{path_seg(username)}", json_body=payload)
+            return await client.request("patch", f"/guest/username/{path_seg(username)}", params=coa, json_body=payload)
         # delete
         if guest_id:
             return await client.request("delete", f"/guest/{path_seg(guest_id)}")
-        return await client.request("delete", f"/guest/username/{path_seg(username)}")
+        return await client.request("delete", f"/guest/username/{path_seg(username)}", params=coa)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/manage_identities.py
@@ -180,6 +180,13 @@ async def clearpass_manage_device(
     payload: Annotated[dict, Field(description="Device config payload. Empty dict {} for delete.")],
     device_id: Annotated[str | None, Field(description="Device ID (required for update/delete).")] = None,
     macaddr: Annotated[str | None, Field(description="MAC address (alternative to device_id).")] = None,
+    change_of_authorization: Annotated[
+        str | None,
+        Field(
+            description="'true' to push the network-state change via a RADIUS Disconnect/CoA request. "
+            "Honored on create and on the MAC-based update/delete (the ID-based endpoints don't support it)."
+        ),
+    ] = None,
     confirmed: Annotated[
         bool,
         Field(
@@ -195,6 +202,7 @@ async def clearpass_manage_device(
         payload: JSON config body. Required for create/update. Empty dict for delete.
         device_id: Numeric device ID. Required for update/delete (or use macaddr).
         macaddr: Device MAC address. Alternative to device_id.
+        change_of_authorization: 'true' to push the change via a RADIUS Disconnect/CoA.
         confirmed: Fallback confirmation flag — honored only when the client cannot show a
             confirmation prompt (the universal gate prompts otherwise).
     """
@@ -207,18 +215,22 @@ async def clearpass_manage_device(
         )
     try:
         client = await get_clearpass_client()
+        # CoA is documented only on POST /device and the MAC-based update/delete
+        # (it needs the MAC to locate the live session), not the ID-based ones.
+        coa = {"change_of_authorization": change_of_authorization} if change_of_authorization else None
         if action_type == "create":
-            return await client.request("post", "/device", json_body=payload)
+            return await client.request("post", "/device", params=coa, json_body=payload)
         if not device_id and not macaddr:
             raise ToolError(
                 {"status_code": 400, "message": "Either device_id or macaddr is required for update/delete."}
             )
         if action_type == "update":
-            path = f"/device/{path_seg(device_id)}" if device_id else f"/device/mac/{path_seg(macaddr)}"
-            return await client.request("patch", path, json_body=payload)
+            if device_id:
+                return await client.request("patch", f"/device/{path_seg(device_id)}", json_body=payload)
+            return await client.request("patch", f"/device/mac/{path_seg(macaddr)}", params=coa, json_body=payload)
         if device_id:
             return await client.request("delete", f"/device/{path_seg(device_id)}")
-        return await client.request("delete", f"/device/mac/{path_seg(macaddr)}")
+        return await client.request("delete", f"/device/mac/{path_seg(macaddr)}", params=coa)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
+++ b/src/hpe_networking_mcp/platforms/clearpass/tools/sessions.py
@@ -65,6 +65,8 @@ async def clearpass_get_sessions(
 async def clearpass_get_session_action_status(
     ctx: Context,
     action_id: str,
+    offset: int | None = None,
+    limit: int | None = None,
 ) -> dict | str:
     """Get the status of a ClearPass session action (e.g. disconnect or CoA).
 
@@ -73,10 +75,13 @@ async def clearpass_get_session_action_status(
 
     Args:
         action_id: The action ID returned from a session action request.
+        offset: Pagination offset into the action's result set.
+        limit: Max results per page.
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/session-action/{path_seg(action_id)}")
+        params = {k: v for k, v in {"offset": offset, "limit": limit}.items() if v is not None}
+        return await client.request("get", f"/session-action/{path_seg(action_id)}", params=params or None)
     except ToolError:
         raise
     except Exception as e:
@@ -87,6 +92,7 @@ async def clearpass_get_session_action_status(
 async def clearpass_get_reauth_profiles(
     ctx: Context,
     session_id: str,
+    template_type: str | None = None,
 ) -> dict | str:
     """Get available reauthorization profiles for a ClearPass session.
 
@@ -95,10 +101,12 @@ async def clearpass_get_reauth_profiles(
 
     Args:
         session_id: Session ID to retrieve reauthorization profiles for.
+        template_type: Reauthorize profile type to filter by (e.g. "Disconnect" or "CoA").
     """
     try:
         client = await get_clearpass_client()
-        return await client.request("get", f"/session/{path_seg(session_id)}/reauthorize")
+        params = {"template_type": template_type} if template_type else None
+        return await client.request("get", f"/session/{path_seg(session_id)}/reauthorize", params=params)
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/agents.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/agents.py
@@ -17,6 +17,7 @@ async def uxi_list_agents(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI agents with name, MAC addresses, model, serial, group assignment, and notes.
 
@@ -29,7 +30,9 @@ async def uxi_list_agents(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/agents", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/agents", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/assignments.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/assignments.py
@@ -17,6 +17,7 @@ async def uxi_list_agent_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI agent-to-group assignments.
 
@@ -28,7 +29,12 @@ async def uxi_list_agent_group_assignments(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/agent-group-assignments", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/agent-group-assignments",
+            next_cursor=next_cursor,
+            limit=page_size,
+            extra_params={"id": id} if id else None,
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -40,6 +46,7 @@ async def uxi_list_sensor_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI sensor-to-group assignments.
 
@@ -51,7 +58,12 @@ async def uxi_list_sensor_group_assignments(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/sensor-group-assignments", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/sensor-group-assignments",
+            next_cursor=next_cursor,
+            limit=page_size,
+            extra_params={"id": id} if id else None,
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -63,6 +75,7 @@ async def uxi_list_network_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI network-to-group assignments.
 
@@ -74,7 +87,12 @@ async def uxi_list_network_group_assignments(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/network-group-assignments", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/network-group-assignments",
+            next_cursor=next_cursor,
+            limit=page_size,
+            extra_params={"id": id} if id else None,
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -86,6 +104,7 @@ async def uxi_list_service_test_group_assignments(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI service-test-to-group assignments.
 
@@ -97,7 +116,12 @@ async def uxi_list_service_test_group_assignments(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/service-test-group-assignments", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/service-test-group-assignments",
+            next_cursor=next_cursor,
+            limit=page_size,
+            extra_params={"id": id} if id else None,
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/groups.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/groups.py
@@ -17,6 +17,7 @@ async def uxi_list_groups(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI groups with id, name, path, and parent group.
 
@@ -30,7 +31,9 @@ async def uxi_list_groups(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/groups", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/groups", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/networks.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/networks.py
@@ -17,6 +17,7 @@ async def uxi_list_wired_networks(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI wired (Ethernet) networks.
 
@@ -29,7 +30,9 @@ async def uxi_list_wired_networks(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/wired-networks", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/wired-networks", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:
@@ -41,6 +44,7 @@ async def uxi_list_wireless_networks(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI wireless (Wi-Fi) networks.
 
@@ -53,7 +57,9 @@ async def uxi_list_wireless_networks(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/wireless-networks", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/wireless-networks", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/sensors.py
@@ -19,6 +19,7 @@ async def uxi_list_sensors(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI sensors with serial, name, model, MAC addresses, location coordinates, and type.
 
@@ -31,7 +32,9 @@ async def uxi_list_sensors(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/sensors", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/sensors", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/src/hpe_networking_mcp/platforms/uxi/tools/service_tests.py
+++ b/src/hpe_networking_mcp/platforms/uxi/tools/service_tests.py
@@ -17,6 +17,7 @@ async def uxi_list_service_tests(
     ctx: Context,
     next_cursor: str | None = None,
     page_size: int = 50,
+    id: str | None = None,
 ) -> dict[str, Any] | str:
     """List UXI service tests (connectivity, DNS, speed, and other test types).
 
@@ -29,7 +30,9 @@ async def uxi_list_service_tests(
     """
     try:
         client = await get_uxi_client()
-        return await client.uxi_get("/service-tests", next_cursor=next_cursor, limit=page_size)
+        return await client.uxi_get(
+            "/service-tests", next_cursor=next_cursor, limit=page_size, extra_params={"id": id} if id else None
+        )
     except ToolError:
         raise
     except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.6.1.1"
+version = "3.6.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
First of two PRs from a spec-vs-signature audit of **every** platform's tools against the vendored OpenAPI, prompted by the Central config-tool gaps.

**Headline: no other platform has Central's systemic breakage.** The generated surfaces emit every documented param — **EdgeConnect 1216/1216, GreenLake 251/251, Mist 1032/1037** (the 5 Mist gaps are spec-drift, handled in the follow-up regen PR). Only a handful of hand-curated ClearPass/UXI tools dropped **optional** query params. This PR fixes those.

## ClearPass (4)
- `get_session_action_status` → `offset` / `limit` (pagination)
- `get_reauth_profiles` → `template_type` (Disconnect/CoA filter)
- `manage_guest_user` / `manage_device` → `change_of_authorization` (push the change via a RADIUS Disconnect/CoA)

The CoA param is threaded **only** onto the endpoints that document it — create, and the username-/MAC-based update/delete — **not** the ID-based variants (the API doesn't accept it there, and I didn't want to advertise a param the endpoint ignores).

## UXI (10)
The documented `id` filter added to every list tool (`uxi_list_agents`, `_sensors`, `_groups`, the four `*_group_assignments`, `_wired_networks`, `_wireless_networks`, `_service_tests`) via the client's existing `extra_params` hook.

## Not touched (correctly)
- **AOS8** is a CLI/show-command wrapper — no per-endpoint REST params to audit.
- **Apstra / Axis** ship no vendored OpenAPI spec, so they can't be diffed yet — a separate effort to vendor their specs first.

## Verification
Full suite **2154 passed**; ruff / format / mypy clean. Params confirmed to register on each tool.