### PR TITLE
fix(redaction): mask serials inside stringified @ annotation wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.4] - 2026-07-20
+
+### Security
+- **Device serials no longer leak inside a stringified `@` annotation wrapper.** Central sometimes serializes an object's *entire* annotation set as one stringified value under `@` (observed on alias reads), rather than an expanded dict. The redaction walker saw `@` as one opaque string and never descended, so a DEVICE serial nested inside its `scope_device_function` shipped cleartext — even while the same serial was tokenized elsewhere in the response, so the mask was defeatable by correlation. This is the same class as the earlier `scope_device_function` fix, one level up at the wrapper. The walker now parses the `@` blob (JSON or Python-`repr`) and re-walks its contents, routing the nested `scope_device_function` back through the existing DEVICE-serial handler. The DEVICE-only rule is preserved (SITE / collection names stay cleartext); non-`@` JSON-looking strings are untouched; idempotent. Live-verified: 0 serials leaked across stringified blobs on a real tenant.
+
 ## [3.6.1.3] - 2026-07-17
 
 Mist tool surface resynced from the current vendored OpenAPI spec (regenerated via `scripts/internal/regenerate_mist_tools.py`), closing the drift the cross-platform audit surfaced. Net **+13 tools (1037 → 1050)**; nothing removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.3"
+version = "3.6.1.4"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/redaction/walker.py
+++ b/src/hpe_networking_mcp/redaction/walker.py
@@ -266,6 +266,16 @@ def _walk_dict(
 #: asks for annotations.
 _STRINGIFIED_RECORD_FIELDS: frozenset[str] = frozenset({"aruba_annotation:scope_device_function"})
 
+#: Fields whose value is sometimes the *entire* per-object annotation set
+#: serialized as one stringified dict/list (rather than an expanded nested
+#: structure). Central returns the ``@`` annotation wrapper this way on some
+#: reads (aliases, and others) — and a DEVICE serial nested inside it (via
+#: ``scope_device_function``) then reaches the client cleartext, because the
+#: walker sees ``@`` as one opaque string and never descends. Parsing the blob
+#: and re-walking it routes the nested fields back through the normal rules
+#: (including the ``scope_device_function`` serial handler above).
+_STRINGIFIED_BLOB_FIELDS: frozenset[str] = frozenset({"@"})
+
 
 def _parse_stringified_records(value: str) -> list | None:
     """Parse a stringified list-of-records, or None if it isn't one.
@@ -332,6 +342,63 @@ def _tokenize_stringified_records(value: str, tokenizer: Tokenizer) -> str:
     return json.dumps(records)
 
 
+def _parse_stringified_value(value: str) -> dict | list | None:
+    """Parse a stringified dict OR list, preserving its container type.
+
+    Unlike :func:`_parse_stringified_records` (which normalizes a dict to a
+    one-element list), this keeps a dict a dict so the ``@`` wrapper re-walks
+    and re-serializes as the object it is. Tries JSON then Python-``repr``
+    (``literal_eval`` — literals only, never executes code).
+    """
+    if not value or value[0] not in "[{":
+        return None
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(value)
+        except (ValueError, SyntaxError, TypeError):
+            continue
+        if isinstance(parsed, dict | list):
+            return parsed
+    return None
+
+
+def _tokenize_stringified_blob(
+    value: str,
+    tokenizer: Tokenizer,
+    *,
+    depth: int,
+    parent_keys: frozenset[str],
+    parent_field_name: str | None,
+) -> str:
+    """Parse a stringified annotation wrapper (``@``) and re-walk its contents.
+
+    The wrapper holds the whole annotation set as one opaque string, so nested
+    identifiers — notably a DEVICE serial inside ``scope_device_function`` —
+    never get reached by the recursive walk and ship cleartext. Parse it, run
+    the parsed structure back through the normal walker (which routes the nested
+    ``scope_device_function`` field to its serial handler), and re-serialize.
+    Returns ``value`` unchanged when it doesn't parse or nothing was masked, so
+    responses that need no masking keep their original serialization.
+    """
+    parsed = _parse_stringified_value(value)
+    if parsed is None:
+        return value
+    if isinstance(parsed, dict):
+        walked: dict | list = _walk_dict(parsed, tokenizer, depth=depth + 1, parent_field_name=parent_field_name)
+    else:
+        walked = _walk_list(
+            parent_field_name,
+            parsed,
+            tokenizer,
+            depth=depth + 1,
+            parent_keys=parent_keys,
+            parent_field_name=parent_field_name,
+        )
+    if walked == parsed:
+        return value
+    return json.dumps(walked)
+
+
 def _walk_pair(
     key: object,
     value: object,
@@ -375,6 +442,14 @@ def _walk_pair(
     # identifier serialized into it ships cleartext.
     if field_name_lower in _STRINGIFIED_RECORD_FIELDS and isinstance(value, str):
         return _tokenize_stringified_records(value, tokenizer)
+
+    # Stringified annotation wrapper (``@``): parse and re-walk so nested
+    # identifiers (e.g. a DEVICE serial inside ``scope_device_function``) are
+    # reached instead of shipping cleartext inside one opaque string.
+    if field_name_lower in _STRINGIFIED_BLOB_FIELDS and isinstance(value, str):
+        return _tokenize_stringified_blob(
+            value, tokenizer, depth=depth, parent_keys=parent_keys, parent_field_name=parent_field_name
+        )
 
     classification, kind = classify_field(key, value, parent_keys=parent_keys, parent_field_name=parent_field_name)
 

--- a/tests/unit/test_redaction_embedded_leaks.py
+++ b/tests/unit/test_redaction_embedded_leaks.py
@@ -193,6 +193,80 @@ class TestScopeAnnotationBlob:
         assert out["@"]["aruba-annotation:scope_device_function"] == blob
 
 
+class TestStringifiedAnnotationWrapper:
+    """Central sometimes serializes the WHOLE per-object annotation set as one
+    stringified value under ``@`` (seen on alias reads). The walker saw ``@`` as
+    one opaque string and never descended, so a DEVICE serial nested inside its
+    ``scope_device_function`` shipped cleartext — even though the same serial was
+    tokenized elsewhere. Found during scope-visualizer work."""
+
+    # A DEVICE serial nested inside a stringified @ wrapper (single-quoted repr).
+    _WRAPPER = (
+        "{'aruba-annotation:object_type': 'LOCAL', "
+        "'aruba-annotation:scope_device_function': "
+        "\"[{'scope_type': 'DEVICE', 'scope_name': 'CNABC12345'}]\"}"
+    )
+
+    def test_serial_inside_stringified_wrapper_is_masked(self):
+        tok = _tokenizer()
+        out = tokenize_response({"name": "a", "@": self._WRAPPER}, tok)
+
+        blob = json.dumps(out)
+        assert "CNABC12345" not in blob
+        assert "[[SERIAL:" in blob
+        assert "LOCAL" in blob  # non-sensitive annotation preserved
+
+    def test_json_serialized_wrapper_is_handled(self):
+        """The wrapper also arrives JSON-serialized (double quotes)."""
+        tok = _tokenizer()
+        wrapper = json.dumps(
+            {
+                "aruba-annotation:object_type": "LOCAL",
+                "aruba-annotation:scope_device_function": json.dumps(
+                    [{"scope_type": "DEVICE", "scope_name": "CNABC12345"}]
+                ),
+            }
+        )
+        out = tokenize_response({"@": wrapper}, tok)
+
+        assert "CNABC12345" not in json.dumps(out)
+
+    def test_site_name_in_wrapper_stays_cleartext(self):
+        """The DEVICE-only rule still applies inside the wrapper — architecture
+        labels (SITE/collection names) must not be over-masked."""
+        tok = _tokenizer()
+        wrapper = "{'aruba-annotation:scope_device_function': \"[{'scope_type': 'SITE', 'scope_name': 'Branch-1'}]\"}"
+
+        out = tokenize_response({"@": wrapper}, tok)
+
+        assert "Branch-1" in json.dumps(out)
+
+    def test_wrapper_needing_no_masking_is_unchanged(self):
+        tok = _tokenizer()
+        wrapper = "{'aruba-annotation:object_type': 'SHARED', 'aruba-annotation:is_editable': False}"
+
+        out = tokenize_response({"@": wrapper}, tok)
+
+        assert out["@"] == wrapper  # byte-identical when nothing masked
+
+    def test_idempotent(self):
+        tok = _tokenizer()
+        once = tokenize_response({"@": self._WRAPPER}, tok)
+        twice = tokenize_response(once, tok)
+
+        assert twice == once
+        assert "CNABC12345" not in json.dumps(twice)
+
+    def test_non_wrapper_json_string_is_untouched(self):
+        """Only the ``@`` field triggers blob parsing — a JSON-looking string
+        under an ordinary field must not be reparsed/reserialized."""
+        tok = _tokenizer()
+
+        out = tokenize_response({"description": "{'foo': 'bar'}"}, tok)
+
+        assert out["description"] == "{'foo': 'bar'}"
+
+
 class TestCertificateOverMasking:
     """TokenKind.CERT exists for PEM blocks, but its field names are ordinary
     words, so short scalars that merely reused the key were masked."""

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.6.1.3"
+version = "3.6.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Surfaced while nailing down local-vs-shared for the scope-visualizer work: a live PII leak on the exact read path that skill will use.

## The leak
Central sometimes serializes an object's **entire** annotation set as one stringified value under `@` (observed on alias reads) instead of an expanded dict. The redaction walker saw `@` as one opaque string and never descended — so a **DEVICE serial** nested inside its `scope_device_function` shipped **cleartext**, even though the same serial was tokenized elsewhere in the response (so the mask was defeatable by correlation).

Same bug class as the earlier `scope_device_function` fix, one level up at the wrapper. Verified before fixing:

| `@` shape | serial masked? |
|---|---|
| parsed dict | ✅ (walker descends → serial handler) |
| **stringified blob** | ❌ **leaked** |

## The fix
When a value under `@` is a stringified dict/list, parse it (JSON or Python-`repr`) and **re-walk the parsed structure** through the normal rules — which routes the nested `scope_device_function` field back to the existing DEVICE-serial handler. Structure-parsing composes with the narrow serial masking; no logic duplicated.

Carefully bounded:
- **DEVICE-only rule preserved** — SITE / collection names inside the wrapper stay cleartext (architecture labels, per the privacy model), not over-masked.
- **Only the `@` field triggers blob parsing** — a JSON-looking string under an ordinary field (e.g. `description`) is untouched, so no arbitrary re-serialization.
- **Idempotent** — re-walking already-tokenized output is stable.

## Verification
- 6 new regression tests (stringified + JSON `@`, SITE-not-over-masked, no-op byte-identical, idempotent, non-`@` untouched).
- **Live:** 119 real device serials, 25 stringified blobs processed → **0 leaked**.
- Full suite **2160 passed**; ruff / format / mypy / bandit clean.

This unblocks the scope-visualizer skill (which reads `detailed=True` config full of `@` blobs with PII on) — it can now surface device data without leaking serials by construction.