### PR TITLE
fix(central): WIDS monitored-APs route moved v1alpha1 -> v1

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1646,7 +1646,7 @@ Diagnostics for the New Central Configuration API config-health surface (`/netwo
 
 ### WIDS (Wireless Intrusion Detection) (v3.1.1.1)
 
-Wraps the `network-services/v1alpha1/wids-monitored-aps` endpoint — undocumented in the public Central API reference but tenant-scoped (no cross-tenant exposure) and in-policy under the `network-*/v1alpha1` rule. Returns the caller's APs' reports of neighbor / rogue / suspect / interfering APs they've detected.
+Wraps the `network-services/v1/wids-monitored-aps` endpoint — tenant-scoped (no cross-tenant exposure) and publicly documented at developer.arubanetworks.com (`listMonitoredApsV1`, updated 2026-07-14). The route moved from `v1alpha1` to `v1`; the old path 404s. Returns the caller's APs' reports of neighbor / rogue / suspect / interfering APs they've detected.
 
 #### `central_get_wids_monitored_aps`
 

--- a/src/hpe_networking_mcp/INSTRUCTIONS.md
+++ b/src/hpe_networking_mcp/INSTRUCTIONS.md
@@ -531,7 +531,7 @@ When asked to create a new site based on an existing site:
   - **Shared helpers**: `central_get_troubleshooting_task_status` polls any async action (every troubleshooting POST returns a `task_id`). `central_list_troubleshooting_tasks` lists queued / running / completed tasks. `central_list_supported_show_commands` lists which show commands a device accepts.
   - **Events**: `central_get_event_extra_attributes` documents the attribute catalogue driving `central_get_events` filters.
 - **WIDS (Wireless Intrusion Detection)**: central_get_wids_monitored_aps
-  - Reads neighbor / rogue / suspect / interfering APs detected by the caller's APs at `network-services/v1alpha1/wids-monitored-aps`. Tenant-scoped.
+  - Reads neighbor / rogue / suspect / interfering APs detected by the caller's APs at `network-services/v1/wids-monitored-aps`. Tenant-scoped.
   - Use `classification="ROGUE" | "SUSPECT_ROGUE" | "INTERFERING" | "VALID"` to narrow; `contained_only=True` for APs the fabric is actively de-authing; `site_id` to scope by site.
   - For filters not covered by the structured args, pass `odata_filter` (raw OData 4.0). Mutually exclusive with the structured args — pick one or the other.
   - Page through via `limit` + `offset`; envelope returns `total` for pagination accounting.

--- a/src/hpe_networking_mcp/platforms/central/tools/wids.py
+++ b/src/hpe_networking_mcp/platforms/central/tools/wids.py
@@ -1,11 +1,17 @@
 """Aruba Central WIDS (Wireless Intrusion Detection) tools.
 
-Wraps the ``network-services/v1alpha1/wids-monitored-aps`` endpoint. The
-endpoint is undocumented in the public Central API reference but tenant-
-scoped (no cross-tenant exposure) and lives under the in-policy
-``network-*/v1alpha1`` path family, so building it as a tool is allowed
-per the 2026-05-15 build-policy guidance recorded in
-``docs/central-undocumented-endpoints.md``.
+Wraps the ``network-services/v1/wids-monitored-aps`` endpoint. The
+endpoint is tenant-scoped (no cross-tenant exposure) and is now publicly
+documented at
+https://developer.arubanetworks.com/new-central/reference/listmonitoredapsv1.md
+(updated 2026-07-14), which supersedes the 2026-05-15 undocumented-endpoint
+build-policy note in ``docs/central-undocumented-endpoints.md``.
+
+NOTE 2026-08-30: the route moved ``v1alpha1`` -> ``v1``. The old path 404s,
+and 404 is not a documented response for this endpoint, so a 404 here means
+the caller is on a stale version rather than the feature being absent. The
+``network-config/*`` tools remain correctly on ``v1alpha1``; only
+``network-services`` moved.
 
 Returns the caller's APs' reports of nearby APs they've detected,
 classified as one of:
@@ -94,7 +100,7 @@ async def central_get_wids_monitored_aps(
 ) -> dict | str:
     """Get WIDS monitored-AP records from Central.
 
-    Reads the ``network-services/v1alpha1/wids-monitored-aps`` endpoint
+    Reads the ``network-services/v1/wids-monitored-aps`` endpoint
     which lists neighbor / rogue / suspect / interfering APs detected by
     the caller's APs. Tenant-scoped.
 
@@ -157,7 +163,7 @@ async def central_get_wids_monitored_aps(
     response = await retry_central_command(
         central_conn=conn,
         api_method="GET",
-        api_path="network-services/v1alpha1/wids-monitored-aps",
+        api_path="network-services/v1/wids-monitored-aps",
         api_params=api_params,
     )
 

--- a/tests/unit/test_central_wids.py
+++ b/tests/unit/test_central_wids.py
@@ -1,0 +1,71 @@
+"""Unit tests for the central WIDS tool.
+
+Regression coverage for the API-version fix: the live route is
+``network-services/v1/wids-monitored-aps`` — the tool previously called the
+``v1alpha1`` variant, which gateway-404s. Same defect, same family, as the
+audit-trail routes already covered in ``test_central_audit_logs.py``.
+
+Probed read-only on the lab tenant (US-1) 2026-09-02:
+``network-services/v1alpha1/wids-monitored-aps`` -> 404,
+``network-services/v1/wids-monitored-aps``       -> 200.
+
+Mocks ``retry_central_command`` at the import site, matching the audit-logs
+tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"central_conn": MagicMock()}
+    return ctx
+
+
+class TestCentralGetWidsMonitoredAps:
+    @patch("hpe_networking_mcp.platforms.central.tools.wids.retry_central_command")
+    async def test_uses_v1_path(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.wids import central_get_wids_monitored_aps
+
+        mock_cmd.return_value = {"code": 200, "msg": {"items": [], "total": 0, "count": 0, "offset": 0}}
+        result = await central_get_wids_monitored_aps(_ctx())
+
+        kwargs = mock_cmd.call_args.kwargs
+        assert kwargs["api_method"] == "GET"
+        # The bug was v1alpha1; the live route is v1.
+        assert kwargs["api_path"] == "network-services/v1/wids-monitored-aps"
+        assert kwargs["api_params"] == {"limit": 100, "offset": 0}
+        assert result == {"items": [], "total": 0, "count": 0, "offset": 0}
+
+    @patch("hpe_networking_mcp.platforms.central.tools.wids.retry_central_command")
+    async def test_structured_args_compose_odata_filter(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.wids import central_get_wids_monitored_aps
+
+        mock_cmd.return_value = {"code": 200, "msg": {"items": []}}
+        await central_get_wids_monitored_aps(_ctx(), classification="ROGUE", contained_only=True, site_id="s1")
+
+        params = mock_cmd.call_args.kwargs["api_params"]
+        assert params["filter"] == ("classification eq 'ROGUE' and containmentStatus eq 'CONTAINED' and siteId eq 's1'")
+
+    @patch("hpe_networking_mcp.platforms.central.tools.wids.retry_central_command")
+    async def test_mixing_raw_and_structured_filters_is_refused(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.wids import central_get_wids_monitored_aps
+
+        result = await central_get_wids_monitored_aps(_ctx(), classification="ROGUE", odata_filter="signal gt -70")
+        assert isinstance(result, str) and result.startswith("Error:")
+        mock_cmd.assert_not_called()
+
+    @patch("hpe_networking_mcp.platforms.central.tools.wids.retry_central_command")
+    async def test_non_2xx_returns_error_envelope(self, mock_cmd):
+        from hpe_networking_mcp.platforms.central.tools.wids import central_get_wids_monitored_aps
+
+        mock_cmd.return_value = {"code": 404, "msg": {"message": "404 Route Not Found"}}
+        result = await central_get_wids_monitored_aps(_ctx())
+        assert result["status"] == "error"
+        assert result["code"] == 404


### PR DESCRIPTION
central_get_wids_monitored_aps called
network-services/v1alpha1/wids-monitored-aps, which 404s. The route moved to v1 - the same move already fixed for network-services/v1/audits and network-services/v1/audit/{id}. It is now publicly documented as listMonitoredApsV1 (developer.arubanetworks.com, updated 2026-07-14), which supersedes the 2026-05-15 undocumented-endpoint note in docs/central-undocumented-endpoints.md.

Probed read-only on two independent tenants:
  2026-08-30 (trial tenant)
    network-services/v1alpha1/wids-monitored-aps -> 404
    network-services/v1/wids-monitored-aps       -> 200 total=0
    network-services/v1/wids-intrusions          -> 200 total=0
  2026-09-02 (lab tenant, US-1)
    network-services/v1alpha1/wids-monitored-aps -> 404
    network-services/v1/wids-monitored-aps       -> 200 total=0

Swept every remaining non-network-config v1alpha1 caller in the shipped image; this is the only stale one:
  network-monitoring/v1alpha1/gateways     -> 200 (correct as-is)
  network-monitoring/v1alpha1/applications -> live; the v1 variant rejects
      its query params outright ("Unknown query parameter:
      start-query-time"), so v1 is a different contract, not a newer
      version of this route. Leave on v1alpha1.
  network-troubleshooting/v1alpha1/*       -> POST .../{serial}/ping|
      traceroute; not probed (firing a live ping is not a read).
  network-config/v1alpha1/*                -> unaffected; only
      network-services moved.

Why this matters beyond one tool: a stale caller version is indistinguishable from an absent feature. This 404 was first written up as a tenant/feature fault. tests/unit/test_central_wids.py now pins the api_path so the next version drift fails in CI instead of in the field; verified load-bearing by reverting the path and watching it fail.