### PR TITLE
feat(code-mode): stream progress from execute() sandbox via report_progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.6] - 2026-07-20
+
+### Added
+- **Code-mode `execute()` sandbox can now stream progress to the client via `report_progress`.** Long-running skill blocks — the central-scope-visualizer per-scope classification sweep, the aos-migration multi-stage plan, any fan-out across many sites — previously ran as a single opaque `execute()` call, leaving the client on a silent spinner for the whole duration. The sandbox now injects a second external function alongside `call_tool`: `await report_progress(progress: float, total: float | None = None, message: str | None = None)`. Code blocks call it as they advance (`await report_progress(i, n, f"classifying scope {i}/{n}")`) and the client renders a live status line. Per the FastMCP progress contract it is a harmless no-op when the client didn't send a `progressToken`, so it is always safe to include and degrades gracefully on clients that don't render progress. Wired via a new `_HpeCodeMode` subclass of FastMCP's `CodeMode` (`server._hpe_code_mode_class`) that overrides `_make_execute_tool` to add the function bound to the live per-call `ctx`; a faithful copy of the upstream `call_tool` closure with the addition, pinned by `tests/unit/test_code_mode_progress.py` so a fastmcp upgrade that changes the copied internals fails loudly. The `execute` tool description and INSTRUCTIONS.md sandbox guidance (pattern 5) document the function for the model.
+
 ## [3.6.1.5] - 2026-07-20
 
 ### Changed

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -10,7 +10,7 @@ Tools are namespaced by platform: `mist_*` (Juniper Mist), `central_*` (Aruba Ce
 
 The server ships with `MCP_TOOL_MODE=code` by default since v3.0.0.0. At session start the AI sees **6 tools**:
 
-- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 4149 underlying tools
+- **`execute(code)`** — run async Python in a sandbox; `await call_tool(name, params)` is available in scope and dispatches to any of the 4149 underlying tools, and `await report_progress(progress, total=None, message=None)` streams status to the client during long multi-call blocks
 - **`tags(detail="brief")`** — browse the catalog by platform / module
 - **`search(query, tags=[...], detail)`** — BM25 search the catalog
 - **`get_schema(tools=[...], detail)`** — fetch parameter shape for named tools
@@ -94,6 +94,8 @@ The `pydantic-monty` sandbox restricts duration (30s), memory (128 MB), and recu
 Inside `execute()`, `call_tool(name, params)` resolves any registered platform tool — every name starting with `mist_` / `central_` / `greenlake_` / `clearpass_` / `apstra_` / `axis_` / `aos8_` / `uxi_` / `edgeconnect_` (Mist included, since v3.4.5.6), plus cross-platform `health` and the `translate_*` tools, and each platform's `<platform>_list_tools` / `<platform>_get_tool_schema` / `<platform>_invoke_tool` meta-tools. A per-platform tool is callable either directly by name or via `<platform>_invoke_tool`. The TOP-LEVEL discovery tools (`tags` / `search` / `get_schema` / `skills_list` / `skills_load`) are NOT callable from inside `execute()` — they live at the outer MCP surface for planning; use them (or the in-sandbox `<platform>_list_tools`) BEFORE chaining platform tools.
 
 If you do try to dispatch to a discovery tool by mistake, `SandboxErrorCatchMiddleware` returns a string like `Sandbox error: Exception: Unknown tool: search` so you can fix the call on the next turn (rather than seeing a generic masked error). See v2.2.0.4 release notes / #208.
+
+Alongside `call_tool`, the sandbox exposes `await report_progress(progress: float, total: float | None = None, message: str | None = None)` (v3.6.1.6) — a second injected external function that streams a progress notification to the client. Call it as a long block advances (`await report_progress(i, n, f"classifying scope {i}/{n}")`) so the client shows a live status line instead of a silent spinner. It is a no-op when the client didn't send a `progressToken`, so it is always safe to include. Wired via the `_HpeCodeMode` subclass of FastMCP's `CodeMode` (see `server._hpe_code_mode_class`).
 
 ### When to use which mode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.5"
+version = "3.6.1.6"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -270,6 +270,7 @@ The `execute()` sandbox uses `pydantic-monty` for its Python parser. It supports
 - `re` (verified — used by Stage 9b filtering helpers)
 - The clock: `datetime.now()`, `datetime.now(datetime.timezone.utc)`, `datetime.date.today()` (verified — the sandbox grants a read-only host clock; see the blocked table for the `utcnow()` / `time` gaps)
 - The injected `await call_tool(name, params)` for platform tool dispatch
+- The injected `await report_progress(progress, total=None, message=None)` for streaming status to the client during long multi-call blocks (harmless no-op when the client didn't request progress — always safe to call; see pattern 5)
 
 **Known-blocked** — using any of these returns a sandbox error:
 
@@ -302,7 +303,26 @@ The sandbox kills any `execute()` block that runs longer than the configured bud
 
 For these tools: **call them in their own `execute()` block — don't chain other calls after them** — and lower `max_attempts` / `poll_interval` when you need a tighter budget. A block that runs `central_cable_test` plus another Central read will routinely breach the default 30s with `TimeoutError: time limit exceeded`.
 
-### 5. Write confirmation is structural — a real prompt first, `confirmation_required` only as fallback
+### 5. Stream progress on long multi-call blocks with `report_progress`
+
+When a block makes many sequential `call_tool` invocations — a per-scope classification sweep, a multi-stage migration plan, a fan-out across sites — call `await report_progress(done, total, message)` as you go so the client can show a live status line instead of a silent spinner. It's a harmless no-op on clients that didn't request progress, so it is always safe to include.
+
+```python
+# ✅ Stream status across a per-scope sweep.
+scopes = (await call_tool("central_get_scope_tree", {}))["data"]["children"]
+total = len(scopes)
+results = []
+for i, s in enumerate(scopes):
+    await report_progress(i + 1, total, f"classifying {s['scope_name']} ({i + 1}/{total})")
+    cfg = await call_tool("central_get_config_assignments", {"scope_id": s["scope_id"]})
+    results.append(cfg["data"])
+result = {"scope_count": total, "results": results}
+result
+```
+
+Signature: `report_progress(progress: float, total: float | None = None, message: str | None = None)`. `total` lets the client render a percentage; `message` is a short human-readable status. Do NOT `report_progress` from a block that makes only one call — the overhead isn't worth it, and the sandbox already returns quickly.
+
+### 6. Write confirmation is structural — a real prompt first, `confirmation_required` only as fallback
 
 Destructive tools are confirmed by a universal gate at `<platform>_invoke_tool` dispatch: it shows a REAL confirmation prompt whenever your client supports MCP elicitation — including from inside code-mode `execute()` blocks, where the prompt round-trips transparently. Passing `confirmed=true` does NOT skip a working prompt; the human's answer always wins. Only when no prompt can be shown does the flow below apply.
 

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -912,6 +912,92 @@ def _make_spec_enriched_get_schema(tool: FunctionTool) -> _SpecEnrichedGetSchema
     return _SpecEnrichedGetSchemaTool(**{f: getattr(tool, f) for f in type(tool).model_fields})
 
 
+def _hpe_code_mode_class() -> type:
+    """Build and return the ``_HpeCodeMode`` subclass (lazy fastmcp import).
+
+    Defined as a module-level factory (rather than a local class inside
+    ``_register_code_mode``) so ``test_code_mode_progress`` can exercise the
+    REAL production class end-to-end. The import is lazy so non-code tool modes
+    don't require the ``fastmcp[code-mode]`` extra just to import this module.
+
+    ``_HpeCodeMode`` overrides the stock ``_make_execute_tool``: upstream builds
+    an ``execute(code, ctx)`` closure whose only sandbox-visible external function
+    is ``call_tool``. Long-running skills (central-scope-visualizer's per-scope
+    classification sweep, aos-migration's multi-stage plan) can take many seconds;
+    without a progress channel the client shows a silent spinner. The override is
+    a faithful copy of the upstream closure that additionally injects a
+    ``report_progress`` external function bound to the live per-call ``ctx``, so
+    code blocks can ``await report_progress(done, total, "message")`` to stream
+    status.
+
+    ``ctx.report_progress`` is a no-op unless the MCP client sent a
+    ``progressToken`` with the request (per the FastMCP progress contract), so
+    this is safe on clients that don't render progress — it simply does nothing.
+
+    Kept intentionally close to ``CodeMode._make_execute_tool``;
+    ``test_code_mode_progress`` pins the fastmcp internals this copy relies on
+    (``get_tool_catalog`` / ``_find_tool`` / ``sandbox_provider`` /
+    ``max_tool_calls`` / ``_unwrap_tool_result``) so a fastmcp upgrade that
+    changes them fails loudly instead of silently dropping either capability.
+    """
+    from fastmcp.exceptions import NotFoundError, ToolError
+    from fastmcp.experimental.transforms.code_mode import (
+        CodeMode,
+        _unwrap_tool_result,
+    )
+    from fastmcp.server.context import Context
+    from fastmcp.tools.base import Tool
+
+    class _HpeCodeMode(CodeMode):
+        def _make_execute_tool(self) -> Tool:
+            transform = self
+            max_tool_calls = self.max_tool_calls
+
+            async def execute(code: str, ctx: Context = None) -> Any:  # type: ignore[assignment]
+                call_count = 0
+
+                async def call_tool(tool_name: str, params: dict[str, Any]) -> Any:
+                    nonlocal call_count
+                    if max_tool_calls is not None:
+                        call_count += 1
+                        if call_count > max_tool_calls:
+                            raise ToolError(
+                                f"Tool call limit exceeded: at most {max_tool_calls} "
+                                "call_tool() invocations are allowed per execute()."
+                            )
+                    backend_tools = await transform.get_tool_catalog(ctx)
+                    tool = transform._find_tool(tool_name, backend_tools)
+                    if tool is None:
+                        raise NotFoundError(f"Unknown tool: {tool_name}")
+                    result = await ctx.fastmcp.call_tool(tool.name, params)
+                    return _unwrap_tool_result(result)
+
+                async def report_progress(
+                    progress: float,
+                    total: float | None = None,
+                    message: str | None = None,
+                ) -> None:
+                    """Stream a progress update to the client (no-op without a progressToken)."""
+                    if ctx is not None:
+                        await ctx.report_progress(progress=progress, total=total, message=message)
+
+                return await transform.sandbox_provider.run(
+                    code,
+                    external_functions={
+                        "call_tool": call_tool,
+                        "report_progress": report_progress,
+                    },
+                )
+
+            return Tool.from_function(
+                fn=execute,
+                name=self.execute_tool_name,
+                description=self._build_execute_description(),
+            )
+
+    return _HpeCodeMode
+
+
 def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """Install the FastMCP CodeMode transform for ``MCP_TOOL_MODE=code``.
 
@@ -921,7 +1007,6 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
     """
     try:
         from fastmcp.experimental.transforms.code_mode import (
-            CodeMode,
             GetSchemas,
             GetTags,
             Search,
@@ -962,6 +1047,8 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
             tool.description = _GET_SCHEMA_DESCRIPTION
             return _make_spec_enriched_get_schema(tool)
 
+    hpe_code_mode_cls = _hpe_code_mode_class()
+
     limits = ResourceLimits(
         max_duration_secs=max_duration_secs,
         max_memory=128 * 1024 * 1024,
@@ -992,6 +1079,14 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
         "code block when `skills_list` returns no applicable skill "
         "(issue #338).\n\n"
         "In scope: `await call_tool(name: str, params: dict) -> Any`.\n\n"
+        "Also in scope: `await report_progress(progress: float, total: float | "
+        "None = None, message: str | None = None) -> None` — stream a status "
+        "update to the client during long multi-call work (e.g. a per-scope sweep "
+        "or a multi-stage migration). Call it as you go: "
+        "`await report_progress(i, n, f'classifying scope {i}/{n}')`. It is a "
+        "harmless no-op on clients that don't request progress, so it is always "
+        "safe to include; use it whenever a block makes many sequential "
+        "`call_tool` invocations.\n\n"
         "`call_tool` reaches:\n"
         "  - Any per-platform tool (mist / central / greenlake / clearpass / "
         "apstra / axis / aos8 / uxi / edgeconnect) — discover names with "
@@ -1095,7 +1190,7 @@ def _register_code_mode(mcp: FastMCP, max_duration_secs: float = 30.0) -> None:
                 logger.warning("MCP Apps: could not expose {} top-level: {}", app_tool_name, e)
 
     mcp.add_transform(
-        CodeMode(
+        hpe_code_mode_cls(
             # ClockEnabledMontySandboxProvider passes os=OSAccess() so sandbox
             # code can call datetime.now()/date.today() (the stock provider
             # blocks the clock); the FS/env stay fully sandboxed. See

--- a/tests/unit/test_code_mode_progress.py
+++ b/tests/unit/test_code_mode_progress.py
@@ -1,0 +1,131 @@
+"""Progress-reporting capability of the code-mode ``execute`` sandbox.
+
+``_HpeCodeMode`` (built by ``server._hpe_code_mode_class``) overrides the stock
+``CodeMode._make_execute_tool`` to inject a ``report_progress`` external function
+alongside ``call_tool``, bound to the live per-call ``ctx``. This lets long-running
+skill code blocks stream status to the client via
+``await report_progress(done, total, "message")``.
+
+These tests drive the REAL production class end-to-end through an in-memory
+``fastmcp.Client`` whose ``progress_handler`` records the notifications. They also
+serve as the pin on the fastmcp internals the override copies
+(``get_tool_catalog`` / ``_find_tool`` / ``sandbox_provider`` / ``max_tool_calls`` /
+``_unwrap_tool_result`` / ``ctx.report_progress``): if a fastmcp upgrade changes
+any of them, either ``call_tool`` or ``report_progress`` stops working and a test
+here fails loudly rather than the capability silently regressing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client, FastMCP
+
+pytestmark = pytest.mark.unit
+
+pytest.importorskip("pydantic_monty", reason="code-mode extra not installed")
+
+
+def _build_code_mode_server() -> FastMCP:
+    """A minimal FastMCP server with one tool and the real ``_HpeCodeMode`` transform.
+
+    Uses the production class from ``server._hpe_code_mode_class`` with the real
+    ``ClockEnabledMontySandboxProvider`` — the same wiring ``_register_code_mode``
+    uses, minus the discovery-tool/skills plumbing which is orthogonal to progress.
+    """
+    from pydantic_monty import ResourceLimits
+
+    from hpe_networking_mcp.code_sandbox import ClockEnabledMontySandboxProvider
+    from hpe_networking_mcp.server import _hpe_code_mode_class
+
+    mcp = FastMCP("progress-test")
+
+    @mcp.tool
+    async def central_get_sites() -> dict:
+        return {"sites": ["HQ", "BRANCH-1", "BRANCH-2"]}
+
+    limits = ResourceLimits(
+        max_duration_secs=30,
+        max_memory=128 * 1024 * 1024,
+        max_recursion_depth=50,
+    )
+    cls = _hpe_code_mode_class()
+    mcp.add_transform(cls(sandbox_provider=ClockEnabledMontySandboxProvider(limits=limits)))
+    return mcp
+
+
+async def _run(code: str) -> tuple[object, list[tuple]]:
+    """Execute ``code`` in the sandbox, returning (result, progress_events)."""
+    mcp = _build_code_mode_server()
+    seen: list[tuple] = []
+
+    async def progress_handler(progress, total, message):
+        seen.append((progress, total, message))
+
+    async with Client(mcp, progress_handler=progress_handler) as client:
+        result = await client.call_tool("execute", {"code": code})
+    return result.data, seen
+
+
+@pytest.mark.asyncio
+async def test_report_progress_reaches_client_handler():
+    """A sandbox block calling report_progress streams every update to the client."""
+    code = (
+        "await report_progress(0, 3, 'start')\n"
+        "await report_progress(1, 3, 'middle')\n"
+        "await report_progress(3, 3, 'done')\n"
+        "return {'status': 'ok'}\n"
+    )
+    result, seen = await _run(code)
+    assert result == {"status": "ok"}
+    assert seen == [
+        (0.0, 3.0, "start"),
+        (1.0, 3.0, "middle"),
+        (3.0, 3.0, "done"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_report_progress_and_call_tool_coexist():
+    """report_progress does not displace call_tool — a realistic sweep uses both."""
+    code = (
+        "sites = await call_tool('central_get_sites', {})\n"
+        "names = sites['sites']\n"
+        "total = len(names)\n"
+        "for i, n in enumerate(names):\n"
+        "    await report_progress(i + 1, total, 'classifying ' + n)\n"
+        "return {'count': total}\n"
+    )
+    result, seen = await _run(code)
+    assert result == {"count": 3}
+    assert len(seen) == 3
+    assert seen[0] == (1.0, 3.0, "classifying HQ")
+    assert seen[-1] == (3.0, 3.0, "classifying BRANCH-2")
+
+
+@pytest.mark.asyncio
+async def test_report_progress_optional_args():
+    """total and message are optional (matches the FastMCP report_progress contract)."""
+    code = "await report_progress(5)\nreturn None\n"
+    _result, seen = await _run(code)
+    assert seen == [(5.0, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_execute_still_works_without_progress_calls():
+    """A block that never calls report_progress behaves exactly as before (no events)."""
+    code = "x = await call_tool('central_get_sites', {})\nreturn {'count': len(x['sites'])}\n"
+    result, seen = await _run(code)
+    assert result == {"count": 3}
+    assert seen == []
+
+
+def test_hpe_code_mode_subclasses_code_mode():
+    """The factory returns a genuine CodeMode subclass (not a stand-in)."""
+    from fastmcp.experimental.transforms.code_mode import CodeMode
+
+    from hpe_networking_mcp.server import _hpe_code_mode_class
+
+    cls = _hpe_code_mode_class()
+    assert issubclass(cls, CodeMode)
+    assert cls is not CodeMode
+    assert "_make_execute_tool" in cls.__dict__  # override is present locally

--- a/tests/unit/test_server_code_mode.py
+++ b/tests/unit/test_server_code_mode.py
@@ -120,6 +120,19 @@ def test_execute_description_mentions_in_sandbox_discovery_path() -> None:
 
 
 @pytest.mark.unit
+def test_execute_description_mentions_report_progress() -> None:
+    """The execute() sandbox exposes ``report_progress`` (via ``_HpeCodeMode``);
+    the description must advertise it so the model streams status during long
+    multi-call blocks instead of leaving the client on a silent spinner. Behavior
+    is verified end-to-end in ``test_code_mode_progress.py``.
+    """
+    body = _read_execute_description_block()
+    assert "report_progress" in body, (
+        "execute_description must present `report_progress` as an in-sandbox external function."
+    )
+
+
+@pytest.mark.unit
 def test_discovery_tool_descriptions_carry_platform_keywords() -> None:
     """v3.0.1.15 (issue #302): top-level discovery tool descriptions must
     include the HPE networking platform names so client semantic tool_search

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.6.1.5"
+version = "3.6.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
## What

Adds a second injected external function to the code-mode `execute()` sandbox, alongside `call_tool`:

```python
await report_progress(progress: float, total: float | None = None, message: str | None = None)
```

Long-running skill blocks — the central-scope-visualizer per-scope classification sweep, the aos-migration multi-stage plan, any fan-out across many sites — previously ran as a single opaque `execute()` call, leaving the client on a silent spinner for the whole duration. Blocks can now stream status as they advance:

```python
scopes = (await call_tool("central_get_scope_tree", {}))["data"]["children"]
for i, s in enumerate(scopes):
    await report_progress(i + 1, len(scopes), f"classifying {s['scope_name']}")
    ...
```

## How

FastMCP's `CodeMode._make_execute_tool` builds the `execute(code, ctx)` closure with a hardcoded `external_functions={"call_tool": ...}` dict and exposes no hook to add more. `report_progress` needs the live per-call `ctx`, which only exists inside that closure — so we override the method.

- New `_HpeCodeMode` subclass built by `server._hpe_code_mode_class()` (module-level factory, lazy fastmcp import so non-code modes don't need the extra to import `server`). It's a faithful copy of the upstream `call_tool` closure with `report_progress` added, bound to `ctx`.
- Same subclassing pattern the file already uses for the code-mode transform pieces (`_HpeSearch` / `_HpeGetTags` / `_HpeGetSchemas`).
- Per the [FastMCP progress contract](https://gofastmcp.com/servers/progress), `ctx.report_progress` is a **no-op unless the client sent a `progressToken`** — so this is always safe to include and degrades gracefully on clients that don't render progress.

## Tests

`tests/unit/test_code_mode_progress.py` drives the **real production class** end-to-end through an in-memory `fastmcp.Client` whose `progress_handler` records notifications — verifying `report_progress` round-trips from sandbox code (with `total`/`message`, and with them omitted), that it coexists with `call_tool`, and that blocks which never call it behave exactly as before. It also **pins the fastmcp internals** the override copies (`get_tool_catalog` / `_find_tool` / `sandbox_provider` / `max_tool_calls` / `_unwrap_tool_result` / `ctx.report_progress`) so a fastmcp upgrade that changes them fails loudly instead of silently dropping either capability. Plus a description-literal pin in `test_server_code_mode.py`.

Full gate green in Docker: ruff / format / mypy / bandit clean, 2166 passed / 2 skipped.

## Docs

- `execute` tool description advertises `report_progress` to the model.
- INSTRUCTIONS.md — new sandbox pattern 5 (with example) + known-working entry.
- docs/TOOLS.md — execute bullet + "What `call_tool` can dispatch to" note.
- CHANGELOG 3.6.1.6, version bump.

## Notes

- No tool-count change — `report_progress` is an in-sandbox function, not a top-level tool.
- Sequences after #634 (which claims 3.6.1.5); will reconcile the version if merge order flips.
- Intended first consumers are the central-scope-visualizer and aos-migration skills, as follow-ups.
- The clean long-term home is an upstream fastmcp "extra external functions" hook; can file that request separately so the subclass can eventually be dropped.