### PR TITLE
fix(tools): unconfigured-platform tool call returns 'not configured', not a circular hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.9] - 2026-07-21
+
+### Fixed
+- **Calling a tool on an unconfigured platform now says "not configured" instead of a circular dispatch hint.** When a platform has no credentials (empty or absent secret files — `_read_secret` strips and returns `None`, so both are identical), it is correctly disabled and none of its tools register. But an AI that then called, say, `clearpass_invoke_tool` got `{"error":"unknown_tool","candidates":[],"dispatch":"clearpass_invoke_tool(name, params)"}` — the `dispatch` hint pointed back at the very tool that doesn't exist, with no signal that the platform simply isn't configured. `suggest_tools` now detects a known-platform prefix with **zero** registered tools and returns `{"error":"platform_not_configured","platform":<p>,"message":"…not configured on this deployment; skip it, do not retry","candidates":[]}` instead. Applies uniformly to all nine platforms (mist / central / greenlake / clearpass / apstra / axis / aos8 / uxi / edgeconnect) in both code-mode (`sandbox_error_catch`) and dynamic-mode (`meta_tools`) paths. Reported by Zach (ClearPass not configured). Closes #640.
+
 ## [3.6.1.8] - 2026-07-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.8"
+version = "3.6.1.9"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/_common/tool_suggest.py
+++ b/src/hpe_networking_mcp/platforms/_common/tool_suggest.py
@@ -29,6 +29,16 @@ _UNKNOWN_TOOL_RE = re.compile(r"""Unknown tool:\s*['"]?([A-Za-z0-9_]+)""")
 
 _FUZZY_CUTOFF = 0.6
 
+# Every platform this server can host. Used to tell "the model guessed a bad
+# name on a configured platform" (suggest candidates) apart from "the platform
+# isn't configured on this deployment at all" (say so, don't dispatch). The
+# latter is what Zach hit: a `clearpass_*` call when ClearPass has no credentials
+# (empty/absent secret) — a `clearpass_invoke_tool` dispatch hint there points at
+# a tool that also doesn't exist (issue #640).
+_KNOWN_PLATFORMS = frozenset(
+    {"mist", "central", "greenlake", "clearpass", "apstra", "axis", "aos8", "uxi", "edgeconnect"}
+)
+
 
 def _name_to_platform() -> dict[str, str]:
     """Map every registered underlying tool name to its platform.
@@ -70,6 +80,26 @@ def suggest_tools(requested: str, *, platform: str | None = None, limit: int = 5
     """
     requested = (requested or "").strip()
     name_to_platform = _name_to_platform()
+
+    # A prefix that names a real platform which has ZERO registered tools means
+    # that platform isn't configured/enabled on this deployment (its secrets are
+    # absent or empty). Suggesting a `<plat>_invoke_tool` dispatch here points the
+    # model back at a tool that also doesn't exist — so say so plainly instead,
+    # and it can skip the platform rather than loop (issue #640).
+    prefix = requested.split("_", 1)[0].lower()
+    if prefix in _KNOWN_PLATFORMS and not any(p == prefix for p in name_to_platform.values()):
+        return {
+            "error": "platform_not_configured",
+            "requested": requested,
+            "platform": prefix,
+            "candidates": [],
+            "message": (
+                f"The '{prefix}' platform is not configured on this MCP deployment — no "
+                f"{prefix}_* tools are registered (its credentials are absent or empty). "
+                "Skip it; do not retry."
+            ),
+        }
+
     plat = platform or _platform_from_name(requested)
 
     # Prefer same-platform candidates; widen to the full corpus if the scoped
@@ -106,10 +136,11 @@ def unknown_tool_payload_from_text(text: str) -> dict | None:
         return None
     payload = suggest_tools(match.group(1))
     # Only surface the structured payload when it is actionable — a resolved
-    # platform dispatch hint or at least one real candidate name. A bare name
-    # with neither (e.g. a model calling the top-level `search` tool from
-    # inside execute, #208 — not a platform-tool typo) falls through to the
-    # caller's plain error text so that behavior is preserved.
-    if payload.get("dispatch") or payload.get("candidates"):
+    # platform dispatch hint, at least one real candidate name, or a definitive
+    # "platform not configured" verdict (#640). A bare name with none of these
+    # (e.g. a model calling the top-level `search` tool from inside execute,
+    # #208 — not a platform-tool typo) falls through to the caller's plain error
+    # text so that behavior is preserved.
+    if payload.get("dispatch") or payload.get("candidates") or payload.get("error") == "platform_not_configured":
         return payload
     return None

--- a/tests/unit/test_tool_suggest.py
+++ b/tests/unit/test_tool_suggest.py
@@ -136,3 +136,66 @@ class TestUnknownToolSuggestMiddleware:
 
         with pytest.raises(ValueError):
             await mw.on_call_tool(_Ctx(), call_next)
+
+
+@pytest.mark.unit
+class TestDisabledPlatform:
+    """#640: a call to a platform with zero registered tools (disabled — empty or
+    absent secrets) must return a clear 'not configured' verdict, NOT a
+    ``<plat>_invoke_tool`` dispatch hint that points at a tool that also doesn't
+    exist. Affects every platform identically, so this is verified across all of
+    them."""
+
+    @pytest.fixture
+    def central_on_clearpass_off(self):
+        """Central enabled (has tools); ClearPass disabled (no tools)."""
+        reg = tool_registry.REGISTRIES
+        snap = {p: dict(reg.get(p, {})) for p in ("central", "clearpass")}
+        reg["central"] = {
+            "central_get_sites": ToolSpec(
+                name="central_get_sites", func=lambda: None, platform="central", category="test"
+            )
+        }
+        reg["clearpass"] = {}
+        yield
+        for p, d in snap.items():
+            reg[p] = d
+
+    def test_disabled_platform_returns_not_configured(self, central_on_clearpass_off) -> None:
+        out = suggest_tools("clearpass_get_sessions")
+        assert out["error"] == "platform_not_configured"
+        assert out["platform"] == "clearpass"
+        assert out["candidates"] == []
+        assert "dispatch" not in out  # no circular pointer to a non-existent tool
+        assert "not configured" in out["message"].lower()
+
+    def test_enabled_platform_still_suggests_candidates(self, central_on_clearpass_off) -> None:
+        # A configured platform's bad guess still gets candidates + dispatch.
+        out = suggest_tools("central_list_sites")
+        assert out["error"] == "unknown_tool"
+        assert "central_get_sites" in out["candidates"]
+        assert out["dispatch"] == "central_invoke_tool(name, params)"
+
+    def test_payload_from_text_surfaces_not_configured(self, central_on_clearpass_off) -> None:
+        out = unknown_tool_payload_from_text("Unknown tool: clearpass_invoke_tool")
+        assert out is not None
+        assert out["error"] == "platform_not_configured"
+        assert out["platform"] == "clearpass"
+
+    def test_all_known_platforms_when_empty(self) -> None:
+        """Every platform prefix, when it has zero tools, yields not_configured."""
+        from hpe_networking_mcp.platforms._common.tool_suggest import _KNOWN_PLATFORMS
+
+        reg = tool_registry.REGISTRIES
+        snap = {p: dict(reg.get(p, {})) for p in _KNOWN_PLATFORMS}
+        for p in _KNOWN_PLATFORMS:
+            reg[p] = {}
+        try:
+            for p in _KNOWN_PLATFORMS:
+                out = suggest_tools(f"{p}_invoke_tool")
+                assert out["error"] == "platform_not_configured", p
+                assert out["platform"] == p
+                assert "dispatch" not in out, p
+        finally:
+            for p, d in snap.items():
+                reg[p] = d

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "hpe-networking-mcp"
-version = "3.6.1.8"
+version = "3.6.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
Closes #640. Reported by **Zach** (ClearPass not configured on his deployment).

## Problem

A code-mode block called `clearpass_invoke_tool` where ClearPass has no credentials and got:

```json
{"error":"unknown_tool","requested":"clearpass_invoke_tool","candidates":[],"dispatch":"clearpass_invoke_tool(name, params)"}
```

The `dispatch` hint points the model back at `clearpass_invoke_tool` — the very tool that does not exist because the platform is disabled — with zero candidates. The model gets no signal that ClearPass simply is not configured on this deployment, so it cannot cleanly skip it.

## Diagnosis

Config is correct: `_read_secret` strips file contents and returns `None` for empty/whitespace-only files, so an empty **or** absent secret disables the platform identically (`_load_*` -> missing -> `None` -> disabled). The bug is purely in the error message — `suggest_tools` resolved the `clearpass` prefix (registry key present but empty) and emitted a `<plat>_invoke_tool` dispatch hint despite the platform having **zero** registered tools.

**This affects all nine platforms equally** (mist / central / greenlake / clearpass / apstra / axis / aos8 / uxi / edgeconnect) — each auto-disables the same way. Verified `_KNOWN_PLATFORMS` matches the real registry prefixes exactly.

## Fix

`suggest_tools` now detects a known-platform prefix with zero registered tools and returns `{"error":"platform_not_configured","platform":<p>,"candidates":[],"message":"…not configured on this deployment; skip it, do not retry"}` instead of the circular dispatch. `unknown_tool_payload_from_text` surfaces it. Covers both the code-mode sandbox path (`sandbox_error_catch`) and dynamic-mode `meta_tools`.

## Tests

`test_tool_suggest.py` +4: disabled platform -> `platform_not_configured`; a **configured** platform still gets candidates + dispatch; the text-parser surfaces it; and a parametrized check across **all nine** platforms. Full gate green in Docker: ruff / format / mypy clean, 2181 passed / 2 skipped. No tool-count change. Version 3.6.1.9.
