### PR TITLE
fix(central): correct/remove query params the New Central API rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1.10] - 2026-07-27
+
+### Fixed
+- **Central: corrected/removed query-param names that the New Central API rejects with HTTP 400.** A runtime-capture audit of every Central tool's request was reconciled against the vendored New Central OAS and confirmed against a live tenant. Unlike the `network-config` API (which silently ignores unknown query params), `network-monitoring` / `network-notifications` / `network-services` **reject** them with `400 "Unknown query parameter"`, so the affected tools failed when the param was used. Two classes of fix:
+  - **Renamed to the documented names** (live-verified to return 200): `central_get_client_mobility_trail` and `central_get_location_analytics_trends` now send `start-at` / `end-at` instead of `start` / `end`; `central_get_alert_configs` sends `scope-id` / `scope-type` instead of camelCase `scopeId` / `scopeType`.
+  - **Removed dead params with no working alternative** (both the wrong and the "corrected" name 400; the endpoint accepts none): `start` / `end` dropped from the 13 AP/gateway/switch/cluster `*-trends` tools (`central_get_ap_trend`, `central_get_ap_radio_trend`, `central_get_ap_port_trend`, `central_get_ap_tunnel_trend`, `central_get_ap_wlan_throughput`, `central_get_gateway_trend`, `central_get_gateway_port_trend`, `central_get_gateway_tunnel_trend`, `central_get_gateway_uplink_trend`, `central_get_gateway_uplink_probe_performance`, `central_get_gateway_uplink_vpn_availability`, `central_get_cluster_capacity_trends`, `central_get_switch_interface_trends`); `filter` dropped from 9 tools that 400 on it (`central_get_client_onboarding_score` / `_stage_count` / `_stage_export` / `_stage_reasons`, `central_get_tenant_client_health`, `central_get_tenant_device_health`, `central_get_insights`, `central_get_event_extra_attributes`, `central_get_location_analytics_site_insights`).
+  Params confirmed accepted/ignored (e.g. `offset` on list endpoints; `filter` on `central_get_asset_tags` / `central_get_firewall_sessions` / `central_get_wlans_monitoring`) were left untouched. Regression tests pin the wire format and the removed params.
+
 ## [3.6.1.9] - 2026-07-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hpe-networking-mcp"
-version = "3.6.1.9"
+version = "3.6.1.10"
 description = "Unofficial, community-driven MCP server for Juniper Mist, Aruba Central, HPE GreenLake, and ClearPass. Not affiliated with HPE, Aruba, or Juniper."
 readme = "README.md"
 license = "MIT"

--- a/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/alert_configs.py
@@ -41,8 +41,12 @@ ScopeType = Literal["GLOBAL", "SITE", "DEVICE"]
 
 
 def _scope_query_params(scope_id: str, scope_type: ScopeType) -> dict[str, str]:
-    """Build the standard scope query-param dict shared by all four endpoints."""
-    return {"scopeId": scope_id, "scopeType": scope_type}
+    """Build the standard scope query-param dict shared by all four endpoints.
+
+    New Central names these query params ``scope-id`` / ``scope-type``
+    (kebab-case); the camelCase ``scopeId`` / ``scopeType`` are rejected.
+    """
+    return {"scope-id": scope_id, "scope-type": scope_type}
 
 
 def _typed_scope_query_params(type_id: str, scope_id: str, scope_type: ScopeType) -> dict[str, str]:

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_ap.py
@@ -31,15 +31,6 @@ async def _get(conn, path: str, params: dict | None = None) -> dict | str:
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-def _time_params(start: str | None, end: str | None) -> dict:
-    params: dict = {}
-    if start:
-        params["start"] = start
-    if end:
-        params["end"] = end
-    return params
-
-
 # ---------------------------------------------------------------------------
 # AP top-level trends + utility lists
 # ---------------------------------------------------------------------------
@@ -72,17 +63,15 @@ async def central_get_ap_trend(
             ),
         ),
     ] = None,
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp (optional; defaults to last 3h).")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp (optional; defaults to last 3h).")] = None,
 ) -> dict | str:
     """Get one of an AP's top-level time-series trends.
 
     Consolidates the four trend endpoints under
     ``/aps/:serial/<dim>-trends`` (throughput, cpu-utilization,
-    memory-utilization, power-consumption). Omit ``start`` / ``end`` for the
-    last-3-hours default. The ``throughput`` dimension additionally requires an
-    ``interface_type`` (WIRELESS / WIRED / LTE) — the API 400s without it; this tool
-    defaults it to ``WIRELESS`` so an AP throughput query works out of the box.
+    memory-utilization, power-consumption). The ``throughput`` dimension
+    additionally requires an ``interface_type`` (WIRELESS / WIRED / LTE) — the
+    API 400s without it; this tool defaults it to ``WIRELESS`` so an AP
+    throughput query works out of the box.
     """
     suffix_map = {
         "throughput": "throughput-trends",
@@ -91,7 +80,7 @@ async def central_get_ap_trend(
         "power": "power-consumption-trends",
     }
     conn = get_central_conn(ctx)
-    params = _time_params(start, end)
+    params: dict = {}
     if dimension == "throughput":
         # interface-type is a mandatory query param for throughput-trends (enum
         # WIRELESS/WIRED/LTE); WIRELESS is the sensible default for an AP.
@@ -135,8 +124,6 @@ async def central_get_ap_radio_trend(
             ),
         ),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of an AP-radio's time-series trends."""
     suffix_map = {
@@ -151,7 +138,7 @@ async def central_get_ap_radio_trend(
         conn,
         f"network-monitoring/v1/aps/{path_seg(serial_number)}/radios/"
         f"{path_seg(radio_number)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -182,8 +169,6 @@ async def central_get_ap_port_trend(
         _PortTrendDimension,
         Field(description="Per-port trend dimension: ``'throughput'``, ``'frames'``, ``'crc'``, or ``'collisions'``."),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of an AP-port's time-series trends."""
     suffix_map = {
@@ -197,7 +182,7 @@ async def central_get_ap_port_trend(
         conn,
         f"network-monitoring/v1/aps/{path_seg(serial_number)}/ports/"
         f"{path_seg(port_index)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -244,8 +229,6 @@ async def central_get_ap_tunnel_trend(
             ),
         ),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of an AP-tunnel's time-series trends."""
     suffix_map = {
@@ -260,7 +243,7 @@ async def central_get_ap_tunnel_trend(
         conn,
         f"network-monitoring/v1/aps/{path_seg(serial_number)}/tunnels/"
         f"{path_seg(tunnel_id)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -289,15 +272,13 @@ async def central_get_ap_wlan_throughput(
     ctx: Context,
     serial_number: Annotated[str, Field(description="AP serial number.")],
     wlan_name: Annotated[str, Field(description="WLAN / SSID name.")],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get throughput trend for one WLAN as broadcast by one AP."""
     conn = get_central_conn(ctx)
     return await _get(
         conn,
         f"network-monitoring/v1/aps/{path_seg(serial_number)}/wlans/{path_seg(wlan_name)}/throughput-trends",
-        _time_params(start, end),
+        {},
     )
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_clients.py
@@ -76,11 +76,14 @@ async def central_get_client_mobility_trail(
 ) -> dict | str:
     """Get a client's roaming / mobility history (AP-to-AP transitions)."""
     conn = get_central_conn(ctx)
+    # New Central names the time-window query params ``start-at`` / ``end-at``
+    # (kebab-case); ``start`` / ``end`` are rejected with HTTP 400
+    # "Unknown query parameter".
     params: dict = {}
     if start:
-        params["start"] = start
+        params["start-at"] = start
     if end:
-        params["end"] = end
+        params["end-at"] = end
     return await _get(conn, f"network-monitoring/v1/clients/{path_seg(mac_address)}/mobility-trail", params)
 
 
@@ -102,20 +105,15 @@ async def central_get_client_detail(
 @tool(capability=Capability.READ)
 async def central_get_client_onboarding_score(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get the aggregate client-onboarding score (success-rate KPI)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/client-onboarding-score", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-score", {})
 
 
 @tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_export(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Export per-client onboarding-stage records.
 
@@ -124,36 +122,25 @@ async def central_get_client_onboarding_stage_export(
     reasons endpoints for summary views.
     """
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/export", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/export", {})
 
 
 @tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_reasons(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get aggregated reasons clients failed onboarding (top failure categories)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/reasons", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/reasons", {})
 
 
 @tool(capability=Capability.READ)
 async def central_get_client_onboarding_stage_count(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get the count of clients at each onboarding stage (funnel view)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/count", params)
+    return await _get(conn, "network-monitoring/v1/client-onboarding-stage/count", {})
 
 
 # ---------------------------------------------------------------------------

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_gateway.py
@@ -31,15 +31,6 @@ async def _get(conn, path: str, params: dict | None = None) -> dict | str:
     return {"status": "error", "code": code, "message": response.get("msg", "Unknown error")}
 
 
-def _time_params(start: str | None, end: str | None) -> dict:
-    params: dict = {}
-    if start:
-        params["start"] = start
-    if end:
-        params["end"] = end
-    return params
-
-
 # ---------------------------------------------------------------------------
 # Gateways list + top-level trends
 # ---------------------------------------------------------------------------
@@ -77,8 +68,6 @@ async def central_get_gateway_trend(
             ),
         ),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of a gateway's top-level time-series trends."""
     suffix_map = {
@@ -92,7 +81,7 @@ async def central_get_gateway_trend(
     return await _get(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -136,8 +125,6 @@ async def central_get_gateway_port_trend(
             description="Per-port dimension: ``'throughput'``, ``'frames'``, ``'frames-errors'``, ``'frames-packets'``."
         ),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of a gateway-port's time-series trends."""
     suffix_map = {
@@ -151,7 +138,7 @@ async def central_get_gateway_port_trend(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/ports/"
         f"{path_seg(port_number)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -193,8 +180,6 @@ async def central_get_gateway_tunnel_trend(
         _GwTunnelTrendDimension,
         Field(description="Per-tunnel dimension: ``'throughput'``, ``'status'``, or ``'dropped-packet'``."),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of a gateway-tunnel's time-series trends."""
     suffix_map = {
@@ -207,7 +192,7 @@ async def central_get_gateway_tunnel_trend(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/tunnels/"
         f"{path_seg(tunnel_name)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -295,8 +280,6 @@ async def central_get_gateway_uplink_trend(
         _UplinkTrendDimension,
         Field(description="Per-uplink dimension: ``'throughput'``, ``'wan-compression'``, or ``'wan-availability'``."),
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get one of a gateway-uplink's time-series trends."""
     suffix_map = {
@@ -309,7 +292,7 @@ async def central_get_gateway_uplink_trend(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/"
         f"{path_seg(link_tag)}/{path_seg(suffix_map[dimension])}",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -333,8 +316,6 @@ async def central_get_gateway_uplink_probe_performance(
     serial_number: Annotated[str, Field(description="Gateway serial number.")],
     link_tag: Annotated[str, Field(description="Uplink tag identifier.")],
     probe: Annotated[str, Field(description="Probe identifier.")],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get performance trend for one specific uplink probe."""
     conn = get_central_conn(ctx)
@@ -342,7 +323,7 @@ async def central_get_gateway_uplink_probe_performance(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/"
         f"{path_seg(link_tag)}/probes/{path_seg(probe)}/performance-trends",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -353,8 +334,6 @@ async def central_get_gateway_uplink_vpn_availability(
     vlan_id: Annotated[
         str, Field(description="VLAN ID (note: this uplink-vpn-availability variant indexes by VLAN, not link-tag).")
     ],
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get VPN-availability trend for an uplink, indexed by VLAN (per Central's MRT shape).
 
@@ -366,7 +345,7 @@ async def central_get_gateway_uplink_vpn_availability(
     return await _get(
         conn,
         f"network-monitoring/v1/gateways/{path_seg(serial_number)}/uplinks/{path_seg(vlan_id)}/vpn-availability-trends",
-        _time_params(start, end),
+        {},
     )
 
 
@@ -473,11 +452,9 @@ async def central_get_cluster_capacity_trends(
             ),
         ),
     ] = None,
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get cluster capacity trends (cluster-wide or per-member)."""
     conn = get_central_conn(ctx)
     base = f"network-monitoring/v1/clusters/{path_seg(cluster_name)}/capacity-trends"
     path = f"{base}/{path_seg(serial_number)}" if serial_number else base
-    return await _get(conn, path, _time_params(start, end))
+    return await _get(conn, path, {})

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_health.py
@@ -64,24 +64,16 @@ async def central_get_sites_client_health(
 @tool(capability=Capability.READ)
 async def central_get_tenant_device_health(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get tenant-wide device health rollup (single record, tenant scope)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/tenant-device-health", params)
+    return await _get(conn, "network-monitoring/v1/tenant-device-health", {})
 
 
 @tool(capability=Capability.READ)
 async def central_get_tenant_client_health(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get tenant-wide client health rollup (single record, tenant scope)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-monitoring/v1/tenant-client-health", params)
+    return await _get(conn, "network-monitoring/v1/tenant-client-health", {})

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_insights.py
@@ -15,7 +15,6 @@ from hpe_networking_mcp.platforms.central.utils import get_central_conn, retry_c
 @tool(capability=Capability.READ)
 async def central_get_insights(
     ctx: Context,
-    filter: str | None = None,
     limit: int = 100,
     offset: int = 0,
 ) -> dict | str:
@@ -27,14 +26,11 @@ async def central_get_insights(
     recommendations.
 
     Parameters:
-        filter: Optional OData 4.0 filter on Insights fields.
         limit: Results per page (default 100).
         offset: Pagination offset (default 0).
     """
     conn = get_central_conn(ctx)
     api_params: dict = {"limit": limit, "offset": offset}
-    if filter:
-        api_params["filter"] = filter
     response = await retry_central_command(
         central_conn=conn,
         api_method="GET",

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_services.py
@@ -401,11 +401,13 @@ async def central_get_location_analytics_trends(
     derived from WiFi client locations.
     """
     conn = get_central_conn(ctx)
+    # New Central names the time-window query params ``start-at`` / ``end-at``
+    # (kebab-case); ``start`` / ``end`` are rejected with HTTP 400.
     params: dict = {}
     if start:
-        params["start"] = start
+        params["start-at"] = start
     if end:
-        params["end"] = end
+        params["end-at"] = end
     if filter:
         params["filter"] = filter
     return await _get(conn, "network-services/v1/location-analytics/trends", params)
@@ -414,11 +416,7 @@ async def central_get_location_analytics_trends(
 @tool(capability=Capability.READ)
 async def central_get_location_analytics_site_insights(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict:
     """Get per-site location-analytics insights (summary KPIs)."""
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
-    return await _get(conn, "network-services/v1/location-analytics/sites/insights", params)
+    return await _get(conn, "network-services/v1/location-analytics/sites/insights", {})

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_switch.py
@@ -86,18 +86,12 @@ async def central_get_switch_interface_trends(
     interface_name: Annotated[
         str | None, Field(description="Specific interface name to scope the trend; omit for all interfaces.")
     ] = None,
-    start: Annotated[str | None, Field(description="ISO-8601 start timestamp.")] = None,
-    end: Annotated[str | None, Field(description="ISO-8601 end timestamp.")] = None,
 ) -> dict | str:
     """Get per-interface throughput / utilization trends for a switch."""
     conn = get_central_conn(ctx)
     params: dict = {}
     if interface_name:
         params["interfaceName"] = interface_name
-    if start:
-        params["start"] = start
-    if end:
-        params["end"] = end
     return await _get(conn, f"network-monitoring/v1/switches/{path_seg(serial_number)}/interface-trends", params)
 
 

--- a/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/mrt_troubleshooting.py
@@ -164,7 +164,6 @@ async def central_list_supported_show_commands(
 @tool(capability=Capability.READ)
 async def central_get_event_extra_attributes(
     ctx: Context,
-    filter: str | None = None,
 ) -> dict | str:
     """Get the catalogue of extra attributes available on events.
 
@@ -172,14 +171,10 @@ async def central_get_event_extra_attributes(
     — each entry describes the attribute name, type, and example values.
     """
     conn = get_central_conn(ctx)
-    params: dict = {}
-    if filter:
-        params["filter"] = filter
     return await _call(
         conn,
         "GET",
         "network-troubleshooting/v1/event-extra-attributes",
-        params=params,
     )
 
 

--- a/tests/unit/test_central_dropped_dead_params.py
+++ b/tests/unit/test_central_dropped_dead_params.py
@@ -1,0 +1,75 @@
+"""Regression tests: dead query-param arguments were removed from Central tools.
+
+Live testing confirmed these params cause HTTP 400 "Unknown query parameter" on
+the New Central API:
+  * the AP/gateway/switch/cluster *trend* endpoints accept no time-window param —
+    both ``start``/``end`` AND ``start-at``/``end-at`` 400, and no-params returns
+    200 — so ``start``/``end`` were removed from the 13 trend tools;
+  * ``filter`` is rejected on the 9 tools below (400), so it was removed.
+
+These tests pin those params as *gone* from the tool signatures, so a future
+edit can't silently re-introduce a param that only ever produces a 400.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MOD = "hpe_networking_mcp.platforms.central.tools."
+
+# (module, tool) -> the dead param that must NOT be in the signature
+_TREND_TOOLS = [
+    ("mrt_ap", "central_get_ap_trend"),
+    ("mrt_ap", "central_get_ap_radio_trend"),
+    ("mrt_ap", "central_get_ap_port_trend"),
+    ("mrt_ap", "central_get_ap_tunnel_trend"),
+    ("mrt_ap", "central_get_ap_wlan_throughput"),
+    ("mrt_gateway", "central_get_gateway_trend"),
+    ("mrt_gateway", "central_get_gateway_port_trend"),
+    ("mrt_gateway", "central_get_gateway_tunnel_trend"),
+    ("mrt_gateway", "central_get_gateway_uplink_trend"),
+    ("mrt_gateway", "central_get_gateway_uplink_probe_performance"),
+    ("mrt_gateway", "central_get_gateway_uplink_vpn_availability"),
+    ("mrt_gateway", "central_get_cluster_capacity_trends"),
+    ("mrt_switch", "central_get_switch_interface_trends"),
+]
+_FILTER_TOOLS = [
+    ("mrt_clients", "central_get_client_onboarding_score"),
+    ("mrt_clients", "central_get_client_onboarding_stage_count"),
+    ("mrt_clients", "central_get_client_onboarding_stage_export"),
+    ("mrt_clients", "central_get_client_onboarding_stage_reasons"),
+    ("mrt_health", "central_get_tenant_client_health"),
+    ("mrt_health", "central_get_tenant_device_health"),
+    ("mrt_insights", "central_get_insights"),
+    ("mrt_troubleshooting", "central_get_event_extra_attributes"),
+    ("mrt_services", "central_get_location_analytics_site_insights"),
+]
+
+
+def _params(module: str, tool: str) -> set[str]:
+    fn = getattr(importlib.import_module(_MOD + module), tool)
+    return set(inspect.signature(fn).parameters)
+
+
+@pytest.mark.parametrize(("module", "tool"), _TREND_TOOLS)
+def test_trend_tools_have_no_time_window_params(module, tool):
+    params = _params(module, tool)
+    assert "start" not in params, f"{tool} still exposes a dead 'start' param"
+    assert "end" not in params, f"{tool} still exposes a dead 'end' param"
+
+
+@pytest.mark.parametrize(("module", "tool"), _FILTER_TOOLS)
+def test_filter_rejecting_tools_have_no_filter_param(module, tool):
+    assert "filter" not in _params(module, tool), f"{tool} still exposes a dead 'filter' param"
+
+
+def test_time_params_helper_is_gone():
+    # The shared helper that built the dead start/end params was removed.
+    for module in ("mrt_ap", "mrt_gateway"):
+        mod = importlib.import_module(_MOD + module)
+        assert not hasattr(mod, "_time_params"), f"{module}._time_params should be removed"

--- a/tests/unit/test_central_query_param_kebab.py
+++ b/tests/unit/test_central_query_param_kebab.py
@@ -1,0 +1,61 @@
+"""Regression tests for kebab-case query-param names on Central monitoring/
+notification tools.
+
+Unlike the ``network-config`` API (which silently *ignores* unknown query
+params), the ``network-monitoring`` and ``network-notifications`` APIs **reject**
+them with HTTP 400 "Unknown query parameter". These tools previously sent the
+wrong names — ``start`` / ``end`` instead of the documented ``start-at`` /
+``end-at``, and camelCase ``scopeId`` / ``scopeType`` instead of ``scope-id`` /
+``scope-type`` — so scoped/time-windowed reads 400'd. Confirmed against the live
+API and the vendored New Central OAS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+@patch("hpe_networking_mcp.platforms.central.tools.mrt_clients.retry_central_command")
+async def test_mobility_trail_sends_start_at_end_at(mock_cmd):
+    from hpe_networking_mcp.platforms.central.tools.mrt_clients import central_get_client_mobility_trail
+
+    mock_cmd.return_value = {"code": 200, "msg": {}}
+    await central_get_client_mobility_trail(_ctx(), mac_address="d8:eb:46:0f:12:fb", start="T0", end="T1")
+
+    params = mock_cmd.call_args.kwargs["api_params"]
+    assert params == {"start-at": "T0", "end-at": "T1"}
+    assert "start" not in params and "end" not in params
+
+
+@patch("hpe_networking_mcp.platforms.central.tools.mrt_services.retry_central_command")
+async def test_location_analytics_trends_sends_start_at_end_at(mock_cmd):
+    from hpe_networking_mcp.platforms.central.tools.mrt_services import central_get_location_analytics_trends
+
+    mock_cmd.return_value = {"code": 200, "msg": {}}
+    await central_get_location_analytics_trends(_ctx(), start="T0", end="T1")
+
+    params = mock_cmd.call_args.kwargs["api_params"]
+    assert params.get("start-at") == "T0" and params.get("end-at") == "T1"
+    assert "start" not in params and "end" not in params
+
+
+@patch("hpe_networking_mcp.platforms.central.tools.alert_configs.retry_central_command")
+async def test_get_alert_configs_sends_kebab_scope_params(mock_cmd):
+    from hpe_networking_mcp.platforms.central.tools.alert_configs import central_get_alert_configs
+
+    mock_cmd.return_value = {"code": 200, "msg": {}}
+    await central_get_alert_configs(_ctx(), scope_id="site-123", scope_type="SITE")
+
+    params = mock_cmd.call_args.kwargs["api_params"]
+    assert params == {"scope-id": "site-123", "scope-type": "SITE"}
+    assert "scopeId" not in params and "scopeType" not in params


### PR DESCRIPTION
Backport of the Central query-param audit fixes. A **runtime-capture audit** of every Central tool (driven with placeholder args through a fake connection recording the exact request) was reconciled against the vendored New Central OAS and **confirmed against a live tenant**. `network-monitoring` / `network-notifications` / `network-services` **reject** unknown query params with `HTTP 400 "Unknown query parameter"` (unlike `network-config`, which ignores them), so affected tools failed when the param was used.

## Renamed to the documented names (live-verified → 200)
- `central_get_client_mobility_trail`, `central_get_location_analytics_trends`: `start`/`end` → `start-at`/`end-at`
- `central_get_alert_configs`: `scopeId`/`scopeType` → `scope-id`/`scope-type`

## Removed dead params with no working alternative (both the wrong and "corrected" name 400)
- `start`/`end` from 13 `*-trends` tools (AP/gateway/switch/cluster) — these endpoints accept **no** time window (both `start`/`end` and `start-at`/`end-at` 400; no-params → 200)
- `filter` from 9 tools that 400 on it (`client_onboarding_*`, `tenant_*_health`, `insights`, `event_extra_attributes`, `location_analytics_site_insights`)

## Left untouched (verified accepted/ignored)
`offset` on list endpoints; `filter` on `central_get_asset_tags` / `central_get_firewall_sessions` / `central_get_wlans_monitoring`.

## Verification
Regression tests (`test_central_query_param_kebab.py`, `test_central_dropped_dead_params.py`) pin the corrected wire format and removed params. Full suite **2196 passed**; ruff + format clean. Version → 3.6.1.10.