### PR TITLE
fix(mist): enrich raised ToolErrors via spec-index + guide SLE metric keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.8] - 2026-07-21
+
+### Fixed
+- **Raised `ToolError`s now get the same spec-index error enrichment that returned-error envelopes already got.** Platform tools that follow the ToolError contract (Mist's `_client`, others) **raise** `ToolError` on a non-2xx upstream response — which bypassed the reactive spec-index enrichment entirely (it only fired on *returned* non-2xx envelopes via `ResponseEnvelopeMiddleware` and on 422 `ValidationError`s via `ValidationCatchMiddleware`). So a model that guessed and hit, say, a Mist 404 or 429 got only the bare error with no `[spec-index]` hint. New `ToolErrorEnrichMiddleware` catches raised `ToolError`s at `on_call_tool` and appends `reactive_hint(tool_name, status_code)` — the API's documented meaning of the code (e.g. Mist 429 → "5000 API Calls per hour threshold") plus the legal body fields for 400/422 — so the model self-corrects. Best-effort and non-destructive: the original status_code/message are preserved, the suffix is idempotent, and an enrichment failure never breaks dispatch. Reported by Zach (Mist SLE transcript). Closes #638.
+- **Mist SLE tools: guessed `metric` keys now return actionable guidance instead of a bare `404 "no such metric"`.** The SLE `metric` path key is not free-form — valid keys are per-scope and come from `mist_list_site_sles_metrics` (they are dynamic and not in the OpenAPI spec, so the spec-index cannot enumerate them). A model guessing a plausible-but-wrong name (e.g. `successful-connect`, which does not exist — the connection SLE is `time-to-connect`) hit a dead 404. `platforms/mist/_client.py` now enriches that specific 404 with the real common keys and a pointer to `mist_list_site_sles_metrics`.
+- **Corrected the Mist 403 hint, which named a non-existent tool.** The `_raise_for_status` 403 enrichment told the model to call `mist_get_self_account_info` — that tool does not exist (it returns `unknown_tool`); the real one is `mist_get_self`. Fixed the hint and the docstring.
+
 ## [3.6.1.7] - 2026-07-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.7"
+version = "3.6.1.8"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/middleware/tool_error_enrich.py
+++ b/src/hpe_networking_mcp/middleware/tool_error_enrich.py
@@ -1,0 +1,70 @@
+"""Reactive spec-index enrichment for RAISED ``ToolError``s (issue #638).
+
+Platform tools that follow the ToolError contract (e.g. Mist's ``_client``)
+**raise** ``ToolError({"status_code": N, "message": ...})`` on a non-2xx
+upstream response. Two existing hooks already enrich errors from the spec-index:
+``ResponseEnvelopeMiddleware`` (tools that *return* a non-2xx envelope) and
+``ValidationCatchMiddleware`` (422 ``ValidationError``). A **raised** ToolError
+hits neither — so it reaches the model (or the code-mode sandbox) with only its
+bare message and no ``[spec-index]`` hint. That is the gap Zach's Mist SLE 404
+fell through.
+
+This middleware closes it: it catches ``ToolError`` at ``on_call_tool`` and
+appends ``reactive_hint(tool_name, status_code)`` — the API's *documented*
+meaning of the status code (+ the legal body field set for 400/422) — so a model
+that guessed and hit an error learns to self-correct instead of retrying blind.
+Best-effort and non-destructive: the original ToolError (type, status_code,
+message) is preserved; only the message string gains a suffix, and only when the
+spec-index actually has something to say.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mcp.types
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+from fastmcp.tools.tool import ToolResult
+
+
+class ToolErrorEnrichMiddleware(Middleware):
+    """Append spec-index status guidance to raised ``ToolError``s."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mcp.types.CallToolRequestParams],
+        call_next: Any,
+    ) -> ToolResult:
+        try:
+            return await call_next(context)  # type: ignore[no-any-return]
+        except ToolError as err:
+            tool_name = getattr(context.message, "name", "") or ""
+            enriched = self._enriched(tool_name, err)
+            if enriched is not None:
+                raise enriched from err
+            raise
+
+    @staticmethod
+    def _enriched(tool_name: str, err: ToolError) -> ToolError | None:
+        """Return a new ToolError with the spec-index hint appended, or ``None``.
+
+        Only structured ``{"status_code", "message"}`` payloads are enrichable;
+        string-only ToolErrors carry no status code to look up and pass through.
+        Skips messages already carrying a ``[spec-index]`` suffix (idempotent).
+        """
+        payload = err.args[0] if err.args else None
+        if not isinstance(payload, dict):
+            return None
+        message = payload.get("message")
+        if not isinstance(message, str) or "[spec-index]" in message:
+            return None
+        try:
+            from hpe_networking_mcp.spec_index.error_help import reactive_hint
+
+            hint = reactive_hint(tool_name, payload.get("status_code"))
+        except Exception:  # pragma: no cover - enrichment must never break dispatch
+            hint = None
+        if not hint:
+            return None
+        return ToolError({**payload, "message": message + hint})

--- a/src/hpe_networking_mcp/platforms/mist/_client.py
+++ b/src/hpe_networking_mcp/platforms/mist/_client.py
@@ -139,8 +139,9 @@ def _raise_for_status(response: httpx.Response) -> None:
     """Convert non-2xx responses to ``ToolError`` with structured details.
 
     Mist returns useful error bodies on 4xx/5xx; surface them to the AI.
-    For 403, include the standard hint about `mist_get_self_account_info`
-    being the canonical org_id source.
+    For 403, include the standard hint about `mist_get_self` being the
+    canonical org_id source; for a 404 "no such metric" (guessed SLE metric
+    key) point to `mist_list_site_sles_metrics` with the valid keys (#638).
     """
     if response.status_code < 400:
         return
@@ -161,8 +162,29 @@ def _raise_for_status(response: httpx.Response) -> None:
                     "Permission Denied. This usually means you are using a "
                     "tool with an invalid id (e.g. org_id, site_id). Make "
                     "sure to retrieve them from another tool (e.g. use "
-                    "`mist_get_self_account_info` to retrieve the correct "
-                    "org_id)."
+                    "`mist_get_self` to retrieve the correct org_id)."
+                ),
+            }
+        )
+
+    # SLE endpoints take a `metric` path key that is NOT free-form — valid keys
+    # are per-scope and come from `mist_list_site_sles_metrics`. Guessed names
+    # (a common one: "successful-connect", which does not exist) return a bare
+    # 404 `{"detail": "no such metric"}`; enrich it so the AI self-corrects
+    # instead of guessing again (issue #638).
+    if response.status_code == 404 and "no such metric" in _json.dumps(detail).lower():
+        raise ToolError(
+            {
+                "status_code": 404,
+                "message": (
+                    "No such SLE metric. The `metric` must be an exact key from "
+                    "`mist_list_site_sles_metrics` for this site/scope — do not "
+                    "guess. Common wireless keys: coverage, capacity, "
+                    "time-to-connect, failed-to-connect, roaming, throughput, "
+                    "ap-availability, ap-health. There is NO 'successful-connect' "
+                    "/ 'successful-connects' — use 'time-to-connect' (or "
+                    "'failed-to-connect'). Call `mist_list_site_sles_metrics` "
+                    "first to get the valid keys for this scope."
                 ),
             }
         )

--- a/src/hpe_networking_mcp/server.py
+++ b/src/hpe_networking_mcp/server.py
@@ -378,6 +378,9 @@ def create_server(config: ServerConfig) -> FastMCP:
     from hpe_networking_mcp.middleware.sandbox_error_catch import (
         SandboxErrorCatchMiddleware,
     )
+    from hpe_networking_mcp.middleware.tool_error_enrich import (
+        ToolErrorEnrichMiddleware,
+    )
     from hpe_networking_mcp.middleware.unknown_tool_suggest import (
         UnknownToolSuggestMiddleware,
     )
@@ -396,6 +399,7 @@ def create_server(config: ServerConfig) -> FastMCP:
     # Middleware order (outermost → innermost):
     #   NullStrip           — drop nulls before validation
     #   ValidationCatch     — Pydantic ValidationError → readable string return
+    #   ToolErrorEnrich     — raised ToolError → append spec-index status hint (#638)
     #   SandboxErrorCatch   — code-mode MontyRuntimeError on execute → string return
     #   UnknownToolSuggest  — top-level "Unknown tool" → structured "did you
     #                         mean" candidate list (#489)
@@ -418,6 +422,7 @@ def create_server(config: ServerConfig) -> FastMCP:
         middleware=[
             NullStripMiddleware(),
             ValidationCatchMiddleware(),
+            ToolErrorEnrichMiddleware(),
             SandboxErrorCatchMiddleware(),
             UnknownToolSuggestMiddleware(),
             PIITokenizationMiddleware(token_store, enabled=config.enable_pii_tokenization),

--- a/tests/unit/test_mist_client_response.py
+++ b/tests/unit/test_mist_client_response.py
@@ -102,3 +102,38 @@ async def test_empty_collection_survives_envelope_end_to_end():
     assert (dict_res.structured_content or {}).get("data") == _EMPTY
     # A bare empty list collapses to data:null — documents WHY the dict is needed.
     assert (list_res.structured_content or {}).get("data") is None
+
+
+async def test_no_such_metric_404_enriched_with_sle_metric_guidance():
+    """#638: a guessed SLE metric key returns a bare 404 `{"detail": "no such
+    metric"}`; the enricher must point at `mist_list_site_sles_metrics` and name
+    real keys so the AI stops guessing (e.g. `successful-connect` is NOT a key)."""
+    from fastmcp.exceptions import ToolError
+
+    ctx = _ctx(_resp(status=404, json_value={"detail": "no such metric"}))
+    with pytest.raises(ToolError) as e:
+        await mist_request(
+            ctx,
+            "GET",
+            "/api/v1/sites/s/sle/site/s/metric/successful-connect/impact-summary",
+        )
+    payload = e.value.args[0]
+    assert payload["status_code"] == 404
+    msg = payload["message"]
+    assert "mist_list_site_sles_metrics" in msg
+    assert "time-to-connect" in msg
+    assert "successful-connect" in msg  # explicitly called out as NOT a key
+
+
+async def test_403_hint_points_to_existing_self_tool():
+    """The 403 hint must name a real tool: `mist_get_self`, not the
+    non-existent `mist_get_self_account_info` (which itself returned unknown_tool)."""
+    from fastmcp.exceptions import ToolError
+
+    ctx = _ctx(_resp(status=403, json_value={"detail": "permission denied"}))
+    with pytest.raises(ToolError) as e:
+        await mist_request(ctx, "GET", "/api/v1/orgs/x/sites")
+    payload = e.value.args[0]
+    assert payload["status_code"] == 403
+    assert "mist_get_self" in payload["message"]
+    assert "mist_get_self_account_info" not in payload["message"]

--- a/tests/unit/test_tool_error_enrich.py
+++ b/tests/unit/test_tool_error_enrich.py
@@ -1,0 +1,89 @@
+"""Unit tests for ToolErrorEnrichMiddleware (#638).
+
+Raised ``ToolError``s bypass the spec-index enrichment that returned-envelope
+and ValidationError paths get. This middleware closes that gap by appending
+``reactive_hint(tool_name, status_code)`` to the message. These tests pin the
+enrichment logic (the ``_enriched`` decision) with ``reactive_hint`` stubbed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from hpe_networking_mcp.middleware.tool_error_enrich import ToolErrorEnrichMiddleware
+
+pytestmark = pytest.mark.unit
+
+_HINT = "  [spec-index] API documents 404: The requested resource does not exist"
+
+
+def test_structured_toolerror_gets_hint_appended(monkeypatch):
+    monkeypatch.setattr(
+        "hpe_networking_mcp.spec_index.error_help.reactive_hint",
+        lambda tool, code: _HINT,
+    )
+    err = ToolError({"status_code": 404, "message": "boom"})
+    out = ToolErrorEnrichMiddleware._enriched("mist_get_site_sle_impact_summary", err)
+    assert out is not None
+    assert out.args[0]["status_code"] == 404
+    assert out.args[0]["message"] == "boom" + _HINT
+
+
+def test_string_payload_passes_through():
+    # No status_code to look up → nothing to enrich.
+    err = ToolError("plain string error")
+    assert ToolErrorEnrichMiddleware._enriched("mist_get_x", err) is None
+
+
+def test_already_enriched_is_idempotent(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "hpe_networking_mcp.spec_index.error_help.reactive_hint",
+        lambda tool, code: calls.append(1) or "x",
+    )
+    err = ToolError({"status_code": 404, "message": "boom  [spec-index] already there"})
+    assert ToolErrorEnrichMiddleware._enriched("mist_get_x", err) is None
+    assert not calls  # short-circuits before calling reactive_hint
+
+
+def test_no_hint_available_passes_through(monkeypatch):
+    monkeypatch.setattr(
+        "hpe_networking_mcp.spec_index.error_help.reactive_hint",
+        lambda tool, code: None,
+    )
+    err = ToolError({"status_code": 500, "message": "boom"})
+    assert ToolErrorEnrichMiddleware._enriched("central_get_x", err) is None
+
+
+def test_enrichment_failure_never_breaks(monkeypatch):
+    def _boom(tool, code):
+        raise RuntimeError("index blew up")
+
+    monkeypatch.setattr("hpe_networking_mcp.spec_index.error_help.reactive_hint", _boom)
+    err = ToolError({"status_code": 404, "message": "boom"})
+    # Must swallow the enrichment failure and pass the original through unchanged.
+    assert ToolErrorEnrichMiddleware._enriched("mist_get_x", err) is None
+
+
+async def test_middleware_enriches_raised_toolerror_end_to_end(monkeypatch):
+    """The wired middleware catches a tool's raised ToolError and the enriched
+    message reaches the client — the path a raw `_enriched` unit test can't prove."""
+    from fastmcp import Client, FastMCP
+
+    monkeypatch.setattr(
+        "hpe_networking_mcp.spec_index.error_help.reactive_hint",
+        lambda tool, code: "  [spec-index] API documents 404: Not found",
+    )
+    mcp = FastMCP("enrich-test", middleware=[ToolErrorEnrichMiddleware()])
+
+    @mcp.tool
+    async def boom_tool() -> dict:
+        raise ToolError({"status_code": 404, "message": "no such metric"})
+
+    async with Client(mcp) as client:
+        with pytest.raises(ToolError) as e:
+            await client.call_tool("boom_tool", {})
+    text = str(e.value)
+    assert "no such metric" in text
+    assert "[spec-index] API documents 404" in text

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.6.1.7"
+version = "3.6.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Closes #638. Reported by **Zach** (Mist SLE code-mode transcript).

## Problem

A block hit `mist_get_site_sle_impact_summary(..., metric='successful-connect')` → `404 {"detail": "no such metric"}`. Two layer defects turned a wrong guess into a dead end:

1. **Raised `ToolError`s bypass the spec-index enrichment.** The reactive enrichment (`spec_index/error_help.reactive_hint`) only fires on **returned** non-2xx envelopes (`ResponseEnvelopeMiddleware`) and 422 `ValidationError`s (`ValidationCatchMiddleware`). Mist tools **raise** `ToolError`, so they got **no** `[spec-index]` hint at all — the whole Mist error surface was uncovered.
2. **The `metric` key was a guess.** Valid SLE keys are per-scope and come from `mist_list_site_sles_metrics`; the param description only said *"Values from `listSiteSlesMetrics`"*. `successful-connect` isn't a key (the connection SLE is `time-to-connect`); `capacity` was fine.
3. **Bonus bug:** the Mist 403 hint told the model to call `mist_get_self_account_info` — which doesn't exist (`unknown_tool`); real tool is `mist_get_self`.

## Fix

- **`ToolErrorEnrichMiddleware`** (new) — catches raised `ToolError` at `on_call_tool` and appends `reactive_hint(tool_name, status_code)`, the same DB-backed enrichment the returned-envelope path already gets. Verified live: the spec-index yields real Mist meanings (404 → "Not found…", 429 → "5000 API Calls per hour threshold", 403 → "Permission Denied"). Best-effort, idempotent, non-destructive; an enrichment failure never breaks dispatch.
- **`mist/_client.py`** — the SLE metric keys are **dynamic** (from `mist_list_site_sles_metrics`) and not in the OpenAPI spec, so the DB structurally can't supply them; the 404 "no such metric" branch now points the model at that list tool + names the real common keys. Also corrected the 403 hint → `mist_get_self`.

The two compose: the middleware supplies what the DB *can* (documented status meaning), the `_client.py` pointer supplies what it *can't* (the dynamic key list).

## Tests

`test_tool_error_enrich.py` (6): enrichment logic + an **end-to-end** test proving the wired middleware catches a raised `ToolError` through the real chain and the enriched message reaches the client. `test_mist_client_response.py` (+2): the SLE 404 pointer and the corrected 403 hint via `mist_request`.

Full gate green in Docker: ruff / format / mypy / bandit clean, **2177 passed / 2 skipped**. No tool-count change. `docker-compose.yml` untouched. Version 3.6.1.8.