### PR TITLE
chore(vendor): sync HPE GreenLake OAS

### DIFF
--- a/vendor/greenlake/compute-ops-mgmt.json
+++ b/vendor/greenlake/compute-ops-mgmt.json
@@ -2375,13 +2375,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "type",
-          "generation",
-          "createdAt",
-          "updatedAt"
-        ],
         "type": "object"
       },
       "activityCollection-v1beta2": {

--- a/vendor/greenlake/subscription-management.json
+++ b/vendor/greenlake/subscription-management.json
@@ -3223,9 +3223,7 @@
                       "errorDetails": [
                         {
                           "metadata": {
-                            "id": {
-                              "message": "Resource with id [00000000-0000-0000-0000-000000000000] not found"
-                            }
+                            "id": "Subscription with id [00000000-0000-0000-0000-000000000000] was not found in this workspace"
                           },
                           "source": "hpe.greenlake.subscriptionmanagement",
                           "type": "hpe.greenlake.metadata"

--- a/vendor/greenlake/workspace__workspace-management-v1-nb-openapi-workspace.json
+++ b/vendor/greenlake/workspace__workspace-management-v1-nb-openapi-workspace.json
@@ -8,6 +8,10 @@
           "generation": 1,
           "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
           "resourceUri": "/workspaces/v1/workspaces/3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "tags": {
+            "cost-center": "finops",
+            "hpe:partner": "true"
+          },
           "type": "workspace",
           "updatedAt": "2025-09-17T13:06:59.001Z",
           "workspaceName": "New Workspace",
@@ -381,6 +385,9 @@
             "title": "Resource Uri",
             "type": "string"
           },
+          "tags": {
+            "$ref": "#/components/schemas/TagMap"
+          },
           "type": {
             "description": "Type of data",
             "title": "Type of data",
@@ -658,6 +665,14 @@
           "message"
         ],
         "title": "StandardErrorResponse",
+        "type": "object"
+      },
+      "TagMap": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Map of user and system tag keys to string values associated with the workspace. The property is omitted when the workspace-tags feature is disabled and is an empty object when enabled for a workspace with no tags.",
+        "title": "Workspace tags",
         "type": "object"
       }
     },


### PR DESCRIPTION
Automated weekly sync of the HPE GreenLake public northbound OpenAPI specs.

- **Source**: https://developer.greenlake.hpe.com (`/_bundle/.../<spec>.json?download`)
- **Vendored to**: `vendor/greenlake/` (driven by `sources.json`)
- Check the run log for `::warning::` lines about **newly-published
  services** to add to `sources.json`.

Tool regeneration is **not** triggered by this PR — the maintainer
regenerates the GreenLake tool surface at release time so tool-surface
changes are reviewed before shipping.

This PR has auto-merge enabled and will merge once required status
checks pass.